### PR TITLE
feat: add Umami analytics + update privacy policy

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -4,6 +4,7 @@ import './globals.css';
 import { ServiceWorkerRegistration } from '@/components/ServiceWorkerRegistration';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import Script from 'next/script';
 
 const geistSans = Geist({
     variable: '--font-geist-sans',
@@ -63,6 +64,12 @@ export default function RootLayout({
                 {children}
                 <Analytics />
                 <SpeedInsights />
+                <Script
+                    defer
+                    src="https://cloud.umami.is/script.js"
+                    data-website-id="48515832-b19f-49ad-a82d-9a4018d0ad96"
+                    strategy="afterInteractive"
+                />
                 {/* JSON-LD structured data: tells Google this is a free web application */}
                 <script
                     type="application/ld+json"

--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -91,11 +91,12 @@ export default function PrivacyPolicy() {
                             3. Third-Party Services
                         </h3>
                         <p>
-                            Floe is hosted on Vercel (frontend) and DigitalOcean
-                            (signaling server and TURN relay). We also use{' '}
-                            Sentry for error monitoring and performance
-                            tracking. Please refer to their respective privacy policies
-                            regarding data handling.
+                            Floe uses third-party infrastructure providers for
+                            hosting and network relay services. We also use
+                            Sentry for error monitoring and Umami for
+                            privacy-respecting usage analytics. Please refer to
+                            their respective privacy policies regarding data
+                            handling.
                         </p>
                     </section>
 
@@ -145,6 +146,36 @@ export default function PrivacyPolicy() {
                                 className="text-zinc-400 hover:text-white underline underline-offset-2 transition-colors"
                             >
                                 Sentry Privacy Policy
+                            </a>
+                            .
+                        </p>
+                    </section>
+
+                    <section className="space-y-3">
+                        <h3 className="text-xl font-semibold text-white">
+                            6. Usage Analytics
+                        </h3>
+                        <p>
+                            Floe uses Umami, a privacy-focused analytics tool, to
+                            understand how the service is used. Umami collects:
+                        </p>
+                        <ul className="list-disc list-inside space-y-2 ml-2 text-zinc-400">
+                            <li>Aggregate transfer metrics: number of files and total bytes transferred per session</li>
+                            <li>Connection type (direct or relay) and whether a transfer succeeded or failed</li>
+                            <li>Standard page view data: pages visited, browser type, country (not city)</li>
+                        </ul>
+                        <p>
+                            Umami does <strong>not</strong> use cookies, does not collect
+                            personally identifiable information, and does not track
+                            individuals across sessions or websites. File names and file
+                            contents are never recorded.{' '}
+                            <a
+                                href="https://umami.is/privacy"
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-zinc-400 hover:text-white underline underline-offset-2 transition-colors"
+                            >
+                                Umami Privacy Policy
                             </a>
                             .
                         </p>

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -18,6 +18,12 @@ import * as Sentry from '@sentry/nextjs';
 
 import { QRCodeSVG } from 'qrcode.react';
 
+interface UmamiWindow extends Window {
+    umami?: {
+        track: (event: string, data?: Record<string, unknown>) => void;
+    };
+}
+
 import {
     Card,
     CardContent,
@@ -406,8 +412,8 @@ export function P2PTransfer() {
                 setError(`Connection error: ${err.message}`);
             }
             // Track failed connection attempt
-            if (typeof window !== 'undefined' && (window as any).umami) {
-                (window as any).umami.track('transfer-failed', {
+            if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
+                (window as UmamiWindow).umami.track('transfer-failed', {
                     reason: err.message?.includes('User-Initiated Abort') ? 'abort'
                         : err.message === 'Ice connection failed.' ? 'ice-failed'
                         : err.message === 'Connection failed.' ? 'conn-failed'
@@ -489,8 +495,8 @@ export function P2PTransfer() {
                                     currentMetadata.id
                                 );
                                 // Track received file (aggregate only)
-                                if (typeof window !== 'undefined' && (window as any).umami) {
-                                    (window as any).umami.track('transfer-received', {
+                                if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
+                                    (window as UmamiWindow).umami.track('transfer-received', {
                                         files: receivedFilesRef.current.length,
                                         bytes: fileData.received,
                                         connection: connectionType ?? 'unknown',
@@ -841,8 +847,8 @@ export function P2PTransfer() {
                     setError(`Connection error: ${err.message}`);
                 }
                 // Track failed connection attempt
-                if (typeof window !== 'undefined' && (window as any).umami) {
-                    (window as any).umami.track('transfer-failed', {
+                if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
+                    (window as UmamiWindow).umami.track('transfer-failed', {
                         reason: !relayEnabled ? 'relay-disabled'
                             : err.message?.includes('User-Initiated Abort') ? 'abort'
                             : err.message === 'Ice connection failed.' ? 'ice-failed'
@@ -877,8 +883,8 @@ export function P2PTransfer() {
             transferCompleteRef.current = true;
             releaseWakeLock();
             // Track successful transfer (aggregate only — no file names, no identifiers)
-            if (typeof window !== 'undefined' && (window as any).umami) {
-                (window as any).umami.track('transfer-complete', {
+            if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
+                (window as UmamiWindow).umami.track('transfer-complete', {
                     files: fileList.length,
                     bytes: fileList.reduce((s, f) => s + f.file.size, 0),
                     connection: connectionType ?? 'unknown',

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -412,8 +412,8 @@ export function P2PTransfer() {
                 setError(`Connection error: ${err.message}`);
             }
             // Track failed connection attempt
-            if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
-                (window as UmamiWindow).umami.track('transfer-failed', {
+            if (typeof window !== 'undefined') {
+                (window as UmamiWindow).umami?.track('transfer-failed', {
                     reason: err.message?.includes('User-Initiated Abort') ? 'abort'
                         : err.message === 'Ice connection failed.' ? 'ice-failed'
                         : err.message === 'Connection failed.' ? 'conn-failed'
@@ -495,8 +495,8 @@ export function P2PTransfer() {
                                     currentMetadata.id
                                 );
                                 // Track received file (aggregate only)
-                                if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
-                                    (window as UmamiWindow).umami.track('transfer-received', {
+                                if (typeof window !== 'undefined') {
+                                    (window as UmamiWindow).umami?.track('transfer-received', {
                                         files: receivedFilesRef.current.length,
                                         bytes: fileData.received,
                                         connection: connectionType ?? 'unknown',
@@ -847,8 +847,8 @@ export function P2PTransfer() {
                     setError(`Connection error: ${err.message}`);
                 }
                 // Track failed connection attempt
-                if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
-                    (window as UmamiWindow).umami.track('transfer-failed', {
+                if (typeof window !== 'undefined') {
+                    (window as UmamiWindow).umami?.track('transfer-failed', {
                         reason: !relayEnabled ? 'relay-disabled'
                             : err.message?.includes('User-Initiated Abort') ? 'abort'
                             : err.message === 'Ice connection failed.' ? 'ice-failed'
@@ -883,8 +883,8 @@ export function P2PTransfer() {
             transferCompleteRef.current = true;
             releaseWakeLock();
             // Track successful transfer (aggregate only — no file names, no identifiers)
-            if (typeof window !== 'undefined' && (window as UmamiWindow).umami) {
-                (window as UmamiWindow).umami.track('transfer-complete', {
+            if (typeof window !== 'undefined') {
+                (window as UmamiWindow).umami?.track('transfer-complete', {
                     files: fileList.length,
                     bytes: fileList.reduce((s, f) => s + f.file.size, 0),
                     connection: connectionType ?? 'unknown',

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -405,6 +405,16 @@ export function P2PTransfer() {
                 });
                 setError(`Connection error: ${err.message}`);
             }
+            // Track failed connection attempt
+            if (typeof window !== 'undefined' && (window as any).umami) {
+                (window as any).umami.track('transfer-failed', {
+                    reason: err.message?.includes('User-Initiated Abort') ? 'abort'
+                        : err.message === 'Ice connection failed.' ? 'ice-failed'
+                        : err.message === 'Connection failed.' ? 'conn-failed'
+                        : 'unknown',
+                    role: 'receiver',
+                });
+            }
             setStatus('Connection failed');
         });
 
@@ -478,6 +488,15 @@ export function P2PTransfer() {
                                 partialDownloads.current.delete(
                                     currentMetadata.id
                                 );
+                                // Track received file (aggregate only)
+                                if (typeof window !== 'undefined' && (window as any).umami) {
+                                    (window as any).umami.track('transfer-received', {
+                                        files: receivedFilesRef.current.length,
+                                        bytes: fileData.received,
+                                        connection: connectionType ?? 'unknown',
+                                        role: 'receiver',
+                                    });
+                                }
                             }
                             setStatus('File Received. Waiting for next...');
                             setProgress(0);
@@ -821,6 +840,19 @@ export function P2PTransfer() {
                     });
                     setError(`Connection error: ${err.message}`);
                 }
+                // Track failed connection attempt
+                if (typeof window !== 'undefined' && (window as any).umami) {
+                    (window as any).umami.track('transfer-failed', {
+                        reason: !relayEnabled ? 'relay-disabled'
+                            : err.message?.includes('User-Initiated Abort') ? 'abort'
+                            : err.message === 'Ice connection failed.' ? 'ice-failed'
+                            : err.message === 'Connection failed.' ? 'conn-failed'
+                            : 'unknown',
+                        role: 'sender',
+                        files: files.length,
+                        bytes: totalBytes,
+                    });
+                }
                 setStatus('Connection failed');
             });
 
@@ -844,6 +876,15 @@ export function P2PTransfer() {
             setProgress(100);
             transferCompleteRef.current = true;
             releaseWakeLock();
+            // Track successful transfer (aggregate only — no file names, no identifiers)
+            if (typeof window !== 'undefined' && (window as any).umami) {
+                (window as any).umami.track('transfer-complete', {
+                    files: fileList.length,
+                    bytes: fileList.reduce((s, f) => s + f.file.size, 0),
+                    connection: connectionType ?? 'unknown',
+                    role: 'sender',
+                });
+            }
         }
     };
 


### PR DESCRIPTION
- Add Umami Cloud script to layout (data-website-id set)
- Track transfer-complete on sender with file count, bytes, connection type
- Track transfer-received on receiver with file count, bytes, connection type
- Track transfer-failed on both sender/receiver with failure reason
- No PII tracked: no file names, no room IDs, no user identifiers
- Privacy policy section 3: remove Vercel/DigitalOcean names
- Privacy policy section 6: add Umami analytics disclosure