### PR TITLE
chore(security): flatten server ws transitive deps to 8.21.0

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -420,27 +420,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/engine.io/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -1285,27 +1264,6 @@
       "dependencies": {
         "debug": "~4.4.1",
         "ws": "~8.20.1"
-      }
-    },
-    "node_modules/socket.io-adapter/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/socket.io-parser": {

--- a/server/package.json
+++ b/server/package.json
@@ -21,5 +21,8 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.11"
+  },
+  "overrides": {
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary

- `engine.io` and `socket.io-adapter` each pulled in `ws@8.20.1` as a nested dependency, keeping Dependabot alert #73 alive even though the direct `ws` dep was already `^8.21.0`
- Added `overrides.ws: ^8.21.0` to `server/package.json` (npm v7+ overrides) so all transitive `ws` instances resolve to the patched version
- The two nested `node_modules/{engine.io,socket.io-adapter}/node_modules/ws` entries are gone from the lockfile; everything uses the single hoisted `8.21.0`
- All 25 server unit tests pass after regeneration

## What changed

| File | Change |
|---|---|
| `server/package.json` | Added `overrides.ws: ^8.21.0` |
| `server/package-lock.json` | Regenerated; nested `ws@8.20.1` entries removed (-42 lines) |

## Test plan

- [x] `npm test` (25/25 server unit tests pass)
- [ ] CI