### PR TITLE
fix(e2e): stop signaling rate limit from flaking the CLI interop tran…

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
     // parallel on a 2-core CI runner starves the transfers and trips flaky
     // timeouts, so serialize on CI. Local runs keep Playwright's default workers.
     workers: process.env.CI ? 1 : undefined,
+    // Retry once on CI to absorb transient WebRTC handshake hiccups. A genuine
+    // protocol break fails every attempt; the unit tests are the real correctness
+    // guard, this just stops infra jitter from reddening the build.
+    retries: process.env.CI ? 1 : 0,
     use: {
         baseURL: 'http://localhost:3000',
         headless: true,
@@ -30,6 +34,10 @@ export default defineConfig({
             env: {
                 CLIENT_URL: 'http://localhost:3000',
                 PORT: '3001',
+                // The whole e2e suite drives many Socket.IO/WebSocket connections
+                // from one IP; lift the per-IP connection cap so the shared signaling
+                // server does not rate-limit a peer mid-suite and stall a transfer.
+                MAX_CONNECTIONS_PER_IP: '1000',
             },
         },
         {

--- a/server/server.js
+++ b/server/server.js
@@ -149,7 +149,9 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 const connectionCounts = new Map();
 const RATE_LIMIT_WINDOW = 60000;
-const MAX_CONNECTIONS_PER_IP = 30;
+// Configurable so test/staging environments (which drive many connections from a
+// single IP) can raise the ceiling. Production keeps the default of 30.
+const MAX_CONNECTIONS_PER_IP = parseInt(process.env.MAX_CONNECTIONS_PER_IP, 10) || 30;
 
 function checkRateLimit(ip) {
     const now = Date.now();


### PR DESCRIPTION
…sfer

The e2e suite grew from 2 tests (CLI interop only) to 5 when the browser-to- browser specs were wired in. All of them drive Socket.IO/WebSocket connections from a single CI IP against the signaling server, whose per-IP cap is 30 per 60s. Under the denser suite a peer intermittently got rate-limited mid-run, could not join its room, and the WebRTC transfer stalled until the 90s test timeout - which is why identical code passed on the PR branch but failed on the merge to main (a flake, not a regression).

- server: make MAX_CONNECTIONS_PER_IP configurable via env (default stays 30 for production; server unit tests, which set no env, are unaffected).
- playwright: start the test signaling server with MAX_CONNECTIONS_PER_IP=1000 so the shared server never rate-limits a peer mid-suite.
- playwright: retry once on CI to absorb any residual WebRTC handshake jitter.