### PR TITLE
docs: fix inaccuracies and tighten accuracy across docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Browser peers communicate via **Socket.IO**; CLI peers communicate via **WebSock
 `GET /api/turn-credentials` issues short-lived (24h) Coturn HMAC-SHA1 credentials. Called by both client and CLI before connecting. If `TURN_SECRET` is unset, only STUN is returned.
 
 ### Rate Limiting
-30 connections per IP per 60s — shared across Socket.IO, WebSocket, and the TURN endpoint. Tracked in a plain `Map`; cleaned every 60s.
+Two independent per-IP limiters, each over a 60s window, tracked in plain `Map`s and cleaned every 60s. Connection limiter: 30 per IP, shared across Socket.IO and WebSocket connections (`checkRateLimit`). TURN endpoint: a separate 20 requests per IP for `GET /api/turn-credentials` (`turnRateLimits`).
 
 ### React Strict Mode is intentionally disabled
 `next.config.mjs` sets `reactStrictMode: false`. Strict Mode's double-mount breaks Socket.IO connections and `simple-peer` instances. All socket/peer logic uses refs and cleanup functions to handle component lifecycle correctly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,8 +86,10 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `CLIENT_URL` | Yes | Frontend origin for CORS (default: `http://localhost:3000`) |
+| `CLIENT_URL` | Prod | Frontend origin added to the CORS allow-list. `http://localhost:3000` is already allowed by default, so this is only needed for other origins (production). |
 | `PORT` | No | Signaling server port (default: `3001`) |
+| `NODE_ENV` | No | Runtime environment (default: `production`). Set to `development` for verbose logging. |
+| `TRUSTED_PROXY_COUNT` | No | Trusted reverse-proxy hop count for correct client-IP parsing and rate limiting (default: `1`). Set to `0` for direct exposure with no proxy. |
 | `TURN_SECRET` | No | Shared secret for coturn HMAC credentials. Omit to use STUN-only (direct connections). |
 | `TURN_DOMAIN` | No | Your TURN relay server domain. |
 

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -37,6 +37,8 @@ floe receive olive-tiger-castle -y
 
 ## Output
 
+Running `floe receive olive-tiger-castle -o ~/Downloads`:
+
 ```
 Connecting to sender...
 Connected
@@ -49,8 +51,10 @@ Connected
 
   [2/2] notes.txt  [████████████████] 14 KB/14 KB
 
-  Done. 2 file(s) received in .
+  Done. 2 file(s) received in ~/Downloads
 ```
+
+With no `-o` flag, files save to the current directory.
 
 ## Confirmation prompt
 

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -40,7 +40,7 @@ The signaling server never touches file data, never stores anything about your t
   5. Both peers exchange ICE candidates via `signal` events (trickle ICE).
   6. Once ICE negotiation completes, the WebRTC data channel opens directly between the peers.
 
-  **Short codes:** Registered via `POST /api/code` with a room UUID. The server picks three random words from a 384-word list and maps them to the room ID with a 10-minute TTL. `GET /api/code/:code` resolves a code back to its room UUID.
+  **Short codes:** Registered via `POST /api/code` with a room UUID. The server picks three random words from a 288-word list and maps them to the room ID with a 10-minute TTL. `GET /api/code/:code` resolves a code back to its room UUID.
 
   **TURN credentials:** Issued via `GET /api/turn-credentials`. Credentials use HMAC-SHA1 with a 24-hour expiry. If `TURN_SECRET` is not set, the endpoint returns STUN servers only.
 
@@ -49,7 +49,7 @@ The signaling server never touches file data, never stores anything about your t
   **Data-channel transfer protocol:** Once the WebRTC data channel labeled `floe` opens, the sender runs this sequence for each file:
   1. Sends a JSON `metadata` message containing the filename, size in bytes, and MIME type.
   2. Waits for the receiver to reply with a JSON `ack` message.
-  3. Streams the file as binary chunks of up to 16 KB each until the full file is sent.
+  3. Streams the file as binary chunks until the whole file is sent. The CLI uses 16 KB chunks; the browser sender uses larger adaptive chunks.
   4. Sends a JSON `end` message to signal completion.
 
   For multi-file transfers, this four-step sequence repeats for each file in order.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -61,7 +61,7 @@ description: "Send your first file in under a minute."
     The recipient runs:
 
     ```bash
-    floe receive olive-tiger-castle
+    floe receive olive-tiger-castle -o ~/Downloads
     ```
 
     Or they can open the link in any browser. Once connected, the CLI shows a confirmation prompt and then a live progress bar:
@@ -76,10 +76,10 @@ description: "Send your first file in under a minute."
 
       [1/1] photo.jpg  [████████░░░░░░░] 4.2 MB/6.0 MB
 
-      Done. 1 file(s) received in .
+      Done. 1 file(s) received in ~/Downloads
     ```
 
-    Pass `-y` to auto-accept without the prompt. Pass `-o <dir>` to save files to a specific directory.
+    Pass `-y` to auto-accept without the prompt. Omit `-o` to save to the current directory instead.
   </Step>
 </Steps>
 

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -13,7 +13,7 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 | `PORT` | server | No | `3001` | Port the signaling server listens on inside the container. The host port is set separately in `docker-compose.yml`. |
 | `NODE_ENV` | server | No | `production` | Runtime environment. Set to `development` to enable verbose logging. |
 | `CLIENT_URL` | server | Yes (prod) | _(none)_ | Frontend origin allowed by CORS. Set to your client's public URL (e.g. `https://app.your-domain.com`). |
-| `TRUSTED_PROXY_COUNT` | server | No | `0` | Number of trusted reverse-proxy hops in front of the server. Used for correct `X-Forwarded-For` parsing and per-IP rate limiting. Set to `1` if you are behind a single proxy. |
+| `TRUSTED_PROXY_COUNT` | server | No | `1` | Number of trusted reverse-proxy hops in front of the server, used for correct `X-Forwarded-For` parsing and per-IP rate limiting. Defaults to `1` (behind one proxy such as Render, Fly, or Vercel). Set to `0` only for direct exposure with no proxy. |
 | `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for coturn credentials. If empty, the server returns STUN-only and no TURN is offered. Must match coturn's `static-auth-secret`. |
 | `TURN_DOMAIN` | server | No | _(none)_ | Public hostname of your TURN server (e.g. `turn.your-domain.com`). Must match coturn's `realm`. |
 


### PR DESCRIPTION
- Correct short-code word list size (384 -> 288) in signaling.mdx to match server/words.json
- Correct TRUSTED_PROXY_COUNT default (0 -> 1) in configuration.mdx to match server.js and the example env files
- Generalize the data-channel chunk size note: CLI uses 16 KB, the browser sender uses larger adaptive chunks
- Use a concrete output directory in the receive samples so the completion line reads naturally (was "received in .")
- Align CONTRIBUTING server env table with the code: add NODE_ENV and TRUSTED_PROXY_COUNT, fix the CLIENT_URL row (no default; localhost is already allowed)