### PR TITLE
perf(client): eliminate mobile CLS — fix real experience score

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -83,7 +83,10 @@ interface ReceivedFile {
 
 
 export function P2PTransfer() {
-    const [isSender, setIsSender] = useState<boolean | null>(null);
+    const [isSender] = useState<boolean | null>(() => {
+        if (typeof window === 'undefined') return null;
+        return !new URLSearchParams(window.location.search).has('room');
+    });
     const [status, setStatus] = useState('Idle');
     const [isConnected, setIsConnected] = useState(false);
     const [ping, setPing] = useState(0);
@@ -572,10 +575,8 @@ export function P2PTransfer() {
         const roomFromUrl = params.get('room');
 
         if (roomFromUrl) {
-            setIsSender(false);
             fetchIceServers().then(() => joinRoomAsReceiver(roomFromUrl));
         } else {
-            setIsSender(true);
             fetchIceServers();
         }
 

--- a/client/components/layout/AboutSection.tsx
+++ b/client/components/layout/AboutSection.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import { ShieldCheck, Zap, Server } from 'lucide-react';
 

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
+  '@sentry/cli': true
   sharp: true
   unrs-resolver: true


### PR DESCRIPTION
## Summary

- **Root cause 1 (primary):** `P2PTransfer` initialized `isSender` as `null`, rendering a ~150px spinner card that expanded to ~400px after `useEffect` read the URL — shifting About/FAQ/footer ~250px on every load. Fixed by using a lazy `useState` initializer that reads `window.location.search` synchronously on first render, so `isSender` is immediately `true`/`false` and the null-state spinner never mounts.
- **Root cause 2:** `page.tsx` was `'use client'`, making the entire page tree client-rendered. Static content (h1, description, footer) now painted at the same moment the card expanded, amplifying CLS. Removed `'use client'` — all interactive children already have their own directive.
- **Root cause 3:** `AboutSection.tsx` was `'use client'` with no hooks or browser APIs. Removed directive — now a server component included in the initial SSR payload.
- **Bonus:** Approved `@sentry/cli` build script in `pnpm-workspace.yaml` (unblocks `pnpm install` without `--ignore-scripts`).

## Test plan

- [ ] Verify Vercel preview build passes
- [ ] Open preview URL on mobile — no visible layout shift on load
- [ ] Run Lighthouse mobile audit on preview URL — CLS should be near 0
- [ ] Sender path works: file drop zone appears immediately (no spinner flash)
- [ ] Receiver path works: open `/?room=<id>` — shows receiver UI immediately