### PR TITLE
fix(cli): fix transfer sync bugs, add cross-implementation tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,59 @@ jobs:
       - name: Build
         run: go build ./cmd/floe
         working-directory: cli
+
+  cli-interop:
+    name: CLI↔Browser Interop (Go + Node)
+    runs-on: ubuntu-latest
+    # Requires both Go (CLI binary) and Node (server + client + Playwright)
+    needs: [cli, build-and-lint, server]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: cli/go.sum
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.2
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install client dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: client
+
+      - name: Install server dependencies
+        run: npm install
+        working-directory: server
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+        working-directory: client
+
+      - name: Run CLI↔browser interop tests
+        run: pnpm exec playwright test cli-interop.spec.ts
+        working-directory: client
+        env:
+          NEXT_PUBLIC_SOCKET_URL: http://localhost:3001

--- a/cli/internal/signaling/client.go
+++ b/cli/internal/signaling/client.go
@@ -67,7 +67,7 @@ func Connect(serverURL string) (*Client, error) {
 		conn:          conn,
 		Role:          make(chan string, 1),
 		PeerConnected: make(chan string, 1),
-		Signal:        make(chan json.RawMessage, 32),
+		Signal:        make(chan json.RawMessage, 128),
 		PeerLeft:      make(chan struct{}, 1),
 		RoomFull:      make(chan struct{}, 1),
 		Errors:        make(chan string, 4),

--- a/cli/internal/transfer/loopback_test.go
+++ b/cli/internal/transfer/loopback_test.go
@@ -1,0 +1,180 @@
+package transfer
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// newConnectedPair wires two in-process pion PeerConnections together over
+// loopback ICE and returns the sender's open data channel plus a channel that
+// yields the receiver's data channel once it opens. Non-trickle signaling
+// (gather-then-exchange) keeps the handshake free of candidate-ordering races.
+func newConnectedPair(t *testing.T) (sender *webrtc.DataChannel, recvCh <-chan *webrtc.DataChannel, closeFn func()) {
+	t.Helper()
+
+	se := webrtc.SettingEngine{}
+	se.SetIncludeLoopbackCandidate(true) // ensure connectivity on isolated hosts
+	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
+
+	pcSender, err := api.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("create sender PC: %v", err)
+	}
+	pcReceiver, err := api.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("create receiver PC: %v", err)
+	}
+
+	got := make(chan *webrtc.DataChannel, 1)
+	pcReceiver.OnDataChannel(func(dc *webrtc.DataChannel) {
+		dc.OnOpen(func() { got <- dc })
+	})
+
+	dc, err := pcSender.CreateDataChannel("floe", nil)
+	if err != nil {
+		t.Fatalf("create data channel: %v", err)
+	}
+	senderOpen := make(chan struct{})
+	dc.OnOpen(func() { close(senderOpen) })
+
+	// Offer (sender) → fully gather → receiver.
+	offer, err := pcSender.CreateOffer(nil)
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+	gatherSender := webrtc.GatheringCompletePromise(pcSender)
+	if err := pcSender.SetLocalDescription(offer); err != nil {
+		t.Fatalf("sender SetLocalDescription: %v", err)
+	}
+	<-gatherSender
+	if err := pcReceiver.SetRemoteDescription(*pcSender.LocalDescription()); err != nil {
+		t.Fatalf("receiver SetRemoteDescription: %v", err)
+	}
+
+	// Answer (receiver) → fully gather → sender.
+	answer, err := pcReceiver.CreateAnswer(nil)
+	if err != nil {
+		t.Fatalf("create answer: %v", err)
+	}
+	gatherReceiver := webrtc.GatheringCompletePromise(pcReceiver)
+	if err := pcReceiver.SetLocalDescription(answer); err != nil {
+		t.Fatalf("receiver SetLocalDescription: %v", err)
+	}
+	<-gatherReceiver
+	if err := pcSender.SetRemoteDescription(*pcReceiver.LocalDescription()); err != nil {
+		t.Fatalf("sender SetRemoteDescription: %v", err)
+	}
+
+	select {
+	case <-senderOpen:
+	case <-time.After(20 * time.Second):
+		pcSender.Close()
+		pcReceiver.Close()
+		t.Fatal("sender data channel never opened")
+	}
+
+	return dc, got, func() {
+		pcSender.Close()
+		pcReceiver.Close()
+	}
+}
+
+// runTransfer sends srcPaths over a connected pair into a fresh output dir and
+// returns it. The receiver's OnMessage handler (registered inside ReceiveFiles)
+// must be set before the first byte is sent; since the test controls when
+// SendFiles runs, a short delay after starting the receiver guarantees that.
+func runTransfer(t *testing.T, srcPaths []string) string {
+	t.Helper()
+
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true)
+	}()
+
+	// Let the receiver register its OnMessage handler before any data is sent.
+	time.Sleep(300 * time.Millisecond)
+
+	if err := SendFiles(sender, srcPaths); err != nil {
+		t.Fatalf("SendFiles: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err != nil {
+			t.Fatalf("ReceiveFiles: %v", err)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("ReceiveFiles did not complete")
+	}
+	return outDir
+}
+
+// TestLoopbackLargeFile is the end-to-end regression guard for the backpressure
+// and flush fixes: a 20 MB file exceeds the 8 MB high-water mark, so it exercises
+// multiple drain cycles. The received bytes must match the source exactly.
+func TestLoopbackLargeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ICE loopback transfer in -short mode")
+	}
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "blob.bin")
+	data := make([]byte, 20*1024*1024)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("generate random data: %v", err)
+	}
+	if err := os.WriteFile(srcPath, data, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	want := sha256.Sum256(data)
+
+	outDir := runTransfer(t, []string{srcPath})
+
+	got, err := os.ReadFile(filepath.Join(outDir, "blob.bin"))
+	if err != nil {
+		t.Fatalf("read received file: %v", err)
+	}
+	if len(got) != len(data) {
+		t.Fatalf("size mismatch: got %d bytes, want %d", len(got), len(data))
+	}
+	if sha256.Sum256(got) != want {
+		t.Fatal("content hash mismatch: received file is corrupt")
+	}
+}
+
+// TestLoopbackSmallJSONFile guards the framing fix end to end: a file whose
+// bytes are a sub-1 KB JSON object must arrive byte-identical, not be mistaken
+// for a control message and dropped.
+func TestLoopbackSmallJSONFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ICE loopback transfer in -short mode")
+	}
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "config.json")
+	data := []byte(`{"name":"floe","type":"settings","values":[1,2,3],"nested":{"k":"v"}}`)
+	if err := os.WriteFile(srcPath, data, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	outDir := runTransfer(t, []string{srcPath})
+
+	got, err := os.ReadFile(filepath.Join(outDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read received file: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Fatalf("JSON file corrupted in transit:\n got: %q\nwant: %q", got, data)
+	}
+}

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/pion/webrtc/v4"
 	"github.com/schollz/progressbar/v3"
@@ -30,12 +31,20 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 	// We use a channel so the OnMessage callback (goroutine) feeds a sequential loop.
 	msgCh := make(chan webrtc.DataChannelMessage, 256)
 
+	// done is closed when the data channel closes. We signal via a separate
+	// channel instead of closing msgCh from OnClose: closing msgCh while the
+	// OnMessage callback might still push would panic ("send on closed channel").
+	// The OnMessage send selects on done so it can never block or panic after close.
+	done := make(chan struct{})
+	var closeOnce sync.Once
 	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
-		msgCh <- msg
+		select {
+		case msgCh <- msg:
+		case <-done:
+		}
 	})
-
 	dc.OnClose(func() {
-		close(msgCh)
+		closeOnce.Do(func() { close(done) })
 	})
 
 	// Process messages sequentially
@@ -54,100 +63,123 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 		}
 	}()
 
-	for msg := range msgCh {
-		// Try to parse as a JSON control message.
-		// Browser (SimplePeer) sends metadata/end as strings, but they may
-		// arrive as binary depending on SCTP framing. We attempt JSON parsing
-		// on any string message OR any small binary message (< 1 KB).
-		if msg.IsString || len(msg.Data) < 1024 {
-			var base map[string]interface{}
-			if err := json.Unmarshal(msg.Data, &base); err == nil {
-				msgType, _ := base["type"].(string)
+	for {
+		// Prefer draining buffered messages over reacting to a close: a normal
+		// transfer ends with the final "end" marker already queued in msgCh,
+		// which must be processed even if OnClose has fired alongside it.
+		var msg webrtc.DataChannelMessage
+		select {
+		case msg = <-msgCh:
+		default:
+			select {
+			case msg = <-msgCh:
+			case <-done:
+				// Channel closed before the transfer finished normally.
+				if currentFile != nil {
+					return fmt.Errorf("connection closed mid-transfer: %s (%d of %d bytes)",
+						currentInfo.FileName, bytesReceived, currentInfo.FileSize)
+				}
+				return nil
+			}
+		}
 
-				switch msgType {
+		// Decide whether this is a Floe control message (metadata/end) or file
+		// data. Only recognized control types are consumed as control — a small
+		// binary chunk that merely happens to be a JSON object is file data and
+		// must be written, never dropped.
+		msgType, isControl := classifyControl(msg.Data, msg.IsString)
+		if isControl {
+			switch msgType {
 
-				case "metadata":
-					// A new file is starting
-					info, err := parseMetadata(string(msg.Data))
-					if err != nil {
-						continue
-					}
-					currentInfo = info
-					bytesReceived = 0
+			case "metadata":
+				// A new file is starting
+				info, err := parseMetadata(string(msg.Data))
+				if err != nil {
+					continue
+				}
+				currentInfo = info
+				bytesReceived = 0
 
-					// On first file: show summary and optionally prompt
-					if waitingForFirst {
-						waitingForFirst = false
-						fmt.Printf("\n  Incoming: %d file(s)\n\n", info.Total)
-						if !autoAccept {
-							fmt.Print("  Accept? [Y/n] ")
-							var answer string
-							fmt.Scanln(&answer)
-							answer = strings.TrimSpace(strings.ToLower(answer))
-							if answer == "n" || answer == "no" {
-								dc.Close()
-								return fmt.Errorf("transfer declined")
-							}
-						}
-					}
-
-					// Create destination file (create parent dirs for folder transfers)
-					destPath := safeJoin(outputDir, info.FileName)
-					if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-						return fmt.Errorf("cannot create directory: %w", err)
-					}
-					currentFile, err = os.Create(destPath)
-					if err != nil {
-						return fmt.Errorf("cannot create file %s: %w", destPath, err)
-					}
-
-					// Progress bar for this file
-					bar = progressbar.NewOptions64(
-						info.FileSize,
-						progressbar.OptionSetDescription(
-							fmt.Sprintf("  [%d/%d] %s", info.Index, info.Total, truncateName(info.FileName, 30)),
-						),
-						progressbar.OptionSetWidth(30),
-						progressbar.OptionShowBytes(true),
-						progressbar.OptionSetTheme(progressbar.Theme{
-							Saucer:        "█",
-							SaucerPadding: "░",
-							BarStart:      "[",
-							BarEnd:        "]",
-						}),
-					)
-
-					// Send ack as BINARY — the browser checks data.byteLength before
-					// decoding, which is only defined on ArrayBuffer/Buffer, not strings.
-					ack := map[string]interface{}{
-						"type":   "ack",
-						"id":     info.ID,
-						"offset": 0,
-					}
-					ackJSON, _ := json.Marshal(ack)
-					dc.Send([]byte(ackJSON))
-
-				case "end":
-					// Current file is complete
-					if currentFile != nil {
-						currentFile.Close()
-						currentFile = nil
-						fmt.Println()
-						filesReceived++
-
-						if filesReceived >= currentInfo.Total {
-							fmt.Printf("  Done. %d file(s) received in %s\n", filesReceived, outputDir)
-							return nil
+				// On first file: show summary and optionally prompt
+				if waitingForFirst {
+					waitingForFirst = false
+					fmt.Printf("\n  Incoming: %d file(s)\n\n", info.Total)
+					if !autoAccept {
+						fmt.Print("  Accept? [Y/n] ")
+						var answer string
+						fmt.Scanln(&answer)
+						answer = strings.TrimSpace(strings.ToLower(answer))
+						if answer == "n" || answer == "no" {
+							dc.Close()
+							return fmt.Errorf("transfer declined")
 						}
 					}
 				}
-				continue // successfully parsed JSON — skip binary write
+
+				// Create destination file (create parent dirs for folder transfers)
+				destPath := safeJoin(outputDir, info.FileName)
+				if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+					return fmt.Errorf("cannot create directory: %w", err)
+				}
+				currentFile, err = os.Create(destPath)
+				if err != nil {
+					return fmt.Errorf("cannot create file %s: %w", destPath, err)
+				}
+
+				// Progress bar for this file
+				bar = progressbar.NewOptions64(
+					info.FileSize,
+					progressbar.OptionSetDescription(
+						fmt.Sprintf("  [%d/%d] %s", info.Index, info.Total, truncateName(info.FileName, 30)),
+					),
+					progressbar.OptionSetWidth(30),
+					progressbar.OptionShowBytes(true),
+					progressbar.OptionSetTheme(progressbar.Theme{
+						Saucer:        "█",
+						SaucerPadding: "░",
+						BarStart:      "[",
+						BarEnd:        "]",
+					}),
+				)
+
+				// Send ack as BINARY — the browser checks data.byteLength before
+				// decoding, which is only defined on ArrayBuffer/Buffer, not strings.
+				ack := map[string]interface{}{
+					"type":   "ack",
+					"id":     info.ID,
+					"offset": 0,
+				}
+				ackJSON, _ := json.Marshal(ack)
+				dc.Send([]byte(ackJSON))
+
+			case "end":
+				// Current file is complete
+				if currentFile != nil {
+					currentFile.Close()
+					currentFile = nil
+					fmt.Println()
+
+					// Integrity guard: a short byte count means the transfer was
+					// truncated (e.g. the sender closed early). Fail loudly rather
+					// than leave a corrupt file that looks complete.
+					if bytesReceived != currentInfo.FileSize {
+						return fmt.Errorf("incomplete file %q: received %d of %d bytes",
+							currentInfo.FileName, bytesReceived, currentInfo.FileSize)
+					}
+
+					filesReceived++
+					if filesReceived >= currentInfo.Total {
+						fmt.Printf("  Done. %d file(s) received in %s\n", filesReceived, outputDir)
+						return nil
+					}
+				}
 			}
-			// JSON parse failed on a string message — skip it
-			if msg.IsString {
-				continue
-			}
-			// JSON parse failed on a small binary message — fall through to chunk write
+			continue
+		}
+
+		// A string that wasn't a recognized control message is never file data.
+		if msg.IsString {
+			continue
 		}
 
 		// Binary chunk — write directly to disk
@@ -161,8 +193,51 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 		bytesReceived += int64(n)
 		bar.Add(n)
 	}
+}
 
-	return nil
+// classifyControl reports whether a data channel message is a Floe control
+// message and, if so, its type ("metadata" or "end").
+//
+// Control messages are JSON objects. The browser (SimplePeer) sends them as
+// strings, but depending on SCTP framing they can also arrive as small binary
+// messages, so binary payloads up to 1000 bytes are probed too (matching the
+// browser's `data.byteLength <= 1000` guard). Crucially, a message is treated
+// as control ONLY when it parses as a JSON object whose "type" is a known
+// control type. Anything else — including a small file whose bytes happen to be
+// a JSON object — is file data and must be written, not dropped.
+func classifyControl(data []byte, isString bool) (msgType string, isControl bool) {
+	if !isString && len(data) > 1000 {
+		return "", false
+	}
+	if !looksLikeJSONObject(data) {
+		return "", false
+	}
+	var base map[string]interface{}
+	if err := json.Unmarshal(data, &base); err != nil {
+		return "", false
+	}
+	t, _ := base["type"].(string)
+	if t == "metadata" || t == "end" {
+		return t, true
+	}
+	return "", false
+}
+
+// looksLikeJSONObject reports whether data's first non-whitespace byte is '{',
+// a cheap pre-check (mirroring the browser's `text.startsWith('{')`) that avoids
+// a full JSON parse attempt on raw binary chunks.
+func looksLikeJSONObject(data []byte) bool {
+	for _, b := range data {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '{':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // parseMetadata extracts FileInfo from a raw metadata JSON string.

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -23,6 +23,17 @@ import (
 
 const chunkSize = 16 * 1024
 
+// Backpressure watermarks mirror the browser sender (P2PTransfer.tsx): pause
+// sending once pion's SCTP send buffer reaches the high-water mark, resume once
+// it drains back below the low-water mark. Without this the sender enqueues the
+// whole file as fast as the disk reads it — the progress bar races to 100% while
+// the receiver is still mid-transfer, and large files overflow pion's buffer and
+// stall the connection.
+const (
+	bufferedAmountHighWater = 8 * 1024 * 1024 // pause sending at/above 8 MB buffered
+	bufferedAmountLowWater  = 4 * 1024 * 1024 // resume sending below 4 MB buffered
+)
+
 func truncateName(name string, maxLen int) string {
 	if len(name) <= maxLen {
 		return name
@@ -71,21 +82,48 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
 		// Accept ack as either string or binary — the CLI receiver sends
 		// binary for browser compatibility, CLI-to-CLI also works.
-		ackCh <- msg.Data
+		// Non-blocking: a full buffer means a stray/duplicate message arrived;
+		// dropping it is safe because the ack loop already matched its ID.
+		select {
+		case ackCh <- msg.Data:
+		default:
+		}
+	})
+
+	// Backpressure: pion calls OnBufferedAmountLow once the send buffer drains
+	// to bufferedAmountLowWater. The send loop blocks on sendMore whenever the
+	// buffer is full so we never enqueue faster than the peer can drain.
+	sendMore := make(chan struct{}, 1)
+	dc.SetBufferedAmountLowThreshold(bufferedAmountLowWater)
+	dc.OnBufferedAmountLow(func() {
+		select {
+		case sendMore <- struct{}{}:
+		default:
+		}
 	})
 
 	for i, entry := range files {
-		if err := sendFile(dc, ackCh, entry, i+1, len(files)); err != nil {
+		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files)); err != nil {
 			return fmt.Errorf("error sending %s: %w", entry.displayName, err)
 		}
 	}
 
 	fmt.Println("\n  All files sent.")
 
-	// Allow SCTP to flush buffered data before the caller closes the connection.
-	// Without this pause, conn.Close() fires immediately and the receiver may
-	// not receive the last chunks / end markers.
-	time.Sleep(2 * time.Second)
+	// Flush: wait for pion to push every buffered byte (including the final end
+	// marker) onto the wire before the caller closes the connection. Closing
+	// while data is still buffered truncates the transfer. Capped so a dead peer
+	// can't hang the process forever.
+	drainDeadline := time.Now().Add(30 * time.Second)
+	for dc.BufferedAmount() > 0 {
+		if time.Now().After(drainDeadline) {
+			return fmt.Errorf("timed out flushing %d buffered bytes to peer", dc.BufferedAmount())
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// Brief grace period so the receiver can process the final end marker
+	// before the data channel is torn down.
+	time.Sleep(250 * time.Millisecond)
 	return nil
 }
 
@@ -134,7 +172,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 }
 
 // sendFile handles the full send sequence for a single file.
-func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, entry fileEntry, index, total int) error {
+func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int) error {
 	f, err := os.Open(entry.absPath)
 	if err != nil {
 		return err
@@ -163,16 +201,27 @@ func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, entry fileEntry, inde
 		return fmt.Errorf("failed to send metadata: %w", err)
 	}
 
-	// Step 2: Wait for ack (with 30-second timeout)
+	// Step 2: Wait for this file's ack (with 30-second timeout).
+	// Discard any stray or stale message until we see the ack whose ID matches
+	// this file — otherwise an out-of-order message could be misread as the ack
+	// (sending from offset 0) or leak into the next file's handshake.
 	var offset int64
-	select {
-	case raw := <-ackCh:
-		var ack ackMsg
-		if err := json.Unmarshal(raw, &ack); err == nil && ack.Type == "ack" && ack.ID == fileID {
-			offset = ack.Offset
+	// 120 s lets a human at the interactive [Y/n] receiver prompt accept without
+	// triggering a spurious timeout on the sender.
+	ackDeadline := time.After(120 * time.Second)
+ackLoop:
+	for {
+		select {
+		case raw := <-ackCh:
+			var ack ackMsg
+			if err := json.Unmarshal(raw, &ack); err == nil && ack.Type == "ack" && ack.ID == fileID {
+				offset = ack.Offset
+				break ackLoop
+			}
+			// Not our ack — keep waiting.
+		case <-ackDeadline:
+			return fmt.Errorf("timed out waiting for ack")
 		}
-	case <-time.After(30 * time.Second):
-		return fmt.Errorf("timed out waiting for ack")
 	}
 
 	// Seek to resume offset (normally 0)
@@ -201,6 +250,16 @@ func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, entry fileEntry, inde
 	for {
 		n, err := f.Read(buf)
 		if n > 0 {
+			// Backpressure: block until pion's buffer drains below the low-water
+			// mark before queuing more. The loop re-checks after each wakeup so a
+			// stale signal can't let us run away from the receiver.
+			for dc.BufferedAmount() >= bufferedAmountHighWater {
+				select {
+				case <-sendMore:
+				case <-time.After(60 * time.Second):
+					return fmt.Errorf("backpressure stall: peer not draining (%d bytes buffered)", dc.BufferedAmount())
+				}
+			}
 			if sendErr := dc.Send(buf[:n]); sendErr != nil {
 				return fmt.Errorf("failed to send chunk: %w", sendErr)
 			}

--- a/cli/internal/transfer/transfer_test.go
+++ b/cli/internal/transfer/transfer_test.go
@@ -71,3 +71,65 @@ func TestParseMetadata(t *testing.T) {
 		t.Error("parseMetadata(invalid json) should error")
 	}
 }
+
+// TestLooksLikeJSONObject covers the cheap pre-check used before JSON parsing.
+func TestLooksLikeJSONObject(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`{"type":"end"}`, true},
+		{"  \r\n\t{\"a\":1}", true}, // leading whitespace tolerated
+		{`[1,2,3]`, false},         // array, not object
+		{`"a string"`, false},
+		{`123`, false},
+		{"", false},
+		{"\x00\x01\x02binary", false},
+	}
+	for _, tc := range cases {
+		if got := looksLikeJSONObject([]byte(tc.in)); got != tc.want {
+			t.Errorf("looksLikeJSONObject(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestClassifyControl is the regression guard for the framing bug: only genuine
+// metadata/end JSON objects are control messages. A small file whose bytes are a
+// JSON object must be classified as DATA (isControl=false) so it is never dropped.
+func TestClassifyControl(t *testing.T) {
+	cases := []struct {
+		name        string
+		data        string
+		isString    bool
+		wantType    string
+		wantControl bool
+	}{
+		{"metadata string", `{"type":"metadata","id":"x","fileName":"a","fileSize":1,"index":1,"total":1}`, true, "metadata", true},
+		{"end string", `{"type":"end"}`, true, "end", true},
+		{"metadata as small binary", `{"type":"metadata","id":"x"}`, false, "metadata", true},
+		// A tiny JSON file (its own content) must be treated as DATA, not dropped.
+		{"json file content under 1KB", `{"hello":"world","n":42}`, false, "", false},
+		// A JSON object whose type is unknown is still data, not control.
+		{"unknown type", `{"type":"chat","msg":"hi"}`, false, "", false},
+		// Raw binary that isn't JSON is data.
+		{"raw binary", "\x89PNG\r\n\x1a\n....", false, "", false},
+		// A string that isn't a control message is skipped (not control, not data).
+		{"non-control string", "just some text", true, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, gotControl := classifyControl([]byte(tc.data), tc.isString)
+			if gotType != tc.wantType || gotControl != tc.wantControl {
+				t.Errorf("classifyControl(%q, isString=%v) = (%q, %v), want (%q, %v)",
+					tc.data, tc.isString, gotType, gotControl, tc.wantType, tc.wantControl)
+			}
+		})
+	}
+
+	// A binary JSON object LARGER than 1000 bytes must be data (control probe is
+	// capped at 1000 bytes for binary, matching the browser guard).
+	big := `{"type":"metadata",` + `"pad":"` + strings.Repeat("x", 1100) + `"}`
+	if _, isControl := classifyControl([]byte(big), false); isControl {
+		t.Errorf("classifyControl on >1000-byte binary should be data, got control")
+	}
+}

--- a/client/e2e/cli-interop.spec.ts
+++ b/client/e2e/cli-interop.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * CLI↔Browser interop tests.
+ *
+ * These tests are the cross-implementation deployment guard for Floe — they
+ * prove that the Go CLI and the JS browser client share a working wire protocol
+ * in both transfer directions.
+ *
+ * Prerequisites (handled by playwright.config.ts webServer entries):
+ *   - signaling server on :3001
+ *   - Next.js client on :3000
+ *
+ * The CLI binary is built once in a globalSetup-style beforeAll and cached in
+ * a temp path for the duration of the suite.
+ *
+ * --no-relay keeps both peers on host/loopback candidates so the tests run
+ * hermetically without a TURN server or real network.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+import {
+    createHash,
+    randomBytes,
+} from 'crypto';
+import {
+    writeFileSync,
+    mkdirSync,
+    rmSync,
+    readFileSync,
+    existsSync,
+} from 'fs';
+import { join, basename } from 'path';
+import { tmpdir, platform } from 'os';
+import { execSync, spawn, type ChildProcess } from 'child_process';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SERVER_URL = 'http://localhost:3001';
+const WEB_URL = 'http://localhost:3000';
+const FIXTURE_DIR = join(tmpdir(), 'floe-cli-interop');
+// File size: large enough to exercise the 8 MB backpressure loop (~12 MB).
+const FIXTURE_SIZE = 12 * 1024 * 1024;
+// Max time to wait for CLI process output / completion.
+const CLI_TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Build the CLI binary once for the whole suite
+// ---------------------------------------------------------------------------
+
+const CLI_BINARY = join(
+    tmpdir(),
+    platform() === 'win32' ? 'floe-test.exe' : 'floe-test',
+);
+
+/** Build the floe binary into a temp path and return the path. */
+function buildCLI(): string {
+    const repoRoot = join(__dirname, '..', '..');
+    execSync(
+        `go build -o "${CLI_BINARY}" ./cmd/floe`,
+        { cwd: join(repoRoot, 'cli'), stdio: 'inherit' },
+    );
+    return CLI_BINARY;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: fixtures
+// ---------------------------------------------------------------------------
+
+function createFixture(size: number): { path: string; sha256: string } {
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+    const data = size > 0 ? randomBytes(size) : Buffer.alloc(0);
+    const filePath = join(FIXTURE_DIR, `fixture-${size}.bin`);
+    writeFileSync(filePath, data);
+    const sha256 = createHash('sha256').update(data).digest('hex');
+    return { path: filePath, sha256 };
+}
+
+function sha256OfFile(filePath: string): string {
+    return createHash('sha256').update(readFileSync(filePath)).digest('hex');
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: browser
+// ---------------------------------------------------------------------------
+
+async function sha256OfBlobUrl(page: Page, blobUrl: string): Promise<string> {
+    return page.evaluate(async (url) => {
+        const buf = await fetch(url).then((r) => r.arrayBuffer());
+        const hash = await crypto.subtle.digest('SHA-256', buf);
+        return Array.from(new Uint8Array(hash))
+            .map((b) => b.toString(16).padStart(2, '0'))
+            .join('');
+    }, blobUrl);
+}
+
+/** Load the browser sender page, pick a file, and return the room URL. */
+async function browserSenderSetup(page: Page, fixturePath: string): Promise<string> {
+    await page.goto('/');
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(fixturePath);
+    await page.locator('button', { hasText: 'Create Secure Link' }).click();
+    const linkEl = page.locator('code').filter({ hasText: '?room=' });
+    await expect(linkEl).toBeVisible({ timeout: 10_000 });
+    return (await linkEl.textContent())!.trim();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: CLI process
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn `floe send` and return a promise that resolves to the room link once
+ * it appears in stdout, and a cleanup function that kills the process.
+ */
+function spawnSend(fixturePath: string): {
+    linkPromise: Promise<string>;
+    proc: ChildProcess;
+} {
+    const proc = spawn(CLI_BINARY, [
+        'send', fixturePath,
+        '--server', SERVER_URL,
+        '--web', WEB_URL,
+        '--no-relay',
+    ]);
+
+    const linkPromise = new Promise<string>((resolve, reject) => {
+        let stdout = '';
+        const timer = setTimeout(
+            () => reject(new Error(`CLI send did not emit a room link within ${CLI_TIMEOUT_MS} ms`)),
+            CLI_TIMEOUT_MS,
+        );
+
+        proc.stdout?.on('data', (chunk: Buffer) => {
+            stdout += chunk.toString();
+            // Room link always contains ?room=
+            const match = stdout.match(/https?:\/\/\S*\?room=[^\s]+/);
+            if (match) {
+                clearTimeout(timer);
+                resolve(match[0].trim());
+            }
+        });
+
+        proc.on('error', (err) => { clearTimeout(timer); reject(err); });
+        proc.on('close', (code) => {
+            if (code !== 0 && code !== null) {
+                clearTimeout(timer);
+                reject(new Error(`floe send exited with code ${code}`));
+            }
+        });
+    });
+
+    return { linkPromise, proc };
+}
+
+/**
+ * Spawn `floe receive` and return a promise that resolves once the process
+ * exits successfully.
+ */
+function spawnReceive(link: string, outputDir: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const proc = spawn(CLI_BINARY, [
+            'receive', link,
+            '--server', SERVER_URL,
+            '--output', outputDir,
+            '--yes',       // auto-accept
+            '--no-relay',
+        ]);
+
+        const timer = setTimeout(
+            () => { proc.kill(); reject(new Error(`floe receive timed out after ${CLI_TIMEOUT_MS} ms`)); },
+            CLI_TIMEOUT_MS,
+        );
+
+        proc.on('error', (err) => { clearTimeout(timer); reject(err); });
+        proc.on('close', (code) => {
+            clearTimeout(timer);
+            if (code === 0) resolve();
+            else reject(new Error(`floe receive exited with code ${code}`));
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Suite setup / teardown
+// ---------------------------------------------------------------------------
+
+let cliBinary: string;
+
+test.beforeAll(() => {
+    cliBinary = buildCLI();
+    mkdirSync(FIXTURE_DIR, { recursive: true });
+});
+
+test.afterAll(() => {
+    try { rmSync(FIXTURE_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+    try { if (existsSync(CLI_BINARY)) rmSync(CLI_BINARY); } catch { /* ignore */ }
+    void cliBinary; // satisfy no-unused-vars
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test('Direction 1: CLI send → browser receive (SHA-256 integrity)', async ({ browser }) => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_SIZE);
+
+    // Start the CLI sender first so the room exists before the browser joins.
+    const { linkPromise, proc } = spawnSend(fixturePath);
+    const roomLink = await linkPromise;
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    try {
+        await page.goto(roomLink);
+
+        // Wait for the download button — file fully received in browser.
+        const downloadLink = page.locator('a[download]').first();
+        await expect(downloadLink).toBeVisible({ timeout: 90_000 });
+
+        const blobUrl = (await downloadLink.getAttribute('href'))!;
+        const receivedHash = await sha256OfBlobUrl(page, blobUrl);
+        expect(receivedHash).toBe(expectedHash);
+    } finally {
+        await ctx.close();
+        proc.kill();
+    }
+});
+
+test('Direction 2: browser send → CLI receive (SHA-256 integrity)', async ({ browser }) => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_SIZE);
+    const outputDir = join(FIXTURE_DIR, 'received');
+    mkdirSync(outputDir, { recursive: true });
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    try {
+        // Start the browser sender and get the room link.
+        const roomLink = await browserSenderSetup(page, fixturePath);
+
+        // Spawn CLI receiver pointing at the room link.
+        await spawnReceive(roomLink, outputDir);
+
+        // Verify the file landed on disk with correct content.
+        const expectedName = basename(fixturePath);
+        const receivedPath = join(outputDir, expectedName);
+        expect(existsSync(receivedPath)).toBe(true);
+        expect(sha256OfFile(receivedPath)).toBe(expectedHash);
+    } finally {
+        await ctx.close();
+    }
+});


### PR DESCRIPTION
## Problem

CLI-to-CLI transfers were unreliable: the sender's progress bar raced to 100% while the receiver stalled partway through, and larger files failed to synchronize.

Root cause: the Go sender called `dc.Send()` as fast as the disk could read, with no SCTP backpressure. The progress bar measured bytes *enqueued into pion's buffer*, not delivered to the peer. On larger files the buffer overflowed and the connection stalled. A hard-coded `time.Sleep(2s)` before close then truncated transfers that had a large backlog. The browser sender already handled this correctly with 8MB/4MB watermarks.

## Changes

**Core transfer fixes (`cli/internal/transfer/`)**

- `sender.go`: Added backpressure via `SetBufferedAmountLowThreshold` (8MB/4MB watermarks) mirroring the browser sender. The chunk loop now blocks on `OnBufferedAmountLow` when the buffer is full. Replaced the 2s blind sleep with a real `BufferedAmount()` drain loop (30s cap) + 250ms grace period.
- `receiver.go`: Added `bytesReceived == FileSize` integrity check on the `end` marker so truncated transfers fail loudly instead of silently. Fixed a framing bug where small binary chunks whose bytes happened to be a JSON object were dropped as control messages (`classifyControl()` now only consumes known `metadata`/`end` types). Replaced `close(msgCh)` in `OnClose` with a `done` channel to eliminate a send-on-closed-channel panic risk.

**Additional hardening**

- `sender.go`: Ack `OnMessage` callback made non-blocking (`select/default`). Ack timeout raised from 30s to 120s for human-interactive receivers. Ack matching loops and discards non-matching messages.
- `signaling/client.go`: Signal buffer widened from 32 to 128 to reduce ICE candidate drops on slow networks.

**Tests**

- `transfer_test.go`: Unit tests for `classifyControl` / `looksLikeJSONObject` covering the framing regression.
- `loopback_test.go`: CLI-CLI Go loopback tests over real pion in-process peers - 20MB file (backpressure exercised, SHA-256 verified) and a small JSON file (framing fix verified byte-for-byte).
- `client/e2e/cli-interop.spec.ts`: Playwright cross-implementation tests in both directions (CLI send -> browser receive, browser send -> CLI receive) with SHA-256 integrity on 12MB fixtures.
- `.github/workflows/ci.yml`: New `cli-interop` job runs the interop spec on every PR (requires existing `cli`, `build-and-lint`, and `server` jobs to pass first).

## Notes

- `client/patches/next@16.2.6.patch` (upgrading Next's vendored postcss from 8.4.31) exists untracked. Wiring it up requires `pnpm patch-commit` (not a manual package.json edit) — tracked separately.
- All changes are CLI-side and preserve the existing wire protocol, so browser-to-CLI transfers remain compatible.