### PR TITLE
chore: make project fork-friendly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,5 @@ jobs:
         run: pnpm build
         working-directory: client
         env:
-          # Provide dummy value so Next.js does not fail on missing env var
+          # Use the live signaling server — matches the default in client/.env.example
           NEXT_PUBLIC_SOCKET_URL: https://api.floe.one

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 .env
 .env.local
 .env.*
+!.env.example
 
 # --- Build Outputs ---
 dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,82 +1,112 @@
 # Contributing to Floe
 
-Thank you for your interest in contributing to Floe! All contributions are welcome.
+Thank you for your interest in contributing! All contributions are welcome.
 
 ## Getting Started
 
-1. Fork the repository
+1. Fork the repository on GitHub
 2. Clone your fork locally
-3. Install dependencies for both client and server
-4. Make your changes
-5. Test your changes
-6. Submit a pull request
+3. Follow the setup below
+4. Make your changes on a new branch
+5. Submit a pull request with a clear description
+
+---
 
 ## Development Setup
 
+Floe has two parts: a **Next.js client** and a **Node.js signaling server**.
+
+For most contributions (UI, pages, components), you only need to run the client. It connects to the live signaling server at `api.floe.one` by default.
+
+### Client Only (Recommended for most contributors)
+
 ```bash
-# Clone your fork
 git clone https://github.com/YOUR_USERNAME/floe.git
-cd floe
+cd floe/client
 
-# Install server dependencies
-cd server
+cp .env.example .env.local
 npm install
-
-# Install client dependencies
-cd ../client
-npm install
-
-# Start the server
-cd ../server
-npm start
-
-# In a new terminal, start the client
-cd client
 npm run dev
 ```
 
+Open [http://localhost:3000](http://localhost:3000). The client connects to `api.floe.one` automatically.
+
+### Client + Server (Only needed if you're changing server code)
+
+```bash
+# Terminal 1 — Server
+cd floe/server
+cp .env.example .env
+npm install
+npm start
+
+# Terminal 2 — Client
+cd floe/client
+cp .env.example .env.local
+# Change NEXT_PUBLIC_SOCKET_URL to http://localhost:3001
+npm install
+npm run dev
+```
+
+---
+
 ## Environment Variables
 
-The server requires the following environment variables for full functionality:
+### Client (`client/.env.local`)
 
-| Variable | Description |
-|---|---|
-| `CLIENT_URL` | Frontend origin URL (e.g., `https://floe.one`) |
-| `TURN_SECRET` | Shared secret for coturn HMAC credential generation |
-| `TURN_DOMAIN` | Domain of the TURN relay server (e.g., `turn.floe.one`) |
-| `PORT` | Port for the signaling server (default: `3001`) |
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `NEXT_PUBLIC_SOCKET_URL` | Yes | Signaling server URL. Defaults to `https://api.floe.one` — no changes needed for UI contributions. |
+| `NEXT_PUBLIC_SENTRY_DSN` | No | Your Sentry DSN for client-side error tracking. Leave empty to disable. |
+| `SENTRY_DSN` | No | Your Sentry DSN for server-side error tracking. Leave empty to disable. |
+| `SENTRY_ORG` | No | Your Sentry organization slug. |
+| `SENTRY_PROJECT` | No | Your Sentry project slug. |
+| `NEXT_PUBLIC_UMAMI_WEBSITE_ID` | No | Your Umami analytics website ID. Leave empty to disable. |
 
-See `server/.env.example` for reference. If `TURN_SECRET` or `TURN_DOMAIN` are not set, the server falls back to Google public STUN servers (no relay support).
+### Server (`server/.env`)
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CLIENT_URL` | Yes | Frontend origin for CORS (default: `http://localhost:3000`) |
+| `PORT` | No | Signaling server port (default: `3001`) |
+| `TURN_SECRET` | No | Shared secret for coturn HMAC credentials. Omit to use STUN-only (direct connections). |
+| `TURN_DOMAIN` | No | Your TURN relay server domain. |
+
+> **Note:** TURN is optional. Without it, only direct connections work — which is fine for local development and most home networks.
+
+---
 
 ## Pull Request Process
 
-1. Create a new branch for your feature or fix
+1. Create a new branch: `git checkout -b your-branch-name`
 2. Make your changes
-3. Ensure the code builds without errors
-4. Submit a pull request with a clear description of your changes
+3. Ensure the build passes: `npm run build` (in `client/`)
+4. Run the linter: `npm run lint` (in `client/`)
+5. Submit a pull request with a clear title and description
+
+---
 
 ## Code Style
 
-- Use TypeScript for new code
-- Follow the existing code formatting
-- Keep code simple and readable
+- TypeScript for all new client code
+- Follow the existing formatting (Prettier is configured)
+- Keep components focused and readable
+
+---
 
 ## Reporting Bugs
 
-If you find a bug, please open an issue with:
+Open an issue with:
 - A clear description of the problem
 - Steps to reproduce it
-- What you expected to happen
-- What actually happened
+- What you expected vs. what happened
 
 ## Suggesting Features
 
-Feature suggestions are welcome! Open an issue and describe:
-- What you'd like to see
-- Why it would be useful
+Open an issue and describe what you'd like and why it would be useful.
 
 ## Questions
 
-If you have questions, feel free to open an issue. We're happy to help.
+Feel free to open an issue — we're happy to help.
 
 Thank you for contributing!

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,13 @@
+# Required: Signaling server URL
+# Point to the live server to skip running it locally (works out of the box for UI contributions)
+# Use http://localhost:3001 if you need to run the server yourself
+NEXT_PUBLIC_SOCKET_URL=https://api.floe.one
+
+# Optional: Sentry error tracking (leave empty to disable)
+NEXT_PUBLIC_SENTRY_DSN=
+SENTRY_DSN=
+SENTRY_ORG=
+SENTRY_PROJECT=
+
+# Optional: Umami analytics (leave empty to disable)
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -64,12 +64,14 @@ export default function RootLayout({
                 {children}
                 <Analytics />
                 <SpeedInsights />
-                <Script
-                    defer
-                    src="https://cloud.umami.is/script.js"
-                    data-website-id="48515832-b19f-49ad-a82d-9a4018d0ad96"
-                    strategy="afterInteractive"
-                />
+                {process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID && (
+                    <Script
+                        defer
+                        src="https://cloud.umami.is/script.js"
+                        data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
+                        strategy="afterInteractive"
+                    />
+                )}
                 {/* JSON-LD structured data: tells Google this is a free web application */}
                 <script
                     type="application/ld+json"

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -11,8 +11,10 @@ const nextConfig = {
 };
 
 export default withSentryConfig(nextConfig, {
-    org: 'jannskiee',
-    project: 'floe',
+    // Set SENTRY_ORG and SENTRY_PROJECT in your environment for source map uploads.
+    // Leave empty to skip (the app still works; you just won't get annotated stack traces).
+    org: process.env.SENTRY_ORG || '',
+    project: process.env.SENTRY_PROJECT || '',
 
     // Suppress non-error logs during build
     silent: !process.env.CI,

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-    dsn: 'https://9b833210196a72eee96c035c0926ed09@o4511410609192960.ingest.us.sentry.io/4511410652708864',
+    // Set NEXT_PUBLIC_SENTRY_DSN in your environment to enable error tracking.
+    // Leave empty (or omit) to disable Sentry — safe for local development and forks.
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || '',
 
     // Capture 100% of transactions in production — adjust to 0.1 at scale
     tracesSampleRate: 1.0,

--- a/client/sentry.edge.config.ts
+++ b/client/sentry.edge.config.ts
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-    dsn: 'https://9b833210196a72eee96c035c0926ed09@o4511410609192960.ingest.us.sentry.io/4511410652708864',
+    // Set SENTRY_DSN in your environment to enable edge-side error tracking.
+    // Leave empty (or omit) to disable Sentry.
+    dsn: process.env.SENTRY_DSN || '',
     tracesSampleRate: 1.0,
     debug: false,
 });

--- a/client/sentry.server.config.ts
+++ b/client/sentry.server.config.ts
@@ -1,7 +1,9 @@
 import * as Sentry from '@sentry/nextjs';
 
 Sentry.init({
-    dsn: 'https://9b833210196a72eee96c035c0926ed09@o4511410609192960.ingest.us.sentry.io/4511410652708864',
+    // Set SENTRY_DSN in your environment to enable server-side error tracking.
+    // Leave empty (or omit) to disable Sentry.
+    dsn: process.env.SENTRY_DSN || '',
     tracesSampleRate: 1.0,
     debug: false,
 });

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,12 @@
+# Frontend origin URL (for CORS)
+CLIENT_URL=http://localhost:3000
+
+PORT=3001
+
+NODE_ENV=development
+
+# Optional: TURN relay server
+# Without these, the server falls back to Google public STUN servers.
+# Direct connections still work on most home and mobile networks.
+TURN_SECRET=
+TURN_DOMAIN=


### PR DESCRIPTION
- Move Sentry DSN to env vars (NEXT_PUBLIC_SENTRY_DSN / SENTRY_DSN)
- Move Sentry org/project to env vars (SENTRY_ORG / SENTRY_PROJECT)
- Make Umami analytics conditional on NEXT_PUBLIC_UMAMI_WEBSITE_ID env var
- Update client/.env.example with dev-ready defaults pointing to api.floe.one
- Update server/.env.example with localhost defaults and optional TURN vars
- Fix .gitignore to track .env.example files (was excluded by .env.* pattern)
- Rewrite CONTRIBUTING.md with client-only setup path and full env var docs
- Update CI comment to reflect new .env.example default