### PR TITLE
fix: remove hardcoded og:url so Messenger preserves ?room=UUID on click

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -27,7 +27,6 @@ export const metadata: Metadata = {
         title: 'Floe — Encrypted P2P File Transfer. No Uploads.',
         description:
             'Send files directly from your device to anyone in the world. No accounts, no file storage, no size limits on direct transfers. Fully end-to-end encrypted with WebRTC.',
-        url: 'https://www.floe.one',
         siteName: 'Floe',
         images: [
             {


### PR DESCRIPTION
og:url was set to https://www.floe.one, causing Facebook/Messenger to use the root URL as the click destination, stripping the room parameter. Removing og:url lets the platform use the actual scraped URL (?room=UUID) so recipients land on the correct room page.