### PR TITLE
fix(client): hotfix - restore transfers broken by over-broad signal guard

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -619,11 +619,14 @@ export function P2PTransfer() {
             if (!sig) return;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const pc = (peer as any)._pc as RTCPeerConnection | undefined;
-            if (pc && pc.signalingState === 'stable' && (sig.type === 'answer' || sig.type === 'offer')) {
+            // A duplicate/late SDP answer applied after negotiation completes throws
+            // InvalidStateError ("Called in wrong state: stable"). Skip only answers.
+            // Applying an offer in `stable` is the receiver's normal first step.
+            if (pc && pc.signalingState === 'stable' && sig.type === 'answer') {
                 Sentry.addBreadcrumb({
                     category: 'webrtc',
                     level: 'warning',
-                    message: `Skipped ${sig.type} signal: peer already in stable state`,
+                    message: 'Skipped duplicate answer signal: peer already in stable state',
                 });
                 return;
             }


### PR DESCRIPTION
## Critical hotfix

After PR #74 deployed, **no transfer completes** (PC↔PC, PC↔phone). The sender hangs at "Peer joined. Starting transfer" and nothing is sent.

### Root cause

PR #74 added a guard in the shared `socket.on('signal')` handler that skipped **both** `offer` and `answer` SDP signals when the `RTCPeerConnection` was already `stable`:

```js
if (pc && pc.signalingState === 'stable' && (sig.type === 'answer' || sig.type === 'offer')) return;
```

A fresh `RTCPeerConnection` **starts in `stable`**. The receiver (non-initiator) must apply the sender's offer while still in `stable` - `setRemoteDescription(offer)` is valid there and transitions to `have-remote-offer`. The guard dropped that offer, so the receiver never answered and the sender waited forever (its `connect` event, which triggers `sendAllFiles`, never fired).

The original crash PR #74 targeted was a **duplicate answer** arriving after the sender was already connected (`stable` + `answer`, which genuinely throws `InvalidStateError: ... Called in wrong state: stable`). Only `answer` should be guarded.

### Fix

Narrow the guard to skip only `answer` signals in `stable`. This restores the receiver's normal handshake while preserving the duplicate-answer crash fix. ICE candidates and the `try/catch` safety net are unaffected.

```js
if (pc && pc.signalingState === 'stable' && sig.type === 'answer') return;
```

WebRTC spec reference: `setRemoteDescription(offer)` is legal in `stable` and `have-remote-offer`; `setRemoteDescription(answer)` is legal only in `have-local-offer`.

## Test plan

- [ ] PC→PC: create a link, open in a second browser, select a file. Sender must advance past "Peer joined. Starting transfer" to "Sending: <file>" and the receiver downloads it.
- [ ] PC→phone: same flow across devices.
- [ ] Duplicate-answer crash stays fixed: with both peers connected, reload the receiver tab; sender must not show the red "Connection error: ... Called in wrong state: stable" banner.

Follows #74 and #75.