### PR TITLE
style(docs): match docs theme to Floe monochrome branding

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,9 +9,9 @@
   },
   "favicon": "/favicon.svg",
   "colors": {
-    "primary": "#3b82f6",
-    "light": "#60a5fa",
-    "dark": "#2563eb"
+    "primary": "#09090b",
+    "light": "#fafafa",
+    "dark": "#09090b"
   },
   "navbar": {
     "links": [

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,3 +1,3 @@
 <svg width="64" height="64" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" fill="#3b82f6" stroke="#3b82f6" stroke-width="1" stroke-linejoin="round"/>
+    <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
Replaces the blue accent and blue favicon with Floe's monochrome palette (near-black #09090b accent, white dark-mode accent), matching the main site and the app icon. Logos were already monochrome.