### PR TITLE
chore(release): group changelog and exclude merge commits

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,11 +38,26 @@ snapshot:
 changelog:
   use: github
   sort: asc
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Other
+      order: 999
   filters:
     exclude:
       - "^docs:"
       - "^test:"
       - "^chore:"
+      - "^style:"
+      - "^refactor:"
+      - "^Merge pull request"
+      - "^Merge branch"
+      - "^Merge remote-tracking"
+      - "^initial commit"
 
 release:
   github:


### PR DESCRIPTION
## Summary

Improves the GoReleaser changelog config so future releases produce clean, professional release notes:

- **Groups** commits into `Features` and `Bug fixes` sections
- **Excludes** merge commits and `style:`/`refactor:` noise (in addition to the existing `docs:`/`test:`/`chore:` filters)

## Notes

- Affects only how the **next** release's notes are generated — no change to built binaries, no version bump required.
- The v1.0.0 notes (which dumped all historical commits because there was no prior tag to diff against) are being cleaned up separately by editing the release directly.

## Test plan

- [ ] CI passes
- [ ] Verified on next tagged release (`v1.0.x` / `v1.1.0`)