### PR TITLE
docs: troubleshooting page, social preview metadata, and footer/appearance polish

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -19,7 +19,8 @@
     "body": { "family": "Geist" }
   },
   "appearance": {
-    "default": "dark"
+    "default": "dark",
+    "strict": true
   },
   "seo": {
     "metatags": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,6 +21,15 @@
   "appearance": {
     "default": "dark"
   },
+  "seo": {
+    "metatags": {
+      "og:type": "website",
+      "og:site_name": "Floe",
+      "og:image": "https://floe.one/og.png",
+      "twitter:card": "summary_large_image",
+      "twitter:image": "https://floe.one/og.png"
+    }
+  },
   "navbar": {
     "links": [
       {
@@ -59,7 +68,7 @@
     "groups": [
       {
         "group": "Getting Started",
-        "pages": ["introduction", "quickstart"]
+        "pages": ["introduction", "quickstart", "troubleshooting"]
       },
       {
         "group": "CLI",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,14 +47,6 @@
         ]
       },
       {
-        "header": "Documentation",
-        "items": [
-          { "label": "Quick Start", "href": "/quickstart" },
-          { "label": "CLI", "href": "/cli/installation" },
-          { "label": "Self-Hosting", "href": "/self-hosting/overview" }
-        ]
-      },
-      {
         "header": "Legal",
         "items": [
           { "label": "Privacy Policy", "href": "https://floe.one/privacy" },

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,0 +1,88 @@
+---
+title: "Troubleshooting"
+description: "Fixes for the most common issues when sending, receiving, or self-hosting Floe."
+---
+
+Most Floe transfers just work. When something goes wrong, it is almost always one of the cases below.
+
+## Sending and receiving
+
+<AccordionGroup>
+  <Accordion title="The page says my browser is not supported">
+    Floe needs WebRTC, which is unavailable in some in-app browsers (the web views embedded in Facebook, Instagram, TikTok, and similar apps). Open the link in a real browser instead: Chrome, Safari, Edge, or Firefox. Floe detects these in-app browsers and prompts you to switch.
+  </Accordion>
+
+  <Accordion title="The transfer never starts or is stuck connecting">
+    Both peers must be present at the same time, and the connection is direct, so a few things can hold it up:
+
+    - The sender must keep their browser tab open for the entire transfer. If the sender closes the tab, the session ends.
+    - The recipient must actually open the shared link (or run `floe receive`). The transfer begins automatically once both sides connect.
+    - On strict networks, a direct path may not be possible. Make sure **Network Relay Fallback** is enabled (it is on by default) so Floe can route through the encrypted relay.
+  </Accordion>
+
+  <Accordion title="Transfer blocked: relay limit exceeded">
+    Relay connections are capped at **2 GB per session** to keep the service free. Direct connections have no size limit. To get a direct connection:
+
+    - Use a standard home or personal Wi-Fi network.
+    - Disconnect from any VPN.
+    - Avoid strict corporate or university networks.
+    - Try a personal mobile hotspot.
+
+    See [The 2 GB Relay Limit](/how-it-works/2gb-limit) for the details.
+  </Accordion>
+
+  <Accordion title="The transfer is slow">
+    Check the connection indicator. **Green (Direct)** is as fast as the slower of the two connections. **Amber (Relay)** routes through a TURN server, so speed depends on relay load and network conditions. To force the faster direct path, follow the steps above to obtain a direct connection.
+  </Accordion>
+
+  <Accordion title="Downloads fail or behave oddly on iOS">
+    On iOS, use **Download ZIP** rather than downloading files individually. It is the most reliable option on Safari and iOS web views.
+  </Accordion>
+
+  <Accordion title="My short code does not work">
+    Short codes expire **10 minutes** after the sender starts the session. After that, only the full link works, and only while the sender is still connected. Ask the sender to start a new session for a fresh code.
+  </Accordion>
+</AccordionGroup>
+
+## CLI
+
+<AccordionGroup>
+  <Accordion title="The CLI cannot reach the server">
+    The CLI connects to `https://api.floe.one` by default. If you are using a self-hosted instance, pass `--server` with your signaling server URL, and make sure **both** the sender and receiver use the same value. See [Against a Self-Hosted Server](/cli/self-hosted-server).
+  </Accordion>
+
+  <Accordion title="A browser recipient cannot join my CLI transfer">
+    A browser can only join by opening the link, not by entering a short code (there is no code field in the web UI). Share the **link** printed by `floe send` with browser recipients, and the **code** with CLI recipients.
+  </Accordion>
+</AccordionGroup>
+
+## Self-hosting
+
+<AccordionGroup>
+  <Accordion title="The browser cannot connect to my signaling server">
+    This is the most common self-hosting issue. `NEXT_PUBLIC_SOCKET_URL` is inlined into the client **at build time**, so changing it on a running container has no effect. After changing it, rebuild the client image:
+
+    ```bash
+    docker compose build client
+    docker compose up -d
+    ```
+
+    Also confirm the URL is reachable from the end user's browser. `http://localhost:3001` only works when the browser runs on the same machine as the server. See [Build-Time URL Caveat](/self-hosting/build-time-url).
+  </Accordion>
+
+  <Accordion title="Browser requests are blocked by CORS">
+    Set `CLIENT_URL` to your client's public origin (e.g. `https://app.your-domain.com`). It is added to the server's CORS allow-list. `http://localhost:3000` is already allowed by default. See [Production Deployment](/self-hosting/production).
+  </Accordion>
+
+  <Accordion title="I am being rate limited (429 or Rate limit exceeded)">
+    The server allows 30 connections per IP per 60 seconds (Socket.IO and WebSocket) and 20 requests per IP per 60 seconds for TURN credentials. Behind a reverse proxy, set `TRUSTED_PROXY_COUNT` to the number of proxy hops so the server reads real client IPs instead of the proxy IP. See [Configuration](/self-hosting/configuration).
+  </Accordion>
+
+  <Accordion title="The TURN relay is not working">
+    The bundled coturn service uses host networking, so it runs on a **Linux host** with a public IP, a domain, and TLS certificates. On macOS or Windows with Docker Desktop, run coturn separately or on a Linux VM. Confirm that `TURN_SECRET` and `TURN_DOMAIN` in `.env` match coturn's `static-auth-secret` and `realm`, then start the stack with `docker compose --profile turn up -d --build`. See [TURN Relay](/self-hosting/turn-relay).
+  </Accordion>
+</AccordionGroup>
+
+## Still stuck?
+
+If none of the above helps, open an issue on [GitHub](https://github.com/jannskiee/floe/issues) with your browser and OS, whether the connection was direct or relay, and any error message you saw.


### PR DESCRIPTION
## Summary

Final polish pass on the Floe documentation site (docs.floe.one), building on the earlier rebuild and accuracy work. This PR adds a troubleshooting guide, makes shared docs links render a proper social preview, and tidies the footer and theme behavior.

## Changes

**New: Troubleshooting page**
- Adds `docs/troubleshooting.mdx`, linked into the Getting Started group (Introduction, Quick Start, Troubleshooting).
- Consolidates the common issues that were previously scattered across pages, grouped into Sending and receiving, CLI, and Self-hosting.
- Covers unsupported in-app browsers, stuck transfers, the 2 GB relay cap, iOS downloads, expired short codes, CLI server flags, and the main self-hosting pitfalls (build-time URL rebuild, CORS, rate limiting, TURN on Linux). Each item links to the deeper reference page.

**SEO and social preview**
- Adds a `seo.metatags` block so links to the docs render an Open Graph / Twitter preview card.
- Reuses the already-deployed 1200x630 `floe.one/og.png` for consistent branding.
- Only static and image tags are set globally, so Mintlify's per-page Open Graph titles (generated from each page's frontmatter) stay intact.

**Footer**
- Slims the footer to two clean columns: Product (Floe App, How It Works) and Legal (Privacy Policy, Terms of Use), plus the GitHub social icon.

**Appearance**
- Sets `appearance.strict` so the docs lock to dark mode and the System/Light/Dark switcher no longer renders in the footer, matching Floe's brand and decluttering the footer.

## Verification

- `docs.json` validated as well-formed JSON.
- No em dashes in any docs page (project style rule).
- All internal links in the troubleshooting page resolve to existing pages.
- Technical claims cross-checked against the source (`server/server.js`, the CLI `internal/` packages, and the client) in the preceding accuracy pass.