### PR TITLE
chore(ci): opt in to Node.js 24 actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build-and-lint:
     name: Build & Lint


### PR DESCRIPTION
## Summary

- GitHub deprecated the Node.js 20 runtime used by `actions/checkout@v4`, `actions/setup-node@v4`, `actions/cache@v4`, `pnpm/action-setup@v4`, and `actions/setup-go@v5`
- Starting 2026-06-16 (today), Node.js 24 is the forced default on GitHub runners
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` at the workflow `env` level to opt in explicitly and stop the yellow deprecation annotations on every CI run

## What changed

One line added at the top of `.github/workflows/ci.yml`:

```yaml
env:
  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
```

No action versions changed, no logic changed.

## Test plan

- [ ] CI runs clean with no Node.js 20 deprecation warnings