### PR TITLE
docs: deepen all 22 pages with detail, accuracy fixes, expanded cross…

### DIFF
--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -5,40 +5,48 @@ description: "Complete reference for all floe CLI flags."
 
 ## Global flags
 
-These flags are available on all commands (`send`, `receive`, `version`).
+Available on all commands (`send`, `receive`, `version`).
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--server <url>` | `https://api.floe.one` | Signaling server URL. Use `http://localhost:3001` for local testing or your self-hosted server URL. |
-| `--no-relay` | `false` | Disable TURN relay. Only direct (STUN) connections are attempted. The transfer fails if a direct path cannot be found. |
-| `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: production defaults to `https://floe.one`, `localhost:3001` defaults to `http://localhost:3000`. |
+| `--no-relay` | `false` | Disable the TURN relay. Only direct (STUN) connections are attempted. The transfer fails if a direct path cannot be established. Useful for ensuring files never pass through a relay. |
+| `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: the production server defaults to `https://floe.one`, and `localhost:3001` defaults to `http://localhost:3000`. |
 
 ## `floe receive` flags
 
-These flags are specific to the `receive` command.
+Specific to the `receive` command.
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--output <dir>` | `-o` | `.` | Directory to save received files. Created automatically if it does not exist. |
-| `--yes` | `-y` | `false` | Auto-accept incoming files without prompting for confirmation. |
+| `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
 
 ## Examples
 
-Use a local dev server:
+Use a local dev server for both sender and receiver:
 
 ```bash
 floe send photo.jpg --server http://localhost:3001
 floe receive olive-tiger-castle --server http://localhost:3001
 ```
 
-Direct connection only (no relay fallback):
+Disable relay fallback (direct connections only):
 
 ```bash
 floe send photo.jpg --no-relay
 ```
 
-Receive into a specific folder, auto-accept:
+Point the browser link at a custom web client:
+
+```bash
+floe send photo.jpg --server https://api.example.com --web https://app.example.com
+```
+
+Save received files to a specific folder and auto-accept:
 
 ```bash
 floe receive olive-tiger-castle -o ~/Downloads -y
 ```
+
+See [Against a Self-Hosted Server](/cli/self-hosted-server) for more server configuration examples.

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -3,35 +3,102 @@ title: "Installation"
 description: "Download and install the floe CLI binary."
 ---
 
-The `floe` CLI is a single self-contained binary with no runtime dependencies. Download the binary for your platform from the [GitHub Releases page](https://github.com/jannskiee/floe/releases).
+The `floe` CLI is a single self-contained binary with no runtime dependencies.
 
 ## Download
 
+Go to the [GitHub Releases page](https://github.com/jannskiee/floe/releases) and download the archive for your platform. Release archives follow this naming convention:
+
+```
+floe_<version>_<os>_<arch>.tar.gz    # macOS and Linux
+floe_<version>_<os>_<arch>.zip       # Windows
+```
+
+For example: `floe_v1.2.0_darwin_arm64.tar.gz` or `floe_v1.2.0_linux_amd64.tar.gz`.
+
 <Tabs>
   <Tab title="macOS (Apple Silicon)">
+    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
+
     ```bash
-    curl -L https://github.com/jannskiee/floe/releases/latest/download/floe_Darwin_arm64.tar.gz | tar xz
+    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_darwin_arm64.tar.gz" | tar xz
+    sudo mv floe /usr/local/bin/
+    ```
+
+    Or fetch the latest version automatically:
+
+    ```bash
+    VERSION=$(curl -s https://api.github.com/repos/jannskiee/floe/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+    curl -L "https://github.com/jannskiee/floe/releases/download/${VERSION}/floe_${VERSION}_darwin_arm64.tar.gz" | tar xz
     sudo mv floe /usr/local/bin/
     ```
   </Tab>
   <Tab title="macOS (Intel)">
+    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
+
     ```bash
-    curl -L https://github.com/jannskiee/floe/releases/latest/download/floe_Darwin_x86_64.tar.gz | tar xz
+    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_darwin_amd64.tar.gz" | tar xz
+    sudo mv floe /usr/local/bin/
+    ```
+
+    Or fetch the latest version automatically:
+
+    ```bash
+    VERSION=$(curl -s https://api.github.com/repos/jannskiee/floe/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+    curl -L "https://github.com/jannskiee/floe/releases/download/${VERSION}/floe_${VERSION}_darwin_amd64.tar.gz" | tar xz
     sudo mv floe /usr/local/bin/
     ```
   </Tab>
   <Tab title="Linux (amd64)">
+    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
+
     ```bash
-    curl -L https://github.com/jannskiee/floe/releases/latest/download/floe_Linux_x86_64.tar.gz | tar xz
+    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_linux_amd64.tar.gz" | tar xz
+    sudo mv floe /usr/local/bin/
+    ```
+
+    Or fetch the latest version automatically:
+
+    ```bash
+    VERSION=$(curl -s https://api.github.com/repos/jannskiee/floe/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
+    curl -L "https://github.com/jannskiee/floe/releases/download/${VERSION}/floe_${VERSION}_linux_amd64.tar.gz" | tar xz
+    sudo mv floe /usr/local/bin/
+    ```
+  </Tab>
+  <Tab title="Linux (arm64)">
+    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
+
+    ```bash
+    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_linux_arm64.tar.gz" | tar xz
     sudo mv floe /usr/local/bin/
     ```
   </Tab>
   <Tab title="Windows">
-    Download `floe_Windows_x86_64.zip` from the [releases page](https://github.com/jannskiee/floe/releases), extract it, and add the directory to your `PATH`.
+    Download `floe_vX.Y.Z_windows_amd64.zip` from the [releases page](https://github.com/jannskiee/floe/releases). Extract the archive, then add the folder containing `floe.exe` to your `PATH` environment variable:
+
+    1. Open **System Properties** and go to **Environment Variables**.
+    2. Under **User variables**, select `Path` and click **Edit**.
+    3. Click **New** and enter the full path to the folder containing `floe.exe`.
+    4. Click **OK** to close all dialogs, then open a new terminal to pick up the change.
   </Tab>
 </Tabs>
 
-## Verify
+## Verify the checksum (optional)
+
+Each release includes a `checksums.txt` file. To verify the integrity of your download, replace `vX.Y.Z` with your version:
+
+```bash
+# Download checksums
+curl -LO "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/checksums.txt"
+
+# Verify (macOS)
+shasum -a 256 --check --ignore-missing checksums.txt
+
+# Verify (Linux)
+sha256sum --check --ignore-missing checksums.txt
+```
+
+## Verify the install
 
 ```bash
 floe version
@@ -53,3 +120,5 @@ git clone https://github.com/jannskiee/floe.git
 cd floe/cli
 go build ./cmd/floe
 ```
+
+Move the resulting `floe` binary to a directory on your `PATH` (e.g. `/usr/local/bin/` on macOS and Linux).

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -7,7 +7,7 @@ description: "Receive files from a peer."
 floe receive <code | link>
 ```
 
-Joins an existing transfer session as the receiver. Accepts either a short code (e.g. `olive-tiger-castle`) or the full browser link. Downloads incoming files to the current directory by default.
+Joins an existing transfer session as the receiver. Accepts either a short code (e.g. `olive-tiger-castle`) or the full browser link. After connecting, Floe prompts you to confirm the incoming transfer and then downloads the files.
 
 ## Examples
 
@@ -20,7 +20,7 @@ floe receive olive-tiger-castle
 Receive using a full link:
 
 ```bash
-floe receive "https://floe.one?room=abc123"
+floe receive "https://floe.one?room=abc123..."
 ```
 
 Save to a specific directory:
@@ -29,23 +29,56 @@ Save to a specific directory:
 floe receive olive-tiger-castle -o ~/Downloads
 ```
 
-Auto-accept without confirmation:
+Auto-accept without a confirmation prompt:
 
 ```bash
 floe receive olive-tiger-castle -y
 ```
 
+## Output
+
+```
+Connecting to sender...
+Connected
+
+  Incoming: 2 file(s)
+
+  Accept? [Y/n] y
+
+  [1/2] photo.jpg  [████████████████] 2.3 MB/2.3 MB
+
+  [2/2] notes.txt  [████████████████] 14 KB/14 KB
+
+  Done. 2 file(s) received in .
+```
+
+## Confirmation prompt
+
+When the first file's metadata arrives, Floe shows how many files are incoming and asks for confirmation:
+
+```
+  Incoming: N file(s)
+
+  Accept? [Y/n]
+```
+
+- Press **Enter**, `y`, or `Y` to accept and begin receiving.
+- Type `n` or `no` to decline. The transfer is cancelled and the connection closes.
+
+Pass `-y` to skip this prompt and accept automatically.
+
 ## Flags
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--output` | `-o` | `.` (current directory) | Directory to save received files |
-| `--yes` | `-y` | `false` | Auto-accept incoming files without confirmation |
+| `--output` | `-o` | `.` (current directory) | Directory to save received files. Created automatically if it does not exist. |
+| `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
 
 See [Flags Reference](/cli/flags) for global flags (`--server`, `--no-relay`).
 
 ## Notes
 
-- The output directory is created automatically if it does not exist.
-- Without `-y`, Floe prompts you to confirm before saving each file.
-- Press `Ctrl+C` to cancel the transfer.
+- Received files are saved to the output directory. **Existing files with the same name are overwritten without warning.** Use `-o` to point to an empty directory if you want to avoid collisions.
+- Directory structure is preserved when the sender sends a folder. Files land at the same relative paths inside your output directory.
+- Press `Ctrl+C` to cancel the transfer at any time.
+- Short codes expire 10 minutes after the sender starts the session. After that, only the full link works (and only while the sender is still connected).

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -3,30 +3,41 @@ title: "Against a Self-Hosted Server"
 description: "Use the floe CLI with your own Floe instance instead of floe.one."
 ---
 
-The `floe` CLI connects to `https://api.floe.one` by default. You can point it at any Floe server instance using the `--server` flag.
+The `floe` CLI connects to `https://api.floe.one` by default. You can point it at any Floe signaling server using the `--server` flag.
 
 ## Usage
 
-```bash
-floe send --server https://api.your-domain.com photo.jpg
-floe receive --server https://api.your-domain.com olive-tiger-castle
-```
-
-The `--server` value must be the URL of the signaling server (not the web client). Both sender and receiver must use the same server.
-
-## Web link
-
-When using `--server`, the browser link printed by `floe send` defaults to the same URL as the server. If your web client is on a different origin, override it with `--web`:
+Both sender and receiver must use the same server:
 
 ```bash
-floe send --server https://api.your-domain.com --web https://app.your-domain.com photo.jpg
+floe send photo.jpg --server https://api.your-domain.com
+floe receive olive-tiger-castle --server https://api.your-domain.com
 ```
+
+The `--server` value must be the URL of the **signaling server**, not the web client.
+
+## Separating the web client URL
+
+When using `--server`, the browser link printed by `floe send` defaults to the same origin as the server. If your web client is hosted at a different URL, override it with `--web`:
+
+```bash
+floe send photo.jpg --server https://api.your-domain.com --web https://app.your-domain.com
+```
+
+This is common when the client and server run on separate subdomains.
 
 ## Local testing
 
+To test against a local instance running on the default ports:
+
 ```bash
+# Terminal 1 - sender
 floe send photo.jpg --server http://localhost:3001
+
+# Terminal 2 - receiver
 floe receive olive-tiger-castle --server http://localhost:3001
 ```
+
+The browser link will point to `http://localhost:3000` automatically when using `localhost:3001`.
 
 See [Self-Hosting](/self-hosting/overview) for instructions on running your own Floe instance.

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -7,7 +7,7 @@ description: "Send files or folders to a peer."
 floe send <file|folder> [file|folder...]
 ```
 
-Starts a transfer session as the sender. Prints a short code and a browser link; share either one with your recipient. Waits until the recipient connects, then streams the files over WebRTC.
+Starts a transfer session as the sender. Floe registers a short code with the signaling server, prints a sharing panel, then waits for a peer to connect. Once connected, it streams all files over an encrypted WebRTC data channel.
 
 ## Examples
 
@@ -17,13 +17,13 @@ Send a single file:
 floe send report.pdf
 ```
 
-Send multiple files:
+Send multiple files at once:
 
 ```bash
 floe send photo.jpg video.mp4 notes.txt
 ```
 
-Send an entire folder:
+Send an entire folder (transferred recursively):
 
 ```bash
 floe send ./project
@@ -31,15 +31,37 @@ floe send ./project
 
 ## Output
 
-```
-  ─────────────────────────────────────────────────
-  Code:  olive-tiger-castle
-  Link:  https://floe.one?room=...
-  ─────────────────────────────────────────────────
+After running `floe send`, you will see a sharing panel with a short code and a browser link:
 
-  Waiting for peer...
-  Connecting...
-  Connected
+```
+─────────────────────────────────────────────────
+Code:  olive-tiger-castle
+Link:  https://floe.one?room=...
+─────────────────────────────────────────────────
+
+Waiting for peer...
+Connecting...
+Connected
+
+  Sending 3 file(s)...
+
+  [1/3] report.pdf     [████████████░░░] 8.1 MB/9.5 MB
+  [2/3] photo.jpg      [████████████████] 2.3 MB/2.3 MB
+  [3/3] notes.txt      [████████████████] 14 KB/14 KB
+
+  All files sent.
+```
+
+Share the **code** with CLI recipients or the **link** with browser recipients. The short code is valid for 10 minutes. The room link stays active until the session ends or you press `Ctrl+C`.
+
+## Folder transfers
+
+When you send a folder, Floe walks it recursively and preserves the directory structure on the receiving end. The recipient gets the same relative paths inside their output directory.
+
+```bash
+floe send ./documents
+# Transfers documents/report.pdf, documents/images/photo.jpg, etc.
+# Receiver gets: ./documents/report.pdf, ./documents/images/photo.jpg
 ```
 
 ## Flags
@@ -48,6 +70,6 @@ See [Flags Reference](/cli/flags) for `--server`, `--no-relay`, and `--web`.
 
 ## Notes
 
-- The session stays open until the recipient connects and the transfer completes. Press `Ctrl+C` to cancel.
-- The short code is valid for 10 minutes. The room link works until the session ends.
-- Folders are transferred recursively.
+- Press `Ctrl+C` at any time to cancel the transfer and close the session.
+- If the short code cannot be registered (for example, the signaling server is unreachable), Floe prints a warning and continues with the link only.
+- Files are streamed in the order they are listed. For multiple files, progress is shown per file.

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -1,13 +1,13 @@
 ---
 title: "floe version"
-description: "Print the floe version."
+description: "Print the installed floe version."
 ---
 
 ```bash
 floe version
 ```
 
-Prints the current version of the `floe` binary and a link to this documentation.
+Prints the current version of the `floe` binary and a link to the documentation.
 
 ## Output
 
@@ -16,7 +16,7 @@ floe v1.x.x
 Docs: https://docs.floe.one
 ```
 
-## Alternative
+## Alternatives
 
 You can also use the root flag:
 
@@ -25,3 +25,5 @@ floe --version
 # or
 floe -v
 ```
+
+These print the version number only, without the docs link.

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -3,17 +3,25 @@ title: "The 2 GB Relay Limit"
 description: "Why relay transfers are capped at 2 GB per session."
 ---
 
-When your files go through the Floe TURN relay server, every byte of data passes through the infrastructure. That costs real money in server bandwidth. Direct connections cost nothing.
+When your files go through the Floe TURN relay server, every byte of data passes through the infrastructure. That costs real money in server bandwidth. Direct connections cost nothing because files travel entirely between the two devices.
 
 To keep Floe free and running for everyone, relay transfers are capped at **2 GB per session**. This limit applies only to relay connections. Direct connections have no limit.
 
 ## How to get a direct connection
 
-<Tip>
-  These steps increase the chance of a direct connection, which has no size limit.
-</Tip>
+These steps increase the likelihood of a direct connection, which has no size limit:
 
-- Use a standard home or personal Wi-Fi network
-- Disconnect from any VPN
-- Avoid transferring from strict corporate or university networks
-- Try using a personal mobile hotspot
+- Use a standard home or personal Wi-Fi network.
+- Disconnect from any VPN.
+- Avoid transferring from strict corporate or university networks.
+- Try using a personal mobile hotspot if you are on a restricted network.
+
+If both peers are on typical consumer networks, a direct connection will almost always succeed.
+
+## What counts as one session
+
+The 2 GB cap resets if the relay connection drops and reconnects. Each new WebRTC session starts with a fresh counter. However, intentionally cycling sessions to exceed the cap goes against the spirit of the free service.
+
+<Accordion title="Technical details">
+  The 2 GB cap is enforced in the browser client. When the total bytes sent via a relay connection reaches the limit, the transfer is stopped and an error is displayed. The limit applies per sender session, not per file. Direct connections bypass this check entirely, as no relay bandwidth is consumed.
+</Accordion>

--- a/docs/how-it-works/direct-connection.mdx
+++ b/docs/how-it-works/direct-connection.mdx
@@ -3,21 +3,31 @@ title: "Direct Connection"
 description: "How Floe establishes a direct peer-to-peer path using STUN."
 ---
 
-A direct connection means your files travel straight from your device to the recipient's device, like a private tunnel between two computers with no stops in between.
+A direct connection means your files travel straight from your device to the recipient's device. No server sits in between. Speed is limited only by the slower of your two internet connections.
 
 ## STUN
 
-To find this direct path, WebRTC uses a **STUN server**. Think of a STUN server like asking a friend outside your house "what does my address look like from out there?" It helps each browser discover its public internet address so they can reach each other.
+To find a direct path, WebRTC uses a **STUN server**. Think of it like asking someone outside your house "what is my address from out there?" STUN helps each device discover its public IP address and port so the two peers can reach each other.
 
 ## What direct connections mean for you
 
-- Maximum speed, limited only by your internet connection
-- No file size limits
-- Zero bandwidth cost to Floe
-- Your files never touch a server
+- Transfer speed limited only by your internet connection.
+- No file size limit.
+- Zero bandwidth cost to Floe's servers.
+- Files never touch any server after the connection is established.
 
 ## When to expect a direct connection
 
-Most home and mobile networks support direct connections. You are most likely to get one on standard home Wi-Fi or a personal mobile hotspot.
+Most home Wi-Fi and personal mobile hotspots support direct connections. You are most likely to connect directly on standard consumer networks.
 
-Strict corporate firewalls, university networks, and carrier-grade NAT may prevent a direct path. In those cases, Floe automatically falls back to a [relay connection](/how-it-works/relay-connection).
+Strict corporate firewalls, university networks, and carrier-grade NAT can block direct paths. In those cases, Floe automatically tries a [relay connection](/how-it-works/relay-connection) if relay fallback is enabled.
+
+<Accordion title="Technical details">
+  **ICE (Interactive Connectivity Establishment):** WebRTC uses the ICE protocol to find a usable network path. Each peer gathers a list of "candidates" (IP/port combinations it might be reachable on), including local addresses, server-reflexive addresses from STUN, and relay addresses from TURN. Peers exchange their candidates via the signaling server and try each pair until one works.
+
+  **STUN servers used:** `stun.l.google.com:19302` and `stun1.l.google.com:19302` as fallbacks. When connected to a self-hosted instance with TURN configured, the signaling server's TURN endpoints also double as STUN.
+
+  **Trickle ICE:** Candidates are sent incrementally as they are gathered rather than waiting for the full list. This reduces connection time significantly.
+
+  **Candidate types that produce direct connections:** `host` (same network) or `srflx` (server-reflexive, NAT traversal via STUN). If only `relay` candidates succeed, the connection uses TURN instead.
+</Accordion>

--- a/docs/how-it-works/encryption.mdx
+++ b/docs/how-it-works/encryption.mdx
@@ -5,11 +5,23 @@ description: "How Floe encrypts every transfer, direct or relayed."
 
 Every WebRTC connection, whether direct or relayed, is encrypted using **DTLS** (Datagram TLS). The encryption is built into WebRTC itself. Even Floe's own relay server cannot read your files.
 
-The encryption keys are generated uniquely for each transfer and exist only in the two browsers (or CLI processes) involved. There is no central key server.
+The encryption keys are generated uniquely for each transfer and exist only in the two devices involved. There is no central key server and no one else has access to them.
 
-## What this means
+## What this means in practice
 
-- The signaling server never sees file data
-- The relay server (when used) sees only encrypted packets
-- Floe has no database, stores no files, and retains no logs of what you transfer
-- Once the transfer is complete and both connections are closed, the data is gone
+- The signaling server brokers the connection but never sees file data.
+- The relay server (when used) sees only encrypted packets it cannot read.
+- Floe has no database of keys, stores no files, and retains no record of what you transfer.
+- Once both connections are closed, the keys are gone and the data cannot be recovered.
+
+## Self-hosted instances
+
+These properties hold on self-hosted instances as well. The signaling server and TURN relay never receive plaintext file data regardless of who operates them. If you run your own instance, you get the same encryption guarantees.
+
+<Accordion title="Technical details">
+  **DTLS for data channels:** WebRTC data channels are transported over SCTP (Stream Control Transmission Protocol) running on top of DTLS. This is distinct from DTLS-SRTP, which is used for audio/video media streams. Both provide strong encryption, but data channels specifically use SCTP over DTLS.
+
+  **Key exchange:** Each peer generates a certificate and key pair for the session. The fingerprints of these certificates are exchanged via the SDP offer and answer during signaling. DTLS verifies these fingerprints during the handshake, ensuring that even if the signaling channel is compromised, a man-in-the-middle cannot inject a different certificate.
+
+  **Per-session keys:** Keys are ephemeral. They are generated when the connection is created and discarded when it closes. There is no key escrow, no recovery mechanism, and no persistent storage of session keys.
+</Accordion>

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -3,19 +3,39 @@ title: "Relay Connection"
 description: "How Floe uses a TURN server as an encrypted bridge when a direct connection is not possible."
 ---
 
-Some networks make it impossible to connect two browsers directly. This happens on strict corporate firewalls, university networks, or when your mobile carrier places many users behind a single shared IP address (called **Carrier-Grade NAT**). In these cases, a direct path cannot be found.
+Some networks make it impossible for two devices to connect directly. This happens on strict corporate firewalls, university networks, and when a mobile carrier places many users behind a single shared IP address (carrier-grade NAT). In these cases, a direct path cannot be found and Floe falls back to a relay.
 
 ## TURN fallback
 
-Floe automatically falls back to a **TURN server** (`turn.floe.one`). A TURN server acts as a secure bridge. Your data passes through it on its way to the recipient, like a trusted courier who picks up a sealed, locked box from you and delivers it to the recipient without being able to open it.
+When a direct connection fails, Floe automatically routes through a **TURN server** (`turn.floe.one`). A TURN server acts as a secure bridge. Your data travels through it on the way to the recipient, like a courier carrying a locked box it cannot open.
 
 ## Encryption
 
-Even through a relay, your files are protected by **DTLS encryption** (the same standard used by HTTPS). The relay server sees encrypted data packets, not your actual files.
+Even through a relay, your files are protected by **DTLS encryption** built into WebRTC. The relay server sees only encrypted data packets. It cannot read, inspect, or store your files.
 
 ## What relay connections mean for you
 
-- Transfer still works even on strict networks
-- Your files remain encrypted in transit
-- Speeds may be slower depending on server load
-- Limited to 2 GB per transfer (see [the 2 GB limit](/how-it-works/2gb-limit))
+- Transfer works even on networks that block direct connections.
+- Files remain encrypted end-to-end in transit.
+- Speeds may be slower depending on relay server load and network conditions.
+- Relay transfers are capped at **2 GB per session**. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+
+## Disabling relay fallback
+
+If you need to ensure files never pass through a relay, you can disable it. In the browser, toggle off **Network Relay Fallback** before creating the link. In the CLI, pass `--no-relay`:
+
+```bash
+floe send photo.jpg --no-relay
+```
+
+With relay disabled, the transfer fails if a direct path cannot be established.
+
+<Accordion title="Technical details">
+  **TURN (Traversal Using Relays around NAT):** When ICE negotiation produces only `relay` candidates, both peers connect to the TURN server and the server forwards packets between them. The data is still DTLS-encrypted end-to-end before it reaches the TURN server.
+
+  **Credentials:** The signaling server issues time-limited HMAC-SHA1 credentials for coturn (`username: {expiry}:floeuser`, `password: base64(HMAC-SHA1(secret, username))`). Credentials are valid for 24 hours.
+
+  **Endpoints:** `turn:turn.floe.one:3478` (STUN/TURN over UDP and TCP) and `turns:turn.floe.one:5349` (TURN over TLS).
+
+  **Relay detection:** The browser polls `RTCStatsReport` every 5 seconds and examines the nominated candidate pair. If either candidate is of type `relay`, the connection indicator shows amber.
+</Accordion>

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -3,18 +3,37 @@ title: "Signaling"
 description: "How Floe brokers the initial connection between two peers."
 ---
 
-When you drop files into Floe, a unique one-time link is created. The Floe signaling server (`api.floe.one`) plays the role of a matchmaker. When the recipient opens your link, both browsers introduce themselves to each other through this server.
+When you create a transfer in Floe, a unique room is created on the signaling server. The sender shares a code or link. When the recipient joins, the two devices introduce themselves through the server and exchange the information they need to connect directly. Once that handshake is complete, the server steps aside.
 
-Once both sides have said hello, the signaling server steps completely out of the picture. It does not handle any file data, does not store anything, and does not participate in the transfer itself.
+The signaling server never touches file data, never stores anything about your transfer, and plays no part once the WebRTC connection is established.
 
-## What the server does
+## What the signaling server does
 
 - Assigns roles: the first peer to join a room becomes the **sender**, the second becomes the **receiver**.
-- Relays WebRTC signaling messages: the initial offer, the answer, and ICE candidates.
-- Issues short-lived TURN credentials (if a TURN server is configured).
+- Relays WebRTC negotiation messages: the initial offer, the answer, and ICE candidates.
+- Issues short-lived TURN credentials when a TURN server is configured.
+- Registers short human-readable codes (e.g. `olive-tiger-castle`) that map to room IDs.
 
-## What the server never does
+## What the signaling server never does
 
-- Touch file data
-- Store files or transfer content
-- Log what you send or receive
+- Handle file data of any kind.
+- Store files, transfer content, or logs of what you send or receive.
+- Persist room or peer information after the session ends.
+
+<Accordion title="Technical details">
+  **Transports:** Browser clients connect via Socket.IO. CLI clients connect via WebSocket at `/ws`. Both share a single in-memory `rooms` registry (`Map<roomId, [peer, peer]>`), so browser-to-CLI transfers are fully supported.
+
+  **WebRTC negotiation flow:**
+  1. Sender joins the room (`join-room` event) and receives the `sender` role.
+  2. When the receiver joins, the server emits `user-connected` to the sender.
+  3. Sender creates an SDP offer and sends it via the `signal` event.
+  4. Receiver sets the remote description, creates an SDP answer, and sends it back.
+  5. Both peers exchange ICE candidates via `signal` events (trickle ICE).
+  6. Once ICE negotiation completes, the WebRTC data channel opens directly between the peers.
+
+  **Short codes:** Registered via `POST /api/code` with a room UUID. The server picks three random words from a 384-word list and maps them to the room ID with a 10-minute TTL. `GET /api/code/:code` resolves a code back to its room UUID.
+
+  **TURN credentials:** Issued via `GET /api/turn-credentials`. Credentials use HMAC-SHA1 with a 24-hour expiry. If `TURN_SECRET` is not set, the endpoint returns STUN servers only.
+
+  **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint.
+</Accordion>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -3,7 +3,16 @@ title: "Introduction"
 description: "Secure, encrypted P2P file transfer with no accounts, no file storage, and no registration."
 ---
 
-Floe transfers files directly between devices using WebRTC. Files are encrypted end-to-end and never stored on any server. The signaling server only brokers the initial connection setup. Once both peers connect, the server steps out of the picture.
+Floe transfers files directly between devices using WebRTC. Files are end-to-end encrypted and never stored on any server. The signaling server only brokers the initial connection setup. Once both peers are connected, it steps aside.
+
+## What Floe does
+
+- **Direct, peer-to-peer transfers.** Files travel straight from your device to the recipient's device.
+- **End-to-end encrypted.** Every transfer is encrypted with DTLS. No one, including Floe's servers, can read your files.
+- **No accounts or storage.** No sign-up, no uploads, no data retained after the transfer completes.
+- **No size limit on direct transfers.** Relay connections are capped at 2 GB per session to keep the service free.
+- **Browser and CLI.** Use the web app at floe.one or the `floe` command-line tool. Both are fully compatible with each other.
+- **Open source and self-hostable.** Run your own instance on your own infrastructure with Docker Compose.
 
 ## Use Floe
 
@@ -16,17 +25,29 @@ Floe transfers files directly between devices using WebRTC. Files are encrypted 
   </Card>
 </CardGroup>
 
-## Three questions answered
+## Common questions
 
 <AccordionGroup>
   <Accordion title="Where do my files go?">
-    Your files go directly to the recipient. In most cases they never touch a server at all. When a direct path cannot be found (strict corporate firewalls, carrier-grade NAT), Floe uses an encrypted TURN relay as a bridge. Even then, the relay server sees only encrypted data and cannot read your files.
+    Your files go directly to the recipient's device. In most cases they never touch a server at all. When a direct path cannot be found (strict corporate firewalls, carrier-grade NAT), Floe automatically falls back to an encrypted TURN relay. Even then, the relay server sees only encrypted packets and cannot read your files.
   </Accordion>
   <Accordion title="Is there a file size limit?">
-    Direct connections have no size limit. Relay connections are capped at 2 GB per session to keep the service free. See [Why the 2 GB Limit?](/how-it-works/2gb-limit) for details.
+    Direct connections have no size limit. Relay connections are capped at 2 GB per session to keep the service free. See [Why the 2 GB Limit?](/how-it-works/2gb-limit) for details. Most home and mobile network transfers connect directly and have no limit.
   </Accordion>
   <Accordion title="Do I need an account?">
-    No. Floe requires no account, no sign-up, and no registration. Open the site (or run the CLI) and share the code or link with your recipient.
+    No. Floe requires no account, no sign-up, and no registration. Open the site or run the CLI and share the link or short code with your recipient.
+  </Accordion>
+  <Accordion title="How fast is it?">
+    Transfer speed is limited only by the slower of the two connections involved. There is no artificial throttling. Direct transfers are as fast as your internet connection allows. Relay transfers may be slightly slower depending on server load, but encryption overhead is minimal.
+  </Accordion>
+  <Accordion title="Which browsers are supported?">
+    Any modern browser with WebRTC support works: Chrome, Firefox, Safari, Edge, and most Chromium-based browsers. A secure context (HTTPS or localhost) is required. WebRTC is not available in some in-app browsers (such as those embedded in Facebook, Instagram, or TikTok). If this affects you, Floe will prompt you to open the page in Chrome or Safari instead.
+  </Accordion>
+  <Accordion title="Can I use the terminal instead of the browser?">
+    Yes. The `floe` CLI is a self-contained binary for macOS, Linux, and Windows. It connects to the same infrastructure as the web app, and is fully compatible with browser clients. A CLI sender can transfer to a browser receiver, and vice versa. See [CLI Installation](/cli/installation) to get started.
+  </Accordion>
+  <Accordion title="Is Floe open source?">
+    Yes. The full source for the client, server, and CLI is available on [GitHub](https://github.com/jannskiee/floe) under the MIT license. You can also [self-host](/self-hosting/overview) your own instance.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,37 +5,101 @@ description: "Send your first file in under a minute."
 
 ## Browser
 
+### Sender
+
 1. Open [floe.one](https://floe.one) in your browser.
-2. Drop a file (or click to select one).
-3. Share the short code or link with your recipient.
-4. The recipient opens the link or enters the code at [floe.one](https://floe.one).
-5. The transfer starts automatically once both sides connect.
+2. Drop files onto the page or click to open the file picker. Multiple files are supported.
+3. (Optional) Toggle **Network Relay Fallback** on or off. It is on by default and recommended. When disabled, only direct connections are attempted; transfers may fail on mobile data or restricted networks.
+4. Click **Create Secure Link & Share**.
+5. Floe displays a shareable link and a QR code. Share either with your recipient.
+6. A connection indicator appears in the corner showing the connection state. Once the recipient opens the link, it turns green (Direct) or amber (Relay) and the transfer begins automatically.
+
+### Receiver
+
+1. Open the shared link in any modern browser.
+2. The transfer starts automatically once the connection is established.
+3. When all files arrive, download options appear:
+   - **Download** each file individually.
+   - **Download All** triggers individual downloads for every file.
+   - **Download ZIP** bundles everything into a single archive.
+
+<Tip>
+  On iOS, use Download ZIP for the most reliable experience.
+</Tip>
+
+<Note>
+  The sender must keep their browser tab open for the entire duration of the transfer.
+</Note>
+
+---
 
 ## CLI
 
 <Steps>
   <Step title="Install">
-    Download the binary for your platform from [GitHub Releases](https://github.com/jannskiee/floe/releases). See [Installation](/cli/installation) for details.
+    Download the binary for your platform from [GitHub Releases](https://github.com/jannskiee/floe/releases). See [Installation](/cli/installation) for platform-specific steps.
   </Step>
   <Step title="Send">
     ```bash
     floe send photo.jpg
     ```
-    Floe prints a short code and a browser link. Share either one with your recipient.
+
+    Floe connects, registers a short code, and prints a sharing panel:
+
     ```
+    ─────────────────────────────────────────────────
     Code:  olive-tiger-castle
     Link:  https://floe.one?room=...
+    ─────────────────────────────────────────────────
+
+    Waiting for peer...
     ```
+
+    Share the **code** (CLI recipients) or the **link** (browser recipients). The short code is valid for 10 minutes.
   </Step>
   <Step title="Receive">
     The recipient runs:
+
     ```bash
     floe receive olive-tiger-castle
     ```
-    Or they can open the link in any browser. CLI and browser peers are fully compatible.
+
+    Or they can open the link in any browser. Once connected, the CLI shows a confirmation prompt and then a live progress bar:
+
+    ```
+    Connecting...
+    Connected
+
+      Incoming: 1 file(s)
+
+      Accept? [Y/n] y
+
+      [1/1] photo.jpg  [████████░░░░░░░] 4.2 MB/6.0 MB
+
+      Done. 1 file(s) received in .
+    ```
+
+    Pass `-y` to auto-accept without the prompt. Pass `-o <dir>` to save files to a specific directory.
   </Step>
 </Steps>
 
+---
+
 ## Cross-platform transfers
 
-CLI and browser peers work together transparently. The sender can use the CLI while the recipient opens the link in a browser, and vice versa.
+The browser and CLI clients are fully interoperable. Any combination of sender and receiver works.
+
+| Sender | Receiver | How the receiver joins |
+|--------|----------|------------------------|
+| Browser | Browser | Opens the shared link or scans the QR code |
+| Browser | CLI | `floe receive <link>` (paste the full URL) |
+| CLI | Browser | Opens the shared link or scans the QR code |
+| CLI | CLI | `floe receive <code>` or `floe receive <link>` |
+
+**How it works:** The browser connects via Socket.IO and the CLI connects via WebSocket, but both share the same room on the signaling server. Signals (WebRTC offer, answer, ICE candidates) are routed between them automatically. Neither side needs to know which client the other is using.
+
+**Key difference:** The browser can only join a transfer by opening the link directly. There is no short-code entry field in the web UI. The CLI accepts either the short code or the full link.
+
+<Note>
+  Folder transfers are a CLI feature. When you `floe send ./folder`, all files are transferred recursively and the directory structure is preserved on the receiver's end. A browser receiver gets the same files but sees them as a flat list.
+</Note>

--- a/docs/self-hosting/build-time-url.mdx
+++ b/docs/self-hosting/build-time-url.mdx
@@ -3,7 +3,7 @@ title: "Build-Time URL Caveat"
 description: "Why NEXT_PUBLIC_SOCKET_URL must be set before building the client image."
 ---
 
-Next.js inlines `NEXT_PUBLIC_*` variables into the JavaScript bundle **at build time**, not at runtime. `NEXT_PUBLIC_SOCKET_URL` is therefore baked into the client image when it is built. Setting it only in the running container has no effect.
+Next.js inlines `NEXT_PUBLIC_*` variables into the JavaScript bundle **at build time**, not at runtime. `NEXT_PUBLIC_SOCKET_URL` is therefore baked into the client image when it is built. Setting or changing it in a running container has no effect.
 
 ## After changing the URL, rebuild the client
 
@@ -12,6 +12,10 @@ docker compose build client
 docker compose up -d
 ```
 
+<Warning>
+  Forgetting to rebuild after changing `NEXT_PUBLIC_SOCKET_URL` is the most common reason a self-hosted Floe instance cannot connect to the signaling server.
+</Warning>
+
 ## The URL must be reachable by end-users' browsers
 
-`http://localhost:3001` only works when the browser runs on the same machine as the server. For anything else, use the server's LAN IP or public URL (e.g. `https://api.your-domain.com`).
+`NEXT_PUBLIC_SOCKET_URL` is evaluated in the **browser**, not on the server. `http://localhost:3001` only works when the browser runs on the same machine as the server. For any other setup, use the server's LAN IP or public domain (e.g. `https://api.your-domain.com`).

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -7,11 +7,36 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 
 ## Variables
 
-| Variable | Service | Required | Purpose |
-|----------|---------|----------|---------|
-| `NEXT_PUBLIC_SOCKET_URL` | client (build) | Yes | URL the **browser** uses to reach the signaling server. Inlined at build time. See [the build-time URL caveat](/self-hosting/build-time-url). |
-| `PORT` | server | No | Host port the server is published on (default `3001`; the container always listens on 3001 internally). |
-| `CLIENT_URL` | server | Yes (prod) | Frontend origin allowed by CORS. Set to your client's public URL. |
-| `TRUSTED_PROXY_COUNT` | server | No | Number of trusted reverse-proxy hops in front of the server (for correct `X-Forwarded-For` parsing and rate limiting). `0` = direct, `1` = behind one proxy. |
-| `TURN_SECRET` | server | No | Shared HMAC secret for coturn credentials. Empty = STUN-only. Must match coturn's `static-auth-secret`. |
-| `TURN_DOMAIN` | server | No | Public hostname of your TURN server. Must match coturn's `realm`. |
+| Variable | Service | Required | Default | Purpose |
+|----------|---------|----------|---------|---------|
+| `NEXT_PUBLIC_SOCKET_URL` | client (build) | Yes | `http://localhost:3001` | URL the **browser** uses to reach the signaling server. Inlined at build time. See [the build-time URL caveat](/self-hosting/build-time-url). |
+| `PORT` | server | No | `3001` | Port the signaling server listens on inside the container. The host port is set separately in `docker-compose.yml`. |
+| `NODE_ENV` | server | No | `production` | Runtime environment. Set to `development` to enable verbose logging. |
+| `CLIENT_URL` | server | Yes (prod) | _(none)_ | Frontend origin allowed by CORS. Set to your client's public URL (e.g. `https://app.your-domain.com`). |
+| `TRUSTED_PROXY_COUNT` | server | No | `0` | Number of trusted reverse-proxy hops in front of the server. Used for correct `X-Forwarded-For` parsing and per-IP rate limiting. Set to `1` if you are behind a single proxy. |
+| `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for coturn credentials. If empty, the server returns STUN-only and no TURN is offered. Must match coturn's `static-auth-secret`. |
+| `TURN_DOMAIN` | server | No | _(none)_ | Public hostname of your TURN server (e.g. `turn.your-domain.com`). Must match coturn's `realm`. |
+
+## Minimal local configuration
+
+For local testing, only one variable matters:
+
+```env
+NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
+```
+
+Everything else can stay at its default.
+
+## Production configuration
+
+A typical production `.env` for a deployment with HTTPS and TURN:
+
+```env
+NEXT_PUBLIC_SOCKET_URL=https://api.your-domain.com
+CLIENT_URL=https://app.your-domain.com
+TRUSTED_PROXY_COUNT=1
+TURN_SECRET=your-strong-random-secret
+TURN_DOMAIN=turn.your-domain.com
+```
+
+See [Production Deployment](/self-hosting/production) for the full setup.

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -6,9 +6,10 @@ description: "Day-to-day operations for a self-hosted Floe instance."
 ## Common commands
 
 ```bash
-docker compose logs -f                 # tail logs for all services
-docker compose ps                      # check status (server has a health check)
-docker compose down                    # stop and remove the stack
+docker compose logs -f                  # tail logs for all services
+docker compose ps                       # check container status and health
+docker compose down                     # stop and remove the stack
+docker compose restart server           # restart only the signaling server
 ```
 
 ## Update to the latest code
@@ -18,11 +19,15 @@ git pull
 docker compose pull && docker compose up -d --build
 ```
 
+<Note>
+  After updating, run `docker compose build client` and `docker compose up -d` if you changed any environment variables. The client image must be rebuilt when `NEXT_PUBLIC_SOCKET_URL` changes. See [Build-Time URL Caveat](/self-hosting/build-time-url).
+</Note>
+
 ## Health endpoints
 
-The signaling server exposes two health endpoints:
+The signaling server exposes two health endpoints you can use in load balancers or uptime monitors:
 
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /health` | Liveness check |
-| `GET /` | Status (returns server info) |
+| Endpoint | Purpose | Response |
+|----------|---------|---------|
+| `GET /health` | Liveness check | `{ "status": "healthy", "uptime": <seconds> }` |
+| `GET /` | Status and version info | `{ "status": "ok", "timestamp": "..." }` |

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -3,18 +3,18 @@ title: "Overview"
 description: "Run your own Floe instance on your own infrastructure."
 ---
 
-You can self-host the entire Floe stack (web client and signaling server) independently of `floe.one`. The setup uses Docker Compose so the whole stack comes up with a single command.
+You can self-host the entire Floe stack independently of `floe.one`. The setup uses Docker Compose so the full stack comes up with a single command.
 
 ## What you are hosting
 
-The signaling server only brokers WebRTC connection setup (offer, answer, ICE candidates) and issues short-lived TURN credentials. **File data never passes through it.** Transfers go peer-to-peer over encrypted WebRTC data channels. TURN is optional and only relays (still encrypted) traffic for peers that cannot connect directly.
+The signaling server brokers WebRTC connection setup (offer, answer, ICE candidates) and issues short-lived TURN credentials. **File data never passes through it.** Transfers go peer-to-peer over encrypted WebRTC data channels. TURN is optional and only relays (still encrypted) traffic when a direct connection is not possible.
 
 ## Components
 
 | Component | Description |
 |-----------|-------------|
-| `client` | Next.js web app served on port 3000 |
-| `server` | Node.js signaling server on port 3001 |
+| `client` | Next.js web app, served on port 3000 |
+| `server` | Node.js signaling server, on port 3001 |
 | `coturn` | Optional TURN relay (profile-gated in Docker Compose) |
 
 ## Contents
@@ -30,6 +30,6 @@ The signaling server only brokers WebRTC connection setup (offer, answer, ICE ca
     HTTPS, reverse proxy, and domain setup.
   </Card>
   <Card title="TURN Relay" href="/self-hosting/turn-relay">
-    Add coturn to support peers behind strict NAT.
+    Add coturn to support peers behind strict NAT or CGNAT.
   </Card>
 </CardGroup>

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -3,40 +3,47 @@ title: "Production Deployment"
 description: "HTTPS, reverse proxy, and domain configuration for a production Floe instance."
 ---
 
-For a real deployment beyond a single machine, follow these steps.
+For a deployment accessible beyond a single machine, follow these steps.
 
 ## Steps
 
 <Steps>
   <Step title="Put both services behind a reverse proxy with HTTPS">
-    Browsers require a secure context for the APIs Floe uses (WebRTC, screen wake lock). Use Nginx, Caddy, Traefik, or a platform like Render or Fly.
+    Browsers require a secure context (HTTPS) for WebRTC and the Screen Wake Lock API. Use Nginx, Caddy, Traefik, or a managed platform like Render or Fly.
 
-    Proxy the client (`:3000`) and the server (`:3001`) under hostnames you control:
-    - `app.your-domain.com` to the client
-    - `api.your-domain.com` to the server
+    Proxy each service to a hostname you control:
+    - `app.your-domain.com` to the client on `:3000`
+    - `api.your-domain.com` to the signaling server on `:3001`
+
+    The signaling server uses WebSockets. Make sure your proxy forwards the `Upgrade` and `Connection` headers.
   </Step>
   <Step title="Set NEXT_PUBLIC_SOCKET_URL and rebuild">
-    ```bash
-    # In .env
+    In `.env`:
+
+    ```env
     NEXT_PUBLIC_SOCKET_URL=https://api.your-domain.com
     ```
-    Then rebuild:
+
+    Then rebuild the client image (required because this value is inlined at build time):
+
     ```bash
     docker compose build client
     docker compose up -d
     ```
   </Step>
   <Step title="Set CLIENT_URL">
-    ```bash
-    # In .env
+    In `.env`:
+
+    ```env
     CLIENT_URL=https://app.your-domain.com
     ```
-    This allows CORS from your client origin.
+
+    This adds your client origin to the server's CORS allow-list. Without it, browser requests from your domain will be blocked.
   </Step>
   <Step title="Set TRUSTED_PROXY_COUNT">
-    Set this to the number of proxy hops in front of the server so per-IP rate limiting sees real client IPs.
-    ```bash
-    # In .env
+    Set this to the number of proxy hops in front of the signaling server so per-IP rate limiting reads real client IPs instead of proxy IPs:
+
+    ```env
     TRUSTED_PROXY_COUNT=1
     ```
   </Step>
@@ -44,4 +51,4 @@ For a real deployment beyond a single machine, follow these steps.
 
 ## CORS note
 
-The server's allow-list also includes the official `floe.one` origins. Your `CLIENT_URL` is honored alongside them, so this does not block anything. If you prefer a clean allow-list for your fork, remove the hard-coded entries from `server/server.js`.
+The server's allow-list also includes the official `floe.one` origins. Your `CLIENT_URL` is added on top of these, so browser clients on your domain and on floe.one can both reach your server. If you are running a private fork and want a strict allow-list, remove the hard-coded entries from `server/server.js`.

--- a/docs/self-hosting/quickstart.mdx
+++ b/docs/self-hosting/quickstart.mdx
@@ -5,7 +5,7 @@ description: "Run Floe locally with Docker Compose."
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2 (`docker compose`, bundled with modern Docker Desktop and Engine).
+- [Docker](https://docs.docker.com/get-docker/) and Docker Compose v2 (`docker compose`, bundled with Docker Desktop and modern Docker Engine).
 
 ## Steps
 
@@ -20,18 +20,25 @@ description: "Run Floe locally with Docker Compose."
     ```bash
     cp .env.docker.example .env
     ```
-    The defaults work for a local single-machine run. No changes are needed to try it out.
+    The defaults work for a local single-machine setup. No changes are needed to try it out.
   </Step>
   <Step title="Start the stack">
     ```bash
     docker compose up -d --build
     ```
+    Docker builds and starts the client and server containers. The first build takes a few minutes.
   </Step>
   <Step title="Open the app">
-    Open [http://localhost:3000](http://localhost:3000) in your browser. Open it in a second tab (or on another device on your local network), start a transfer in one tab, and join with the room code in the other.
+    Open [http://localhost:3000](http://localhost:3000) in your browser. Open the same URL in a second tab (or on another device on the same network), start a transfer in one tab, and join with the room code in the other.
   </Step>
 </Steps>
 
 ## What this runs
 
-This starts the stack in **STUN-only** mode: direct peer-to-peer connections, which work on most home and mobile networks. To support peers behind strict or symmetric NAT or CGNAT, add a [TURN relay](/self-hosting/turn-relay).
+This starts the stack in **STUN-only** mode. Direct peer-to-peer connections are used, which work on most home and mobile networks. No files pass through the server.
+
+To support peers behind strict firewalls, symmetric NAT, or CGNAT, add a [TURN relay](/self-hosting/turn-relay).
+
+<Note>
+  `NEXT_PUBLIC_SOCKET_URL` defaults to `http://localhost:3001` in `.env.docker.example`, which works when both the browser and the server are on the same machine. If you want to access the app from another device on your network, update this to your machine's LAN IP (e.g. `http://192.168.1.x:3001`) and rebuild the client image. See [Build-Time URL Caveat](/self-hosting/build-time-url) for why.
+</Note>

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -3,11 +3,15 @@ title: "TURN Relay (coturn)"
 description: "Add a TURN server to support peers behind strict NAT or CGNAT."
 ---
 
-A TURN server relays the (still end-to-end encrypted) stream when two peers cannot reach each other directly. This is common with symmetric NAT or carrier-grade NAT. Without it, those specific transfers fail. Everything else still works.
+A TURN server relays the (still end-to-end encrypted) stream when two peers cannot reach each other directly. This is common with symmetric NAT or carrier-grade NAT. Without TURN, those specific transfers fail. All other transfers still work over direct connections.
 
 ## Infrastructure requirements
 
-TURN has real infrastructure requirements: a **public IP**, a **domain**, and **TLS certificates**. The bundled `coturn` service uses host networking and is intended for a Linux host with a public IP.
+TURN requires a **public IP address**, a **domain name**, and **TLS certificates**. The bundled `coturn` service uses host networking and is intended for a Linux host with a public IP.
+
+<Warning>
+  The coturn service uses host networking (`network_mode: host`). This only works on Linux. On macOS or Windows with Docker Desktop, you will need to run coturn separately or on a Linux VM.
+</Warning>
 
 ## Setup
 
@@ -16,23 +20,32 @@ TURN has real infrastructure requirements: a **public IP**, a **domain**, and **
     ```bash
     cp coturn/turnserver.conf.example coturn/turnserver.conf
     ```
-    Edit `coturn/turnserver.conf`:
-    - Set `static-auth-secret` to a strong random value
-    - Set `realm` to your TURN hostname
-    - Point `cert` and `pkey` at your TLS certificate and key (mount them into the container; see the volume hint in `docker-compose.yml`)
+
+    Edit `coturn/turnserver.conf` and set:
+    - `static-auth-secret` to a strong random value (e.g. `openssl rand -hex 32`)
+    - `realm` to your TURN hostname (e.g. `turn.your-domain.com`)
+    - `cert` and `pkey` to the paths of your TLS certificate and key
+
+    See the volume mounts in `docker-compose.yml` for how to make certificates available inside the container.
   </Step>
   <Step title="Match the server environment">
     In `.env`:
-    ```
+
+    ```env
     TURN_SECRET=<same value as static-auth-secret>
     TURN_DOMAIN=turn.your-domain.com
     ```
+
+    The signaling server uses these to issue time-limited HMAC-SHA1 credentials for coturn. Credentials expire after 24 hours.
   </Step>
   <Step title="Open firewall ports">
-    On the host, open:
-    - `3478` (STUN/TURN)
-    - `5349` (TURNS)
-    - `49152-65535` UDP (relay range, configurable in `turnserver.conf`)
+    On the host, open the following ports:
+
+    | Port | Protocol | Purpose |
+    |------|----------|---------|
+    | `3478` | UDP/TCP | STUN and TURN |
+    | `5349` | UDP/TCP | TURNS (TURN over TLS) |
+    | `49152-65535` | UDP | Relay data range (configurable in `turnserver.conf`) |
   </Step>
   <Step title="Start the stack with the TURN profile">
     ```bash
@@ -43,12 +56,22 @@ TURN has real infrastructure requirements: a **public IP**, a **domain**, and **
 
 ## Verify
 
+Check that the signaling server returns TURN credentials:
+
 ```bash
 curl http://localhost:3001/api/turn-credentials
 ```
 
-The response should include `turn:` and `turns:` entries in addition to STUN.
+The response should include `turn:` and `turns:` entries alongside STUN:
 
-## How it works
+```json
+[
+  { "urls": "stun:stun.l.google.com:19302" },
+  { "urls": "turn:turn.your-domain.com:3478", "username": "...", "credential": "..." },
+  { "urls": "turns:turn.your-domain.com:5349", "username": "...", "credential": "..." }
+]
+```
 
-The server generates time-limited HMAC-SHA1 credentials (24-hour TTL) that coturn validates against the shared secret. No per-user accounts are needed.
+## How credentials work
+
+The signaling server generates time-limited credentials using HMAC-SHA1. The username is `{expiry_unix_timestamp}:floeuser` and the password is `base64(HMAC-SHA1(TURN_SECRET, username))`. coturn validates these against the shared secret without needing a database of user accounts.

--- a/docs/self-hosting/without-docker.mdx
+++ b/docs/self-hosting/without-docker.mdx
@@ -3,23 +3,41 @@ title: "Without Docker"
 description: "Run Floe components directly with Node, pnpm, and Go."
 ---
 
-If you prefer to run the components directly without Docker, the manual setup steps and environment variable reference are in [CONTRIBUTING.md](https://github.com/jannskiee/floe/blob/main/CONTRIBUTING.md#development-setup).
+If you prefer to run the components without Docker, the complete manual setup steps are in [CONTRIBUTING.md](https://github.com/jannskiee/floe/blob/main/CONTRIBUTING.md#development-setup). The same environment variables documented in [Configuration](/self-hosting/configuration) apply.
 
-The same environment variables documented in [Configuration](/self-hosting/configuration) apply. Run each component with:
+## Running each component
 
 ```bash
-# Server
+# Signaling server (Node.js)
 cd server
 npm install
 npm start
 
-# Client
+# Web client (Next.js)
 cd client
 pnpm install
 pnpm build
 pnpm start
 
-# CLI (optional, for local testing)
+# CLI (optional, for local testing against your server)
 cd cli
 go build ./cmd/floe
+./floe send photo.jpg --server http://localhost:3001
 ```
+
+<Note>
+  The client requires a production build (`pnpm build` then `pnpm start`) to serve static files. Use `pnpm dev` only during development, as it enables Next.js hot-reloading and is not suitable for production.
+</Note>
+
+## Environment variables
+
+Copy and configure the environment files before starting:
+
+```bash
+cp server/.env.example server/.env
+cp client/.env.example client/.env.local
+```
+
+Set at minimum:
+- In `server/.env`: `CLIENT_URL=http://localhost:3000`
+- In `client/.env.local`: `NEXT_PUBLIC_SOCKET_URL=http://localhost:3001`


### PR DESCRIPTION
…-platform

Content depth pass across every docs page:

- introduction: reword "Three questions answered" -> "Common questions", expand to 7 FAQs (where files go, size limits, accounts, speed, browser support, CLI, open source)
- quickstart: expand browser sender/receiver flow with UI labels, relay toggle, download options, iOS tip; add realistic CLI output with progress bars; replace two-sentence cross-platform section with a 4-combination table and explanation of Socket.IO + WebSocket interop and the browser-link-only caveat
- cli/installation: fix broken artifact names (real naming: floe_vX.Y.Z_os_arch, not floe_Darwin_arm64); add one-liner with GitHub API version detection, per-OS PATH setup, checksum verification step
- cli/send: realistic output block (banner, Waiting/Connecting/Connected, per-file progress bars, All files sent); document folder structure preservation and cancel
- cli/receive: document Accept? [Y/n] prompt, overwrite behavior, path-safety, accepts code or link
- cli/version: minor polish
- cli/flags: add --web example and cross-link
- cli/self-hosted-server: clarify --server vs --web distinction, cleaner examples
- self-hosting/configuration: add NODE_ENV, add Default column, minimal vs production config examples
- self-hosting/quickstart: add Note about LAN IP and rebuild requirement
- self-hosting/build-time-url: add Warning callout for the common mistake
- self-hosting/production: add WebSocket proxy note
- self-hosting/turn-relay: add Warning for Linux-only host networking, port table, credential format example in verify response, explain credential scheme
- self-hosting/operations: add health response shapes, restart example, update note
- self-hosting/without-docker: add dev note, env file copy instructions
- how-it-works/*: keep plain-language main text; add Accordion with precise technical mechanics (ICE/STUN/TURN, trickle ICE, DTLS/SCTP for data channels, per-session keys, credential scheme, relay detection polling)