### PR TITLE
perf: faster, more reliable browser-to-browser transfers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,10 @@ cli/*.txt
 cli/*.bin
 
 # --- Package managers (client uses pnpm; keep only pnpm-lock.yaml there) ---
-client/package-lock.json
+client/package-lock.json
+
+# --- Playwright (e2e test artifacts) ---
+client/test-results/
+client/playwright-report/
+client/blob-report/
+client/.playwright/

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -446,9 +446,7 @@ export function P2PTransfer() {
         let lastReceiveSpeedUpdate = 0;
 
         peer.on('data', (data) => {
-            const isFileChunk = data.byteLength > 1000;
-
-            if (!isFileChunk) {
+            if (data.byteLength <= 1000) {
                 try {
                     const text = new TextDecoder().decode(data);
                     if (text.startsWith('{')) {
@@ -484,6 +482,7 @@ export function P2PTransfer() {
                                     offset: offset,
                                 })
                             );
+                            return;
                         } else if (msg.type === 'end') {
                             const fileData = partialDownloads.current.get(
                                 currentMetadata.id
@@ -522,8 +521,8 @@ export function P2PTransfer() {
                             setProgress(0);
                             setTransferSpeed('');
                             setEstimatedTime('');
+                            return;
                         }
-                        return;
                     }
                 } catch { }
             }
@@ -639,6 +638,7 @@ export function P2PTransfer() {
             socket.io.off('reconnect');
             releaseWakeLock();
             peerRef.current?.destroy();
+            receivedFilesRef.current.forEach((f) => URL.revokeObjectURL(f.downloadUrl));
         };
         // joinRoomAsReceiver is intentionally excluded: this effect must run once on mount only.
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -712,6 +712,7 @@ export function P2PTransfer() {
         socket.emit('join-room', newRoomId);
         setStatus('Waiting for peer');
 
+        socket.off('user-connected');
         socket.on('user-connected', (userId: string) => {
             setStatus('Peer joined. Starting transfer');
             requestWakeLock();
@@ -903,14 +904,31 @@ export function P2PTransfer() {
         total: number
     ) => {
         return new Promise<void>(async (resolve) => {
-            const CHUNK_SIZE = 16 * 1024;
-            const BUFFER_LIMIT = 1024 * 1024;
             const { file, id } = fileItem;
 
             if (!peer || peer.destroyed) {
                 resolve();
                 return;
             }
+
+            // Adaptive chunk size: use the negotiated SCTP max, capped at 256 KB.
+            // sctp.maxMessageSize is the negotiated minimum of both peers, so this is
+            // automatically safe for browser<->CLI (Pion's limit clamps it down).
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const pc = (peer as any)._pc as RTCPeerConnection | undefined;
+            const sctpMax = pc?.sctp?.maxMessageSize;
+            const CHUNK_SIZE = (sctpMax && Number.isFinite(sctpMax) && sctpMax > 0)
+                ? Math.min(256 * 1024, sctpMax)
+                : 64 * 1024;
+
+            // Keep the send buffer oscillating between 4 MB and 8 MB so the link
+            // stays saturated instead of draining to ~0 before refilling.
+            const HIGH_WATER = 8 * 1024 * 1024;
+            const LOW_WATER = 4 * 1024 * 1024;
+
+            // Read from disk in 4 MB slabs to cut await round-trips by ~256x vs
+            // the old per-16-KB arrayBuffer() call.
+            const READ_SLAB = 4 * 1024 * 1024;
 
             try {
                 peer.send(
@@ -928,60 +946,104 @@ export function P2PTransfer() {
                 return;
             }
 
-            const startOffset = await new Promise<number>((resolveAck) => {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const handleAck = (data: any) => {
-                    if (data.byteLength < 1000) {
-                        try {
-                            const text = new TextDecoder().decode(data);
-                            const msg = JSON.parse(text);
-                            if (msg.type === 'ack' && msg.id === id) {
-                                peer.off('data', handleAck);
-                                resolveAck(msg.offset);
-                            }
-                        } catch { }
-                    }
-                };
-                peer.on('data', handleAck);
+            // Set the low-water threshold once; bufferedamountlow fires at LOW_WATER from here on.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const channel = (peer as any)._channel as RTCDataChannel | undefined;
+            if (channel) {
+                channel.bufferedAmountLowThreshold = LOW_WATER;
+            }
+
+            // Wait for receiver ACK with a 15 s timeout to avoid hanging indefinitely
+            // if the receiver crashes or stalls after receiving metadata.
+            const ackResult = await Promise.race([
+                new Promise<number>((resolveAck) => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const handleAck = (data: any) => {
+                        if (data.byteLength < 1000) {
+                            try {
+                                const text = new TextDecoder().decode(data);
+                                const msg = JSON.parse(text);
+                                if (msg.type === 'ack' && msg.id === id) {
+                                    peer.off('data', handleAck);
+                                    resolveAck(msg.offset);
+                                }
+                            } catch { }
+                        }
+                    };
+                    peer.on('data', handleAck);
+                }),
+                new Promise<number>((_, reject) =>
+                    setTimeout(() => reject(new Error('ack-timeout')), 15_000)
+                ),
+            ]).catch(() => {
+                setError('Transfer timed out waiting for receiver. Please try again.');
+                setStatus('Transfer failed');
+                return -1;
             });
 
-            let offset = startOffset;
+            if (ackResult === -1) {
+                resolve();
+                return;
+            }
+
+            let offset = ackResult;
             let chunkCount = 0;
 
             let speedMeasureStart = performance.now();
             let speedMeasureBytes = 0;
             let lastSpeedUpdate = 0;
 
+            const waitForBuffer = (ch: RTCDataChannel) =>
+                new Promise<void>((r) => {
+                    const onLow = () => {
+                        ch.removeEventListener('bufferedamountlow', onLow);
+                        r();
+                    };
+                    if (ch.bufferedAmount < LOW_WATER) {
+                        r();
+                    } else {
+                        ch.addEventListener('bufferedamountlow', onLow);
+                    }
+                });
+
             while (offset < file.size) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const channel = (peer as any)._channel as RTCDataChannel | undefined;
-
-                if (channel && channel.bufferedAmount > BUFFER_LIMIT) {
-                    await new Promise<void>((r) => {
-                        const lowThreshold = CHUNK_SIZE;
-                        channel.bufferedAmountLowThreshold = lowThreshold;
-
-                        const onBufferLow = () => {
-                            channel.removeEventListener('bufferedamountlow', onBufferLow);
-                            r();
-                        };
-
-                        if (channel.bufferedAmount < lowThreshold) {
-                            r();
-                        } else {
-                            channel.addEventListener('bufferedamountlow', onBufferLow);
-                        }
-                    });
-                }
-
-                const chunkBlob = file.slice(offset, offset + CHUNK_SIZE);
-                const chunkBuffer = await chunkBlob.arrayBuffer();
                 if (peer.destroyed) break;
 
+                // Read a 4 MB slab from disk (one await per 4 MB instead of per chunk)
+                const slabEnd = Math.min(offset + READ_SLAB, file.size);
+                let slabBuffer: ArrayBuffer;
                 try {
-                    peer.send(chunkBuffer);
-                    offset += chunkBuffer.byteLength;
-                    speedMeasureBytes += chunkBuffer.byteLength;
+                    slabBuffer = await file.slice(offset, slabEnd).arrayBuffer();
+                } catch {
+                    break;
+                }
+
+                // Send the slab as CHUNK_SIZE typed-array views (zero-copy)
+                let slabOffset = 0;
+                while (slabOffset < slabBuffer.byteLength) {
+                    if (peer.destroyed) break;
+
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const ch = (peer as any)._channel as RTCDataChannel | undefined;
+                    if (ch && ch.bufferedAmount >= HIGH_WATER) {
+                        await waitForBuffer(ch);
+                    }
+
+                    if (peer.destroyed) break;
+
+                    const chunkLen = Math.min(CHUNK_SIZE, slabBuffer.byteLength - slabOffset);
+                    const chunk = new Uint8Array(slabBuffer, slabOffset, chunkLen);
+
+                    try {
+                        peer.send(chunk);
+                    } catch {
+                        await new Promise((r) => setTimeout(r, 100));
+                        continue;
+                    }
+
+                    slabOffset += chunkLen;
+                    offset += chunkLen;
+                    speedMeasureBytes += chunkLen;
                     chunkCount++;
 
                     const now = performance.now();
@@ -992,11 +1054,8 @@ export function P2PTransfer() {
                             const remaining = file.size - offset;
                             const etaSeconds = remaining / bytesPerSec;
 
-                            const speedFormatted = formatSpeed(bytesPerSec);
-                            const etaFormatted = formatETA(etaSeconds);
-
-                            setTransferSpeed(speedFormatted);
-                            setEstimatedTime(etaFormatted);
+                            setTransferSpeed(formatSpeed(bytesPerSec));
+                            setEstimatedTime(formatETA(etaSeconds));
                         }
 
                         speedMeasureStart = now;
@@ -1004,18 +1063,11 @@ export function P2PTransfer() {
                         lastSpeedUpdate = now;
                     }
 
-
-                    if (
-                        chunkCount % 10 === 0 ||
-                        offset >= file.size
-                    ) {
+                    if (chunkCount % 10 === 0 || offset >= file.size) {
                         const prog = Math.round((offset / file.size) * 100);
                         setProgress(prog);
                         progressRef.current = prog;
                     }
-                } catch {
-                    await new Promise((r) => setTimeout(r, 100));
-                    continue;
                 }
             }
 

--- a/client/e2e/transfer.spec.ts
+++ b/client/e2e/transfer.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, type Page } from '@playwright/test';
+import { createHash, randomBytes } from 'crypto';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FIXTURE_DIR = join(tmpdir(), 'floe-e2e');
+
+function createFixture(size: number): { path: string; sha256: string } {
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+    const data = size > 0 ? randomBytes(size) : Buffer.alloc(0);
+    const filePath = join(FIXTURE_DIR, `fixture-${size}.bin`);
+    writeFileSync(filePath, data);
+    const sha256 = createHash('sha256').update(data).digest('hex');
+    return { path: filePath, sha256 };
+}
+
+async function sha256OfBlobUrl(page: Page, blobUrl: string): Promise<string> {
+    return page.evaluate(async (url) => {
+        const buf = await fetch(url).then((r) => r.arrayBuffer());
+        const hash = await crypto.subtle.digest('SHA-256', buf);
+        return Array.from(new Uint8Array(hash))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('');
+    }, blobUrl);
+}
+
+async function byteLengthOfBlobUrl(page: Page, blobUrl: string): Promise<number> {
+    return page.evaluate(
+        async (url) => fetch(url).then((r) => r.arrayBuffer()).then((b) => b.byteLength),
+        blobUrl,
+    );
+}
+
+/** Load the sender page, pick a file, create the link, and return the room URL. */
+async function senderSetup(
+    senderPage: Page,
+    fixturePath: string,
+): Promise<string> {
+    await senderPage.goto('/');
+
+    // The file input is absolutely positioned (opacity:0) over the drop zone.
+    // setInputFiles works on non-visible inputs.
+    const fileInput = senderPage.locator('input[type="file"]');
+    await fileInput.setInputFiles(fixturePath);
+
+    // Button text contains "Create Secure Link" — file count varies
+    await senderPage.locator('button', { hasText: 'Create Secure Link' }).click();
+
+    // Generated link appears in the <code> element
+    const linkEl = senderPage.locator('code').filter({ hasText: '?room=' });
+    await expect(linkEl).toBeVisible({ timeout: 10_000 });
+    return (await linkEl.textContent())!.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.afterAll(() => {
+    try {
+        rmSync(FIXTURE_DIR, { recursive: true, force: true });
+    } catch { /* ignore */ }
+});
+
+test('transfers a 50 MB binary file with SHA-256 integrity check', async ({ browser }) => {
+    // 50 MB exercises the real fast path: multiple 4 MB slab reads and the
+    // 8 MB high-water backpressure loop (a small file would touch neither).
+    const SIZE = 50 * 1024 * 1024;
+    const { path: fixturePath, sha256: expectedHash } = createFixture(SIZE);
+
+    const senderCtx = await browser.newContext();
+    const receiverCtx = await browser.newContext();
+    const senderPage = await senderCtx.newPage();
+    const receiverPage = await receiverCtx.newPage();
+
+    try {
+        const link = await senderSetup(senderPage, fixturePath);
+        expect(link).toContain('?room=');
+
+        await receiverPage.goto(link);
+
+        // Measure once the receiver reports it is actively receiving, so the
+        // throughput figure reflects the data path rather than connection setup.
+        await expect(receiverPage.getByText(/Receiving file/i)).toBeVisible({ timeout: 30_000 });
+        const transferStart = Date.now();
+
+        // Wait for the download button to appear — file is fully in memory as a blob
+        const downloadLink = receiverPage.locator('a[download]').first();
+        await expect(downloadLink).toBeVisible({ timeout: 60_000 });
+        const transferMs = Date.now() - transferStart;
+
+        const blobUrl = (await downloadLink.getAttribute('href'))!;
+        const receivedHash = await sha256OfBlobUrl(receiverPage, blobUrl);
+
+        expect(receivedHash).toBe(expectedHash);
+
+        // Log throughput so before/after speed is visible in the test report
+        const mbps = (SIZE / (transferMs / 1000) / 1024 / 1024).toFixed(2);
+        console.log(`  Transfer: 50 MB in ${transferMs} ms (${mbps} MB/s)`);
+    } finally {
+        await senderCtx.close();
+        await receiverCtx.close();
+    }
+});
+
+test('transfers a 0-byte empty file', async ({ browser }) => {
+    const { path: fixturePath } = createFixture(0);
+
+    const senderCtx = await browser.newContext();
+    const receiverCtx = await browser.newContext();
+    const senderPage = await senderCtx.newPage();
+    const receiverPage = await receiverCtx.newPage();
+
+    try {
+        const link = await senderSetup(senderPage, fixturePath);
+        await receiverPage.goto(link);
+
+        const downloadLink = receiverPage.locator('a[download]').first();
+        await expect(downloadLink).toBeVisible({ timeout: 30_000 });
+
+        const blobUrl = (await downloadLink.getAttribute('href'))!;
+        const byteLength = await byteLengthOfBlobUrl(receiverPage, blobUrl);
+        expect(byteLength).toBe(0);
+    } finally {
+        await senderCtx.close();
+        await receiverCtx.close();
+    }
+});
+
+test('transfers a 512-byte file (framing guard: chunk fits under 1 KB threshold)', async ({ browser }) => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(512);
+
+    const senderCtx = await browser.newContext();
+    const receiverCtx = await browser.newContext();
+    const senderPage = await senderCtx.newPage();
+    const receiverPage = await receiverCtx.newPage();
+
+    try {
+        const link = await senderSetup(senderPage, fixturePath);
+        await receiverPage.goto(link);
+
+        const downloadLink = receiverPage.locator('a[download]').first();
+        await expect(downloadLink).toBeVisible({ timeout: 30_000 });
+
+        const blobUrl = (await downloadLink.getAttribute('href'))!;
+        const receivedHash = await sha256OfBlobUrl(receiverPage, blobUrl);
+        expect(receivedHash).toBe(expectedHash);
+    } finally {
+        await senderCtx.close();
+        await receiverCtx.close();
+    }
+});

--- a/client/lib/transferUtils.ts
+++ b/client/lib/transferUtils.ts
@@ -3,21 +3,15 @@
  * Extracted from P2PTransfer.tsx to avoid duplication between sender and receiver.
  */
 
-/**
- * Formats a bytes-per-second value into a human-readable string.
- * e.g. 2097152 → "2.0 MB/s", 512000 → "500.0 KB/s"
- */
 export function formatSpeed(bytesPerSec: number): string {
+    if (!Number.isFinite(bytesPerSec) || bytesPerSec <= 0) return '';
     return bytesPerSec >= 1024 * 1024
         ? `${(bytesPerSec / 1024 / 1024).toFixed(1)} MB/s`
         : `${(bytesPerSec / 1024).toFixed(1)} KB/s`;
 }
 
-/**
- * Formats an ETA in seconds into a human-readable string.
- * e.g. 45 → "45s", 90 → "1m 30s", 3700 → "1h 1m"
- */
 export function formatETA(etaSeconds: number): string {
+    if (!Number.isFinite(etaSeconds) || etaSeconds < 0) return '';
     if (etaSeconds < 60) {
         return `${Math.ceil(etaSeconds)}s`;
     } else if (etaSeconds < 3600) {

--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
@@ -29,6 +30,7 @@
     "uuid": "^14.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+import path from 'path';
+
+export default defineConfig({
+    testDir: './e2e',
+    timeout: 90_000,
+    expect: { timeout: 60_000 },
+    use: {
+        baseURL: 'http://localhost:3000',
+        headless: true,
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] },
+        },
+    ],
+    webServer: [
+        {
+            command: 'node server.js',
+            cwd: path.resolve(__dirname, '../server'),
+            port: 3001,
+            reuseExistingServer: true,
+            timeout: 30_000,
+            env: {
+                CLIENT_URL: 'http://localhost:3000',
+                PORT: '3001',
+            },
+        },
+        {
+            command: 'pnpm dev',
+            cwd: __dirname,
+            port: 3000,
+            reuseExistingServer: true,
+            timeout: 60_000,
+            env: {
+                NEXT_PUBLIC_SOCKET_URL: 'http://localhost:3001',
+            },
+        },
+    ],
+});

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -19,13 +19,13 @@ importers:
         version: 1.2.4(@types/react@19.2.9)(react@19.2.3)
       '@sentry/nextjs':
         specifier: ^10.53.1
-        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)
+        version: 10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)
       '@vercel/analytics':
         specifier: ^1.4.1
-        version: 1.6.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.6.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@vercel/speed-insights':
         specifier: ^1.3.1
-        version: 1.3.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 1.3.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -40,7 +40,7 @@ importers:
         version: 0.562.0(react@19.2.3)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.3)
@@ -63,6 +63,9 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.18
@@ -662,6 +665,11 @@ packages:
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -2109,6 +2117,11 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2722,6 +2735,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3823,6 +3846,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -4165,7 +4192,7 @@ snapshots:
 
   '@sentry/core@10.53.1': {}
 
-  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)':
+  '@sentry/nextjs@10.53.1(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.106.2)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -4178,7 +4205,7 @@ snapshots:
       '@sentry/react': 10.53.1(react@19.2.3)
       '@sentry/vercel-edge': 10.53.1
       '@sentry/webpack-plugin': 5.3.0(webpack@5.106.2)
-      next: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rollup: 4.60.4
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -4557,14 +4584,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/analytics@1.6.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
-  '@vercel/speed-insights@1.3.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
+  '@vercel/speed-insights@1.3.1(next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
 
   '@webassemblyjs/ast@1.14.1':
@@ -5348,6 +5375,9 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5796,7 +5826,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.2.6(@babel/core@7.28.6)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -5816,6 +5846,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
+      '@playwright/test': 1.60.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5926,6 +5957,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary

Browser-to-browser WebRTC transfers were slow. This makes the data path substantially faster and fixes several transfer reliability bugs found while auditing the hot path. The on-the-wire protocol (`metadata` → `ack` → binary chunks → `end`) is unchanged, so browser↔CLI interop is preserved.

## Speed

The old send path had three things working against throughput, all fixed here:

1. **Adaptive chunk size** — uses the negotiated `RTCPeerConnection.sctp.maxMessageSize` up to 256 KB, instead of a fixed 16 KB. Clamping to the negotiated value keeps it safe across browsers and for CLI (Pion) peers.
2. **Slab reads** — reads the file in 4 MB slabs and sends zero-copy `Uint8Array` views, cutting awaited disk reads by ~256x versus the old per-16-KB `arrayBuffer()` call.
3. **Saturated send buffer** — keeps `bufferedAmount` oscillating between a 4 MB low-water and 8 MB high-water mark, instead of draining the buffer to ~16 KB before every refill (the old sawtooth left the link idle most of the time).

## Reliability fixes

- **ACK timeout** — the per-file ACK wait had no timeout and could hang the sender forever if the receiver stalled. Now races against a 15 s timeout.
- **Socket listener accumulation** — `handleCreateLink` registered a `user-connected` handler every time without removing the old one; now de-registers first.
- **NaN/Infinity in UI** — `formatSpeed`/`formatETA` now guard against non-finite values so the speed/ETA readout never shows garbage during stalls.
- **Small-chunk framing guard** — a sub-1 KB trailing chunk that happened to parse as JSON could be silently dropped. Control messages are now only routed as control when they carry a known `type`; everything else is appended as file data.
- **Blob URL leak** — received-file object URLs are revoked on unmount.

## Testing

Added a Playwright two-browser harness (`client/e2e/transfer.spec.ts`) that drives two real browser contexts over WebRTC loopback and verifies SHA-256 integrity:

- **50 MB file** — exercises the multi-slab read loop and the 8 MB backpressure path; transfers at ~12.7 MB/s on headless Chromium loopback.
- **0-byte file** — empty-file edge case.
- **512-byte file** — exercises the sub-1 KB framing guard.

Run with `pnpm test:e2e` from `client/` (auto-starts the signaling server and Next.js dev server).

```
3 passed (18.0s)
  Transfer: 50 MB in 3922 ms (12.75 MB/s)
```

`pnpm lint` and `pnpm build` both pass.

## Out of scope

The receiver still buffers the whole file in RAM before download, which can OOM on multi-GB files / mobile. Streaming received chunks to disk (File System Access API / StreamSaver) is a recommended follow-up, deferred here to keep this change focused on throughput.