### PR TITLE
style(docs): custom CSS for sharp Vercel-like typography

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -1,0 +1,64 @@
+/* 1. Font rendering — fixes the blurry/soft look */
+*, *::before, *::after {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* 2. Pure white body text in dark mode */
+html.dark body,
+html[data-appearance="dark"] body {
+  color: #ffffff;
+}
+
+html.dark p,
+html[data-appearance="dark"] p,
+html.dark li,
+html[data-appearance="dark"] li {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+/* 3. Headings — bold, tight letter-spacing, pure white */
+html.dark h1,
+html.dark h2,
+html.dark h3,
+html.dark h4 {
+  color: #ffffff;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+h1 { letter-spacing: -0.03em; }
+h2 { letter-spacing: -0.02em; }
+
+/* 4. Sidebar active item — clean border instead of filled box */
+html.dark [data-active="true"],
+html.dark .active-nav-item,
+html.dark nav a[aria-current="page"] {
+  background: transparent !important;
+  border-left: 2px solid #ffffff;
+  padding-left: calc(1rem - 2px);
+  font-weight: 600;
+  color: #ffffff;
+}
+
+/* 5. Code blocks — sharper border */
+html.dark pre,
+html.dark code {
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* 6. Light mode — bold headings, dark text */
+html:not(.dark) h1,
+html:not(.dark) h2,
+html:not(.dark) h3,
+html:not(.dark) h4 {
+  color: #000000;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+}
+
+html:not(.dark) p,
+html:not(.dark) li {
+  color: rgba(0, 0, 0, 0.8);
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -8,6 +8,7 @@
     "href": "https://floe.one"
   },
   "favicon": "/favicon.svg",
+  "css": ["/custom.css"],
   "colors": {
     "primary": "#000000",
     "light": "#ffffff",


### PR DESCRIPTION
## Summary

Adds `docs/custom.css` to fix the blurry, low-contrast look in dark mode.

- Font smoothing: `-webkit-font-smoothing: antialiased` across all elements (the main fix for blurry text)
- Headings: `font-weight: 700` with tight negative letter-spacing matching Vercel's style
- Body text: pure white at 88% opacity in dark mode instead of Mintlify's muted gray
- Sidebar active item: transparent background with a clean white left-border indicator instead of the filled box
- Code blocks: sharper 1px border at 10% white opacity
- Light mode: matching bold headings with black text

Note: The sidebar active-item selector may need a follow-up tweak after inspecting the live DOM, since Mintlify's internal class names aren't documented. Font/heading/body fixes are certain.