### PR TITLE
style(docs): use github navbar type and add external icon to floe.one…

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -17,12 +17,12 @@
     "links": [
       {
         "label": "floe.one",
-        "href": "https://floe.one"
+        "href": "https://floe.one",
+        "icon": "arrow-up-right"
       }
     ],
     "primary": {
-      "type": "button",
-      "label": "GitHub",
+      "type": "github",
       "href": "https://github.com/jannskiee/floe"
     }
   },


### PR DESCRIPTION
… link

Switches navbar primary from type:button (adds unwanted >) to type:github which shows the GitHub icon with star count. Adds arrow-up-right icon to the floe.one navbar link.