### PR TITLE
fix(client): remove stylistic dot from Floe brand name

### DIFF
--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -15,7 +15,7 @@ export default function Home() {
 
             <div className="mx-auto max-w-3xl text-center mb-8 space-y-4">
                 <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tighter text-white lg:text-9xl drop-shadow-2xl">
-                    Floe.
+                    Floe
                 </h1>
                 <p className="mt-4 text-lg leading-8 text-zinc-400 max-w-lg mx-auto">
                     Secure, encrypted P2P file transfer.{' '}

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -38,7 +38,7 @@ export const Navbar = () => {
                     className="flex items-center gap-1.5 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-semibold text-white transition hover:bg-white/10"
                 >
                     <div className={`h-2 w-2 rounded-full ${dotColor} animate-pulse transition-colors duration-500`} />
-                    Floe.
+                    Floe
                 </button>
                 <div className="h-4 w-px bg-white/10 mx-1" />
                 <div className="flex items-center gap-0.5 sm:gap-1">


### PR DESCRIPTION
## Summary

- Removes the trailing `.` from `Floe.` in the h1 heading and navbar brand mark
- Footer copyright line keeps its period (`© 2026 Floe. Built with...`) as standard sentence punctuation, not the brand dot

## Changes

- `client/app/page.tsx` — h1 heading: `Floe.` → `Floe`
- `client/app/page.tsx` — footer copyright: reverted to formal `Floe.` (sentence period)
- `client/components/layout/Navbar.tsx` — navbar brand: `Floe.` → `Floe`