### PR TITLE
docs: add Mintlify documentation site (docs.floe.one)

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -1,160 +1,16 @@
 # Self-Hosting Floe
 
-Run your own Floe instance (the web client and the signaling server) on your own
-infrastructure, independent of `floe.one`. This guide uses Docker Compose so the whole
-stack comes up with a single command.
+Run your own Floe instance (the web client and the signaling server) on your own infrastructure, independent of `floe.one`.
 
-> **What you're hosting.** The signaling server only brokers WebRTC connection setup
-> (offer/answer/ICE) and issues short-lived TURN credentials. **File data never passes
-> through it. Transfers go peer-to-peer over encrypted WebRTC data channels. TURN is
-> optional and only relays (still encrypted) traffic for peers that can't connect directly.
-
-## Contents
-
-- [Prerequisites](#prerequisites)
-- [Quick start](#quick-start)
-- [Configuration](#configuration)
-- [The build-time URL caveat](#the-build-time-url-caveat)
-- [Production deployment](#production-deployment)
-- [Optional: TURN relay (coturn)](#optional-turn-relay-coturn)
-- [Using the CLI against your server](#using-the-cli-against-your-server)
-- [Operations](#operations)
-- [Self-hosting without Docker](#self-hosting-without-docker)
-
-## Prerequisites
-
-- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2 (`docker compose`,
-  bundled with modern Docker Desktop / Engine).
+Full documentation is at **[docs.floe.one/self-hosting](https://docs.floe.one/self-hosting)**, including configuration reference, production deployment, TURN relay setup, and more.
 
 ## Quick start
 
 ```bash
 git clone https://github.com/jannskiee/floe.git
 cd floe
-
-cp .env.docker.example .env       # defaults work for a local single-machine run
+cp .env.docker.example .env
 docker compose up -d --build
 ```
 
-Open <http://localhost:3000>. Open it in a second tab (or another device on your network,
-pointing at the host's IP), start a transfer in one and join with the room code in the
-other.
-
-This runs **STUN-only**: direct peer-to-peer connections, which work on most home and mobile
-networks. To support peers behind strict/symmetric NAT or CGNAT, add a
-[TURN relay](#optional-turn-relay-coturn).
-
-## Configuration
-
-All settings live in the `.env` file you copied from `.env.docker.example`.
-
-| Variable | Service | Required | Purpose |
-|----------|---------|----------|---------|
-| `NEXT_PUBLIC_SOCKET_URL` | client (build) | Yes | URL the **browser** uses to reach the signaling server. Inlined at build time. See [the caveat below](#the-build-time-url-caveat). |
-| `PORT` | server | No | Host port the server is published on (default `3001`; the container always listens on 3001 internally). |
-| `CLIENT_URL` | server | Yes (prod) | Frontend origin allowed by CORS. Set to your client's public URL. |
-| `TRUSTED_PROXY_COUNT` | server | No | Number of trusted reverse-proxy hops in front of the server (for correct `X-Forwarded-For` parsing / rate limiting). `0` = direct, `1` = behind one proxy. |
-| `TURN_SECRET` | server | No | Shared HMAC secret for coturn credentials. Empty = STUN-only. Must match coturn's `static-auth-secret`. |
-| `TURN_DOMAIN` | server | No | Public hostname of your TURN server. Must match coturn's `realm`. |
-
-## The build-time URL caveat
-
-Next.js inlines `NEXT_PUBLIC_*` variables into the JavaScript bundle **at build time**, not
-at runtime. `NEXT_PUBLIC_SOCKET_URL` is therefore baked into the client image when it's
-built. Setting it only in the running container has no effect.
-
-**After changing `NEXT_PUBLIC_SOCKET_URL`, rebuild the client:**
-
-```bash
-docker compose build client
-docker compose up -d
-```
-
-It must be a URL that **end-users' browsers** can reach. `http://localhost:3001` only works
-when the browser runs on the same machine as the server. For anything else, use the server's
-LAN IP or public URL (e.g. `https://api.your-domain.com`).
-
-## Production deployment
-
-For a real deployment beyond a single machine:
-
-1. **Put both services behind a reverse proxy with HTTPS** (Nginx, Caddy, Traefik, or a
-   platform like Render/Fly). Browsers require a secure context for the APIs Floe uses.
-   Proxy the client (`:3000`) and the server (`:3001`) under hostnames you control, e.g.
-   `app.your-domain.com` → client, `api.your-domain.com` → server.
-2. **Set `NEXT_PUBLIC_SOCKET_URL`** to the server's public URL (e.g.
-   `https://api.your-domain.com`) and rebuild the client.
-3. **Set `CLIENT_URL`** to the client's public origin (e.g. `https://app.your-domain.com`)
-   so CORS allows it.
-4. **Set `TRUSTED_PROXY_COUNT`** to the number of proxy hops in front of the server so
-   per-IP rate limiting sees real client IPs.
-
-> **CORS note.** The server's allow-list also hard-codes the official `floe.one` origins
-> (`server/server.js`). Your `CLIENT_URL` is honored alongside them, so this doesn't block
-> anything, but if you'd prefer a clean allow-list for your fork, you can remove those
-> hard-coded entries.
-
-## Optional: TURN relay (coturn)
-
-A TURN server relays the (still end-to-end encrypted) stream when two peers can't reach each
-other directly, which is common with symmetric NAT or carrier-grade NAT. Without it, those specific
-transfers fail; everything else still works.
-
-TURN has real infrastructure requirements: a **public IP**, a **domain**, and **TLS
-certificates**. The bundled `coturn` service uses host networking and is intended for a
-Linux host with a public IP.
-
-1. **Create the coturn config:**
-   ```bash
-   cp coturn/turnserver.conf.example coturn/turnserver.conf
-   ```
-   Edit it: set `static-auth-secret` to a strong random value, set `realm` to your TURN
-   hostname, and point `cert`/`pkey` at your TLS certificate and key (mount them into the
-   container; see the volume hint in `docker-compose.yml`).
-
-2. **Match the server's env** in `.env`:
-   ```
-   TURN_SECRET=<the same value as static-auth-secret>
-   TURN_DOMAIN=turn.your-domain.com
-   ```
-
-3. **Open the firewall ports** on the host: `3478` (STUN/TURN) and `5349` (TURNS), plus the
-   UDP relay range from the config (`49152-65535` by default).
-
-4. **Start the stack with the TURN profile:**
-   ```bash
-   docker compose --profile turn up -d --build
-   ```
-
-Verify with `curl http://localhost:3001/api/turn-credentials`. The response should now
-include `turn:` / `turns:` entries in addition to STUN.
-
-The server generates time-limited HMAC-SHA1 credentials (24-hour TTL) that coturn validates
-against the shared secret, so no per-user accounts are needed.
-
-## Using the CLI against your server
-
-The Go CLI accepts a `--server` flag, so it can target your instance instead of `floe.one`:
-
-```bash
-floe send --server https://api.your-domain.com photo.jpg
-floe receive --server https://api.your-domain.com olive-tiger-castle
-```
-
-## Operations
-
-```bash
-docker compose logs -f                 # tail logs
-docker compose ps                      # status (server reports a health check)
-docker compose pull && \
-  docker compose up -d --build         # update to the latest code after `git pull`
-docker compose down                    # stop and remove the stack
-```
-
-Health endpoints on the server: `GET /health` (liveness) and `GET /` (status).
-
-## Self-hosting without Docker
-
-If you'd rather run the components directly with Node, pnpm, and Go, the manual setup steps
-and environment-variable reference are in [CONTRIBUTING.md](CONTRIBUTING.md#development-setup).
-The same environment variables documented above apply.
+Open [http://localhost:3000](http://localhost:3000).

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -1,0 +1,44 @@
+---
+title: "Flags Reference"
+description: "Complete reference for all floe CLI flags."
+---
+
+## Global flags
+
+These flags are available on all commands (`send`, `receive`, `version`).
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--server <url>` | `https://api.floe.one` | Signaling server URL. Use `http://localhost:3001` for local testing or your self-hosted server URL. |
+| `--no-relay` | `false` | Disable TURN relay. Only direct (STUN) connections are attempted. The transfer fails if a direct path cannot be found. |
+| `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: production defaults to `https://floe.one`, `localhost:3001` defaults to `http://localhost:3000`. |
+
+## `floe receive` flags
+
+These flags are specific to the `receive` command.
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--output <dir>` | `-o` | `.` | Directory to save received files. Created automatically if it does not exist. |
+| `--yes` | `-y` | `false` | Auto-accept incoming files without prompting for confirmation. |
+
+## Examples
+
+Use a local dev server:
+
+```bash
+floe send photo.jpg --server http://localhost:3001
+floe receive olive-tiger-castle --server http://localhost:3001
+```
+
+Direct connection only (no relay fallback):
+
+```bash
+floe send photo.jpg --no-relay
+```
+
+Receive into a specific folder, auto-accept:
+
+```bash
+floe receive olive-tiger-castle -o ~/Downloads -y
+```

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -1,0 +1,55 @@
+---
+title: "Installation"
+description: "Download and install the floe CLI binary."
+---
+
+The `floe` CLI is a single self-contained binary with no runtime dependencies. Download the binary for your platform from the [GitHub Releases page](https://github.com/jannskiee/floe/releases).
+
+## Download
+
+<Tabs>
+  <Tab title="macOS (Apple Silicon)">
+    ```bash
+    curl -L https://github.com/jannskiee/floe/releases/latest/download/floe_Darwin_arm64.tar.gz | tar xz
+    sudo mv floe /usr/local/bin/
+    ```
+  </Tab>
+  <Tab title="macOS (Intel)">
+    ```bash
+    curl -L https://github.com/jannskiee/floe/releases/latest/download/floe_Darwin_x86_64.tar.gz | tar xz
+    sudo mv floe /usr/local/bin/
+    ```
+  </Tab>
+  <Tab title="Linux (amd64)">
+    ```bash
+    curl -L https://github.com/jannskiee/floe/releases/latest/download/floe_Linux_x86_64.tar.gz | tar xz
+    sudo mv floe /usr/local/bin/
+    ```
+  </Tab>
+  <Tab title="Windows">
+    Download `floe_Windows_x86_64.zip` from the [releases page](https://github.com/jannskiee/floe/releases), extract it, and add the directory to your `PATH`.
+  </Tab>
+</Tabs>
+
+## Verify
+
+```bash
+floe version
+```
+
+Expected output:
+
+```
+floe v1.x.x
+Docs: https://docs.floe.one
+```
+
+## Build from source
+
+Requires Go 1.21 or later.
+
+```bash
+git clone https://github.com/jannskiee/floe.git
+cd floe/cli
+go build ./cmd/floe
+```

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -1,0 +1,51 @@
+---
+title: "floe receive"
+description: "Receive files from a peer."
+---
+
+```bash
+floe receive <code | link>
+```
+
+Joins an existing transfer session as the receiver. Accepts either a short code (e.g. `olive-tiger-castle`) or the full browser link. Downloads incoming files to the current directory by default.
+
+## Examples
+
+Receive using a short code:
+
+```bash
+floe receive olive-tiger-castle
+```
+
+Receive using a full link:
+
+```bash
+floe receive "https://floe.one?room=abc123"
+```
+
+Save to a specific directory:
+
+```bash
+floe receive olive-tiger-castle -o ~/Downloads
+```
+
+Auto-accept without confirmation:
+
+```bash
+floe receive olive-tiger-castle -y
+```
+
+## Flags
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--output` | `-o` | `.` (current directory) | Directory to save received files |
+| `--yes` | `-y` | `false` | Auto-accept incoming files without confirmation |
+
+See [Flags Reference](/cli/flags) for global flags (`--server`, `--no-relay`).
+
+## Notes
+
+- The output directory is created automatically if it does not exist.
+- Without `-y`, Floe prompts you to confirm before saving each file.
+- Press `Ctrl+C` to cancel the transfer.

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -1,0 +1,32 @@
+---
+title: "Against a Self-Hosted Server"
+description: "Use the floe CLI with your own Floe instance instead of floe.one."
+---
+
+The `floe` CLI connects to `https://api.floe.one` by default. You can point it at any Floe server instance using the `--server` flag.
+
+## Usage
+
+```bash
+floe send --server https://api.your-domain.com photo.jpg
+floe receive --server https://api.your-domain.com olive-tiger-castle
+```
+
+The `--server` value must be the URL of the signaling server (not the web client). Both sender and receiver must use the same server.
+
+## Web link
+
+When using `--server`, the browser link printed by `floe send` defaults to the same URL as the server. If your web client is on a different origin, override it with `--web`:
+
+```bash
+floe send --server https://api.your-domain.com --web https://app.your-domain.com photo.jpg
+```
+
+## Local testing
+
+```bash
+floe send photo.jpg --server http://localhost:3001
+floe receive olive-tiger-castle --server http://localhost:3001
+```
+
+See [Self-Hosting](/self-hosting/overview) for instructions on running your own Floe instance.

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -1,0 +1,53 @@
+---
+title: "floe send"
+description: "Send files or folders to a peer."
+---
+
+```bash
+floe send <file|folder> [file|folder...]
+```
+
+Starts a transfer session as the sender. Prints a short code and a browser link; share either one with your recipient. Waits until the recipient connects, then streams the files over WebRTC.
+
+## Examples
+
+Send a single file:
+
+```bash
+floe send report.pdf
+```
+
+Send multiple files:
+
+```bash
+floe send photo.jpg video.mp4 notes.txt
+```
+
+Send an entire folder:
+
+```bash
+floe send ./project
+```
+
+## Output
+
+```
+  ─────────────────────────────────────────────────
+  Code:  olive-tiger-castle
+  Link:  https://floe.one?room=...
+  ─────────────────────────────────────────────────
+
+  Waiting for peer...
+  Connecting...
+  Connected
+```
+
+## Flags
+
+See [Flags Reference](/cli/flags) for `--server`, `--no-relay`, and `--web`.
+
+## Notes
+
+- The session stays open until the recipient connects and the transfer completes. Press `Ctrl+C` to cancel.
+- The short code is valid for 10 minutes. The room link works until the session ends.
+- Folders are transferred recursively.

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -1,0 +1,27 @@
+---
+title: "floe version"
+description: "Print the floe version."
+---
+
+```bash
+floe version
+```
+
+Prints the current version of the `floe` binary and a link to this documentation.
+
+## Output
+
+```
+floe v1.x.x
+Docs: https://docs.floe.one
+```
+
+## Alternative
+
+You can also use the root flag:
+
+```bash
+floe --version
+# or
+floe -v
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "Floe",
+  "theme": "mint",
+  "logo": {
+    "light": "/logo/dark.svg",
+    "dark": "/logo/light.svg",
+    "href": "https://floe.one"
+  },
+  "favicon": "/favicon.svg",
+  "colors": {
+    "primary": "#3b82f6",
+    "light": "#60a5fa",
+    "dark": "#2563eb"
+  },
+  "topbarLinks": [
+    {
+      "name": "floe.one",
+      "url": "https://floe.one"
+    }
+  ],
+  "topbarCtaButton": {
+    "name": "GitHub",
+    "url": "https://github.com/jannskiee/floe"
+  },
+  "navigation": [
+    {
+      "group": "Getting Started",
+      "pages": ["introduction", "quickstart"]
+    },
+    {
+      "group": "CLI",
+      "pages": [
+        "cli/installation",
+        "cli/send",
+        "cli/receive",
+        "cli/version",
+        "cli/flags",
+        "cli/self-hosted-server"
+      ]
+    },
+    {
+      "group": "Self-Hosting",
+      "pages": [
+        "self-hosting/overview",
+        "self-hosting/quickstart",
+        "self-hosting/configuration",
+        "self-hosting/build-time-url",
+        "self-hosting/production",
+        "self-hosting/turn-relay",
+        "self-hosting/operations",
+        "self-hosting/without-docker"
+      ]
+    },
+    {
+      "group": "How It Works",
+      "pages": [
+        "how-it-works/signaling",
+        "how-it-works/direct-connection",
+        "how-it-works/relay-connection",
+        "how-it-works/2gb-limit",
+        "how-it-works/encryption"
+      ]
+    }
+  ],
+  "footerSocials": {
+    "github": "https://github.com/jannskiee/floe"
+  }
+}

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,0 +1,3 @@
+<svg width="64" height="64" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" fill="#3b82f6" stroke="#3b82f6" stroke-width="1" stroke-linejoin="round"/>
+</svg>

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -1,0 +1,19 @@
+---
+title: "The 2 GB Relay Limit"
+description: "Why relay transfers are capped at 2 GB per session."
+---
+
+When your files go through the Floe TURN relay server, every byte of data passes through the infrastructure. That costs real money in server bandwidth. Direct connections cost nothing.
+
+To keep Floe free and running for everyone, relay transfers are capped at **2 GB per session**. This limit applies only to relay connections. Direct connections have no limit.
+
+## How to get a direct connection
+
+<Tip>
+  These steps increase the chance of a direct connection, which has no size limit.
+</Tip>
+
+- Use a standard home or personal Wi-Fi network
+- Disconnect from any VPN
+- Avoid transferring from strict corporate or university networks
+- Try using a personal mobile hotspot

--- a/docs/how-it-works/direct-connection.mdx
+++ b/docs/how-it-works/direct-connection.mdx
@@ -1,0 +1,23 @@
+---
+title: "Direct Connection"
+description: "How Floe establishes a direct peer-to-peer path using STUN."
+---
+
+A direct connection means your files travel straight from your device to the recipient's device, like a private tunnel between two computers with no stops in between.
+
+## STUN
+
+To find this direct path, WebRTC uses a **STUN server**. Think of a STUN server like asking a friend outside your house "what does my address look like from out there?" It helps each browser discover its public internet address so they can reach each other.
+
+## What direct connections mean for you
+
+- Maximum speed, limited only by your internet connection
+- No file size limits
+- Zero bandwidth cost to Floe
+- Your files never touch a server
+
+## When to expect a direct connection
+
+Most home and mobile networks support direct connections. You are most likely to get one on standard home Wi-Fi or a personal mobile hotspot.
+
+Strict corporate firewalls, university networks, and carrier-grade NAT may prevent a direct path. In those cases, Floe automatically falls back to a [relay connection](/how-it-works/relay-connection).

--- a/docs/how-it-works/encryption.mdx
+++ b/docs/how-it-works/encryption.mdx
@@ -1,0 +1,15 @@
+---
+title: "End-to-End Encryption"
+description: "How Floe encrypts every transfer, direct or relayed."
+---
+
+Every WebRTC connection, whether direct or relayed, is encrypted using **DTLS-SRTP**. This is the same encryption standard used by your bank's website. Even Floe's own relay server cannot read your files.
+
+The encryption keys are generated uniquely for each transfer and exist only in the two browsers (or CLI processes) involved. There is no central key server.
+
+## What this means
+
+- The signaling server never sees file data
+- The relay server (when used) sees only encrypted packets
+- Floe has no database, stores no files, and retains no logs of what you transfer
+- Once the transfer is complete and both connections are closed, the data is gone

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -1,0 +1,21 @@
+---
+title: "Relay Connection"
+description: "How Floe uses a TURN server as an encrypted bridge when a direct connection is not possible."
+---
+
+Some networks make it impossible to connect two browsers directly. This happens on strict corporate firewalls, university networks, or when your mobile carrier places many users behind a single shared IP address (called **Carrier-Grade NAT**). In these cases, a direct path cannot be found.
+
+## TURN fallback
+
+Floe automatically falls back to a **TURN server** (`turn.floe.one`). A TURN server acts as a secure bridge. Your data passes through it on its way to the recipient, like a trusted courier who picks up a sealed, locked box from you and delivers it to the recipient without being able to open it.
+
+## Encryption
+
+Even through a relay, your files are protected by **DTLS encryption** (the same standard used by HTTPS). The relay server sees encrypted data packets, not your actual files.
+
+## What relay connections mean for you
+
+- Transfer still works even on strict networks
+- Your files remain encrypted in transit
+- Speeds may be slower depending on server load
+- Limited to 2 GB per transfer (see [the 2 GB limit](/how-it-works/2gb-limit))

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -1,0 +1,20 @@
+---
+title: "Signaling"
+description: "How Floe brokers the initial connection between two peers."
+---
+
+When you drop files into Floe, a unique one-time link is created. The Floe signaling server (`api.floe.one`) plays the role of a matchmaker. When the recipient opens your link, both browsers introduce themselves to each other through this server.
+
+Once both sides have said hello, the signaling server steps completely out of the picture. It does not handle any file data, does not store anything, and does not participate in the transfer itself.
+
+## What the server does
+
+- Assigns roles: the first peer to join a room becomes the **sender**, the second becomes the **receiver**.
+- Relays WebRTC signaling messages: the initial offer, the answer, and ICE candidates.
+- Issues short-lived TURN credentials (if a TURN server is configured).
+
+## What the server never does
+
+- Touch file data
+- Store files or transfer content
+- Log what you send or receive

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,0 +1,35 @@
+---
+title: "Introduction"
+description: "Secure, encrypted P2P file transfer with no accounts, no file storage, and no registration."
+---
+
+Floe transfers files directly between devices using WebRTC. Files are encrypted end-to-end and never stored on any server. The signaling server only brokers the initial connection setup. Once both peers connect, the server steps out of the picture.
+
+## Use Floe
+
+<CardGroup cols={2}>
+  <Card title="Browser" icon="globe" href="https://floe.one">
+    Open floe.one in any modern browser. No installation required.
+  </Card>
+  <Card title="CLI" icon="terminal" href="/cli/installation">
+    Install the `floe` binary for headless, scriptable transfers.
+  </Card>
+</CardGroup>
+
+## Three questions answered
+
+<AccordionGroup>
+  <Accordion title="Where do my files go?">
+    Your files go directly to the recipient. In most cases they never touch a server at all. When a direct path cannot be found (strict corporate firewalls, carrier-grade NAT), Floe uses an encrypted TURN relay as a bridge. Even then, the relay server sees only encrypted data and cannot read your files.
+  </Accordion>
+  <Accordion title="Is there a file size limit?">
+    Direct connections have no size limit. Relay connections are capped at 2 GB per session to keep the service free. See [Why the 2 GB Limit?](/how-it-works/2gb-limit) for details.
+  </Accordion>
+  <Accordion title="Do I need an account?">
+    No. Floe requires no account, no sign-up, and no registration. Open the site (or run the CLI) and share the code or link with your recipient.
+  </Accordion>
+</AccordionGroup>
+
+## Self-hosting
+
+You can run your own Floe instance on your own infrastructure using Docker Compose. See the [Self-Hosting](/self-hosting/overview) section.

--- a/docs/logo/dark.svg
+++ b/docs/logo/dark.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="30" viewBox="0 0 120 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" transform="scale(0.9) translate(0, 1)" fill="#09090b" stroke="#09090b" stroke-width="0.5" stroke-linejoin="round"/>
+  <text x="28" y="20" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-weight="700" font-size="18" fill="#09090b">Floe</text>
+</svg>

--- a/docs/logo/light.svg
+++ b/docs/logo/light.svg
@@ -1,0 +1,4 @@
+<svg width="120" height="30" viewBox="0 0 120 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" transform="scale(0.9) translate(0, 1)" fill="white" stroke="white" stroke-width="0.5" stroke-linejoin="round"/>
+  <text x="28" y="20" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif" font-weight="700" font-size="18" fill="white">Floe</text>
+</svg>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,0 +1,41 @@
+---
+title: "Quick Start"
+description: "Send your first file in under a minute."
+---
+
+## Browser
+
+1. Open [floe.one](https://floe.one) in your browser.
+2. Drop a file (or click to select one).
+3. Share the short code or link with your recipient.
+4. The recipient opens the link or enters the code at [floe.one](https://floe.one).
+5. The transfer starts automatically once both sides connect.
+
+## CLI
+
+<Steps>
+  <Step title="Install">
+    Download the binary for your platform from [GitHub Releases](https://github.com/jannskiee/floe/releases). See [Installation](/cli/installation) for details.
+  </Step>
+  <Step title="Send">
+    ```bash
+    floe send photo.jpg
+    ```
+    Floe prints a short code and a browser link. Share either one with your recipient.
+    ```
+    Code:  olive-tiger-castle
+    Link:  https://floe.one?room=...
+    ```
+  </Step>
+  <Step title="Receive">
+    The recipient runs:
+    ```bash
+    floe receive olive-tiger-castle
+    ```
+    Or they can open the link in any browser. CLI and browser peers are fully compatible.
+  </Step>
+</Steps>
+
+## Cross-platform transfers
+
+CLI and browser peers work together transparently. The sender can use the CLI while the recipient opens the link in a browser, and vice versa.

--- a/docs/self-hosting/build-time-url.mdx
+++ b/docs/self-hosting/build-time-url.mdx
@@ -1,0 +1,17 @@
+---
+title: "Build-Time URL Caveat"
+description: "Why NEXT_PUBLIC_SOCKET_URL must be set before building the client image."
+---
+
+Next.js inlines `NEXT_PUBLIC_*` variables into the JavaScript bundle **at build time**, not at runtime. `NEXT_PUBLIC_SOCKET_URL` is therefore baked into the client image when it is built. Setting it only in the running container has no effect.
+
+## After changing the URL, rebuild the client
+
+```bash
+docker compose build client
+docker compose up -d
+```
+
+## The URL must be reachable by end-users' browsers
+
+`http://localhost:3001` only works when the browser runs on the same machine as the server. For anything else, use the server's LAN IP or public URL (e.g. `https://api.your-domain.com`).

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -1,0 +1,17 @@
+---
+title: "Configuration"
+description: "Environment variable reference for a self-hosted Floe instance."
+---
+
+All settings live in the `.env` file you copied from `.env.docker.example`.
+
+## Variables
+
+| Variable | Service | Required | Purpose |
+|----------|---------|----------|---------|
+| `NEXT_PUBLIC_SOCKET_URL` | client (build) | Yes | URL the **browser** uses to reach the signaling server. Inlined at build time. See [the build-time URL caveat](/self-hosting/build-time-url). |
+| `PORT` | server | No | Host port the server is published on (default `3001`; the container always listens on 3001 internally). |
+| `CLIENT_URL` | server | Yes (prod) | Frontend origin allowed by CORS. Set to your client's public URL. |
+| `TRUSTED_PROXY_COUNT` | server | No | Number of trusted reverse-proxy hops in front of the server (for correct `X-Forwarded-For` parsing and rate limiting). `0` = direct, `1` = behind one proxy. |
+| `TURN_SECRET` | server | No | Shared HMAC secret for coturn credentials. Empty = STUN-only. Must match coturn's `static-auth-secret`. |
+| `TURN_DOMAIN` | server | No | Public hostname of your TURN server. Must match coturn's `realm`. |

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -1,0 +1,28 @@
+---
+title: "Operations"
+description: "Day-to-day operations for a self-hosted Floe instance."
+---
+
+## Common commands
+
+```bash
+docker compose logs -f                 # tail logs for all services
+docker compose ps                      # check status (server has a health check)
+docker compose down                    # stop and remove the stack
+```
+
+## Update to the latest code
+
+```bash
+git pull
+docker compose pull && docker compose up -d --build
+```
+
+## Health endpoints
+
+The signaling server exposes two health endpoints:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /health` | Liveness check |
+| `GET /` | Status (returns server info) |

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -1,0 +1,35 @@
+---
+title: "Overview"
+description: "Run your own Floe instance on your own infrastructure."
+---
+
+You can self-host the entire Floe stack (web client and signaling server) independently of `floe.one`. The setup uses Docker Compose so the whole stack comes up with a single command.
+
+## What you are hosting
+
+The signaling server only brokers WebRTC connection setup (offer, answer, ICE candidates) and issues short-lived TURN credentials. **File data never passes through it.** Transfers go peer-to-peer over encrypted WebRTC data channels. TURN is optional and only relays (still encrypted) traffic for peers that cannot connect directly.
+
+## Components
+
+| Component | Description |
+|-----------|-------------|
+| `client` | Next.js web app served on port 3000 |
+| `server` | Node.js signaling server on port 3001 |
+| `coturn` | Optional TURN relay (profile-gated in Docker Compose) |
+
+## Contents
+
+<CardGroup cols={2}>
+  <Card title="Quick Start" href="/self-hosting/quickstart">
+    Get the stack running with Docker Compose in minutes.
+  </Card>
+  <Card title="Configuration" href="/self-hosting/configuration">
+    Environment variable reference for all settings.
+  </Card>
+  <Card title="Production Deployment" href="/self-hosting/production">
+    HTTPS, reverse proxy, and domain setup.
+  </Card>
+  <Card title="TURN Relay" href="/self-hosting/turn-relay">
+    Add coturn to support peers behind strict NAT.
+  </Card>
+</CardGroup>

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -1,0 +1,47 @@
+---
+title: "Production Deployment"
+description: "HTTPS, reverse proxy, and domain configuration for a production Floe instance."
+---
+
+For a real deployment beyond a single machine, follow these steps.
+
+## Steps
+
+<Steps>
+  <Step title="Put both services behind a reverse proxy with HTTPS">
+    Browsers require a secure context for the APIs Floe uses (WebRTC, screen wake lock). Use Nginx, Caddy, Traefik, or a platform like Render or Fly.
+
+    Proxy the client (`:3000`) and the server (`:3001`) under hostnames you control:
+    - `app.your-domain.com` to the client
+    - `api.your-domain.com` to the server
+  </Step>
+  <Step title="Set NEXT_PUBLIC_SOCKET_URL and rebuild">
+    ```bash
+    # In .env
+    NEXT_PUBLIC_SOCKET_URL=https://api.your-domain.com
+    ```
+    Then rebuild:
+    ```bash
+    docker compose build client
+    docker compose up -d
+    ```
+  </Step>
+  <Step title="Set CLIENT_URL">
+    ```bash
+    # In .env
+    CLIENT_URL=https://app.your-domain.com
+    ```
+    This allows CORS from your client origin.
+  </Step>
+  <Step title="Set TRUSTED_PROXY_COUNT">
+    Set this to the number of proxy hops in front of the server so per-IP rate limiting sees real client IPs.
+    ```bash
+    # In .env
+    TRUSTED_PROXY_COUNT=1
+    ```
+  </Step>
+</Steps>
+
+## CORS note
+
+The server's allow-list also includes the official `floe.one` origins. Your `CLIENT_URL` is honored alongside them, so this does not block anything. If you prefer a clean allow-list for your fork, remove the hard-coded entries from `server/server.js`.

--- a/docs/self-hosting/quickstart.mdx
+++ b/docs/self-hosting/quickstart.mdx
@@ -1,0 +1,37 @@
+---
+title: "Quick Start"
+description: "Run Floe locally with Docker Compose."
+---
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2 (`docker compose`, bundled with modern Docker Desktop and Engine).
+
+## Steps
+
+<Steps>
+  <Step title="Clone the repository">
+    ```bash
+    git clone https://github.com/jannskiee/floe.git
+    cd floe
+    ```
+  </Step>
+  <Step title="Copy the environment file">
+    ```bash
+    cp .env.docker.example .env
+    ```
+    The defaults work for a local single-machine run. No changes are needed to try it out.
+  </Step>
+  <Step title="Start the stack">
+    ```bash
+    docker compose up -d --build
+    ```
+  </Step>
+  <Step title="Open the app">
+    Open [http://localhost:3000](http://localhost:3000) in your browser. Open it in a second tab (or on another device on your local network), start a transfer in one tab, and join with the room code in the other.
+  </Step>
+</Steps>
+
+## What this runs
+
+This starts the stack in **STUN-only** mode: direct peer-to-peer connections, which work on most home and mobile networks. To support peers behind strict or symmetric NAT or CGNAT, add a [TURN relay](/self-hosting/turn-relay).

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -1,0 +1,54 @@
+---
+title: "TURN Relay (coturn)"
+description: "Add a TURN server to support peers behind strict NAT or CGNAT."
+---
+
+A TURN server relays the (still end-to-end encrypted) stream when two peers cannot reach each other directly. This is common with symmetric NAT or carrier-grade NAT. Without it, those specific transfers fail. Everything else still works.
+
+## Infrastructure requirements
+
+TURN has real infrastructure requirements: a **public IP**, a **domain**, and **TLS certificates**. The bundled `coturn` service uses host networking and is intended for a Linux host with a public IP.
+
+## Setup
+
+<Steps>
+  <Step title="Create the coturn config">
+    ```bash
+    cp coturn/turnserver.conf.example coturn/turnserver.conf
+    ```
+    Edit `coturn/turnserver.conf`:
+    - Set `static-auth-secret` to a strong random value
+    - Set `realm` to your TURN hostname
+    - Point `cert` and `pkey` at your TLS certificate and key (mount them into the container; see the volume hint in `docker-compose.yml`)
+  </Step>
+  <Step title="Match the server environment">
+    In `.env`:
+    ```
+    TURN_SECRET=<same value as static-auth-secret>
+    TURN_DOMAIN=turn.your-domain.com
+    ```
+  </Step>
+  <Step title="Open firewall ports">
+    On the host, open:
+    - `3478` (STUN/TURN)
+    - `5349` (TURNS)
+    - `49152-65535` UDP (relay range, configurable in `turnserver.conf`)
+  </Step>
+  <Step title="Start the stack with the TURN profile">
+    ```bash
+    docker compose --profile turn up -d --build
+    ```
+  </Step>
+</Steps>
+
+## Verify
+
+```bash
+curl http://localhost:3001/api/turn-credentials
+```
+
+The response should include `turn:` and `turns:` entries in addition to STUN.
+
+## How it works
+
+The server generates time-limited HMAC-SHA1 credentials (24-hour TTL) that coturn validates against the shared secret. No per-user accounts are needed.

--- a/docs/self-hosting/without-docker.mdx
+++ b/docs/self-hosting/without-docker.mdx
@@ -1,0 +1,25 @@
+---
+title: "Without Docker"
+description: "Run Floe components directly with Node, pnpm, and Go."
+---
+
+If you prefer to run the components directly without Docker, the manual setup steps and environment variable reference are in [CONTRIBUTING.md](https://github.com/jannskiee/floe/blob/main/CONTRIBUTING.md#development-setup).
+
+The same environment variables documented in [Configuration](/self-hosting/configuration) apply. Run each component with:
+
+```bash
+# Server
+cd server
+npm install
+npm start
+
+# Client
+cd client
+pnpm install
+pnpm build
+pnpm start
+
+# CLI (optional, for local testing)
+cd cli
+go build ./cmd/floe
+```


### PR DESCRIPTION
## Summary

- Adds `docs/` directory with 22 MDX pages for Mintlify, covering CLI reference, self-hosting, and how-it-works content
- Replaces `SELF_HOSTING.md` body with a short stub linking to `docs.floe.one/self-hosting` (keeps the file so existing README links stay valid)
- Turns the dead `docs.floe.one` links in `README.md` and `floe --help` into a real site once connected to Mintlify

## Site structure

```
Getting Started
  - Introduction
  - Quick Start
CLI
  - Installation
  - floe send
  - floe receive
  - floe version
  - Flags Reference
  - Against a Self-Hosted Server
Self-Hosting
  - Overview
  - Quick Start (Docker Compose)
  - Configuration (env var table)
  - Build-Time URL Caveat
  - Production Deployment
  - TURN Relay (coturn)
  - Operations
  - Without Docker
How It Works
  - Signaling
  - Direct Connection (STUN)
  - Relay Connection (TURN)
  - The 2 GB Relay Limit
  - End-to-End Encryption
```

## Deployment steps (after merging)

1. Sign in to [mintlify.com](https://mintlify.com) with the GitHub account that owns this repo.
2. Install the Mintlify GitHub App and grant it access to `jannskiee/floe`.
3. Set the docs source to the `docs/` directory on `main` (Mintlify reads `docs/docs.json`).
4. Add custom domain `docs.floe.one` in the Mintlify dashboard.
5. Add the CNAME record Mintlify provides at your DNS provider for `docs.floe.one`.

## Test plan

- [ ] Run `npx mintlify dev` inside `docs/` and verify all pages render and navigation works
- [ ] Check that internal links resolve (e.g. `/cli/flags`, `/self-hosting/overview`)
- [ ] After deploy, confirm `https://docs.floe.one` loads and the `floe version` docs link resolves