### PR TITLE
fix: add client-side Sentry initialization for Next.js 15+ App Router

### DIFF
--- a/client/instrumentation-client.ts
+++ b/client/instrumentation-client.ts
@@ -1,0 +1,5 @@
+// instrumentation-client.ts
+// Next.js 15+ runs this file in the browser before hydration.
+// This is the correct entry point for client-side Sentry initialization
+// in the App Router. The server-side configs are handled by instrumentation.ts.
+import './sentry.client.config';

--- a/client/instrumentation.ts
+++ b/client/instrumentation.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/nextjs';
+
 export async function register() {
     if (process.env.NEXT_RUNTIME === 'nodejs') {
         await import('./sentry.server.config');
@@ -7,3 +9,6 @@ export async function register() {
         await import('./sentry.edge.config');
     }
 }
+
+// Required by @sentry/nextjs v9+ for Next.js App Router server-side error capture
+export const onRequestError = Sentry.captureRequestError;


### PR DESCRIPTION
- Add instrumentation-client.ts (Next.js 15+ browser entry point for Sentry) Without this file, sentry.client.config.ts never runs in the browser in App Router projects — instrumentation.ts is server-side only
- Add onRequestError export to instrumentation.ts (required by @sentry/nextjs v9+ for proper server-side error capture in App Router)