### PR TITLE
style(docs): use monochrome accent instead of blue

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,9 +9,9 @@
   },
   "favicon": "/favicon.svg",
   "colors": {
-    "primary": "#3B82F6",
-    "light": "#60A5FA",
-    "dark": "#2563EB"
+    "primary": "#111111",
+    "light": "#ffffff",
+    "dark": "#111111"
   },
   "fonts": {
     "family": "Geist",


### PR DESCRIPTION
White accents in dark mode (#ffffff light), near-black in light mode (#111111 dark). Works cleanly now that custom.css is gone.