### PR TITLE
fix(docs): update docs.json to Mintlify v4 config format

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -13,57 +13,64 @@
     "light": "#60a5fa",
     "dark": "#2563eb"
   },
-  "topbarLinks": [
-    {
-      "name": "floe.one",
-      "url": "https://floe.one"
+  "navbar": {
+    "links": [
+      {
+        "label": "floe.one",
+        "href": "https://floe.one"
+      }
+    ],
+    "primary": {
+      "type": "button",
+      "label": "GitHub",
+      "href": "https://github.com/jannskiee/floe"
     }
-  ],
-  "topbarCtaButton": {
-    "name": "GitHub",
-    "url": "https://github.com/jannskiee/floe"
   },
-  "navigation": [
-    {
-      "group": "Getting Started",
-      "pages": ["introduction", "quickstart"]
-    },
-    {
-      "group": "CLI",
-      "pages": [
-        "cli/installation",
-        "cli/send",
-        "cli/receive",
-        "cli/version",
-        "cli/flags",
-        "cli/self-hosted-server"
-      ]
-    },
-    {
-      "group": "Self-Hosting",
-      "pages": [
-        "self-hosting/overview",
-        "self-hosting/quickstart",
-        "self-hosting/configuration",
-        "self-hosting/build-time-url",
-        "self-hosting/production",
-        "self-hosting/turn-relay",
-        "self-hosting/operations",
-        "self-hosting/without-docker"
-      ]
-    },
-    {
-      "group": "How It Works",
-      "pages": [
-        "how-it-works/signaling",
-        "how-it-works/direct-connection",
-        "how-it-works/relay-connection",
-        "how-it-works/2gb-limit",
-        "how-it-works/encryption"
-      ]
+  "footer": {
+    "socials": {
+      "github": "https://github.com/jannskiee/floe"
     }
-  ],
-  "footerSocials": {
-    "github": "https://github.com/jannskiee/floe"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Getting Started",
+        "pages": ["introduction", "quickstart"]
+      },
+      {
+        "group": "CLI",
+        "pages": [
+          "cli/installation",
+          "cli/send",
+          "cli/receive",
+          "cli/version",
+          "cli/flags",
+          "cli/self-hosted-server"
+        ]
+      },
+      {
+        "group": "Self-Hosting",
+        "pages": [
+          "self-hosting/overview",
+          "self-hosting/quickstart",
+          "self-hosting/configuration",
+          "self-hosting/build-time-url",
+          "self-hosting/production",
+          "self-hosting/turn-relay",
+          "self-hosting/operations",
+          "self-hosting/without-docker"
+        ]
+      },
+      {
+        "group": "How It Works",
+        "pages": [
+          "how-it-works/signaling",
+          "how-it-works/direct-connection",
+          "how-it-works/relay-connection",
+          "how-it-works/2gb-limit",
+          "how-it-works/encryption"
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Replaces v3 field names that caused the Mintlify build to fail with the correct v4 equivalents
- `topbarLinks` -> `navbar.links` (with `label`/`href` instead of `name`/`url`)
- `topbarCtaButton` -> `navbar.primary` (with `type: "button"`)
- `footerSocials` -> `footer.socials`
- Flat `navigation` array -> `navigation.groups[]`

## Test plan

- Merge and verify Mintlify triggers a new build
- Build should pass and `docs.floe.one` should go live