### PR TITLE
docs(readme): move CLI before Self-Hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,6 @@ Files transfer directly between devices using WebRTC. A signaling server handles
 
 For a detailed explanation of the connection lifecycle, encryption model, and relay fallback, visit [floe.one/how-it-works](https://floe.one/how-it-works).
 
-## Self-Hosting
-
-Prefer to run your own instance instead of using `floe.one`? The web client and signaling server ship with Docker support, so the full stack comes up with one command:
-
-```sh
-cp .env.docker.example .env
-docker compose up -d --build
-```
-
-This runs the client on `:3000` and the signaling server on `:3001` (STUN-only, which works on most networks). See **[SELF_HOSTING.md](SELF_HOSTING.md)** for configuration, production deployment behind HTTPS, and the optional TURN relay.
-
 ## CLI
 
 Floe provides a command-line interface for transferring files from headless devices, servers, and automated workflows. The CLI connects to the same signaling infrastructure as the web app. Browser-to-CLI and CLI-to-browser transfers are fully supported.
@@ -87,6 +76,16 @@ The sender's terminal will display a room code and a browser link. The receiver 
 
 For complete documentation, flags, and advanced usage, see the [CLI Documentation](https://docs.floe.one).
 
+## Self-Hosting
+
+Prefer to run your own instance instead of using `floe.one`? The web client and signaling server ship with Docker support, so the full stack comes up with one command:
+
+```sh
+cp .env.docker.example .env
+docker compose up -d --build
+```
+
+This runs the client on `:3000` and the signaling server on `:3001` (STUN-only, which works on most networks). See **[SELF_HOSTING.md](SELF_HOSTING.md)** for configuration, production deployment behind HTTPS, and the optional TURN relay.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Swaps the CLI and Self-Hosting sections so the README reads: **CLI → Self-Hosting → Contributing → Support → License**
- Nav links already matched this order — no change needed there

## Test plan

- [ ] README renders correctly on GitHub with sections in the right order
- [ ] Nav links (`#cli`, `#self-hosting`, etc.) jump to the correct headings

🤖 Generated with [Claude Code](https://claude.com/claude-code)