### PR TITLE
fix: correct inaccurate technical claims in docs and add dotenv to se…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 |----------|----------|-------------|
 | `CLIENT_URL` | Prod | Frontend origin added to the CORS allow-list. `http://localhost:3000` is already allowed by default, so this is only needed for other origins (production). |
 | `PORT` | No | Signaling server port (default: `3001`) |
-| `NODE_ENV` | No | Runtime environment (default: `production`). Set to `development` for verbose logging. |
+| `NODE_ENV` | No | Standard Node.js runtime flag (`development` or `production`). |
 | `TRUSTED_PROXY_COUNT` | No | Trusted reverse-proxy hop count for correct client-IP parsing and rate limiting (default: `1`). Set to `0` for direct exposure with no proxy. |
 | `TURN_SECRET` | No | Shared secret for coturn HMAC credentials. Omit to use STUN-only (direct connections). |
 | `TURN_DOMAIN` | No | Your TURN relay server domain. |

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you encounter a bug or have a feature suggestion, please open an [issue](http
 
 ## Support
 
-Floe is free and open source. Contributions help cover the ongoing costs of backend infrastructure that keeps the service accessible to everyone. This includes the signaling server for WebRTC connection negotiation and room management, and the TURN relay server for encrypted relay for users behind strict firewalls or Carrier-Grade NAT.
+Floe is free and open source. Contributions help cover the ongoing costs of backend infrastructure that keeps the service accessible to everyone. This includes the signaling server for WebRTC connection negotiation and room management, and the TURN relay server that provides encrypted relay for users behind strict firewalls or Carrier-Grade NAT.
 
 **[GitHub Sponsors](https://github.com/sponsors/jannskiee)**\
 **[Ko-fi](https://ko-fi.com/jannskiee)**

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -46,10 +46,10 @@ The signaling server never touches file data, never stores anything about your t
 
   **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint.
 
-  **Data-channel transfer protocol:** Once the WebRTC data channel labeled `floe` opens, the sender runs this sequence for each file:
-  1. Sends a JSON `metadata` message containing the filename, size in bytes, and MIME type.
-  2. Waits for the receiver to reply with a JSON `ack` message.
-  3. Streams the file as binary chunks until the whole file is sent. The CLI uses 16 KB chunks; the browser sender uses larger adaptive chunks.
+  **Data-channel transfer protocol:** Once the WebRTC data channel opens, the sender runs this sequence for each file:
+  1. Sends a JSON `metadata` message with the filename, size in bytes, and the file's index and total count in the batch.
+  2. Waits for the receiver to reply with a JSON `ack` message. The ack carries a byte offset, so a transfer can resume mid-file.
+  3. Streams the file as 16 KB binary chunks until the whole file is sent. Both the CLI and the browser use 16 KB chunks; the browser sender adds backpressure-based flow control, pausing when the data channel's send buffer fills.
   4. Sends a JSON `end` message to signal completion.
 
   For multi-file transfers, this four-step sequence repeats for each file in order.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -67,7 +67,7 @@ description: "Send your first file in under a minute."
     Or they can open the link in any browser. Once connected, the CLI shows a confirmation prompt and then a live progress bar:
 
     ```
-    Connecting...
+    Connecting to sender...
     Connected
 
       Incoming: 1 file(s)

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -11,7 +11,7 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 |----------|---------|----------|---------|---------|
 | `NEXT_PUBLIC_SOCKET_URL` | client (build) | Yes | `http://localhost:3001` | URL the **browser** uses to reach the signaling server. Inlined at build time. See [the build-time URL caveat](/self-hosting/build-time-url). |
 | `PORT` | server | No | `3001` | Port the signaling server listens on inside the container. The host port is set separately in `docker-compose.yml`. |
-| `NODE_ENV` | server | No | `production` | Runtime environment. Set to `development` to enable verbose logging. |
+| `NODE_ENV` | server | No | `production` | Standard Node.js runtime flag. The server Docker image sets this to `production`. |
 | `CLIENT_URL` | server | Yes (prod) | _(none)_ | Frontend origin allowed by CORS. Set to your client's public URL (e.g. `https://app.your-domain.com`). |
 | `TRUSTED_PROXY_COUNT` | server | No | `1` | Number of trusted reverse-proxy hops in front of the server, used for correct `X-Forwarded-For` parsing and per-IP rate limiting. Defaults to `1` (behind one proxy such as Render, Fly, or Vercel). Set to `0` only for direct exposure with no proxy. |
 | `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for coturn credentials. If empty, the server returns STUN-only and no TURN is offered. Must match coturn's `static-auth-secret`. |

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -30,4 +30,4 @@ The signaling server exposes two health endpoints you can use in load balancers 
 | Endpoint | Purpose | Response |
 |----------|---------|---------|
 | `GET /health` | Liveness check | `{ "status": "healthy", "uptime": <seconds> }` |
-| `GET /` | Status and version info | `{ "status": "ok", "timestamp": "..." }` |
+| `GET /` | Status and timestamp | `{ "status": "ok", "timestamp": "..." }` |

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -62,15 +62,17 @@ Check that the signaling server returns TURN credentials:
 curl http://localhost:3001/api/turn-credentials
 ```
 
-The response should include `turn:` and `turns:` entries alongside STUN:
+When TURN is configured, the response contains `turn:` and `turns:` entries, plus a `stun:` entry pointing at your TURN host:
 
 ```json
 [
-  { "urls": "stun:stun.l.google.com:19302" },
+  { "urls": "stun:turn.your-domain.com:3478" },
   { "urls": "turn:turn.your-domain.com:3478", "username": "...", "credential": "..." },
   { "urls": "turns:turn.your-domain.com:5349", "username": "...", "credential": "..." }
 ]
 ```
+
+When `TURN_SECRET` and `TURN_DOMAIN` are unset, the endpoint instead returns the Google public STUN servers only.
 
 ## How credentials work
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",
+        "dotenv": "^16.4.7",
         "express": "^5.2.1",
         "helmet": "^8.0.0",
         "socket.io": "^4.8.3",
@@ -303,6 +304,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "cors": "^2.8.5",
+    "dotenv": "^16.4.7",
     "express": "^5.2.1",
     "helmet": "^8.0.0",
     "socket.io": "^4.8.3",

--- a/server/server.js
+++ b/server/server.js
@@ -1,3 +1,8 @@
+// Load server/.env into process.env for direct (non-Docker) runs. dotenv does not
+// override variables already set in the environment, so Docker/platform-injected
+// values take precedence and containers without a .env file are unaffected.
+require('dotenv').config();
+
 const express = require('express');
 const http = require('http');
 const { Server } = require('socket.io');


### PR DESCRIPTION
…rver

Fix several factual errors found by auditing docs against the actual source:

- signaling.mdx: metadata has no MIME type field; both CLI and browser use 16 KB chunks (not adaptive); removed the inaccurate "labeled floe" claim; clarified that ack carries a resume offset
- turn-relay.mdx: TURN-configured response returns stun:<turnDomain>:3478, not stun.l.google.com; added note that Google STUN is the STUN-only fallback
- configuration.mdx + CONTRIBUTING.md: removed unsupported "verbose logging" claim for NODE_ENV (server has no logging and never reads it)
- operations.mdx: GET / returns status+timestamp, not version info
- quickstart.mdx: CLI receiver prints "Connecting to sender...", not "Connecting..."
- README.md: minor wording fix in Support section

Add dotenv to server so server/.env is actually loaded for direct (non-Docker) runs, making the documented env-var setup work as described in CONTRIBUTING.md and docs/self-hosting/without-docker.mdx. dotenv does not override vars already set in the environment, so Docker/platform-injected values are unaffected.