### PR TITLE
feat: add Docker self-hosting support and SELF_HOSTING.md guide

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -1,0 +1,29 @@
+# Floe self-hosting configuration for docker compose.
+# Copy this file to `.env` and adjust. Defaults work for a local run on one machine.
+#   cp .env.docker.example .env
+
+# --- Client → server wiring -------------------------------------------------
+# URL the BROWSER uses to reach the signaling server. Inlined into the client at
+# build time, so run `docker compose build client` after changing this.
+# Local:      http://localhost:3001
+# Production: https://api.your-domain.com
+NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
+
+# --- Server -----------------------------------------------------------------
+# Host port the server is published on (container always listens on 3001).
+PORT=3001
+
+# Frontend origin allowed by CORS. Set to your client's public URL in production.
+CLIENT_URL=http://localhost:3000
+
+# Number of trusted reverse-proxy hops in front of the server (X-Forwarded-For
+# parsing for rate limiting). 0 = direct, 1 = behind one proxy (Render/Fly/Nginx).
+TRUSTED_PROXY_COUNT=1
+
+# --- Optional TURN relay (coturn) -------------------------------------------
+# Leave both empty for STUN-only (direct connections). Fill them in AND start the
+# coturn service (`docker compose --profile turn up -d`) to enable relay for users
+# behind strict NAT / CGNAT. TURN_SECRET must match `static-auth-secret` in
+# coturn/turnserver.conf. See SELF_HOSTING.md.
+TURN_SECRET=
+TURN_DOMAIN=

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ Thumbs.db
 .env.local
 .env.*
 !.env.example
+!.env.docker.example
+
+# --- Self-hosting: generated coturn config holds a secret ---
+coturn/turnserver.conf
 
 # --- Build Outputs ---
 dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,17 @@ go build ./cmd/floe
 go test ./...
 ```
 
+### Full stack with Docker (no local toolchain needed)
+
+To run the client and signaling server together in containers — without installing Node, pnpm, or Go locally — use the Docker Compose setup:
+
+```bash
+cp .env.docker.example .env
+docker compose up -d --build
+```
+
+This is aimed at **self-hosting** (running your own instance) rather than active development, since the client image is a production build. See [SELF_HOSTING.md](SELF_HOSTING.md) for configuration and deployment details.
+
 ---
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 <p align="center">
   <a href="https://floe.one">Quick Start</a> |
   <a href="#cli">CLI</a> |
+  <a href="#self-hosting">Self-Hosting</a> |
   <a href="#contributing">Contributing</a> |
   <a href="#support">Support</a>
 </p>
@@ -45,6 +46,17 @@ Visit [floe.one](https://floe.one) to transfer files directly in your browser. N
 Files transfer directly between devices using WebRTC. A signaling server handles connection setup, then steps aside once both peers are connected. When a direct path cannot be established, an optional TURN relay bridges the connection with encrypted data that is never stored.
 
 For a detailed explanation of the connection lifecycle, encryption model, and relay fallback, visit [floe.one/how-it-works](https://floe.one/how-it-works).
+
+## Self-Hosting
+
+Prefer to run your own instance instead of using `floe.one`? The web client and signaling server ship with Docker support, so the full stack comes up with one command:
+
+```sh
+cp .env.docker.example .env
+docker compose up -d --build
+```
+
+This runs the client on `:3000` and the signaling server on `:3001` (STUN-only, which works on most networks). See **[SELF_HOSTING.md](SELF_HOSTING.md)** for configuration, production deployment behind HTTPS, and the optional TURN relay.
 
 ## CLI
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -1,0 +1,160 @@
+# Self-Hosting Floe
+
+Run your own Floe instance — the web client and the signaling server — on your own
+infrastructure, independent of `floe.one`. This guide uses Docker Compose so the whole
+stack comes up with a single command.
+
+> **What you're hosting.** The signaling server only brokers WebRTC connection setup
+> (offer/answer/ICE) and issues short-lived TURN credentials. **File data never passes
+> through it** — transfers go peer-to-peer over encrypted WebRTC data channels. TURN is
+> optional and only relays (still encrypted) traffic for peers that can't connect directly.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick start](#quick-start)
+- [Configuration](#configuration)
+- [The build-time URL caveat](#the-build-time-url-caveat)
+- [Production deployment](#production-deployment)
+- [Optional: TURN relay (coturn)](#optional-turn-relay-coturn)
+- [Using the CLI against your server](#using-the-cli-against-your-server)
+- [Operations](#operations)
+- [Self-hosting without Docker](#self-hosting-without-docker)
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2 (`docker compose`,
+  bundled with modern Docker Desktop / Engine).
+
+## Quick start
+
+```bash
+git clone https://github.com/jannskiee/floe.git
+cd floe
+
+cp .env.docker.example .env       # defaults work for a local single-machine run
+docker compose up -d --build
+```
+
+Open <http://localhost:3000>. Open it in a second tab (or another device on your network,
+pointing at the host's IP), start a transfer in one and join with the room code in the
+other.
+
+This runs **STUN-only**: direct peer-to-peer connections, which work on most home and mobile
+networks. To support peers behind strict/symmetric NAT or CGNAT, add a
+[TURN relay](#optional-turn-relay-coturn).
+
+## Configuration
+
+All settings live in the `.env` file you copied from `.env.docker.example`.
+
+| Variable | Service | Required | Purpose |
+|----------|---------|----------|---------|
+| `NEXT_PUBLIC_SOCKET_URL` | client (build) | Yes | URL the **browser** uses to reach the signaling server. Inlined at build time — see [the caveat below](#the-build-time-url-caveat). |
+| `PORT` | server | No | Host port the server is published on (default `3001`; the container always listens on 3001 internally). |
+| `CLIENT_URL` | server | Yes (prod) | Frontend origin allowed by CORS. Set to your client's public URL. |
+| `TRUSTED_PROXY_COUNT` | server | No | Number of trusted reverse-proxy hops in front of the server (for correct `X-Forwarded-For` parsing / rate limiting). `0` = direct, `1` = behind one proxy. |
+| `TURN_SECRET` | server | No | Shared HMAC secret for coturn credentials. Empty = STUN-only. Must match coturn's `static-auth-secret`. |
+| `TURN_DOMAIN` | server | No | Public hostname of your TURN server. Must match coturn's `realm`. |
+
+## The build-time URL caveat
+
+Next.js inlines `NEXT_PUBLIC_*` variables into the JavaScript bundle **at build time**, not
+at runtime. `NEXT_PUBLIC_SOCKET_URL` is therefore baked into the client image when it's
+built — setting it only in the running container has no effect.
+
+**After changing `NEXT_PUBLIC_SOCKET_URL`, rebuild the client:**
+
+```bash
+docker compose build client
+docker compose up -d
+```
+
+It must be a URL that **end-users' browsers** can reach — `http://localhost:3001` only works
+when the browser runs on the same machine as the server. For anything else, use the server's
+LAN IP or public URL (e.g. `https://api.your-domain.com`).
+
+## Production deployment
+
+For a real deployment beyond a single machine:
+
+1. **Put both services behind a reverse proxy with HTTPS** (Nginx, Caddy, Traefik, or a
+   platform like Render/Fly). Browsers require a secure context for the APIs Floe uses.
+   Proxy the client (`:3000`) and the server (`:3001`) under hostnames you control, e.g.
+   `app.your-domain.com` → client, `api.your-domain.com` → server.
+2. **Set `NEXT_PUBLIC_SOCKET_URL`** to the server's public URL (e.g.
+   `https://api.your-domain.com`) and rebuild the client.
+3. **Set `CLIENT_URL`** to the client's public origin (e.g. `https://app.your-domain.com`)
+   so CORS allows it.
+4. **Set `TRUSTED_PROXY_COUNT`** to the number of proxy hops in front of the server so
+   per-IP rate limiting sees real client IPs.
+
+> **CORS note.** The server's allow-list also hard-codes the official `floe.one` origins
+> (`server/server.js`). Your `CLIENT_URL` is honored alongside them, so this doesn't block
+> anything — but if you'd prefer a clean allow-list for your fork, you can remove those
+> hard-coded entries.
+
+## Optional: TURN relay (coturn)
+
+A TURN server relays the (still end-to-end encrypted) stream when two peers can't reach each
+other directly — common with symmetric NAT or carrier-grade NAT. Without it, those specific
+transfers fail; everything else still works.
+
+TURN has real infrastructure requirements: a **public IP**, a **domain**, and **TLS
+certificates**. The bundled `coturn` service uses host networking and is intended for a
+Linux host with a public IP.
+
+1. **Create the coturn config:**
+   ```bash
+   cp coturn/turnserver.conf.example coturn/turnserver.conf
+   ```
+   Edit it: set `static-auth-secret` to a strong random value, set `realm` to your TURN
+   hostname, and point `cert`/`pkey` at your TLS certificate and key (mount them into the
+   container — see the volume hint in `docker-compose.yml`).
+
+2. **Match the server's env** in `.env`:
+   ```
+   TURN_SECRET=<the same value as static-auth-secret>
+   TURN_DOMAIN=turn.your-domain.com
+   ```
+
+3. **Open the firewall ports** on the host: `3478` (STUN/TURN) and `5349` (TURNS), plus the
+   UDP relay range from the config (`49152-65535` by default).
+
+4. **Start the stack with the TURN profile:**
+   ```bash
+   docker compose --profile turn up -d --build
+   ```
+
+Verify with `curl http://localhost:3001/api/turn-credentials` — the response should now
+include `turn:` / `turns:` entries in addition to STUN.
+
+The server generates time-limited HMAC-SHA1 credentials (24-hour TTL) that coturn validates
+against the shared secret, so no per-user accounts are needed.
+
+## Using the CLI against your server
+
+The Go CLI accepts a `--server` flag, so it can target your instance instead of `floe.one`:
+
+```bash
+floe send --server https://api.your-domain.com photo.jpg
+floe receive --server https://api.your-domain.com olive-tiger-castle
+```
+
+## Operations
+
+```bash
+docker compose logs -f                 # tail logs
+docker compose ps                      # status (server reports a health check)
+docker compose pull && \
+  docker compose up -d --build         # update to the latest code after `git pull`
+docker compose down                    # stop and remove the stack
+```
+
+Health endpoints on the server: `GET /health` (liveness) and `GET /` (status).
+
+## Self-hosting without Docker
+
+If you'd rather run the components directly with Node, pnpm, and Go, the manual setup steps
+and environment-variable reference are in [CONTRIBUTING.md](CONTRIBUTING.md#development-setup).
+The same environment variables documented above apply.

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+.next
+out
+.env
+.env.*
+!.env.example
+.git
+.gitignore
+Dockerfile
+.dockerignore
+.DS_Store
+Thumbs.db
+*.log
+.vercel

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,44 @@
+# Floe web client — multi-stage production image.
+#
+# IMPORTANT: NEXT_PUBLIC_SOCKET_URL is inlined into the bundle at BUILD time by
+# Next.js, not read at runtime. Pass it as a build arg pointing at your signaling
+# server's externally reachable URL. Changing it later requires rebuilding this
+# image (`docker compose build client`).
+
+# ---- Builder ---------------------------------------------------------------
+FROM node:20-alpine AS builder
+
+RUN npm install -g pnpm@10
+WORKDIR /app
+
+# Install dependencies first for layer caching.
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Build the standalone server. Sentry source-map upload stays disabled unless you
+# also provide SENTRY_* build args, so the build works with no extra config.
+COPY . .
+ARG NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
+ENV NEXT_PUBLIC_SOCKET_URL=${NEXT_PUBLIC_SOCKET_URL}
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm build
+
+# ---- Runner ----------------------------------------------------------------
+FROM node:20-alpine AS runner
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+# The standalone server reads HOSTNAME/PORT; bind all interfaces for Docker.
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+WORKDIR /app
+
+# Copy only the self-contained output produced by `output: 'standalone'`.
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+USER node
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -2,6 +2,11 @@ import { withSentryConfig } from '@sentry/nextjs';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+    // Emit a self-contained production server (.next/standalone) so the Docker
+    // image can run with only the built output — no full node_modules at runtime.
+    // Vercel ignores this flag, so the hosted deploy is unaffected.
+    output: 'standalone',
+
     // React Strict Mode intentionally double-mounts components in development
     // to surface side-effect bugs. This would create two Socket.io connections
     // and two WebRTC peer instances — breaking the transfer logic entirely.

--- a/coturn/turnserver.conf.example
+++ b/coturn/turnserver.conf.example
@@ -1,0 +1,35 @@
+# Example coturn configuration for Floe's TURN relay.
+# Copy to coturn/turnserver.conf and edit before enabling the `turn` profile.
+#   cp coturn/turnserver.conf.example coturn/turnserver.conf
+#
+# Floe issues time-limited HMAC-SHA1 credentials, so coturn must run in
+# shared-secret mode. The secret below MUST equal the server's TURN_SECRET, and
+# `realm` MUST equal the server's TURN_DOMAIN.
+
+# Time-limited credential mode (matches the server's generateCoturnCredentials()).
+use-auth-secret
+static-auth-secret=CHANGE_ME_TO_MATCH_TURN_SECRET
+
+# Must match TURN_DOMAIN passed to the Floe server.
+realm=turn.your-domain.com
+
+# Listening ports. 3478 = STUN/TURN, 5349 = TURNS (TLS).
+listening-port=3478
+tls-listening-port=5349
+listening-ip=0.0.0.0
+
+# Advertise your server's PUBLIC IP so relayed candidates are reachable.
+# external-ip=203.0.113.10
+
+# Relay port range — open these UDP ports on your firewall as well.
+min-port=49152
+max-port=65535
+
+# TLS for turns:5349. Mount your certificate/key into the container and point here.
+# cert=/etc/coturn/certs/fullchain.pem
+# pkey=/etc/coturn/certs/privkey.pem
+
+# Hardening.
+no-cli
+no-tcp-relay
+fingerprint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+# Floe — self-hosting stack.
+#
+# Quick start:
+#   cp .env.docker.example .env
+#   docker compose up -d --build
+#   open http://localhost:3000
+#
+# The `client` and `server` services run out of the box (STUN-only, which works on
+# most home and mobile networks). The optional `coturn` relay is only started with
+# the `turn` profile and requires a public IP, domain, and TLS certificates — see
+# SELF_HOSTING.md.
+
+services:
+  server:
+    build: ./server
+    image: floe-server
+    restart: unless-stopped
+    ports:
+      - "${PORT:-3001}:3001"
+    environment:
+      # The server always listens on 3001 inside the container; the host port above
+      # is what changes. CLIENT_URL / TRUSTED_PROXY_COUNT / TURN_* come from .env.
+      PORT: 3001
+      CLIENT_URL: ${CLIENT_URL:-http://localhost:3000}
+      TRUSTED_PROXY_COUNT: ${TRUSTED_PROXY_COUNT:-1}
+      TURN_SECRET: ${TURN_SECRET:-}
+      TURN_DOMAIN: ${TURN_DOMAIN:-}
+
+  client:
+    build:
+      context: ./client
+      args:
+        # Baked into the bundle at build time — must point at the server URL that
+        # browsers can reach. Rebuild this service after changing it.
+        NEXT_PUBLIC_SOCKET_URL: ${NEXT_PUBLIC_SOCKET_URL:-http://localhost:3001}
+    image: floe-client
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server
+
+  # Optional TURN relay. Start with: docker compose --profile turn up -d
+  # Uses host networking because relaying needs a wide UDP port range and the
+  # client's real public IP. Linux hosts with a public IP only.
+  coturn:
+    image: coturn/coturn:latest
+    profiles: ["turn"]
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ./coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro
+      # Mount your TLS cert/key here and reference them in turnserver.conf, e.g.:
+      # - ./coturn/certs:/etc/coturn/certs:ro
+    command: ["-c", "/etc/coturn/turnserver.conf"]

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+npm-debug.log*
+.env
+.env.*
+!.env.example
+*.test.js
+Dockerfile
+.dockerignore
+.git
+.gitignore
+.DS_Store
+Thumbs.db

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,32 @@
+# Floe signaling server — production image.
+# The server only brokers WebRTC signaling and issues TURN credentials; it never
+# touches file data. It binds 0.0.0.0:$PORT (default 3001) and reads its config
+# from environment variables (see server/.env.example).
+
+FROM node:20-alpine
+
+# dumb-init reaps zombies and forwards SIGTERM/SIGINT so the server's graceful
+# shutdown handlers fire cleanly on `docker stop`.
+RUN apk add --no-cache dumb-init
+
+ENV NODE_ENV=production
+WORKDIR /app
+
+# Install production dependencies first so this layer is cached across code changes.
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# Application files. words.json is required at runtime (require('./words.json')).
+COPY server.js words.json ./
+
+# Run as the unprivileged user that the node image already provides.
+USER node
+
+EXPOSE 3001
+
+# Hit the built-in health endpoint. PORT is honored if overridden at runtime.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||3001)+'/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

- Adds `docker-compose.yml` + `Dockerfile`s for the client and server so a self-hoster can run the full stack with `docker compose up -d --build`
- Adds `SELF_HOSTING.md` — comprehensive guide covering quick start, config table, the Next.js build-time URL caveat, production/HTTPS notes, optional coturn TURN relay, CLI usage, and ops commands
- Enables `output: 'standalone'` in `client/next.config.mjs` for lean Docker images (Vercel ignores this flag — hosted deploy unaffected)
- Updates `README.md` with a Self-Hosting section and nav link
- Updates `CONTRIBUTING.md` with a "Full stack with Docker" note
- Updates `.gitignore` to keep `.env.docker.example` committable and ignore the secret-bearing `coturn/turnserver.conf`

## What was tested

- `docker compose config` — parses for both default and `--profile turn`
- `server` and `client` images build clean from scratch
- Stack started with `docker compose up -d --build`: server reports `healthy`, `/health` and `/api/turn-credentials` respond correctly (STUN-only), client serves HTTP 200
- `NEXT_PUBLIC_SOCKET_URL` confirmed baked into the JS bundle at build time
- gitignore rules verified: `.env.docker.example` committable, `coturn/turnserver.conf` ignored

## Test plan

- [ ] `cp .env.docker.example .env && docker compose up -d --build` — both containers start
- [ ] `curl http://localhost:3001/health` returns `{"status":"healthy",...}`
- [ ] `curl http://localhost:3001/api/turn-credentials` returns STUN entries
- [ ] `http://localhost:3000` loads the Floe UI
- [ ] Open two browser tabs/windows, send a file from one and receive with the room code in the other
- [ ] CI passes (client build/lint, server tests, CLI vet/test/build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)