### PR TITLE
fix(server): harden IP resolution, add collision-safe codes, graceful…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,27 @@ jobs:
           # Use the live signaling server — matches the default in client/.env.example
           NEXT_PUBLIC_SOCKET_URL: https://api.floe.one
 
+  server:
+    name: Server (Node.js)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: server
+
+      - name: Test
+        run: npm test
+        working-directory: server
+
   cli:
     name: CLI (Go)
     runs-on: ubuntu-latest

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,6 +5,12 @@ PORT=3001
 
 NODE_ENV=development
 
+# Number of trusted reverse-proxy hops in front of this server.
+# Set to 0 for direct exposure (no proxy), 1 (default) behind a single proxy
+# (Render / Fly / Vercel), higher for multiple proxy layers.
+# Controls how X-Forwarded-For is parsed for rate limiting.
+TRUSTED_PROXY_COUNT=1
+
 # Optional: TURN relay server
 # Without these, the server falls back to Google public STUN servers.
 # Direct connections still work on most home and mobile networks.

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "P2P file sharing backend using WebRTC and Socket.io",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test server.test.js",
     "start": "node server.js",
     "dev": "nodemon server.js"
   },

--- a/server/server.js
+++ b/server/server.js
@@ -14,6 +14,23 @@ const app = express();
 app.use(helmet());
 app.use(express.json());
 
+// Trust N proxy hops so req.ip resolves to the real client IP.
+// Set TRUSTED_PROXY_COUNT=0 for direct exposure, 1 (default) behind one proxy (Render/Fly/Vercel).
+const TRUSTED_PROXY_COUNT = parseInt(process.env.TRUSTED_PROXY_COUNT || '1', 10);
+app.set('trust proxy', TRUSTED_PROXY_COUNT);
+
+// Extract the real client IP from an X-Forwarded-For header, discarding
+// client-supplied spoofed entries by only trusting the rightmost N hops.
+function getClientIp(xffHeader, socketAddr) {
+    if (!xffHeader) return socketAddr || 'unknown';
+    const hops = String(xffHeader).split(',').map(s => s.trim()).filter(Boolean);
+    if (hops.length === 0) return socketAddr || 'unknown';
+    // The rightmost TRUSTED_PROXY_COUNT entries were appended by trusted proxies;
+    // the entry just before them is the genuine client.
+    const idx = Math.max(0, hops.length - TRUSTED_PROXY_COUNT);
+    return hops[idx] || socketAddr || 'unknown';
+}
+
 const allowedOrigins = [
     process.env.CLIENT_URL,
     'https://www.floe.one',
@@ -66,7 +83,7 @@ function generateCoturnCredentials() {
 }
 
 app.get('/api/turn-credentials', (req, res) => {
-    const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    const ip = req.ip;  // Express resolves this correctly via trust proxy
     const now = Date.now();
 
     if (!turnRateLimits.has(ip)) turnRateLimits.set(ip, []);
@@ -89,7 +106,13 @@ const codeToRoom = new Map(); // code → { roomId, expires }
 
 function generateCode() {
     const pick = () => words[Math.floor(Math.random() * words.length)];
-    return `${pick()}-${pick()}-${pick()}`;
+    for (let i = 0; i < 10; i++) {
+        const code = `${pick()}-${pick()}-${pick()}`;
+        const existing = codeToRoom.get(code);
+        if (!existing || Date.now() > existing.expires) return code;
+    }
+    // Extremely unlikely collision after 10 attempts; add a 4th word to widen the space.
+    return `${pick()}-${pick()}-${pick()}-${pick()}`;
 }
 
 // POST /api/code — register a code for a room ID (called by CLI sender)
@@ -133,7 +156,8 @@ function checkRateLimit(ip) {
 }
 
 // Periodic cleanup of old rate limit entries and expired codes
-setInterval(() => {
+// .unref() so the interval doesn't prevent the process from exiting (e.g. in tests).
+const cleanupInterval = setInterval(() => {
     const now = Date.now();
     for (const [ip, timestamps] of connectionCounts.entries()) {
         const valid = timestamps.filter(t => now - t < RATE_LIMIT_WINDOW);
@@ -148,7 +172,7 @@ setInterval(() => {
     for (const [code, entry] of codeToRoom.entries()) {
         if (now > entry.expires) codeToRoom.delete(code);
     }
-}, 60000);
+}, 60000).unref();
 
 // ---------------------------------------------------------------------------
 // Unified room registry
@@ -293,7 +317,7 @@ const io = new Server(server, {
 });
 
 io.use((socket, next) => {
-    const ip = socket.handshake.headers['x-forwarded-for'] || socket.handshake.address;
+    const ip = getClientIp(socket.handshake.headers['x-forwarded-for'], socket.handshake.address);
     if (!checkRateLimit(ip)) return next(new Error('Rate limit exceeded'));
     next();
 });
@@ -345,7 +369,7 @@ server.on('upgrade', (req, socket, head) => {
 });
 
 wss.on('connection', (ws, req) => {
-    const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+    const ip = getClientIp(req.headers['x-forwarded-for'], req.socket.remoteAddress);
     if (!checkRateLimit(ip)) {
         ws.close(1008, 'Rate limit exceeded');
         return;
@@ -386,7 +410,7 @@ const heartbeat = setInterval(() => {
         ws.isAlive = false;
         ws.ping();
     });
-}, 30000);
+}, 30000).unref();
 
 wss.on('close', () => clearInterval(heartbeat));
 
@@ -395,4 +419,41 @@ wss.on('close', () => clearInterval(heartbeat));
 // ---------------------------------------------------------------------------
 
 const PORT = process.env.PORT || 3001;
-server.listen(PORT);
+
+// ---------------------------------------------------------------------------
+// Graceful shutdown (SIGTERM from platform, SIGINT from Ctrl-C)
+// ---------------------------------------------------------------------------
+
+function shutdown() {
+    clearInterval(cleanupInterval);
+    clearInterval(heartbeat);
+    for (const ws of wss.clients) ws.close(1001, 'Server shutting down');
+    io.close();
+    server.close(() => process.exit(0));
+    // Force-exit after 10 s if connections don't drain in time.
+    setTimeout(() => process.exit(1), 10_000).unref();
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — only bind / register OS signals when run directly (not in tests)
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+    server.listen(PORT);
+    process.on('SIGTERM', shutdown);
+    process.on('SIGINT', shutdown);
+}
+
+// Exported for unit tests — not part of the public API.
+module.exports = {
+    getClientIp,
+    generateCode,
+    checkRateLimit,
+    handleJoinRoom,
+    handleSignal,
+    handleDisconnect,
+    rooms,
+    codeToRoom,
+    connectionCounts,
+    turnRateLimits,
+};

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -1,0 +1,302 @@
+'use strict';
+
+// Unit tests for pure server logic — no network I/O.
+// Uses Node's built-in test runner (node:test), available from Node 18+.
+// Run with: npm test
+
+const { describe, it, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+    getClientIp,
+    generateCode,
+    checkRateLimit,
+    handleJoinRoom,
+    handleSignal,
+    handleDisconnect,
+    rooms,
+    codeToRoom,
+    connectionCounts,
+} = require('./server');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROOM_ID   = '11111111-1111-1111-1111-111111111111';
+
+function makePeer(id) {
+    const msgs = [];
+    return {
+        id,
+        roomId: null,
+        msgs,
+        send(type, data) { msgs.push({ type, data }); },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// getClientIp
+// ---------------------------------------------------------------------------
+
+describe('getClientIp', () => {
+    it('returns socket address when XFF header is absent', () => {
+        assert.equal(getClientIp(undefined, '1.2.3.4'), '1.2.3.4');
+    });
+
+    it('returns "unknown" when both header and socket address are absent', () => {
+        assert.equal(getClientIp(undefined, undefined), 'unknown');
+    });
+
+    it('returns the client IP from a single-hop XFF (TRUSTED_PROXY_COUNT=1)', () => {
+        // With one trusted proxy, the proxy appended '10.0.0.1' — that IS the client IP.
+        // hops=['10.0.0.1'], idx=max(0, 1-1)=0 → '10.0.0.1'
+        assert.equal(getClientIp('10.0.0.1', '172.16.0.1'), '10.0.0.1');
+    });
+
+    it('ignores a client-supplied spoofed prefix and uses the entry added by the trusted proxy', () => {
+        // Client forges 'spoofed' in XFF; proxy appends 'real'.
+        // hops=['spoofed','real'], idx=max(0, 2-1)=1 → 'real'
+        assert.equal(getClientIp('spoofed, real', '172.16.0.1'), 'real');
+    });
+
+    it('trims whitespace around comma-separated hops', () => {
+        assert.equal(getClientIp('  192.168.1.1  ,  10.0.0.5  ', '127.0.0.1'), '10.0.0.5');
+    });
+
+    it('falls back to socket address for an empty XFF string', () => {
+        assert.equal(getClientIp('', '9.9.9.9'), '9.9.9.9');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// generateCode
+// ---------------------------------------------------------------------------
+
+describe('generateCode', () => {
+    beforeEach(() => { codeToRoom.clear(); });
+
+    it('returns a three-word hyphen-delimited code', () => {
+        const code = generateCode();
+        const parts = code.split('-');
+        assert.ok(parts.length >= 3, `expected ≥3 parts, got: ${code}`);
+        parts.forEach(p => assert.ok(p.length > 0, `empty part in code: ${code}`));
+    });
+
+    it('falls back to a 4-word code after 10 collisions with active entries', () => {
+        // Force Math.random to always return 0 so every attempt generates the same code.
+        const orig = Math.random;
+        Math.random = () => 0;
+        try {
+            const fixed = generateCode();                           // e.g. "apple-apple-apple"
+            codeToRoom.set(fixed, { roomId: ROOM_ID, expires: Date.now() + 60_000 });
+            const next = generateCode();
+            assert.equal(next.split('-').length, 4, `expected 4-word fallback, got: ${next}`);
+        } finally {
+            Math.random = orig;
+        }
+    });
+
+    it('treats an expired entry as a free slot and reuses the same 3-word code', () => {
+        const orig = Math.random;
+        Math.random = () => 0;
+        try {
+            const fixed = generateCode();
+            codeToRoom.set(fixed, { roomId: ROOM_ID, expires: Date.now() - 1 }); // already expired
+            const next = generateCode();
+            assert.equal(next, fixed, 'expired slot should be reused');
+            assert.equal(next.split('-').length, 3, 'should return the 3-word form');
+        } finally {
+            Math.random = orig;
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Room lifecycle — handleJoinRoom
+// ---------------------------------------------------------------------------
+
+describe('handleJoinRoom', () => {
+    beforeEach(() => { rooms.clear(); });
+
+    it('assigns sender role to the first peer in a room', () => {
+        const p = makePeer('peer-A');
+        handleJoinRoom(p, ROOM_ID);
+
+        assert.equal(p.msgs.length, 1);
+        assert.equal(p.msgs[0].type, 'room-joined');
+        assert.equal(p.msgs[0].data.role, 'sender');
+        assert.equal(p.roomId, ROOM_ID);
+    });
+
+    it('assigns receiver role to the second peer and notifies the first', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+
+        assert.equal(pB.msgs[0].type, 'room-joined');
+        assert.equal(pB.msgs[0].data.role, 'receiver');
+
+        const notify = pA.msgs.find(m => m.type === 'user-connected');
+        assert.ok(notify, 'first peer should receive user-connected');
+    });
+
+    it('sends room-full to a third peer and leaves it unjoined', () => {
+        const [pA, pB, pC] = ['A', 'B', 'C'].map(makePeer);
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+        handleJoinRoom(pC, ROOM_ID);
+
+        const full = pC.msgs.find(m => m.type === 'room-full');
+        assert.ok(full, 'third peer should receive room-full');
+        assert.equal(pC.roomId, null);
+    });
+
+    it('sends an error for a non-UUID room ID', () => {
+        const p = makePeer('peer-A');
+        handleJoinRoom(p, 'not-a-uuid');
+        assert.equal(p.msgs[0].type, 'error');
+        assert.equal(p.roomId, null);
+    });
+
+    it('sends an error for a null room ID', () => {
+        const p = makePeer('peer-A');
+        handleJoinRoom(p, null);
+        assert.equal(p.msgs[0].type, 'error');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Signal routing — handleSignal
+// ---------------------------------------------------------------------------
+
+describe('handleSignal', () => {
+    beforeEach(() => { rooms.clear(); });
+
+    it('routes signal to the other peer when targeted by ID', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+        pA.msgs.length = 0;
+        pB.msgs.length = 0;
+
+        handleSignal(pA, { type: 'offer' }, 'peer-B', null);
+
+        assert.equal(pB.msgs.length, 1);
+        assert.equal(pB.msgs[0].type, 'signal');
+        assert.equal(pA.msgs.length, 0, 'sender should not receive its own signal');
+    });
+
+    it('routes signal by roomId when no targetId is given', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+        pA.msgs.length = 0;
+        pB.msgs.length = 0;
+
+        handleSignal(pA, { type: 'candidate' }, null, ROOM_ID);
+
+        assert.equal(pB.msgs.length, 1);
+        assert.equal(pB.msgs[0].type, 'signal');
+    });
+
+    it('falls back to sender.roomId when neither targetId nor explicit roomId is given', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+        pA.msgs.length = 0;
+        pB.msgs.length = 0;
+
+        handleSignal(pA, { type: 'candidate' }, null, null);
+
+        assert.equal(pB.msgs.length, 1);
+    });
+
+    it('is a no-op when the target peer does not exist', () => {
+        const pA = makePeer('peer-A');
+        handleJoinRoom(pA, ROOM_ID);
+        pA.msgs.length = 0;
+
+        // Should not throw.
+        handleSignal(pA, { type: 'offer' }, 'nonexistent-id', null);
+        assert.equal(pA.msgs.length, 0);
+    });
+
+    it('is a no-op when signal payload is falsy', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+        pB.msgs.length = 0;
+
+        handleSignal(pA, null, 'peer-B', null);
+        assert.equal(pB.msgs.length, 0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Peer disconnect — handleDisconnect
+// ---------------------------------------------------------------------------
+
+describe('handleDisconnect', () => {
+    beforeEach(() => { rooms.clear(); });
+
+    it('notifies the remaining peer and removes the room', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+        pA.msgs.length = 0;
+        pB.msgs.length = 0;
+
+        handleDisconnect(pA);
+
+        assert.ok(pB.msgs.some(m => m.type === 'peer-disconnected'));
+        assert.equal(pB.roomId, null);
+        assert.equal(rooms.has(ROOM_ID), false);
+    });
+
+    it('clears roomId on the disconnecting peer', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+
+        handleDisconnect(pA);
+        assert.equal(pA.roomId, null);
+    });
+
+    it('is a no-op when the peer is not in any room', () => {
+        const p = makePeer('lone');
+        handleDisconnect(p); // should not throw
+        assert.equal(p.msgs.length, 0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Rate limiting — checkRateLimit
+// ---------------------------------------------------------------------------
+
+describe('checkRateLimit', () => {
+    beforeEach(() => { connectionCounts.clear(); });
+
+    it('allows up to 30 connections from the same IP', () => {
+        for (let i = 0; i < 30; i++) {
+            assert.equal(checkRateLimit('1.2.3.4'), true, `attempt ${i + 1} should be allowed`);
+        }
+    });
+
+    it('blocks the 31st connection from the same IP within the window', () => {
+        for (let i = 0; i < 30; i++) checkRateLimit('1.2.3.4');
+        assert.equal(checkRateLimit('1.2.3.4'), false);
+    });
+
+    it('tracks different IPs independently', () => {
+        for (let i = 0; i < 30; i++) checkRateLimit('1.1.1.1');
+        assert.equal(checkRateLimit('2.2.2.2'), true);
+    });
+});


### PR DESCRIPTION
… shutdown, and unit tests

- Replace raw X-Forwarded-For reads with getClientIp() helper that respects TRUSTED_PROXY_COUNT, preventing rate-limit bypass via spoofed headers
- Add collision loop to generateCode(): retries up to 10 times before falling back to a 4-word phrase, eliminating silent overwrites
- Add shutdown() with SIGTERM/SIGINT handlers and a 10s force-exit safety net so in-flight transfers survive rolling restarts
- Guard server.listen() and signal registration with require.main check to make the module safely importable in tests
- Add 25-test suite (server.test.js) using node:test — no new deps
- Wire npm test and a new server CI job in ci.yml