### PR TITLE
fix(client): guard duplicate WebRTC signals, fix hydration, redesign in-app browser page

### DIFF
--- a/client/components/InAppBrowserGuard.tsx
+++ b/client/components/InAppBrowserGuard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { ExternalLink, Copy, Check } from 'lucide-react';
+import { ExternalLink, Copy, Check, SquareArrowOutUpRight } from 'lucide-react';
 
 interface UmamiWindow extends Window {
     umami?: {
@@ -29,28 +29,12 @@ function detectInAppBrowser(ua: string): DetectedApp | null {
     if (/\bLine\/\d/i.test(ua)) return 'LINE';
     if (/Twitter/i.test(ua)) return 'Twitter';
     if (/MicroMessenger|WeChat/i.test(ua)) return 'WeChat';
-    // Generic Android WebView (non-Chrome)
     if (/Android/.test(ua) && /wv\)/.test(ua) && !/Chrome\/\d/.test(ua)) return 'InAppBrowser';
     return null;
 }
 
 function isAndroid(ua: string): boolean {
     return /Android/i.test(ua);
-}
-
-function getAppIcon(app: DetectedApp): string {
-    const icons: Record<DetectedApp, string> = {
-        Facebook: '📘',
-        Messenger: '💬',
-        Instagram: '📷',
-        TikTok: '🎵',
-        Snapchat: '👻',
-        LINE: '💚',
-        Twitter: '🐦',
-        WeChat: '💬',
-        InAppBrowser: '📱',
-    };
-    return icons[app] ?? '📱';
 }
 
 function copyLinkFallback(url: string) {
@@ -64,7 +48,7 @@ function copyLinkFallback(url: string) {
         document.execCommand('copy');
         document.body.removeChild(textarea);
     } catch {
-        // If even this fails, the URL is shown on screen so user can manually copy
+        // URL is visible on screen so user can copy manually
     }
 }
 
@@ -112,89 +96,130 @@ export function InAppBrowserGuard({ children }: Props) {
         return <>{children}</>;
     }
 
-    const icon = getAppIcon(detectedApp);
     const appName = detectedApp === 'InAppBrowser' ? 'this app' : detectedApp;
 
     return (
         <>
             {/* Blurred background content */}
-            <div className="pointer-events-none select-none blur-sm opacity-40" aria-hidden>
+            <div className="pointer-events-none select-none blur-sm opacity-30" aria-hidden>
                 {children}
             </div>
 
-            {/* Overlay */}
-            <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/95 p-4 backdrop-blur-sm">
-                <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-zinc-900 p-6 shadow-2xl">
+            {/* Full-screen overlay */}
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/90 p-5 backdrop-blur-md">
+                <div className="w-full max-w-sm overflow-hidden rounded-2xl border border-white/[0.08] bg-zinc-900 shadow-[0_32px_64px_-12px_rgba(0,0,0,0.8)]">
 
-                    {/* Icon + heading */}
-                    <div className="mb-5 flex flex-col items-center gap-3 text-center">
-                        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/5 text-3xl">
-                            {icon}
+                    {/* Top accent strip */}
+                    <div className="h-px w-full bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+
+                    <div className="p-6">
+                        {/* Icon + heading */}
+                        <div className="mb-6 flex flex-col items-center gap-4 text-center">
+                            {/* Gradient ring with lucide glyph */}
+                            <div className="relative flex h-16 w-16 items-center justify-center">
+                                <div className="absolute inset-0 rounded-full bg-gradient-to-br from-white/20 via-white/5 to-transparent" />
+                                <div className="absolute inset-[2px] rounded-full bg-zinc-900" />
+                                <SquareArrowOutUpRight className="relative h-6 w-6 text-white" strokeWidth={1.75} />
+                            </div>
+
+                            <div className="space-y-1.5">
+                                <h2 className="text-xl font-bold tracking-tight text-white">
+                                    Open in your browser
+                                </h2>
+                                <p className="text-sm leading-relaxed text-zinc-400">
+                                    {appName === 'this app' ? 'This in-app browser' : `${appName}’s browser`} has limited support for file transfers. Open Floe in Chrome or Safari for the best experience.
+                                </p>
+                            </div>
                         </div>
-                        <div>
-                            <h2 className="text-lg font-semibold text-white">
-                                Open in your browser
-                            </h2>
-                            <p className="mt-1 text-sm text-zinc-400">
-                                {appName === 'this app' ? 'This in-app browser' : `${appName}'s browser`} has limited
-                                support for file transfers. Open Floe in Chrome or Safari for the best experience.
+
+                        {/* Platform-specific instructions */}
+                        <div className="mb-5 rounded-xl border border-white/[0.06] bg-white/[0.03] p-4">
+                            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-zinc-500">
+                                How to open in your browser
                             </p>
+                            {android ? (
+                                <ol className="space-y-3">
+                                    <li className="flex items-start gap-3 text-sm text-zinc-400">
+                                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white/10 text-[11px] font-bold text-zinc-300">
+                                            1
+                                        </span>
+                                        <span>
+                                            Tap the{' '}
+                                            <kbd className="mx-0.5 inline-flex items-center rounded bg-white/10 px-1.5 py-0.5 font-mono text-xs text-zinc-200">
+                                                &#8942;
+                                            </kbd>{' '}
+                                            menu at the top right
+                                        </span>
+                                    </li>
+                                    <li className="flex items-start gap-3 text-sm text-zinc-400">
+                                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white/10 text-[11px] font-bold text-zinc-300">
+                                            2
+                                        </span>
+                                        <span>
+                                            Tap{' '}
+                                            <span className="font-medium text-zinc-200">&quot;Open in browser&quot;</span>
+                                            {' '}or{' '}
+                                            <span className="font-medium text-zinc-200">&quot;Open in Chrome&quot;</span>
+                                        </span>
+                                    </li>
+                                </ol>
+                            ) : (
+                                <ol className="space-y-3">
+                                    <li className="flex items-start gap-3 text-sm text-zinc-400">
+                                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white/10 text-[11px] font-bold text-zinc-300">
+                                            1
+                                        </span>
+                                        <span>
+                                            Tap the{' '}
+                                            <ExternalLink className="mx-0.5 inline h-3.5 w-3.5 align-middle text-zinc-300" />
+                                            {' '}icon or{' '}
+                                            <kbd className="mx-0.5 inline-flex items-center rounded bg-white/10 px-1.5 py-0.5 font-mono text-xs text-zinc-200">
+                                                &middot;&middot;&middot;
+                                            </kbd>{' '}
+                                            menu
+                                        </span>
+                                    </li>
+                                    <li className="flex items-start gap-3 text-sm text-zinc-400">
+                                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-white/10 text-[11px] font-bold text-zinc-300">
+                                            2
+                                        </span>
+                                        <span>
+                                            Tap{' '}
+                                            <span className="font-medium text-zinc-200">&quot;Open in Safari&quot;</span>
+                                            {' '}or{' '}
+                                            <span className="font-medium text-zinc-200">&quot;Open in Browser&quot;</span>
+                                        </span>
+                                    </li>
+                                </ol>
+                            )}
                         </div>
+
+                        {/* Copy link button */}
+                        <button
+                            onClick={handleCopy}
+                            className="mb-3 flex w-full items-center justify-center gap-2 rounded-xl bg-white px-4 py-3 text-sm font-semibold text-black transition-all duration-150 hover:bg-zinc-100 active:scale-[0.98]"
+                        >
+                            {copied ? (
+                                <>
+                                    <Check className="h-4 w-4 text-green-600" strokeWidth={2.5} />
+                                    Link copied
+                                </>
+                            ) : (
+                                <>
+                                    <Copy className="h-4 w-4" />
+                                    Copy link to paste in browser
+                                </>
+                            )}
+                        </button>
+
+                        {/* Continue anyway */}
+                        <button
+                            onClick={() => setDismissed(true)}
+                            className="w-full py-1 text-center text-xs text-zinc-600 transition-colors hover:text-zinc-400"
+                        >
+                            Continue anyway (some features may not work)
+                        </button>
                     </div>
-
-                    {/* Platform-specific instructions */}
-                    <div className="mb-5 rounded-xl bg-white/5 p-4 text-sm">
-                        <p className="mb-2 font-medium text-zinc-300">How to open in your browser:</p>
-                        {android ? (
-                            <ol className="space-y-1.5 text-zinc-400">
-                                <li className="flex gap-2">
-                                    <span className="shrink-0 font-medium text-zinc-300">1.</span>
-                                    Tap the <span className="mx-0.5 rounded bg-white/10 px-1 font-mono text-xs text-zinc-200">⋮</span> three-dot menu at the top right
-                                </li>
-                                <li className="flex gap-2">
-                                    <span className="shrink-0 font-medium text-zinc-300">2.</span>
-                                    Tap <span className="font-medium text-zinc-200">&quot;Open in browser&quot;</span> or <span className="font-medium text-zinc-200">&quot;Open in Chrome&quot;</span>
-                                </li>
-                            </ol>
-                        ) : (
-                            <ol className="space-y-1.5 text-zinc-400">
-                                <li className="flex gap-2">
-                                    <span className="shrink-0 font-medium text-zinc-300">1.</span>
-                                    Tap the <ExternalLink className="mx-0.5 inline h-3.5 w-3.5 text-zinc-300" /> icon or <span className="mx-0.5 rounded bg-white/10 px-1 font-mono text-xs text-zinc-200">···</span> menu
-                                </li>
-                                <li className="flex gap-2">
-                                    <span className="shrink-0 font-medium text-zinc-300">2.</span>
-                                    Tap <span className="font-medium text-zinc-200">&quot;Open in Safari&quot;</span> or <span className="font-medium text-zinc-200">&quot;Open in Browser&quot;</span>
-                                </li>
-                            </ol>
-                        )}
-                    </div>
-
-                    {/* Copy link button */}
-                    <button
-                        onClick={handleCopy}
-                        className="mb-3 flex w-full items-center justify-center gap-2 rounded-lg bg-white px-4 py-2.5 text-sm font-semibold text-black transition hover:bg-zinc-200 active:scale-[0.98]"
-                    >
-                        {copied ? (
-                            <>
-                                <Check className="h-4 w-4 text-green-600" />
-                                Link copied
-                            </>
-                        ) : (
-                            <>
-                                <Copy className="h-4 w-4" />
-                                Copy link to paste in browser
-                            </>
-                        )}
-                    </button>
-
-                    {/* Continue anyway */}
-                    <button
-                        onClick={() => setDismissed(true)}
-                        className="w-full text-center text-xs text-zinc-500 transition hover:text-zinc-300"
-                    >
-                        Continue anyway (some features may not work)
-                    </button>
                 </div>
             </div>
         </>

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -83,10 +83,7 @@ interface ReceivedFile {
 
 
 export function P2PTransfer() {
-    const [isSender] = useState<boolean | null>(() => {
-        if (typeof window === 'undefined') return null;
-        return !new URLSearchParams(window.location.search).has('room');
-    });
+    const [isSender, setIsSender] = useState<boolean | null>(null);
     const [status, setStatus] = useState('Idle');
     const [isConnected, setIsConnected] = useState(false);
     const [ping, setPing] = useState(0);
@@ -162,6 +159,11 @@ export function P2PTransfer() {
             });
         } catch { }
     };
+
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setIsSender(!new URLSearchParams(window.location.search).has('room'));
+    }, []);
 
     useEffect(() => {
         const timer = setTimeout(() => {
@@ -611,8 +613,28 @@ export function P2PTransfer() {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         socket.on('signal', (data: any) => {
-            if (peerRef.current && !peerRef.current.destroyed) {
-                peerRef.current.signal(data.signal);
+            const peer = peerRef.current;
+            if (!peer || peer.destroyed) return;
+            const sig = data?.signal;
+            if (!sig) return;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const pc = (peer as any)._pc as RTCPeerConnection | undefined;
+            if (pc && pc.signalingState === 'stable' && (sig.type === 'answer' || sig.type === 'offer')) {
+                Sentry.addBreadcrumb({
+                    category: 'webrtc',
+                    level: 'warning',
+                    message: `Skipped ${sig.type} signal: peer already in stable state`,
+                });
+                return;
+            }
+            try {
+                peer.signal(sig);
+            } catch (err) {
+                Sentry.addBreadcrumb({
+                    category: 'webrtc',
+                    level: 'warning',
+                    message: `Ignored signal in state ${pc?.signalingState}: ${(err as Error).message}`,
+                });
             }
         });
 
@@ -715,6 +737,9 @@ export function P2PTransfer() {
 
         socket.off('user-connected');
         socket.on('user-connected', (userId: string) => {
+            if (peerRef.current && !peerRef.current.destroyed) {
+                peerRef.current.destroy();
+            }
             setStatus('Peer joined. Starting transfer');
             requestWakeLock();
 


### PR DESCRIPTION
## Summary

- **WebRTC crash fix:** Sender was crashing with `InvalidStateError: Failed to set remote answer sdp: Called in wrong state: stable` when a duplicate/late SDP answer arrived (e.g. receiver reloads inside Facebook's in-app browser). The shared `socket.on('signal')` handler now checks `signalingState` before forwarding offer/answer signals to `peer.signal()`, and wraps the call in try/catch to log a Sentry breadcrumb instead of throwing. Also destroys the previous `SimplePeer` before creating a new one on `user-connected` to prevent orphaned peer instances.
- **Hydration error fix:** `isSender` was reading `window.location.search` inside the `useState` initializer, causing a React #418 hydration mismatch (server rendered `null`, client rendered `true`/`false`). Now initializes to `null` and resolves in a mount `useEffect`.
- **In-app browser page redesign:** Replaced per-app emoji icons with a `SquareArrowOutUpRight` lucide glyph inside a gradient ring. Refined card with top accent strip, numbered step badges, `kbd`-styled menu chips, and tighter typography - all matching the Floe dark theme.

## Test plan

- [ ] `pnpm lint && pnpm build` passes clean (verified locally)
- [ ] Spoof an in-app UA (`FBAN/FBAV` for iOS, Android with `wv)`) in DevTools and confirm the redesigned interstitial renders correctly for both platforms
- [ ] "Copy link to paste in browser" copies the URL and shows the check state; "Continue anyway" dismisses to the app
- [ ] Open sender + receiver tabs locally, reload the receiver after connection to force a duplicate answer - sender should no longer show the red "Connection error" banner
- [ ] Load `/` and `/?room=<uuid>` in dev mode - no hydration warning in the console