### PR TITLE
feat: trim /how-it-works, add Docs links, deepen docs How It Works

### DIFF
--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { ArrowLeft, Zap, Server, ShieldCheck } from 'lucide-react';
+import { ArrowLeft, Zap, Server, ShieldCheck, BookOpen } from 'lucide-react';
 import Link from 'next/link';
 
 export default function HowItWorks() {
@@ -19,7 +19,7 @@ export default function HowItWorks() {
                         How Floe Works
                     </h1>
                     <p className="text-zinc-400">
-                        A plain-language guide to what happens behind the scenes when you share a file.
+                        A plain-language overview of what happens behind the scenes when you share a file.
                     </p>
                 </div>
 
@@ -34,151 +34,106 @@ export default function HowItWorks() {
                         one browser to another. Think of it like handing a USB drive to someone. It
                         happens over the internet, in real time. In most cases, no one else is in the middle.
                         <br /><br />
-                        In some network situations, a secure relay
-                        server acts as a bridge. Either way, your files are <strong>end-to-end encrypted</strong> and
-                        never stored on any server.
+                        In some network situations, a secure relay server acts as a bridge. Either way,
+                        your files are <strong>end-to-end encrypted</strong> and never stored on any server.
                     </p>
                 </div>
 
-                <div className="space-y-10 text-zinc-300 leading-relaxed">
-
-                    {/* Section 1 */}
-                    <section className="space-y-4">
-                        <h3 className="text-xl font-semibold text-white">Signaling</h3>
-                        <p>
-                            When you drop files into Floe, a unique one-time link is created. Our signaling server
-                            (<code className="text-xs bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-300">api.floe.one</code>) plays
-                            the role of a matchmaker. When the recipient opens your link, both browsers
-                            introduce themselves to each other through this server.
-                        </p>
-                        <p>
-                            Once both sides have said hello, the signaling server steps completely out of the
-                            picture. It does not handle any file data, does not store anything, and does not
-                            participate in the transfer.
-                        </p>
-                    </section>
-
-                    {/* Section 2 */}
-                    <section className="space-y-4">
-                        <div className="flex items-center gap-3">
-                            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-green-500/10 ring-1 ring-green-500/20">
+                {/* Direct + Relay side-by-side cards */}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div className="p-5 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-3">
+                        <div className="flex items-center gap-2.5">
+                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-green-500/10 ring-1 ring-green-500/20">
                                 <Zap className="w-4 h-4 text-green-400" />
                             </div>
-                            <h3 className="text-xl font-semibold text-white">
-                                Direct Connection
-                                <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-400 ring-1 ring-green-500/20">Fastest</span>
-                            </h3>
+                            <div>
+                                <p className="text-sm font-semibold text-white leading-none">Direct Connection</p>
+                                <span className="text-[10px] text-green-400 font-medium uppercase tracking-wide">Fastest</span>
+                            </div>
                         </div>
-                        <p>
-                            A direct connection means your files travel straight from your device to the
-                            recipient&apos;s device, like a private tunnel between two computers with no stops
-                            in between.
+                        <p className="text-sm text-zinc-400 leading-relaxed">
+                            Files travel straight from your device to the recipient. No server sits in between.
+                            Speed is limited only by your internet connection.
                         </p>
-                        <p>
-                            To find this direct path, WebRTC uses a <strong>STUN server</strong>. Think of a STUN
-                            server like asking a friend outside your house &quot;what does my address look like from
-                            out there?&quot; It helps each browser discover its public internet address so they can
-                            reach each other.
-                        </p>
-                        <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4 space-y-2">
-                            <p className="text-sm font-semibold text-white">Direct Connection: what it means for you</p>
-                            <ul className="list-disc list-inside space-y-1.5 text-sm text-zinc-400 ml-2">
-                                <li>Maximum speed, limited only by your internet connection</li>
-                                <li>No file size limits</li>
-                                <li>Zero bandwidth cost to Floe</li>
-                                <li>Your files never touch a server</li>
-                            </ul>
-                        </div>
-                        <p>
-                            Most home and mobile networks support direct connections. You are most likely to see
-                            this on standard home Wi-Fi or a personal mobile hotspot.
-                        </p>
-                    </section>
+                        <ul className="space-y-1 text-xs text-zinc-500">
+                            <li className="flex items-center gap-1.5"><span className="text-green-500">+</span> No file size limit</li>
+                            <li className="flex items-center gap-1.5"><span className="text-green-500">+</span> Zero bandwidth cost to Floe</li>
+                            <li className="flex items-center gap-1.5"><span className="text-green-500">+</span> Works on most home and mobile networks</li>
+                        </ul>
+                    </div>
 
-                    {/* Section 3 */}
-                    <section className="space-y-4">
-                        <div className="flex items-center gap-3">
-                            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-500/10 ring-1 ring-amber-500/20">
+                    <div className="p-5 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-3">
+                        <div className="flex items-center gap-2.5">
+                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-500/10 ring-1 ring-amber-500/20">
                                 <Server className="w-4 h-4 text-amber-400" />
                             </div>
-                            <h3 className="text-xl font-semibold text-white">
-                                Relay Connection
-                                <span className="ml-2 inline-flex items-center gap-1 rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-400 ring-1 ring-amber-500/20">Via TURN Server</span>
-                            </h3>
+                            <div>
+                                <p className="text-sm font-semibold text-white leading-none">Relay Connection</p>
+                                <span className="text-[10px] text-amber-400 font-medium uppercase tracking-wide">Via TURN Server</span>
+                            </div>
                         </div>
-                        <p>
-                            Some networks make it impossible to connect two browsers directly. This happens
-                            on strict corporate firewalls, university networks, or when your mobile carrier
-                            places many users behind a single shared IP address (called{' '}
-                            <strong>Carrier-Grade NAT</strong>). In these cases, a direct path simply cannot
-                            be found.
+                        <p className="text-sm text-zinc-400 leading-relaxed">
+                            Used on strict corporate firewalls or carrier-grade NAT networks where a direct
+                            path cannot be found. Floe falls back automatically.
                         </p>
-                        <p>
-                            Floe automatically falls back to a <strong>TURN server</strong>
-                            (<code className="text-xs bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-300">turn.floe.one</code>).
-                            A TURN server acts as a secure bridge. Your data passes through it on its way to
-                            the recipient. Think of it like a trusted courier who picks up a sealed, locked
-                            box from you and delivers it to the recipient without being able to open it.
-                        </p>
-                        <p>
-                            Even through a relay, your files are protected by <strong>DTLS encryption</strong>.
-                            This is the same standard used by HTTPS. The relay server sees encrypted data packets, not
-                            your actual files.
-                        </p>
-                        <div className="rounded-xl bg-zinc-900 border border-zinc-800 p-4 space-y-2">
-                            <p className="text-sm font-semibold text-white">Relay Connection: what it means for you</p>
-                            <ul className="list-disc list-inside space-y-1.5 text-sm text-zinc-400 ml-2">
-                                <li>Transfer still works even on strict networks</li>
-                                <li>Your files remain encrypted in transit</li>
-                                <li>Speeds may be slower depending on server load</li>
-                                <li>Limited to 2 GB per transfer (see below)</li>
-                            </ul>
-                        </div>
-                    </section>
+                        <ul className="space-y-1 text-xs text-zinc-500">
+                            <li className="flex items-center gap-1.5"><span className="text-amber-500">~</span> Works on restricted networks</li>
+                            <li className="flex items-center gap-1.5"><span className="text-amber-500">~</span> Files remain encrypted in transit</li>
+                            <li className="flex items-center gap-1.5"><span className="text-amber-500">~</span> Capped at 2 GB per session</li>
+                        </ul>
+                    </div>
+                </div>
 
-                    {/* Section 4 */}
-                    <section className="space-y-4">
-                        <h3 className="text-xl font-semibold text-white">Why the 2 GB Limit on Relay?</h3>
-                        <p>
-                            When your files go through our TURN relay server, every byte of data passes through
-                            our infrastructure. That costs real money in server bandwidth. Direct connections
-                            cost us nothing.
-                        </p>
-                        <p>
-                            To keep Floe free and running for everyone, relay transfers are capped at
-                            <strong> 2 GB per session</strong>. This limit only applies to relay connections.
-                            Direct connections have no limit whatsoever.
-                        </p>
-                        <div className="rounded-xl bg-amber-500/5 border border-amber-500/20 p-4 space-y-2">
-                            <p className="text-sm font-semibold text-amber-400">How to get a Direct Connection</p>
-                            <ul className="list-disc list-inside space-y-1.5 text-sm text-zinc-400 ml-2">
-                                <li>Use a standard home or personal Wi-Fi network</li>
-                                <li>Disconnect from any VPN</li>
-                                <li>Avoid transferring from strict corporate or university networks</li>
-                                <li>Try using a personal mobile hotspot</li>
-                            </ul>
-                        </div>
-                    </section>
+                {/* Encryption note */}
+                <p className="text-sm text-zinc-500 text-center px-4">
+                    Every connection, direct or relayed, is encrypted with{' '}
+                    <strong className="text-zinc-400">DTLS</strong> built into WebRTC. Even the relay server cannot read your files.
+                </p>
 
-                    {/* Section 5 */}
-                    <section className="space-y-4">
-                        <h3 className="text-xl font-semibold text-white">End-to-End Encryption</h3>
-                        <p>
-                            Every WebRTC connection, whether direct or relayed, is encrypted using{' '}
-                            <strong>DTLS-SRTP</strong>. This is the same encryption standard used by your
-                            bank&apos;s website. It means even Floe&apos;s own relay server cannot read your files.
-                            The encryption keys are generated uniquely for each transfer and exist only in
-                            the two browsers involved.
-                        </p>
-                        <p>
-                            Floe has no database, stores no files, and retains no logs of what you transfer.
-                            Once the transfer is complete and both tabs are closed, the data is gone.
-                        </p>
-                    </section>
+                {/* Docs CTA */}
+                <div className="p-6 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-4">
+                    <div className="flex items-center gap-3">
+                        <BookOpen className="w-5 h-5 text-zinc-400" />
+                        <h2 className="text-base font-semibold text-white">Want the full technical detail?</h2>
+                    </div>
+                    <p className="text-sm text-zinc-400">
+                        The Floe documentation covers signaling, ICE and NAT traversal, DTLS encryption,
+                        and the binary transfer protocol in depth.
+                    </p>
+                    <a
+                        href="https://docs.floe.one/how-it-works/signaling"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-bold text-black transition hover:bg-zinc-200"
+                    >
+                        Read the full technical breakdown
+                        <ArrowLeft className="w-3.5 h-3.5 rotate-180" />
+                    </a>
+                    <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
+                        {[
+                            { label: 'Signaling', href: 'https://docs.floe.one/how-it-works/signaling' },
+                            { label: 'Direct Connection', href: 'https://docs.floe.one/how-it-works/direct-connection' },
+                            { label: 'Relay Connection', href: 'https://docs.floe.one/how-it-works/relay-connection' },
+                            { label: '2 GB Limit', href: 'https://docs.floe.one/how-it-works/2gb-limit' },
+                            { label: 'Encryption', href: 'https://docs.floe.one/how-it-works/encryption' },
+                        ].map(({ label, href }) => (
+                            <a
+                                key={label}
+                                href={href}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-[10px] text-zinc-500 uppercase tracking-wide hover:text-white transition-colors whitespace-nowrap"
+                            >
+                                {label}
+                            </a>
+                        ))}
+                    </div>
                 </div>
 
                 {/* Footer nav */}
                 <div className="pt-4 border-t border-white/5 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[10px] text-zinc-500 uppercase tracking-wide">
+                    <a href="https://docs.floe.one" target="_blank" rel="noreferrer" className="whitespace-nowrap hover:text-white transition-colors">Docs</a>
+                    <span>•</span>
                     <Link href="/privacy" className="whitespace-nowrap hover:text-white transition-colors">Privacy Policy</Link>
                     <span>•</span>
                     <Link href="/terms" className="whitespace-nowrap hover:text-white transition-colors">Terms of Use</Link>

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -60,6 +60,8 @@ export default function Home() {
                 <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[10px] text-zinc-500 uppercase tracking-wide">
                     <Link href="/how-it-works" className="whitespace-nowrap hover:text-white transition-colors">How It Works</Link>
                     <span>•</span>
+                    <a href="https://docs.floe.one" target="_blank" rel="noreferrer" className="whitespace-nowrap hover:text-white transition-colors">Docs</a>
+                    <span>•</span>
                     <Link href="/privacy" className="whitespace-nowrap hover:text-white transition-colors">Privacy Policy</Link>
                     <span>•</span>
                     <Link href="/terms" className="whitespace-nowrap hover:text-white transition-colors">Terms of Use</Link>

--- a/client/components/layout/FAQSection.tsx
+++ b/client/components/layout/FAQSection.tsx
@@ -74,7 +74,7 @@ export const FAQSection = () => {
                 />
                 <FAQItem
                     question="Is this secure?"
-                    answer="Yes. All transfers use DTLS-SRTP encryption, the same standard used to secure video calls. Whether your connection is direct or relayed, only you and your recipient can read the data. Even our own relay server handles only encrypted packets and cannot access your files."
+                    answer="Yes. All transfers use DTLS encryption built into WebRTC. Whether your connection is direct or relayed, only you and your recipient can read the data. Even our own relay server handles only encrypted packets and cannot access your files."
                 />
             </div>
         </section>

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -44,6 +44,7 @@ export const Navbar = () => {
                 <div className="flex items-center gap-0.5 sm:gap-1">
                     <button onClick={() => scrollToSection('about')} className="rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white">About</button>
                     <button onClick={() => scrollToSection('faq')} className="rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white">FAQs</button>
+                    <a href="https://docs.floe.one" target="_blank" rel="noreferrer" className="rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white">Docs</a>
                 </div>
                 <div className="h-4 w-px bg-white/10 mx-1" />
                 <a href="https://github.com/jannskiee/floe" target="_blank" rel="noreferrer" className="flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-bold text-black transition hover:bg-zinc-200">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -37,7 +37,23 @@
   "footer": {
     "socials": {
       "github": "https://github.com/jannskiee/floe"
-    }
+    },
+    "links": [
+      {
+        "header": "Floe",
+        "items": [
+          { "label": "Home", "href": "https://floe.one" },
+          { "label": "How It Works", "href": "https://floe.one/how-it-works" }
+        ]
+      },
+      {
+        "header": "Legal",
+        "items": [
+          { "label": "Privacy Policy", "href": "https://floe.one/privacy" },
+          { "label": "Terms of Use", "href": "https://floe.one/terms" }
+        ]
+      }
+    ]
   },
   "navigation": {
     "groups": [

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -5,6 +5,16 @@ description: "How Floe uses a TURN server as an encrypted bridge when a direct c
 
 Some networks make it impossible for two devices to connect directly. This happens on strict corporate firewalls, university networks, and when a mobile carrier places many users behind a single shared IP address (carrier-grade NAT). In these cases, a direct path cannot be found and Floe falls back to a relay.
 
+## Direct vs relay at a glance
+
+| | Direct | Relay |
+|---|---|---|
+| Speed | Limited only by your internet | Depends on relay server load |
+| File size limit | None | 2 GB per session |
+| When used | Most home and mobile networks | Strict firewalls, carrier-grade NAT |
+| Bandwidth cost | Zero (files never touch a server) | Uses Floe relay infrastructure |
+| Encryption | DTLS end-to-end | DTLS end-to-end |
+
 ## TURN fallback
 
 When a direct connection fails, Floe automatically routes through a **TURN server** (`turn.floe.one`). A TURN server acts as a secure bridge. Your data travels through it on the way to the recipient, like a courier carrying a locked box it cannot open.

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -7,6 +7,15 @@ When you create a transfer in Floe, a unique room is created on the signaling se
 
 The signaling server never touches file data, never stores anything about your transfer, and plays no part once the WebRTC connection is established.
 
+## Connection lifecycle
+
+1. You create a transfer and share the link or short code with the recipient.
+2. Both devices join the same room on the signaling server.
+3. The server assigns roles: the first peer to join is the **sender**, the second is the **receiver**.
+4. Peers exchange a WebRTC offer, answer, and ICE candidates through the server.
+5. Once a usable network path is found, a direct data channel opens between the two devices.
+6. The signaling server plays no further part. All file data flows over the data channel.
+
 ## What the signaling server does
 
 - Assigns roles: the first peer to join a room becomes the **sender**, the second becomes the **receiver**.
@@ -36,4 +45,12 @@ The signaling server never touches file data, never stores anything about your t
   **TURN credentials:** Issued via `GET /api/turn-credentials`. Credentials use HMAC-SHA1 with a 24-hour expiry. If `TURN_SECRET` is not set, the endpoint returns STUN servers only.
 
   **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint.
+
+  **Data-channel transfer protocol:** Once the WebRTC data channel labeled `floe` opens, the sender runs this sequence for each file:
+  1. Sends a JSON `metadata` message containing the filename, size in bytes, and MIME type.
+  2. Waits for the receiver to reply with a JSON `ack` message.
+  3. Streams the file as binary chunks of up to 16 KB each until the full file is sent.
+  4. Sends a JSON `end` message to signal completion.
+
+  For multi-file transfers, this four-step sequence repeats for each file in order.
 </Accordion>


### PR DESCRIPTION
- Replace 5-section technical page with concise overview and prominent CTA linking to docs.floe.one for full technical detail
- Fix DTLS-SRTP inaccuracy in how-it-works page and FAQSection (data channels use DTLS over SCTP, not DTLS-SRTP which is for media)
- Add Docs link to site navbar and home/how-it-works footer nav rows
- Add footer link groups (Floe and Legal) to docs.json pointing to floe.one/how-it-works, /privacy, and /terms
- Add Direct vs Relay comparison table to relay-connection.mdx
- Add connection lifecycle section and data-channel transfer protocol detail (metadata/ack/16 KB chunks/end) to signaling.mdx