### PR TITLE
fix: enforce relay gate post-ICE, hard-reset navbar, add Sentry priva…

### DIFF
--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -92,9 +92,10 @@ export default function PrivacyPolicy() {
                         </h3>
                         <p>
                             Floe is hosted on Vercel (frontend) and DigitalOcean
-                            (signaling server and TURN relay). Please refer to
-                            their respective privacy policies regarding server
-                            access logs.
+                            (signaling server and TURN relay). We also use{' '}
+                            <strong>Sentry</strong> for error monitoring and performance
+                            tracking. Please refer to their respective privacy policies
+                            regarding data handling.
                         </p>
                     </section>
 
@@ -113,6 +114,39 @@ export default function PrivacyPolicy() {
                             Relay sessions are limited to 2 GB per session. Connection
                             metadata (timestamps, IP addresses) may be logged by the
                             hosting provider for security purposes.
+                        </p>
+                    </section>
+
+                    <section className="space-y-3">
+                        <h3 className="text-xl font-semibold text-white">
+                            5. Error Monitoring &amp; Session Replay
+                        </h3>
+                        <p>
+                            Floe uses <strong>Sentry</strong> to monitor application errors
+                            and performance. When an error occurs, Sentry may capture:
+                        </p>
+                        <ul className="list-disc list-inside space-y-2 ml-2 text-zinc-400">
+                            <li>Error stack traces and browser metadata (browser version, OS, device type)</li>
+                            <li>Connection type (direct or relay) and transfer progress at time of error</li>
+                            <li>
+                                <strong>Session Replay:</strong> An anonymized video-like recording of
+                                your browser session may be captured when an error occurs. Text inputs
+                                are masked. File contents are never captured.
+                            </li>
+                        </ul>
+                        <p>
+                            Sentry does <strong>not</strong> capture file names, file contents,
+                            or any personally identifiable information. Session recordings are
+                            used solely for debugging technical issues.{' '}
+                            <a
+                                href="https://sentry.io/privacy/"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-zinc-400 hover:text-white underline underline-offset-2 transition-colors"
+                            >
+                                Sentry Privacy Policy
+                            </a>
+                            .
                         </p>
                     </section>
                 </div>

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -714,6 +714,23 @@ export function P2PTransfer() {
                         data: { isRelay, totalBytes },
                     });
 
+                    // Relay enforcement: if the actual negotiated path is relay
+                    // but the user disabled relay fallback, block the transfer.
+                    // This catches all cases regardless of which side generated
+                    // relay candidates during ICE negotiation.
+                    if (isRelay && !relayEnabled) {
+                        setError('Connection failed. Enable "Network Relay" to connect across restrictive networks, or ensure both devices are on the same network.');
+                        setStatus('Connection failed');
+                        Sentry.addBreadcrumb({
+                            category: 'transfer',
+                            message: 'Transfer blocked: relay detected but relay fallback disabled by user',
+                            level: 'warning',
+                            data: { isRelay, relayEnabled },
+                        });
+                        peer.destroy();
+                        return;
+                    }
+
                     const totalSize = files.reduce((s, f) => s + f.file.size, 0);
                     if (isRelay && totalSize > 2 * 1024 * 1024 * 1024) {
                         setStatus('Transfer blocked. Relay limit exceeded.');

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -32,11 +32,14 @@ export const Navbar = () => {
     return (
         <nav className="fixed top-0 left-0 right-0 z-50 flex justify-center py-6 pointer-events-none">
             <div className="pointer-events-auto flex items-center gap-1 rounded-full border border-white/10 bg-zinc-900/80 p-1.5 shadow-2xl backdrop-blur-md transition-all hover:border-white/20">
-                {/* Plain <a> forces full page reload — clears all peer/transfer state */}
-                <a href="/" className="flex items-center gap-1.5 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-semibold text-white transition hover:bg-white/10">
+                {/* Button with hard-nav: forces full reload, clearing all peer/transfer state */}
+                <button
+                    onClick={() => { window.location.href = '/'; }}
+                    className="flex items-center gap-1.5 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-semibold text-white transition hover:bg-white/10"
+                >
                     <div className={`h-2 w-2 rounded-full ${dotColor} animate-pulse transition-colors duration-500`} />
                     Floe.
-                </a>
+                </button>
                 <div className="h-4 w-px bg-white/10 mx-1" />
                 <div className="flex items-center gap-0.5 sm:gap-1">
                     <button onClick={() => scrollToSection('about')} className="rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white">About</button>

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import Link from 'next/link';
+
 
 type ConnectionStatus = 'direct' | 'relay' | 'connected' | 'offline';
 
@@ -32,10 +32,11 @@ export const Navbar = () => {
     return (
         <nav className="fixed top-0 left-0 right-0 z-50 flex justify-center py-6 pointer-events-none">
             <div className="pointer-events-auto flex items-center gap-1 rounded-full border border-white/10 bg-zinc-900/80 p-1.5 shadow-2xl backdrop-blur-md transition-all hover:border-white/20">
-                <Link href="/" className="flex items-center gap-1.5 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-semibold text-white transition hover:bg-white/10">
+                {/* Plain <a> forces full page reload — clears all peer/transfer state */}
+                <a href="/" className="flex items-center gap-1.5 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-semibold text-white transition hover:bg-white/10">
                     <div className={`h-2 w-2 rounded-full ${dotColor} animate-pulse transition-colors duration-500`} />
                     Floe.
-                </Link>
+                </a>
                 <div className="h-4 w-px bg-white/10 mx-1" />
                 <div className="flex items-center gap-0.5 sm:gap-1">
                     <button onClick={() => scrollToSection('about')} className="rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white">About</button>


### PR DESCRIPTION
…cy disclosure

- P2PTransfer: block transfer if relay detected but relayEnabled=false, regardless of which side generated relay candidates (bilateral ICE fix)
- Navbar: replace Next.js Link with plain <a> for logo to force full page reload and clear all peer/transfer state on click
- Privacy: add Sentry to third-party services section, new section 5 disclosing error monitoring and session replay data collection