### PR TITLE
fix(e2e): stop signaling rate limit from flaking CLI interop transfer

### DIFF
--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
     // parallel on a 2-core CI runner starves the transfers and trips flaky
     // timeouts, so serialize on CI. Local runs keep Playwright's default workers.
     workers: process.env.CI ? 1 : undefined,
+    // Retry once on CI to absorb transient WebRTC handshake hiccups. A genuine
+    // protocol break fails every attempt; the unit tests are the real correctness
+    // guard, this just stops infra jitter from reddening the build.
+    retries: process.env.CI ? 1 : 0,
     use: {
         baseURL: 'http://localhost:3000',
         headless: true,
@@ -30,6 +34,10 @@ export default defineConfig({
             env: {
                 CLIENT_URL: 'http://localhost:3000',
                 PORT: '3001',
+                // The whole e2e suite drives many Socket.IO/WebSocket connections
+                // from one IP; lift the per-IP connection cap so the shared signaling
+                // server does not rate-limit a peer mid-suite and stall a transfer.
+                MAX_CONNECTIONS_PER_IP: '1000',
             },
         },
         {

--- a/server/server.js
+++ b/server/server.js
@@ -149,7 +149,9 @@ const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12
 
 const connectionCounts = new Map();
 const RATE_LIMIT_WINDOW = 60000;
-const MAX_CONNECTIONS_PER_IP = 30;
+// Configurable so test/staging environments (which drive many connections from a
+// single IP) can raise the ceiling. Production keeps the default of 30.
+const MAX_CONNECTIONS_PER_IP = parseInt(process.env.MAX_CONNECTIONS_PER_IP, 10) || 30;
 
 function checkRateLimit(ip) {
     const now = Date.now();


### PR DESCRIPTION
## Problem

After PR #80 the e2e suite grew from 2 tests (CLI interop only) to 5 (browser to browser specs were wired into CI). All of them open Socket.IO / WebSocket connections from a single CI IP, and the signaling server caps connections at 30 per IP per 60s. Under the denser suite a peer intermittently got rate-limited mid-run, could not join its room, and the WebRTC transfer stalled until the 90s Playwright timeout.

This was a flake, not a code regression: the exact same merged commits passed on the PR branch run but failed on the merge-to-main run (`Direction 1: CLI send -> browser receive` timed out).

## Fix

- **server**: `MAX_CONNECTIONS_PER_IP` is now read from env, defaulting to 30. Production behavior is unchanged; the server unit tests (which set no env) still see 30 and pass.
- **playwright**: the test signaling server is started with `MAX_CONNECTIONS_PER_IP=1000`, so the shared server never rate-limits a peer mid-suite.
- **playwright**: `retries: 1` on CI to absorb any residual WebRTC handshake jitter. A genuine protocol break fails every attempt; the vitest unit tests remain the real correctness guard.

## Test plan

- `cd server && npm test` - 25 pass
- `cd client && pnpm lint` - clean
- CI e2e job should now run all 5 specs green and stay deterministic