### PR TITLE
fix(client): prevent in-app browser from stealing receiver slot

### DIFF
--- a/client/components/InAppBrowserGuard.tsx
+++ b/client/components/InAppBrowserGuard.tsx
@@ -57,11 +57,12 @@ interface Props {
 }
 
 export function InAppBrowserGuard({ children }: Props) {
-    const [{ detectedApp, android, currentUrl }, setInit] = useState<{
+    const [{ detectedApp, android, currentUrl, ready }, setInit] = useState<{
         detectedApp: DetectedApp | null;
         android: boolean;
         currentUrl: string;
-    }>({ detectedApp: null, android: false, currentUrl: '' });
+        ready: boolean;
+    }>({ detectedApp: null, android: false, currentUrl: '', ready: false });
     const [dismissed, setDismissed] = useState(false);
     const [copied, setCopied] = useState(false);
 
@@ -69,7 +70,7 @@ export function InAppBrowserGuard({ children }: Props) {
         const ua = navigator.userAgent;
         const app = detectInAppBrowser(ua);
         // eslint-disable-next-line react-hooks/set-state-in-effect
-        setInit({ detectedApp: app, android: isAndroid(ua), currentUrl: window.location.href });
+        setInit({ detectedApp: app, android: isAndroid(ua), currentUrl: window.location.href, ready: true });
         if (app) {
             try {
                 (window as UmamiWindow).umami?.track('in-app-browser-detected', {
@@ -92,20 +93,19 @@ export function InAppBrowserGuard({ children }: Props) {
         setTimeout(() => setCopied(false), 2000);
     };
 
-    if (!detectedApp || dismissed) {
-        return <>{children}</>;
-    }
+    // Wait for the one-tick detection effect before mounting children.
+    // If we render children immediately (before detection), P2PTransfer's
+    // mount effect will emit join-room and steal the receiver slot even
+    // while the in-app browser overlay is showing.
+    if (!ready) return null;
+    if (!detectedApp || dismissed) return <>{children}</>;
 
     const appName = detectedApp === 'InAppBrowser' ? 'this app' : detectedApp;
 
     return (
         <>
-            {/* Blurred background content */}
-            <div className="pointer-events-none select-none blur-sm opacity-30" aria-hidden>
-                {children}
-            </div>
-
-            {/* Full-screen overlay */}
+            {/* Full-screen overlay — children are intentionally NOT rendered
+                so P2PTransfer cannot join the room from the in-app browser */}
             <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/90 p-5 backdrop-blur-md">
                 <div className="w-full max-w-sm overflow-hidden rounded-2xl border border-white/[0.08] bg-zinc-900 shadow-[0_32px_64px_-12px_rgba(0,0,0,0.8)]">
 


### PR DESCRIPTION
## Summary

Fixes "Link Invalid" shown when a user opens a Floe share link from Facebook Messenger (or any in-app browser), sees the "Open in your browser" screen, then copies the link and opens it in Safari/Chrome.

**Root cause:** `InAppBrowserGuard` was rendering `<P2PTransfer />` as blurred children behind the overlay. React runs child effects before parent effects, so P2PTransfer's mount effect emitted `join-room` and claimed the receiver slot before in-app browser detection had even run. The Messenger webview held that slot in the background, so the real browser hit `room-full` and showed "Link Invalid".

**Fix:** Add a `ready` flag set atomically with `detectedApp` in the detection effect. Children are now held back (`return null`) until detection completes, then only mounted when the path is clear (no in-app browser detected, or user dismissed). The in-app browser session never emits `join-room`, so the slot stays open for the real browser.

## Test plan

- [ ] Open a share link with a spoofed in-app UA (`FBAN/FBAV` in DevTools). Confirm no `join-room` is emitted while the overlay is showing (sender still shows "Waiting for peer").
- [ ] Copy the link and open it in a normal browser tab. It should connect successfully, not show "Link Invalid".
- [ ] "Continue anyway" still works: dismissing the overlay mounts P2PTransfer and joins the room.
- [ ] Normal (non-in-app) receivers are unaffected: one extra `null` render tick, imperceptible.

Follows PR #74.