### PR TITLE
feat(cli): rich transfer summary with size, time, and avg speed

### DIFF
--- a/cli/internal/transfer/format.go
+++ b/cli/internal/transfer/format.go
@@ -1,0 +1,105 @@
+package transfer
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/schollz/progressbar/v3"
+)
+
+func formatBytes(n int64) string {
+	if n == 0 {
+		return "0 Bytes"
+	}
+	units := []string{"Bytes", "KB", "MB", "GB", "TB"}
+	k := 1024.0
+	i := int(math.Log(float64(n)) / math.Log(k))
+	if i >= len(units) {
+		i = len(units) - 1
+	}
+	val := float64(n) / math.Pow(k, float64(i))
+	// Trim trailing zeros after decimal (e.g. "1.20 GB" → "1.2 GB")
+	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", val), "0"), ".") + " " + units[i]
+}
+
+func formatSpeed(bytesPerSec float64) string {
+	if !isFinitePositive(bytesPerSec) {
+		return ""
+	}
+	if bytesPerSec >= 1024*1024 {
+		return fmt.Sprintf("%.1f MB/s", bytesPerSec/1024/1024)
+	}
+	return fmt.Sprintf("%.1f KB/s", bytesPerSec/1024)
+}
+
+func formatDuration(d time.Duration) string {
+	secs := int(d.Seconds())
+	if secs < 0 {
+		secs = 0
+	}
+	if secs < 60 {
+		return fmt.Sprintf("%ds", secs)
+	}
+	if secs < 3600 {
+		return fmt.Sprintf("%dm %ds", secs/60, secs%60)
+	}
+	return fmt.Sprintf("%dh %dm", secs/3600, (secs%3600)/60)
+}
+
+func pluralize(n int, word string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", word)
+	}
+	return fmt.Sprintf("%d %ss", n, word)
+}
+
+func truncateName(name string, maxLen int) string {
+	if len(name) <= maxLen {
+		return name
+	}
+	return name[:maxLen-1] + "…"
+}
+
+func newProgressBar(size int64, index, total int, name string) *progressbar.ProgressBar {
+	return progressbar.NewOptions64(
+		size,
+		progressbar.OptionSetDescription(
+			fmt.Sprintf("  [%d/%d] %s", index, total, truncateName(name, 30)),
+		),
+		progressbar.OptionSetWidth(30),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetTheme(progressbar.Theme{
+			Saucer:        "█",
+			SaucerPadding: "░",
+			BarStart:      "[",
+			BarEnd:        "]",
+		}),
+	)
+}
+
+const divider = "  ─────────────────────────────────────────────────"
+
+// printSummary prints a boxed block with aligned label/value rows.
+// rows is a slice of [2]string{label, value} pairs.
+func printSummary(rows [][2]string) {
+	// Find longest label for alignment
+	maxLabel := 0
+	for _, r := range rows {
+		if len(r[0]) > maxLabel {
+			maxLabel = len(r[0])
+		}
+	}
+	fmt.Println()
+	fmt.Println(divider)
+	for _, r := range rows {
+		pad := strings.Repeat(" ", maxLabel-len(r[0]))
+		fmt.Printf("  %s%s   %s\n", r[0], pad, r[1])
+	}
+	fmt.Println(divider)
+}
+
+func isFinitePositive(f float64) bool {
+	return !math.IsNaN(f) && !math.IsInf(f, 0) && f > 0
+}

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/pion/webrtc/v4"
 	"github.com/schollz/progressbar/v3"
@@ -51,7 +52,9 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 	var currentFile *os.File
 	var currentInfo FileInfo
 	var bytesReceived int64
+	var totalReceived int64
 	var bar *progressbar.ProgressBar
+	var start time.Time
 	filesReceived := 0
 	waitingForFirst := true
 
@@ -103,7 +106,8 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 				// On first file: show summary and optionally prompt
 				if waitingForFirst {
 					waitingForFirst = false
-					fmt.Printf("\n  Incoming: %d file(s)\n\n", info.Total)
+					start = time.Now()
+					fmt.Printf("\n  Incoming: %s\n\n", pluralize(info.Total, "file"))
 					if !autoAccept {
 						fmt.Print("  Accept? [Y/n] ")
 						var answer string
@@ -127,20 +131,7 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 				}
 
 				// Progress bar for this file
-				bar = progressbar.NewOptions64(
-					info.FileSize,
-					progressbar.OptionSetDescription(
-						fmt.Sprintf("  [%d/%d] %s", info.Index, info.Total, truncateName(info.FileName, 30)),
-					),
-					progressbar.OptionSetWidth(30),
-					progressbar.OptionShowBytes(true),
-					progressbar.OptionSetTheme(progressbar.Theme{
-						Saucer:        "█",
-						SaucerPadding: "░",
-						BarStart:      "[",
-						BarEnd:        "]",
-					}),
-				)
+				bar = newProgressBar(info.FileSize, info.Index, info.Total, info.FileName)
 
 				// Send ack as BINARY — the browser checks data.byteLength before
 				// decoding, which is only defined on ArrayBuffer/Buffer, not strings.
@@ -169,7 +160,16 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 
 					filesReceived++
 					if filesReceived >= currentInfo.Total {
-						fmt.Printf("  Done. %d file(s) received in %s\n", filesReceived, outputDir)
+						elapsed := time.Since(start)
+						timeVal := formatDuration(elapsed)
+						if spd := formatSpeed(float64(totalReceived) / elapsed.Seconds()); spd != "" {
+							timeVal += " · avg " + spd
+						}
+						printSummary([][2]string{
+							{"Received", fmt.Sprintf("%s (%s)", pluralize(filesReceived, "file"), formatBytes(totalReceived))},
+							{"Time", timeVal},
+							{"Saved to", outputDir},
+						})
 						return nil
 					}
 				}
@@ -191,6 +191,7 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 			return fmt.Errorf("write error: %w", err)
 		}
 		bytesReceived += int64(n)
+		totalReceived += int64(n)
 		bar.Add(n)
 	}
 }

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pion/webrtc/v4"
-	"github.com/schollz/progressbar/v3"
 )
 
 const chunkSize = 16 * 1024
@@ -33,13 +32,6 @@ const (
 	bufferedAmountHighWater = 8 * 1024 * 1024 // pause sending at/above 8 MB buffered
 	bufferedAmountLowWater  = 4 * 1024 * 1024 // resume sending below 4 MB buffered
 )
-
-func truncateName(name string, maxLen int) string {
-	if len(name) <= maxLen {
-		return name
-	}
-	return name[:maxLen-1] + "…"
-}
 
 // metadataMsg is sent before each file to describe it.
 type metadataMsg struct {
@@ -75,7 +67,13 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 		return fmt.Errorf("no files to send")
 	}
 
-	fmt.Printf("  Sending %d file(s)...\n\n", len(files))
+	var totalBytes int64
+	for _, e := range files {
+		totalBytes += e.size
+	}
+	fmt.Printf("  Sending %s (%s)\n\n", pluralize(len(files), "file"), formatBytes(totalBytes))
+
+	start := time.Now()
 
 	// ackCh receives JSON ack messages from the receiver
 	ackCh := make(chan []byte, 4)
@@ -108,8 +106,6 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 		}
 	}
 
-	fmt.Println("\n  All files sent.")
-
 	// Flush: wait for pion to push every buffered byte (including the final end
 	// marker) onto the wire before the caller closes the connection. Closing
 	// while data is still buffered truncates the transfer. Capped so a dead peer
@@ -124,6 +120,16 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 	// Brief grace period so the receiver can process the final end marker
 	// before the data channel is torn down.
 	time.Sleep(250 * time.Millisecond)
+
+	elapsed := time.Since(start)
+	timeVal := formatDuration(elapsed)
+	if spd := formatSpeed(float64(totalBytes) / elapsed.Seconds()); spd != "" {
+		timeVal += " · avg " + spd
+	}
+	printSummary([][2]string{
+		{"Sent", fmt.Sprintf("%s (%s)", pluralize(len(files), "file"), formatBytes(totalBytes))},
+		{"Time", timeVal},
+	})
 	return nil
 }
 
@@ -131,6 +137,7 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 type fileEntry struct {
 	absPath     string // absolute path on disk
 	displayName string // shown in the UI (basename or relative path for folders)
+	size        int64  // file size in bytes
 }
 
 // collectFiles expands all paths: plain files are added directly,
@@ -147,6 +154,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 			entries = append(entries, fileEntry{
 				absPath:     p,
 				displayName: filepath.Base(p),
+				size:        info.Size(),
 			})
 			continue
 		}
@@ -161,6 +169,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 			entries = append(entries, fileEntry{
 				absPath:     path,
 				displayName: filepath.ToSlash(rel), // use forward slashes in metadata
+				size:        fi.Size(),
 			})
 			return nil
 		})
@@ -232,18 +241,7 @@ ackLoop:
 	}
 
 	// Step 3: Send binary chunks with progress bar
-	bar := progressbar.NewOptions64(
-		fileSize,
-		progressbar.OptionSetDescription(fmt.Sprintf("  [%d/%d] %s", index, total, truncateName(entry.displayName, 30))),
-		progressbar.OptionSetWidth(30),
-		progressbar.OptionShowBytes(true),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "█",
-			SaucerPadding: "░",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}),
-	)
+	bar := newProgressBar(fileSize, index, total, entry.displayName)
 	bar.Set64(offset)
 
 	buf := make([]byte, chunkSize)


### PR DESCRIPTION
## Summary

- **Send header** now shows total size: `Sending 3 files (1.2 GB)` instead of `Sending 3 file(s)...`
- **Boxed completion summary** replaces the bare done line on both sender and receiver:
  ```
  ─────────────────────────────────────────────────
  Sent       3 files (1.2 GB)
  Time       1m 41s · avg 49 MB/s
  ─────────────────────────────────────────────────
  ```
  Receiver also shows `Saved to <dir>`. Average speed is omitted for instant transfers to avoid bogus values.
- **`format.go`** — new shared file with `formatBytes`, `formatSpeed`, `formatDuration`, `pluralize`, `newProgressBar`, `printSummary`, `truncateName`. Deduplicates the identical progress bar config that was copy-pasted in `sender.go` and `receiver.go`.
- Number formats (`MB/s`, `KB/s`, `1.2 GB`) mirror the browser UI exactly for consistency across CLI-to-CLI and browser-to-CLI transfers.

## Test plan

- [x] `go build ./cmd/floe` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass (including cross-implementation transfer tests)
- [ ] CLI-to-CLI: `floe send` + `floe receive` — confirm header and boxed summary on both sides
- [ ] CLI-to-browser: send from web app, receive with CLI — confirm summary matches browser number formats
- [ ] Edge cases: single file (grammar `1 file`), instant transfer (no avg speed line)