### PR TITLE
docs: redesign footer into balanced Product/Documentation/Legal columns

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -40,10 +40,18 @@
     },
     "links": [
       {
-        "header": "Floe",
+        "header": "Product",
         "items": [
-          { "label": "Home", "href": "https://floe.one" },
+          { "label": "Floe App", "href": "https://floe.one" },
           { "label": "How It Works", "href": "https://floe.one/how-it-works" }
+        ]
+      },
+      {
+        "header": "Documentation",
+        "items": [
+          { "label": "Quick Start", "href": "/quickstart" },
+          { "label": "CLI", "href": "/cli/installation" },
+          { "label": "Self-Hosting", "href": "/self-hosting/overview" }
         ]
       },
       {


### PR DESCRIPTION
The footer had two sparse columns that looked unbalanced. Restructure into three professional, evenly weighted columns and surface the docs' own key pages (Quick Start, CLI, Self-Hosting) alongside the product and legal links.