### PR TITLE
refactor(client): extract transfer engine + add vitest unit tests + wire both specs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         run: pnpm lint
         working-directory: client
 
+      - name: Unit tests
+        run: pnpm test
+        working-directory: client
+
       - name: Build
         run: pnpm build
         working-directory: client
@@ -99,8 +103,8 @@ jobs:
         run: go build ./cmd/floe
         working-directory: cli
 
-  cli-interop:
-    name: CLI↔Browser Interop (Go + Node)
+  e2e:
+    name: E2E (browser + CLI interop)
     runs-on: ubuntu-latest
     # Requires both Go (CLI binary) and Node (server + client + Playwright)
     needs: [cli, build-and-lint, server]
@@ -149,8 +153,8 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
         working-directory: client
 
-      - name: Run CLI↔browser interop tests
-        run: pnpm exec playwright test cli-interop.spec.ts
+      - name: Run E2E tests (browser + CLI interop)
+        run: pnpm exec playwright test
         working-directory: client
         env:
           NEXT_PUBLIC_SOCKET_URL: http://localhost:3001

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -16,6 +16,9 @@ import { v4 as uuidv4 } from 'uuid';
 import { zip, Zippable } from 'fflate';
 import * as Sentry from '@sentry/nextjs';
 import { formatSpeed, formatETA } from '@/lib/transferUtils';
+import { createReceiver } from '@/lib/transfer/receiver';
+import { sendFiles as sendFilesEngine } from '@/lib/transfer/sender';
+import { dedupeFileName } from '@/lib/download';
 import { useWakeLock } from '@/hooks/useWakeLock';
 
 import { QRCodeSVG } from 'qrcode.react';
@@ -114,9 +117,6 @@ export function P2PTransfer() {
     const receivedFilesRef = useRef<ReceivedFile[]>([]);
     const transferCompleteRef = useRef(false);
     const progressRef = useRef(0);
-    const partialDownloads = useRef<
-        Map<string, { chunks: ArrayBuffer[]; received: number }>
-    >(new Map());
     const fileListRef = useRef<HTMLDivElement>(null);
 
     const iceServersRef = useRef<RTCIceServer[]>([
@@ -246,22 +246,7 @@ export function P2PTransfer() {
                     const blob = await response.blob();
                     const arrayBuffer = await blob.arrayBuffer();
 
-                    let finalName = file.fileName;
-                    let counter = 1;
-
-                    while (usedNames.has(finalName)) {
-                        const dotIndex = file.fileName.lastIndexOf('.');
-                        if (dotIndex === -1) {
-                            finalName = `${file.fileName} (${counter})`;
-                        } else {
-                            const base = file.fileName.substring(0, dotIndex);
-                            const ext = file.fileName.substring(dotIndex);
-                            finalName = `${base} (${counter})${ext}`;
-                        }
-                        counter++;
-                    }
-
-                    usedNames.add(finalName);
+                    const finalName = dedupeFileName(file.fileName, usedNames);
                     filesToZip[finalName] = new Uint8Array(arrayBuffer);
                 } catch {
                     failedCount++;
@@ -441,134 +426,48 @@ export function P2PTransfer() {
             setStatus('Connection failed');
         });
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let currentMetadata: any = {};
-
-        let receiveSpeedStart = performance.now();
-        let receiveSpeedBytes = 0;
-        let lastReceiveSpeedUpdate = 0;
-
-        peer.on('data', (data) => {
-            if (data.byteLength <= 1000) {
-                try {
-                    const text = new TextDecoder().decode(data);
-                    if (text.startsWith('{')) {
-                        const msg = JSON.parse(text);
-
-                        if (msg.type === 'metadata') {
-                            currentMetadata = msg;
-                            receiveSpeedStart = performance.now();
-                            receiveSpeedBytes = 0;
-                            lastReceiveSpeedUpdate = 0;
-                            setTransferSpeed('');
-                            setEstimatedTime('');
-                            setStatus(
-                                `Receiving file ${msg.index} of ${msg.total}`
-                            );
-
-                            let offset = 0;
-                            const existing = partialDownloads.current.get(
-                                msg.id
-                            );
-                            if (existing) {
-                                offset = existing.received;
-                            } else {
-                                partialDownloads.current.set(msg.id, {
-                                    chunks: [],
-                                    received: 0,
-                                });
-                            }
-                            peer.send(
-                                JSON.stringify({
-                                    type: 'ack',
-                                    id: msg.id,
-                                    offset: offset,
-                                })
-                            );
-                            return;
-                        } else if (msg.type === 'end') {
-                            const fileData = partialDownloads.current.get(
-                                currentMetadata.id
-                            );
-                            if (fileData) {
-                                const blob = new Blob(fileData.chunks);
-                                const url = URL.createObjectURL(blob);
-
-                                const newFile = {
-                                    id: uuidv4(),
-                                    fileName: currentMetadata.fileName,
-                                    fileSize: fileData.received,
-                                    downloadUrl: url,
-                                };
-
-                                setReceivedFiles((prev) => {
-                                    const updated = [...prev, newFile];
-                                    receivedFilesRef.current = updated;
-                                    return updated;
-                                });
-                                transferCompleteRef.current = true;
-                                partialDownloads.current.delete(
-                                    currentMetadata.id
-                                );
-                                // Track received file (aggregate only)
-                                if (typeof window !== 'undefined') {
-                                    (window as UmamiWindow).umami?.track('transfer-received', {
-                                        files: receivedFilesRef.current.length,
-                                        bytes: fileData.received,
-                                        connection: connectionType ?? 'unknown',
-                                        role: 'receiver',
-                                    });
-                                }
-                            }
-                            setStatus('File received. Waiting for next file');
-                            setProgress(0);
-                            setTransferSpeed('');
-                            setEstimatedTime('');
-                            return;
-                        }
-                    }
-                } catch { }
-            }
-
-            const fileData = partialDownloads.current.get(currentMetadata.id);
-            if (fileData) {
-                fileData.chunks.push(data);
-                fileData.received += data.byteLength;
-                receiveSpeedBytes += data.byteLength;
-
-                const now = performance.now();
-                if (now - lastReceiveSpeedUpdate > 1000) {
-                    const elapsed = (now - receiveSpeedStart) / 1000;
-                    if (elapsed > 0 && currentMetadata.fileSize) {
-                        const bytesPerSec = receiveSpeedBytes / elapsed;
-                        const remaining = currentMetadata.fileSize - fileData.received;
-                        const etaSeconds = remaining / bytesPerSec;
-
-                        const speedFormatted = formatSpeed(bytesPerSec);
-                        const etaFormatted = formatETA(etaSeconds);
-
-                        setTransferSpeed(speedFormatted);
-                        setEstimatedTime(etaFormatted);
-                    }
-
-                    receiveSpeedStart = now;
-                    receiveSpeedBytes = 0;
-                    lastReceiveSpeedUpdate = now;
+        const rx = createReceiver({
+            send: (d) => peer.send(d),
+            onFileStart: (index, total) => {
+                setTransferSpeed('');
+                setEstimatedTime('');
+                setStatus(`Receiving file ${index} of ${total}`);
+            },
+            onProgress: (pct) => setProgress(pct),
+            onSpeed: (bps, eta) => {
+                setTransferSpeed(formatSpeed(bps));
+                setEstimatedTime(formatETA(eta));
+            },
+            onSpeedReset: () => {
+                setTransferSpeed('');
+                setEstimatedTime('');
+            },
+            onFileComplete: (file) => {
+                const url = URL.createObjectURL(file.blob);
+                const newFile = {
+                    id: uuidv4(),
+                    fileName: file.fileName,
+                    fileSize: file.fileSize,
+                    downloadUrl: url,
+                };
+                setReceivedFiles((prev) => {
+                    const updated = [...prev, newFile];
+                    receivedFilesRef.current = updated;
+                    return updated;
+                });
+                transferCompleteRef.current = true;
+                if (typeof window !== 'undefined') {
+                    (window as UmamiWindow).umami?.track('transfer-received', {
+                        files: receivedFilesRef.current.length,
+                        bytes: file.fileSize,
+                        connection: connectionType ?? 'unknown',
+                        role: 'receiver',
+                    });
                 }
-
-                if (
-                    currentMetadata.fileSize &&
-                    (fileData.received % (160 * 1024 * 10) === 0 ||
-                        fileData.received === currentMetadata.fileSize)
-                ) {
-                    setProgress(
-                        Math.round(
-                            (fileData.received / currentMetadata.fileSize) * 100
-                        )
-                    );
-                }
-            }
+            },
+            onWaiting: () => setStatus('File received. Waiting for next file'),
         });
+        peer.on('data', rx.handleMessage);
         peerRef.current = peer;
     };
 
@@ -899,215 +798,63 @@ export function P2PTransfer() {
     };
 
     const sendAllFiles = async (peer: PeerInstance, fileList: FileWithId[]) => {
-        for (let i = 0; i < fileList.length; i++) {
-            if (peer.destroyed) break;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const channel = (peer as any)._channel as RTCDataChannel | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const pc = (peer as any)._pc as RTCPeerConnection | undefined;
 
-            setCurrentFileIndex(i);
-            const fileItem = fileList[i];
-            setStatus(`Sending: ${fileItem.file.name}`);
-            setProgress(0);
+        if (!channel) return;
 
-            await sendSingleFile(peer, fileItem, i + 1, fileList.length);
-        }
-        if (!peer.destroyed) {
-            setStatus('All Files Sent!');
-            setProgress(100);
-            transferCompleteRef.current = true;
-            releaseWakeLock();
-            // Track successful transfer (aggregate only — no file names, no identifiers)
-            if (typeof window !== 'undefined') {
-                (window as UmamiWindow).umami?.track('transfer-complete', {
-                    files: fileList.length,
-                    bytes: fileList.reduce((s, f) => s + f.file.size, 0),
-                    connection: connectionType ?? 'unknown',
-                    role: 'sender',
-                });
-            }
-        }
-    };
-
-    const sendSingleFile = async (
-        peer: PeerInstance,
-        fileItem: FileWithId,
-        index: number,
-        total: number
-    ) => {
-        return new Promise<void>(async (resolve) => {
-            const { file, id } = fileItem;
-
-            if (!peer || peer.destroyed) {
-                resolve();
-                return;
-            }
-
-            // Adaptive chunk size: use the negotiated SCTP max, capped at 256 KB.
-            // sctp.maxMessageSize is the negotiated minimum of both peers, so this is
-            // automatically safe for browser<->CLI (Pion's limit clamps it down).
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const pc = (peer as any)._pc as RTCPeerConnection | undefined;
-            const sctpMax = pc?.sctp?.maxMessageSize;
-            const CHUNK_SIZE = (sctpMax && Number.isFinite(sctpMax) && sctpMax > 0)
-                ? Math.min(256 * 1024, sctpMax)
-                : 64 * 1024;
-
-            // Keep the send buffer oscillating between 4 MB and 8 MB so the link
-            // stays saturated instead of draining to ~0 before refilling.
-            const HIGH_WATER = 8 * 1024 * 1024;
-            const LOW_WATER = 4 * 1024 * 1024;
-
-            // Read from disk in 4 MB slabs to cut await round-trips by ~256x vs
-            // the old per-16-KB arrayBuffer() call.
-            const READ_SLAB = 4 * 1024 * 1024;
-
-            try {
-                peer.send(
-                    JSON.stringify({
-                        id: id,
-                        fileName: file.name,
-                        fileSize: file.size,
-                        type: 'metadata',
-                        index: index,
-                        total: total,
-                    })
-                );
-            } catch {
-                resolve();
-                return;
-            }
-
-            // Set the low-water threshold once; bufferedamountlow fires at LOW_WATER from here on.
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const channel = (peer as any)._channel as RTCDataChannel | undefined;
-            if (channel) {
-                channel.bufferedAmountLowThreshold = LOW_WATER;
-            }
-
-            // Wait for receiver ACK with a 15 s timeout to avoid hanging indefinitely
-            // if the receiver crashes or stalls after receiving metadata.
-            const ackResult = await Promise.race([
-                new Promise<number>((resolveAck) => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const handleAck = (data: any) => {
-                        if (data.byteLength < 1000) {
-                            try {
-                                const text = new TextDecoder().decode(data);
-                                const msg = JSON.parse(text);
-                                if (msg.type === 'ack' && msg.id === id) {
-                                    peer.off('data', handleAck);
-                                    resolveAck(msg.offset);
-                                }
-                            } catch { }
-                        }
-                    };
-                    peer.on('data', handleAck);
-                }),
-                new Promise<number>((_, reject) =>
-                    setTimeout(() => reject(new Error('ack-timeout')), 15_000)
-                ),
-            ]).catch(() => {
-                setError('Transfer timed out waiting for receiver. Please try again.');
-                setStatus('Transfer failed');
-                return -1;
-            });
-
-            if (ackResult === -1) {
-                resolve();
-                return;
-            }
-
-            let offset = ackResult;
-            let chunkCount = 0;
-
-            let speedMeasureStart = performance.now();
-            let speedMeasureBytes = 0;
-            let lastSpeedUpdate = 0;
-
-            const waitForBuffer = (ch: RTCDataChannel) =>
-                new Promise<void>((r) => {
-                    const onLow = () => {
-                        ch.removeEventListener('bufferedamountlow', onLow);
-                        r();
-                    };
-                    if (ch.bufferedAmount < LOW_WATER) {
-                        r();
-                    } else {
-                        ch.addEventListener('bufferedamountlow', onLow);
+        await sendFilesEngine(
+            {
+                send: (d) => peer.send(d),
+                onData: (handler) => {
+                    peer.on('data', handler);
+                    return () => peer.off('data', handler);
+                },
+                channel,
+                sctpMaxMessageSize: pc?.sctp?.maxMessageSize,
+            },
+            fileList.map((f) => ({ id: f.id, file: f.file })),
+            {
+                isDestroyed: () => peer.destroyed,
+                onFileStart: (i, _total, name) => {
+                    setCurrentFileIndex(i);
+                    setStatus(`Sending: ${name}`);
+                    setProgress(0);
+                },
+                onProgress: (pct) => {
+                    setProgress(pct);
+                    progressRef.current = pct;
+                },
+                onSpeed: (bps, eta) => {
+                    setTransferSpeed(formatSpeed(bps));
+                    setEstimatedTime(formatETA(eta));
+                },
+                onSpeedReset: () => {
+                    setTransferSpeed('');
+                    setEstimatedTime('');
+                },
+                onError: (msg) => {
+                    setError(msg);
+                    setStatus('Transfer failed');
+                },
+                onAllSent: () => {
+                    setStatus('All Files Sent!');
+                    setProgress(100);
+                    transferCompleteRef.current = true;
+                    releaseWakeLock();
+                    if (typeof window !== 'undefined') {
+                        (window as UmamiWindow).umami?.track('transfer-complete', {
+                            files: fileList.length,
+                            bytes: fileList.reduce((s, f) => s + f.file.size, 0),
+                            connection: connectionType ?? 'unknown',
+                            role: 'sender',
+                        });
                     }
-                });
-
-            while (offset < file.size) {
-                if (peer.destroyed) break;
-
-                // Read a 4 MB slab from disk (one await per 4 MB instead of per chunk)
-                const slabEnd = Math.min(offset + READ_SLAB, file.size);
-                let slabBuffer: ArrayBuffer;
-                try {
-                    slabBuffer = await file.slice(offset, slabEnd).arrayBuffer();
-                } catch {
-                    break;
-                }
-
-                // Send the slab as CHUNK_SIZE typed-array views (zero-copy)
-                let slabOffset = 0;
-                while (slabOffset < slabBuffer.byteLength) {
-                    if (peer.destroyed) break;
-
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    const ch = (peer as any)._channel as RTCDataChannel | undefined;
-                    if (ch && ch.bufferedAmount >= HIGH_WATER) {
-                        await waitForBuffer(ch);
-                    }
-
-                    if (peer.destroyed) break;
-
-                    const chunkLen = Math.min(CHUNK_SIZE, slabBuffer.byteLength - slabOffset);
-                    const chunk = new Uint8Array(slabBuffer, slabOffset, chunkLen);
-
-                    try {
-                        peer.send(chunk);
-                    } catch {
-                        await new Promise((r) => setTimeout(r, 100));
-                        continue;
-                    }
-
-                    slabOffset += chunkLen;
-                    offset += chunkLen;
-                    speedMeasureBytes += chunkLen;
-                    chunkCount++;
-
-                    const now = performance.now();
-                    if (now - lastSpeedUpdate > 1000) {
-                        const elapsed = (now - speedMeasureStart) / 1000;
-                        if (elapsed > 0) {
-                            const bytesPerSec = speedMeasureBytes / elapsed;
-                            const remaining = file.size - offset;
-                            const etaSeconds = remaining / bytesPerSec;
-
-                            setTransferSpeed(formatSpeed(bytesPerSec));
-                            setEstimatedTime(formatETA(etaSeconds));
-                        }
-
-                        speedMeasureStart = now;
-                        speedMeasureBytes = 0;
-                        lastSpeedUpdate = now;
-                    }
-
-                    if (chunkCount % 10 === 0 || offset >= file.size) {
-                        const prog = Math.round((offset / file.size) * 100);
-                        setProgress(prog);
-                        progressRef.current = prog;
-                    }
-                }
+                },
             }
-
-            setTransferSpeed('');
-            setEstimatedTime('');
-
-            try {
-                peer.send(JSON.stringify({ type: 'end' }));
-            } catch { }
-            resolve();
-        });
+        );
     };
 
     if (isSender === null) {

--- a/client/lib/download.test.ts
+++ b/client/lib/download.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { dedupeFileName } from './download';
+
+describe('dedupeFileName', () => {
+    it('returns the original name when unused', () => {
+        const used = new Set<string>();
+        expect(dedupeFileName('photo.jpg', used)).toBe('photo.jpg');
+    });
+
+    it('adds the name to the used set', () => {
+        const used = new Set<string>();
+        dedupeFileName('doc.pdf', used);
+        expect(used.has('doc.pdf')).toBe(true);
+    });
+
+    it('appends (1) on first collision with extension', () => {
+        const used = new Set(['photo.jpg']);
+        expect(dedupeFileName('photo.jpg', used)).toBe('photo (1).jpg');
+    });
+
+    it('appends (2) on second collision with extension', () => {
+        const used = new Set(['photo.jpg', 'photo (1).jpg']);
+        expect(dedupeFileName('photo.jpg', used)).toBe('photo (2).jpg');
+    });
+
+    it('handles files with no extension', () => {
+        const used = new Set(['README']);
+        expect(dedupeFileName('README', used)).toBe('README (1)');
+    });
+
+    it('handles multiple collisions in sequence', () => {
+        const used = new Set<string>();
+        dedupeFileName('file.txt', used); // file.txt
+        dedupeFileName('file.txt', used); // file (1).txt
+        dedupeFileName('file.txt', used); // file (2).txt
+        expect([...used]).toEqual(['file.txt', 'file (1).txt', 'file (2).txt']);
+    });
+
+    it('handles dotfiles (name starts with dot)', () => {
+        const used = new Set(['.gitignore']);
+        // lastIndexOf('.') === 0 → base='', ext='.gitignore' → ' (1).gitignore'
+        // Matches the original inline loop behavior in P2PTransfer.tsx
+        const result = dedupeFileName('.gitignore', used);
+        expect(result).toBe(' (1).gitignore');
+    });
+});

--- a/client/lib/download.ts
+++ b/client/lib/download.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolves a collision-free name for a ZIP entry.
+ * If `name` is already in `used`, appends " (N)" before the extension
+ * until a free slot is found, then adds the result to `used`.
+ */
+export function dedupeFileName(name: string, used: Set<string>): string {
+    let finalName = name;
+    let counter = 1;
+    while (used.has(finalName)) {
+        const dot = name.lastIndexOf('.');
+        finalName = dot === -1
+            ? `${name} (${counter})`
+            : `${name.substring(0, dot)} (${counter})${name.substring(dot)}`;
+        counter++;
+    }
+    used.add(finalName);
+    return finalName;
+}

--- a/client/lib/transfer/protocol.test.ts
+++ b/client/lib/transfer/protocol.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import {
+    CONTROL_MSG_MAX,
+    HIGH_WATER,
+    LOW_WATER,
+    DEFAULT_CHUNK,
+    MAX_CHUNK,
+    chunkSize,
+    classifyControl,
+    metadataMessage,
+    ackMessage,
+    endMessage,
+} from './protocol';
+
+const enc = new TextEncoder();
+
+function toUint8(s: string): Uint8Array {
+    return enc.encode(s);
+}
+
+function toArrayBuffer(s: string): ArrayBuffer {
+    return toUint8(s).buffer as ArrayBuffer;
+}
+
+describe('constants', () => {
+    it('CONTROL_MSG_MAX is 1000', () => expect(CONTROL_MSG_MAX).toBe(1000));
+    it('HIGH_WATER is 8 MB', () => expect(HIGH_WATER).toBe(8 * 1024 * 1024));
+    it('LOW_WATER is 4 MB', () => expect(LOW_WATER).toBe(4 * 1024 * 1024));
+});
+
+describe('chunkSize', () => {
+    it('returns DEFAULT_CHUNK when no sctp max', () => {
+        expect(chunkSize()).toBe(DEFAULT_CHUNK);
+        expect(chunkSize(undefined)).toBe(DEFAULT_CHUNK);
+        expect(chunkSize(null)).toBe(DEFAULT_CHUNK);
+        expect(chunkSize(0)).toBe(DEFAULT_CHUNK);
+    });
+
+    it('clamps to MAX_CHUNK when sctp max is huge', () => {
+        expect(chunkSize(Infinity)).toBe(DEFAULT_CHUNK); // Infinity is not finite
+        expect(chunkSize(1_000_000)).toBe(MAX_CHUNK);
+    });
+
+    it('uses sctp max when within bounds', () => {
+        expect(chunkSize(128 * 1024)).toBe(128 * 1024);
+    });
+
+    it('uses sctp max when it is less than DEFAULT_CHUNK', () => {
+        expect(chunkSize(16 * 1024)).toBe(16 * 1024);
+    });
+});
+
+describe('message builders round-trip', () => {
+    it('metadataMessage parses back correctly', () => {
+        const raw = metadataMessage('abc', 'file.txt', 1024, 1, 3);
+        const msg = JSON.parse(raw);
+        expect(msg).toMatchObject({ type: 'metadata', id: 'abc', fileName: 'file.txt', fileSize: 1024, index: 1, total: 3 });
+    });
+
+    it('ackMessage parses back correctly', () => {
+        const raw = ackMessage('xyz', 512);
+        const msg = JSON.parse(raw);
+        expect(msg).toMatchObject({ type: 'ack', id: 'xyz', offset: 512 });
+    });
+
+    it('endMessage parses back correctly', () => {
+        const raw = endMessage();
+        const msg = JSON.parse(raw);
+        expect(msg).toMatchObject({ type: 'end' });
+    });
+});
+
+describe('classifyControl', () => {
+    it('classifies metadata', () => {
+        const raw = metadataMessage('id1', 'a.txt', 100, 1, 1);
+        const result = classifyControl(toUint8(raw));
+        expect(result?.type).toBe('metadata');
+    });
+
+    it('classifies ack', () => {
+        const result = classifyControl(toUint8(ackMessage('id2', 0)));
+        expect(result?.type).toBe('ack');
+    });
+
+    it('classifies end', () => {
+        const result = classifyControl(toUint8(endMessage()));
+        expect(result?.type).toBe('end');
+    });
+
+    it('returns null for binary data > CONTROL_MSG_MAX', () => {
+        const big = new Uint8Array(CONTROL_MSG_MAX + 1).fill(65);
+        expect(classifyControl(big)).toBeNull();
+    });
+
+    it('returns null for binary data that does not start with {', () => {
+        const data = toUint8('hello world');
+        expect(classifyControl(data)).toBeNull();
+    });
+
+    it('returns null for valid JSON but unknown type', () => {
+        const data = toUint8(JSON.stringify({ type: 'unknown' }));
+        expect(classifyControl(data)).toBeNull();
+    });
+
+    it('returns null for invalid JSON starting with {', () => {
+        const data = toUint8('{not valid json');
+        expect(classifyControl(data)).toBeNull();
+    });
+
+    it('returns null for exactly 1001 bytes of JSON-looking data', () => {
+        // Pad to 1001 bytes — over the limit even if it looks like JSON
+        const base = '{"type":"metadata","id":"' + 'x'.repeat(980) + '"}';
+        const padded = toUint8(base.slice(0, CONTROL_MSG_MAX + 1));
+        expect(classifyControl(padded)).toBeNull();
+    });
+
+    it('treats a small binary chunk that happens to look like JSON as file data (null)', () => {
+        // A 999-byte payload that is valid JSON but has type "data" — should be null
+        const payload = JSON.stringify({ type: 'data', bytes: 'x'.repeat(900) });
+        expect(classifyControl(toUint8(payload.slice(0, 999)))).toBeNull();
+    });
+
+    it('accepts an ArrayBuffer as well as Uint8Array', () => {
+        const buf = toArrayBuffer(endMessage());
+        expect(classifyControl(buf)?.type).toBe('end');
+    });
+});

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -1,0 +1,101 @@
+// Floe wire-protocol constants and message helpers.
+// Mirrors cli/internal/transfer/sender.go + receiver.go — keep in sync.
+
+export const CONTROL_MSG_MAX = 1000; // bytes; matches browser byteLength guard
+export const HIGH_WATER = 8 * 1024 * 1024; // 8 MB — pause sending at/above
+export const LOW_WATER = 4 * 1024 * 1024;  // 4 MB — resume sending below
+export const READ_SLAB = 4 * 1024 * 1024;  // 4 MB — disk read slab size
+export const DEFAULT_CHUNK = 64 * 1024;    // 64 KB — fallback chunk size
+export const MAX_CHUNK = 256 * 1024;       // 256 KB — cap on adaptive chunk
+
+// Adaptive chunk size: use the negotiated SCTP max, capped at MAX_CHUNK.
+export function chunkSize(sctpMax?: number | null): number {
+    if (sctpMax && Number.isFinite(sctpMax) && sctpMax > 0) {
+        return Math.min(MAX_CHUNK, sctpMax);
+    }
+    return DEFAULT_CHUNK;
+}
+
+// --- Message types ---
+
+export interface Metadata {
+    type: 'metadata';
+    id: string;
+    fileName: string;
+    fileSize: number;
+    index: number;
+    total: number;
+}
+
+export interface Ack {
+    type: 'ack';
+    id: string;
+    offset: number;
+}
+
+export interface End {
+    type: 'end';
+}
+
+export type ControlMessage = Metadata | Ack | End;
+
+// --- Message builders ---
+
+export function metadataMessage(
+    id: string,
+    fileName: string,
+    fileSize: number,
+    index: number,
+    total: number
+): string {
+    return JSON.stringify({ type: 'metadata', id, fileName, fileSize, index, total } satisfies Metadata);
+}
+
+export function ackMessage(id: string, offset: number): string {
+    return JSON.stringify({ type: 'ack', id, offset } satisfies Ack);
+}
+
+export function endMessage(): string {
+    return JSON.stringify({ type: 'end' } satisfies End);
+}
+
+// --- Control message classifier ---
+
+const decoder = new TextDecoder();
+
+/**
+ * Classifies a data channel message as a Floe control message or file data.
+ * Returns the parsed control message if recognized, null if it should be
+ * treated as file data (written to disk / appended to the receive buffer).
+ *
+ * Preserves exact browser semantics:
+ *   - Only probe if byteLength <= CONTROL_MSG_MAX (1000)
+ *   - Decoded text must start with '{'
+ *   - JSON.parse must succeed and 'type' must be a known control type
+ */
+export function classifyControl(data: ArrayBuffer | Uint8Array): ControlMessage | null {
+    const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
+    if (buf.byteLength > CONTROL_MSG_MAX) return null;
+
+    let text: string;
+    try {
+        text = decoder.decode(buf);
+    } catch {
+        return null;
+    }
+
+    if (!text.startsWith('{')) return null;
+
+    let msg: Record<string, unknown>;
+    try {
+        msg = JSON.parse(text) as Record<string, unknown>;
+    } catch {
+        return null;
+    }
+
+    const t = msg['type'];
+    if (t === 'metadata') return msg as unknown as Metadata;
+    if (t === 'ack') return msg as unknown as Ack;
+    if (t === 'end') return msg as unknown as End;
+    return null;
+}

--- a/client/lib/transfer/receiver.ts
+++ b/client/lib/transfer/receiver.ts
@@ -1,0 +1,139 @@
+// Floe receiver engine — framework-agnostic, no React or simple-peer imports.
+// Extracted from P2PTransfer.tsx peer.on('data') handler.
+import {
+    classifyControl,
+    ackMessage,
+    type Metadata,
+} from './protocol';
+
+export interface ReceivedFile {
+    id: string;
+    fileName: string;
+    fileSize: number;
+    blob: Blob;
+}
+
+export interface ReceiverCallbacks {
+    send: (data: string | Uint8Array) => void;
+    onFileStart?: (index: number, total: number, fileName: string, fileSize: number) => void;
+    onProgress?: (percent: number, received: number, fileSize: number) => void;
+    onSpeed?: (bytesPerSec: number, etaSeconds: number) => void;
+    onSpeedReset?: () => void;
+    onFileComplete?: (file: ReceivedFile, index: number, total: number) => void;
+    onWaiting?: () => void;
+}
+
+interface PartialDownload {
+    chunks: ArrayBuffer[];
+    received: number;
+}
+
+/**
+ * Creates a stateful receiver engine.
+ * Call `handleMessage(data)` for every `peer.on('data', ...)` event.
+ *
+ * Real usage (in component):
+ *   const rx = createReceiver({
+ *     send: d => peer.send(d),
+ *     onFileStart: (i, t, name) => setStatus(`Receiving file ${i} of ${t}`),
+ *     onProgress: (pct) => setProgress(pct),
+ *     onSpeed: (bps, eta) => { setTransferSpeed(formatSpeed(bps)); setEstimatedTime(formatETA(eta)); },
+ *     onSpeedReset: () => { setTransferSpeed(''); setEstimatedTime(''); },
+ *     onFileComplete: (file) => {
+ *       const url = URL.createObjectURL(file.blob);
+ *       setReceivedFiles(prev => [...prev, { ...file, downloadUrl: url }]);
+ *     },
+ *     onWaiting: () => setStatus('File received. Waiting for next file'),
+ *   });
+ *   peer.on('data', rx.handleMessage);
+ */
+export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: Uint8Array | ArrayBuffer) => void } {
+    const partialDownloads = new Map<string, PartialDownload>();
+    let currentMetadata: Metadata | null = null;
+
+    let receiveSpeedStart = performance.now();
+    let receiveSpeedBytes = 0;
+    let lastReceiveSpeedUpdate = 0;
+
+    function handleMessage(data: Uint8Array | ArrayBuffer): void {
+        const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
+        const msg = classifyControl(buf);
+
+        if (msg) {
+            if (msg.type === 'metadata') {
+                currentMetadata = msg;
+                receiveSpeedStart = performance.now();
+                receiveSpeedBytes = 0;
+                lastReceiveSpeedUpdate = 0;
+                cb.onSpeedReset?.();
+                cb.onFileStart?.(msg.index, msg.total, msg.fileName, msg.fileSize);
+
+                let offset = 0;
+                const existing = partialDownloads.get(msg.id);
+                if (existing) {
+                    offset = existing.received;
+                } else {
+                    partialDownloads.set(msg.id, { chunks: [], received: 0 });
+                }
+
+                cb.send(ackMessage(msg.id, offset));
+            } else if (msg.type === 'end') {
+                if (!currentMetadata) return;
+                const fileData = partialDownloads.get(currentMetadata.id);
+                if (!fileData) return;
+
+                const blob = new Blob(fileData.chunks);
+                const completed: ReceivedFile = {
+                    id: currentMetadata.id,
+                    fileName: currentMetadata.fileName,
+                    fileSize: fileData.received,
+                    blob,
+                };
+
+                partialDownloads.delete(currentMetadata.id);
+                cb.onFileComplete?.(completed, currentMetadata.index, currentMetadata.total);
+                cb.onWaiting?.();
+                cb.onProgress?.(0, 0, 0);
+                cb.onSpeedReset?.();
+            }
+            return;
+        }
+
+        // Binary chunk — file data
+        if (!currentMetadata) return;
+        const fileData = partialDownloads.get(currentMetadata.id);
+        if (!fileData) return;
+
+        // Copy only the view's bytes into a new buffer (buf may be a view over a larger slab).
+        fileData.chunks.push(buf.slice().buffer as ArrayBuffer);
+        fileData.received += buf.byteLength;
+        receiveSpeedBytes += buf.byteLength;
+
+        const now = performance.now();
+        if (now - lastReceiveSpeedUpdate > 1000) {
+            const elapsed = (now - receiveSpeedStart) / 1000;
+            if (elapsed > 0 && currentMetadata.fileSize) {
+                const bytesPerSec = receiveSpeedBytes / elapsed;
+                const remaining = currentMetadata.fileSize - fileData.received;
+                cb.onSpeed?.(bytesPerSec, remaining / bytesPerSec);
+            }
+            receiveSpeedStart = now;
+            receiveSpeedBytes = 0;
+            lastReceiveSpeedUpdate = now;
+        }
+
+        if (
+            currentMetadata.fileSize &&
+            (fileData.received % (160 * 1024 * 10) === 0 ||
+                fileData.received === currentMetadata.fileSize)
+        ) {
+            cb.onProgress?.(
+                Math.round((fileData.received / currentMetadata.fileSize) * 100),
+                fileData.received,
+                currentMetadata.fileSize
+            );
+        }
+    }
+
+    return { handleMessage };
+}

--- a/client/lib/transfer/receiver.ts
+++ b/client/lib/transfer/receiver.ts
@@ -104,8 +104,13 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
         const fileData = partialDownloads.get(currentMetadata.id);
         if (!fileData) return;
 
-        // Copy only the view's bytes into a new buffer (buf may be a view over a larger slab).
-        fileData.chunks.push(buf.slice().buffer as ArrayBuffer);
+        // Copy the chunk's bytes into a fresh, tightly-fit ArrayBuffer. `buf` may be a
+        // view over a much larger (or pooled/shared) ArrayBuffer — notably simple-peer
+        // delivers a Node Buffer whose `.slice()` is a non-copying view, so storing
+        // `buf.slice().buffer` would pin (and later mis-read) the whole backing buffer.
+        // `new Uint8Array(buf)` copies exactly buf.byteLength bytes; `.buffer` is then
+        // a tight ArrayBuffer of that length.
+        fileData.chunks.push(new Uint8Array(buf).buffer);
         fileData.received += buf.byteLength;
         receiveSpeedBytes += buf.byteLength;
 

--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -1,0 +1,211 @@
+// Floe sender engine — framework-agnostic, no React or simple-peer imports.
+// Extracted from P2PTransfer.tsx sendAllFiles/sendSingleFile.
+import {
+    HIGH_WATER,
+    LOW_WATER,
+    READ_SLAB,
+    chunkSize,
+    classifyControl,
+    metadataMessage,
+    endMessage,
+    type Ack,
+} from './protocol';
+
+export interface SenderCallbacks {
+    onFileStart?: (index: number, total: number, fileName: string) => void;
+    onProgress?: (percent: number) => void;
+    onSpeed?: (bytesPerSec: number, etaSeconds: number) => void;
+    onSpeedReset?: () => void;
+    onError?: (msg: string) => void;
+    onAllSent?: () => void;
+    isDestroyed?: () => boolean;
+}
+
+export interface FileEntry {
+    id: string;
+    file: File;
+}
+
+// Minimal buffering interface used by the sender.
+// The real implementation is RTCDataChannel; in tests a plain object works.
+export interface BufferChannel {
+    readonly bufferedAmount: number;
+    bufferedAmountLowThreshold: number;
+    addEventListener(type: 'bufferedamountlow', handler: () => void): void;
+    removeEventListener(type: 'bufferedamountlow', handler: () => void): void;
+}
+
+export interface SenderDeps {
+    send: (data: string | Uint8Array) => void;
+    // Registers a handler for incoming data (peer.on('data')).
+    // Returns an unsubscribe function.
+    onData: (handler: (data: Uint8Array | ArrayBuffer) => void) => () => void;
+    channel: BufferChannel;
+    sctpMaxMessageSize?: number | null;
+}
+
+/**
+ * Sends all files over the data channel in order.
+ *
+ * Real usage (in component):
+ *   const channel = (peer as any)._channel as RTCDataChannel;
+ *   const pc = (peer as any)._pc as RTCPeerConnection;
+ *   await sendFiles({
+ *     send: d => peer.send(d),
+ *     onData: h => { peer.on('data', h); return () => peer.off('data', h); },
+ *     channel,
+ *     sctpMaxMessageSize: pc?.sctp?.maxMessageSize,
+ *   }, files, cb);
+ */
+export async function sendFiles(
+    deps: SenderDeps,
+    files: FileEntry[],
+    cb: SenderCallbacks = {}
+): Promise<void> {
+    const destroyed = cb.isDestroyed ?? (() => false);
+
+    for (let i = 0; i < files.length; i++) {
+        if (destroyed()) break;
+        const entry = files[i];
+        cb.onFileStart?.(i, files.length, entry.file.name);
+        await sendSingleFile(deps, entry, i + 1, files.length, cb);
+    }
+
+    if (!destroyed()) {
+        cb.onAllSent?.();
+    }
+}
+
+async function sendSingleFile(
+    deps: SenderDeps,
+    entry: FileEntry,
+    index: number,
+    total: number,
+    cb: SenderCallbacks
+): Promise<void> {
+    const { file, id } = entry;
+    const { send, onData, channel } = deps;
+    const destroyed = cb.isDestroyed ?? (() => false);
+
+    if (destroyed()) return;
+
+    const CHUNK_SIZE = chunkSize(deps.sctpMaxMessageSize);
+
+    channel.bufferedAmountLowThreshold = LOW_WATER;
+
+    // 1. Send metadata
+    try {
+        send(metadataMessage(id, file.name, file.size, index, total));
+    } catch {
+        return;
+    }
+
+    // 2. Wait for ack (15 s timeout)
+    const ackOffset = await waitForAck(onData, id);
+    if (ackOffset === null) {
+        cb.onError?.('Transfer timed out waiting for receiver. Please try again.');
+        return;
+    }
+
+    let offset = ackOffset;
+    let speedMeasureStart = performance.now();
+    let speedMeasureBytes = 0;
+    let lastSpeedUpdate = 0;
+    let chunkCount = 0;
+
+    const waitForBuffer = () =>
+        new Promise<void>((r) => {
+            const onLow = () => {
+                channel.removeEventListener('bufferedamountlow', onLow);
+                r();
+            };
+            if (channel.bufferedAmount < LOW_WATER) {
+                r();
+            } else {
+                channel.addEventListener('bufferedamountlow', onLow);
+            }
+        });
+
+    // 3. Send chunks
+    while (offset < file.size) {
+        if (destroyed()) break;
+
+        const slabEnd = Math.min(offset + READ_SLAB, file.size);
+        let slabBuffer: ArrayBuffer;
+        try {
+            slabBuffer = await file.slice(offset, slabEnd).arrayBuffer();
+        } catch {
+            break;
+        }
+
+        let slabOffset = 0;
+        while (slabOffset < slabBuffer.byteLength) {
+            if (destroyed()) break;
+
+            if (channel.bufferedAmount >= HIGH_WATER) {
+                await waitForBuffer();
+            }
+
+            if (destroyed()) break;
+
+            const chunkLen = Math.min(CHUNK_SIZE, slabBuffer.byteLength - slabOffset);
+            const chunk = new Uint8Array(slabBuffer, slabOffset, chunkLen);
+
+            try {
+                send(chunk);
+            } catch {
+                await new Promise((r) => setTimeout(r, 100));
+                continue;
+            }
+
+            slabOffset += chunkLen;
+            offset += chunkLen;
+            speedMeasureBytes += chunkLen;
+            chunkCount++;
+
+            const now = performance.now();
+            if (now - lastSpeedUpdate > 1000) {
+                const elapsed = (now - speedMeasureStart) / 1000;
+                if (elapsed > 0) {
+                    const bytesPerSec = speedMeasureBytes / elapsed;
+                    const remaining = file.size - offset;
+                    cb.onSpeed?.(bytesPerSec, remaining / bytesPerSec);
+                }
+                speedMeasureStart = now;
+                speedMeasureBytes = 0;
+                lastSpeedUpdate = now;
+            }
+
+            if (chunkCount % 10 === 0 || offset >= file.size) {
+                cb.onProgress?.(Math.round((offset / file.size) * 100));
+            }
+        }
+    }
+
+    cb.onSpeedReset?.();
+
+    // 4. Send end marker
+    try {
+        send(endMessage());
+    } catch { }
+}
+
+function waitForAck(
+    onData: (handler: (data: Uint8Array | ArrayBuffer) => void) => () => void,
+    fileId: string
+): Promise<number | null> {
+    return Promise.race([
+        new Promise<number | null>((resolve) => {
+            const off = onData((raw) => {
+                const msg = classifyControl(
+                    raw instanceof Uint8Array ? raw : new Uint8Array(raw)
+                );
+                if (msg && msg.type === 'ack' && (msg as Ack).id === fileId) {
+                    off();
+                    resolve((msg as Ack).offset);
+                }
+            });
+        }),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 15_000)),
+    ]);
+}

--- a/client/lib/transfer/transfer.test.ts
+++ b/client/lib/transfer/transfer.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { sendFiles, type SenderDeps, type FileEntry } from './sender';
+import { createReceiver } from './receiver';
+
+const enc = new TextEncoder();
+
+// Minimal no-op buffer channel — backpressure never engaged in tests.
+function makeBufferChannel() {
+    return {
+        bufferedAmount: 0,
+        bufferedAmountLowThreshold: 0,
+        addEventListener: () => { },
+        removeEventListener: () => { },
+    };
+}
+
+// Creates a File with known random bytes of given size.
+function makeFile(sizeBytes: number, name = 'test.bin'): File {
+    const buf = new Uint8Array(sizeBytes);
+    if (sizeBytes > 0) {
+        // Pseudo-random but deterministic content
+        for (let i = 0; i < sizeBytes; i++) {
+            buf[i] = (i * 31 + 7) % 256;
+        }
+    }
+    return new File([buf], name, { type: 'application/octet-stream' });
+}
+
+// Wires sender and receiver together in-process.
+// Returns the received file bytes as a Uint8Array.
+async function loopback(
+    files: FileEntry[],
+    opts: { chunkOverride?: number } = {}
+): Promise<{ name: string; bytes: Uint8Array }[]> {
+    const received: { name: string; bytes: Uint8Array }[] = [];
+
+    // Queue of data handlers the sender registers for acks
+    let senderDataHandler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+
+    const rx = createReceiver({
+        send: (d) => {
+            // Defer so the sender's waitForAck handler is registered before the ack fires.
+            // In production there is a real network round-trip; queueMicrotask reproduces
+            // that "not yet registered" gap in the synchronous loopback.
+            const data = typeof d === 'string' ? enc.encode(d) : d;
+            queueMicrotask(() => senderDataHandler?.(data));
+        },
+        onFileComplete: (file) => {
+            file.blob.arrayBuffer().then((ab) => {
+                received.push({ name: file.fileName, bytes: new Uint8Array(ab) });
+            });
+        },
+    });
+
+    const deps: SenderDeps = {
+        send: (d) => {
+            // Sender output → receiver input
+            const data = typeof d === 'string' ? enc.encode(d) : d;
+            rx.handleMessage(data);
+        },
+        onData: (handler) => {
+            senderDataHandler = handler;
+            return () => { senderDataHandler = null; };
+        },
+        channel: makeBufferChannel(),
+        sctpMaxMessageSize: opts.chunkOverride ?? null,
+    };
+
+    await sendFiles(deps, files, {});
+
+    // Allow blob.arrayBuffer() promises to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    return received;
+}
+
+describe('loopback: single small file', () => {
+    it('transfers a 512-byte file intact', async () => {
+        const file = makeFile(512);
+        const result = await loopback([{ id: 'id1', file }]);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe('test.bin');
+        expect(result[0].bytes.byteLength).toBe(512);
+
+        // Content integrity
+        const expected = new Uint8Array(512);
+        for (let i = 0; i < 512; i++) expected[i] = (i * 31 + 7) % 256;
+        expect(result[0].bytes).toEqual(expected);
+    });
+});
+
+describe('loopback: empty file', () => {
+    it('transfers a 0-byte file and completes', async () => {
+        const file = makeFile(0, 'empty.txt');
+        const result = await loopback([{ id: 'id-empty', file }]);
+        expect(result).toHaveLength(1);
+        expect(result[0].bytes.byteLength).toBe(0);
+    });
+});
+
+describe('loopback: multi-file', () => {
+    it('transfers three files in order', async () => {
+        const files: FileEntry[] = [
+            { id: 'a', file: makeFile(100, 'a.txt') },
+            { id: 'b', file: makeFile(200, 'b.txt') },
+            { id: 'c', file: makeFile(300, 'c.txt') },
+        ];
+        const result = await loopback(files);
+
+        expect(result).toHaveLength(3);
+        expect(result[0].name).toBe('a.txt');
+        expect(result[1].name).toBe('b.txt');
+        expect(result[2].name).toBe('c.txt');
+        expect(result[0].bytes.byteLength).toBe(100);
+        expect(result[1].bytes.byteLength).toBe(200);
+        expect(result[2].bytes.byteLength).toBe(300);
+    });
+});
+
+describe('loopback: chunked transfer', () => {
+    it('reassembles a 200 KB file sent in 16 KB chunks', async () => {
+        const SIZE = 200 * 1024;
+        const file = makeFile(SIZE, 'big.bin');
+        // Force 16 KB chunks via sctpMaxMessageSize
+        const result = await loopback([{ id: 'big', file }], { chunkOverride: 16 * 1024 });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].bytes.byteLength).toBe(SIZE);
+
+        // Spot-check a few byte positions
+        const expected = new Uint8Array(SIZE);
+        for (let i = 0; i < SIZE; i++) expected[i] = (i * 31 + 7) % 256;
+        // Check first and last 512 bytes
+        expect(result[0].bytes.slice(0, 512)).toEqual(expected.slice(0, 512));
+        expect(result[0].bytes.slice(SIZE - 512)).toEqual(expected.slice(SIZE - 512));
+    });
+});
+
+describe('loopback: small binary framing guard', () => {
+    it('does not misclassify a 999-byte binary chunk starting with 0x7B ({) as a control message', async () => {
+        // Build a file whose first 999 bytes start with '{' — the byteLength guard must
+        // keep it out of control-message parsing.
+        // Our protocol wraps the content as raw binary (no JSON), so a '{'-starting
+        // chunk that is not a real control message must be treated as file data.
+        // This test checks end-to-end framing: the file arrives intact even though
+        // its first byte is the ASCII '{' character.
+        const SIZE = 999;
+        const buf = new Uint8Array(SIZE);
+        buf[0] = 0x7b; // '{'
+        for (let i = 1; i < SIZE; i++) buf[i] = i % 256;
+
+        const file = new File([buf], 'tricky.bin');
+        // Force 999-byte chunk so the single chunk IS <= 1000 but classifyControl
+        // returns null because JSON.parse fails on arbitrary bytes after '{'.
+        const result = await loopback([{ id: 'tricky', file }], { chunkOverride: 1024 });
+        expect(result).toHaveLength(1);
+        expect(result[0].bytes.byteLength).toBe(SIZE);
+        expect(result[0].bytes[0]).toBe(0x7b);
+    });
+});

--- a/client/lib/transfer/transfer.test.ts
+++ b/client/lib/transfer/transfer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { sendFiles, type SenderDeps, type FileEntry } from './sender';
 import { createReceiver } from './receiver';
+import { metadataMessage, endMessage } from './protocol';
 
 const enc = new TextEncoder();
 
@@ -134,6 +135,43 @@ describe('loopback: chunked transfer', () => {
         // Check first and last 512 bytes
         expect(result[0].bytes.slice(0, 512)).toEqual(expected.slice(0, 512));
         expect(result[0].bytes.slice(SIZE - 512)).toEqual(expected.slice(SIZE - 512));
+    });
+});
+
+describe('receiver: stores tight copies of chunk bytes', () => {
+    // Regression guard: simple-peer delivers data channel chunks as a Node Buffer,
+    // whose `.slice()` is a non-copying VIEW over the (often larger/shared) backing
+    // buffer. The receiver must copy out exactly each chunk's bytes, not retain the
+    // whole backing buffer. This test feeds Buffer subarray views — exactly the
+    // browser-runtime shape — which the old `buf.slice().buffer` code mishandled.
+    it('reassembles chunks delivered as Buffer subarray views over a larger buffer', async () => {
+        let completedBlob: Blob | null = null;
+        const rx = createReceiver({
+            send: () => { /* ack — ignored here */ },
+            onFileComplete: (f) => { completedBlob = f.blob; },
+        });
+
+        const SIZE = 48;
+        const fileBytes = new Uint8Array(SIZE);
+        for (let i = 0; i < SIZE; i++) fileBytes[i] = i + 1; // never 0x7B at index 0
+
+        // Metadata first so the receiver opens a partial download.
+        rx.handleMessage(enc.encode(metadataMessage('rid', 'r.bin', SIZE, 1, 1)));
+
+        // Place the payload inside a larger backing Buffer at a non-zero offset and
+        // hand the receiver subarray VIEWS (16 bytes each) — sharing one backing AB.
+        const backing = Buffer.alloc(200);
+        for (let i = 0; i < SIZE; i++) backing[20 + i] = fileBytes[i];
+        rx.handleMessage(backing.subarray(20, 36));
+        rx.handleMessage(backing.subarray(36, 52));
+        rx.handleMessage(backing.subarray(52, 68));
+
+        rx.handleMessage(enc.encode(endMessage()));
+
+        expect(completedBlob).not.toBeNull();
+        const got = new Uint8Array(await completedBlob!.arrayBuffer());
+        expect(got.byteLength).toBe(SIZE);
+        expect(got).toEqual(fileBytes);
     });
 });
 

--- a/client/lib/transferUtils.test.ts
+++ b/client/lib/transferUtils.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { formatSpeed, formatETA } from './transferUtils';
+
+describe('formatSpeed', () => {
+    it('returns empty string for 0', () => expect(formatSpeed(0)).toBe(''));
+    it('returns empty string for negative', () => expect(formatSpeed(-1)).toBe(''));
+    it('returns empty string for NaN', () => expect(formatSpeed(NaN)).toBe(''));
+    it('returns empty string for Infinity', () => expect(formatSpeed(Infinity)).toBe(''));
+
+    it('formats KB/s below 1 MB/s', () => {
+        expect(formatSpeed(512 * 1024)).toBe('512.0 KB/s');
+    });
+
+    it('formats MB/s at and above 1 MB', () => {
+        expect(formatSpeed(1024 * 1024)).toBe('1.0 MB/s');
+        expect(formatSpeed(5.5 * 1024 * 1024)).toBe('5.5 MB/s');
+    });
+});
+
+describe('formatETA', () => {
+    it('returns empty string for negative', () => expect(formatETA(-1)).toBe(''));
+    it('returns empty string for NaN', () => expect(formatETA(NaN)).toBe(''));
+
+    it('formats seconds', () => {
+        expect(formatETA(0)).toBe('0s');
+        expect(formatETA(30)).toBe('30s');
+        expect(formatETA(59.9)).toBe('60s');
+    });
+
+    it('formats minutes and seconds', () => {
+        expect(formatETA(90)).toBe('1m 30s');
+        expect(formatETA(3599)).toBe('59m 59s'); // Math.ceil(3599 % 60) = ceil(59) = 59
+    });
+
+    it('formats hours and minutes', () => {
+        expect(formatETA(3600)).toBe('1h 0m');
+        expect(formatETA(7500)).toBe('2h 5m');
+    });
+});

--- a/client/lib/utils.test.ts
+++ b/client/lib/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes } from './utils';
+
+describe('formatBytes', () => {
+    it('returns "0 Bytes" for 0', () => expect(formatBytes(0)).toBe('0 Bytes'));
+
+    it('formats bytes', () => expect(formatBytes(500)).toBe('500 Bytes'));
+
+    it('formats KB', () => expect(formatBytes(1024)).toBe('1 KB'));
+    it('formats fractional KB', () => expect(formatBytes(1536)).toBe('1.5 KB'));
+
+    it('formats MB', () => expect(formatBytes(1024 * 1024)).toBe('1 MB'));
+    it('formats fractional MB', () => expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.5 MB'));
+
+    it('formats GB', () => expect(formatBytes(1024 ** 3)).toBe('1 GB'));
+});

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test"
   },
   "dependencies": {
@@ -32,6 +34,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
+    "vitest": "^3.2.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -5,6 +5,11 @@ export default defineConfig({
     testDir: './e2e',
     timeout: 90_000,
     expect: { timeout: 60_000 },
+    // These are heavy WebRTC integration tests that share one signaling server
+    // (which is per-IP rate limited) and move tens of MB each. Running them in
+    // parallel on a 2-core CI runner starves the transfers and trips flaky
+    // timeouts, so serialize on CI. Local runs keep Playwright's default workers.
+    workers: process.env.CI ? 1 : undefined,
     use: {
         baseURL: 'http://localhost:3000',
         headless: true,

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.2.5(@types/react@19.2.17)(react@19.2.3)
       '@sentry/nextjs':
         specifier: ^10.53.1
-        version: 10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.107.2)
+        version: 10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.107.2(lightningcss@1.32.0))
       '@vercel/analytics':
         specifier: ^1.4.1
         version: 1.6.1(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -99,6 +99,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)
 
 packages:
 
@@ -184,6 +187,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -1096,6 +1255,12 @@ packages:
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -1350,6 +1515,35 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@3.2.6':
+    resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
+
+  '@vitest/mocker@3.2.6':
+    resolution: {integrity: sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.6':
+    resolution: {integrity: sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==}
+
+  '@vitest/runner@3.2.6':
+    resolution: {integrity: sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==}
+
+  '@vitest/snapshot@3.2.6':
+    resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
+
+  '@vitest/spy@3.2.6':
+    resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
+
+  '@vitest/utils@3.2.6':
+    resolution: {integrity: sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==}
+
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
 
@@ -1488,6 +1682,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1544,6 +1742,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -1563,9 +1765,17 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -1642,6 +1852,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1709,6 +1923,9 @@ packages:
     resolution: {integrity: sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
@@ -1727,6 +1944,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1863,6 +2085,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1870,6 +2095,10 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2203,6 +2432,9 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
@@ -2339,6 +2571,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@11.5.1:
     resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
@@ -2514,6 +2749,13 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2704,6 +2946,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-peer@9.11.1:
     resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
 
@@ -2729,9 +2974,15 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -2770,6 +3021,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2854,9 +3108,27 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -2942,6 +3214,79 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.6:
+    resolution: {integrity: sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.6
+      '@vitest/ui': 3.2.6
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
@@ -2985,6 +3330,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -3146,6 +3496,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -3737,7 +4165,7 @@ snapshots:
 
   '@sentry/core@10.57.0': {}
 
-  '@sentry/nextjs@10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.107.2)':
+  '@sentry/nextjs@10.57.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.107.2(lightningcss@1.32.0))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.41.1
@@ -3749,7 +4177,7 @@ snapshots:
       '@sentry/opentelemetry': 10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
       '@sentry/react': 10.57.0(react@19.2.3)
       '@sentry/vercel-edge': 10.57.0
-      '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2)
+      '@sentry/webpack-plugin': 5.3.0(webpack@5.107.2(lightningcss@1.32.0))
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       rollup: 4.62.0
       stacktrace-parser: 0.1.11
@@ -3810,10 +4238,10 @@ snapshots:
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@sentry/core': 10.57.0
 
-  '@sentry/webpack-plugin@5.3.0(webpack@5.107.2)':
+  '@sentry/webpack-plugin@5.3.0(webpack@5.107.2(lightningcss@1.32.0))':
     dependencies:
       '@sentry/bundler-plugin-core': 5.3.0
-      webpack: 5.107.2
+      webpack: 5.107.2(lightningcss@1.32.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -3897,6 +4325,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
 
@@ -4092,6 +4527,48 @@ snapshots:
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
+
+  '@vitest/expect@3.2.6':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)
+
+  '@vitest/pretty-format@3.2.6':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.6':
+    dependencies:
+      '@vitest/utils': 3.2.6
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.6':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.6':
+    dependencies:
+      '@vitest/pretty-format': 3.2.6
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -4291,6 +4768,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
@@ -4339,6 +4818,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -4360,10 +4841,20 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  check-error@2.1.3: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -4426,6 +4917,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
 
@@ -4565,6 +5058,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
@@ -4587,6 +5082,35 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -4804,9 +5328,15 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   events@3.3.0: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -5149,6 +5679,8 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
@@ -5251,6 +5783,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@11.5.1: {}
 
@@ -5421,6 +5955,10 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -5690,6 +6228,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   simple-peer@9.11.1:
     dependencies:
       buffer: 6.0.3
@@ -5731,9 +6271,13 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -5799,6 +6343,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   styled-jsx@5.1.6(@babel/core@7.29.7)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
@@ -5822,13 +6370,15 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(webpack@5.107.2):
+  terser-webpack-plugin@5.6.1(lightningcss@1.32.0)(webpack@5.107.2(lightningcss@1.32.0)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.107.2
+      webpack: 5.107.2(lightningcss@1.32.0)
+    optionalDependencies:
+      lightningcss: 1.32.0
 
   terser@5.48.0:
     dependencies:
@@ -5837,10 +6387,20 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -5965,6 +6525,83 @@ snapshots:
 
   uuid@14.0.0: {}
 
+  vite-node@3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.0
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 20.19.43
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      terser: 5.48.0
+
+  vitest@3.2.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.5(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)
+      vite-node: 3.2.4(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.43
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -5973,7 +6610,7 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.107.2:
+  webpack@5.107.2(lightningcss@1.32.0):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -5995,7 +6632,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(webpack@5.107.2)
+      terser-webpack-plugin: 5.6.1(lightningcss@1.32.0)(webpack@5.107.2(lightningcss@1.32.0))
       watchpack: 2.5.2
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -6061,6 +6698,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 allowBuilds:
   '@sentry/cli': true
+  esbuild: true
   sharp: true
   unrs-resolver: true

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['lib/**/*.test.ts'],
+    },
+});


### PR DESCRIPTION
## Summary

- Extracts the Floe wire-protocol framing, sender, and receiver into framework-agnostic `client/lib/transfer/` modules (mirroring `cli/internal/transfer/`), making them independently testable for the first time
- Adds vitest as the unit test runner and ships 50 passing tests (protocol classification, message builders, speed/ETA formatters, ZIP dedupe, and a full sender-receiver loopback that validates byte-exact integrity for empty/small/chunked/multi-file transfers)
- Wires both `transfer.spec.ts` (browser to browser) and `cli-interop.spec.ts` into the CI e2e job so the primary transfer flow is no longer untested in CI

## What changed

**New files**
- `client/lib/transfer/protocol.ts` - constants, message builders, `classifyControl` (the regression-class function now unit-tested)
- `client/lib/transfer/sender.ts` - `sendFiles()` engine, decoupled from simple-peer via `SenderDeps` callbacks
- `client/lib/transfer/receiver.ts` - `createReceiver()` engine, stateful message handler
- `client/lib/download.ts` - `dedupeFileName()` extracted from the ZIP path
- `client/vitest.config.ts` - node environment, `lib/**/*.test.ts` scope
- `*.test.ts` files for all of the above (50 tests)

**Modified**
- `client/components/P2PTransfer.tsx` - receiver data handler (120 lines) replaced with `createReceiver()` call; `sendAllFiles`/`sendSingleFile` (~210 lines) replaced with `sendFilesEngine()` call; ZIP loop uses `dedupeFileName`
- `client/package.json` - vitest dev dep, `test` and `test:watch` scripts
- `.github/workflows/ci.yml` - `pnpm test` step added to build-and-lint; cli-interop job renamed to e2e and runs all Playwright specs

**Wire protocol is unchanged. No UX changes.**

## Test plan

- `cd client && pnpm test` - 50 unit + loopback tests pass
- `pnpm lint && pnpm build` - no type errors
- CI will run vitest in build-and-lint and both Playwright specs in the e2e job