### PR TITLE
style(docs): Vercel-style theme with Geist font and true-black dark mode

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8,13 +8,24 @@
     "href": "https://floe.one"
   },
   "favicon": "/favicon.svg",
-  "font": {
-    "family": "Geist"
-  },
   "colors": {
-    "primary": "#18181b",
-    "light": "#a1a1aa",
-    "dark": "#18181b"
+    "primary": "#000000",
+    "light": "#ffffff",
+    "dark": "#000000"
+  },
+  "fonts": {
+    "family": "Geist",
+    "heading": { "family": "Geist" },
+    "body": { "family": "Geist" }
+  },
+  "appearance": {
+    "default": "dark"
+  },
+  "background": {
+    "color": {
+      "light": "#ffffff",
+      "dark": "#000000"
+    }
   },
   "navbar": {
     "links": [


### PR DESCRIPTION
## Summary

- Fixes the `font` (singular) field that was silently ignored by Mintlify v4, replaced with the correct `fonts` (plural) object specifying Geist for heading and body
- Sets `appearance.default: "dark"` so the docs load in dark mode by default (toggle still available)
- Sets `background.color.dark: "#000000"` for a true-black background matching Vercel docs
- Updates `colors` to max-contrast monochrome: black primary for light mode, white light accent for dark mode
- Keeps `mint` theme and all navigation, logos, and branding unchanged