### PR TITLE
feat(cli): one-command install and self-update across all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: Release
 
 # Publishes cross-platform CLI binaries to GitHub Releases when a version tag
 # (e.g. v1.0.0) is pushed. Build/archive/checksum config lives in .goreleaser.yml.
+# Package manager manifests (Homebrew Cask, Scoop, Winget) are also published
+# automatically on each tag using TAP_GITHUB_TOKEN (a PAT with write access to
+# the shared jannskiee/homebrew-tap, jannskiee/scoop-bucket, and the
+# jannskiee/winget-pkgs fork). These repos are reused across all projects.
 on:
   push:
     tags:
@@ -33,3 +37,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with Contents write on the shared homebrew-tap, scoop-bucket, and the
+          # winget-pkgs fork. Create at Settings > Developer settings > Personal access
+          # tokens and add as repo secret TAP_GITHUB_TOKEN. The same PAT/secret pattern is
+          # reused by every project that publishes into these shared repos.
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,6 +59,82 @@ changelog:
       - "^Merge remote-tracking"
       - "^initial commit"
 
+# Homebrew Cask (macOS) — published into the shared jannskiee/homebrew-tap.
+# This tap is reused across projects; floe is one cask inside it.
+# Requires: create jannskiee/homebrew-tap repo and add TAP_GITHUB_TOKEN secret.
+# Install: brew install --cask jannskiee/tap/floe
+# Update:  brew upgrade floe
+homebrew_casks:
+  - name: floe
+    repository:
+      owner: jannskiee
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: "https://floe.one"
+    description: "Secure peer-to-peer file transfer CLI"
+    license: "MIT"
+
+# Scoop (Windows) — published into the shared jannskiee/scoop-bucket.
+# This bucket is reused across projects; floe is one manifest inside it.
+# Requires: create jannskiee/scoop-bucket repo (same TAP_GITHUB_TOKEN).
+# Install: scoop bucket add jannskiee https://github.com/jannskiee/scoop-bucket && scoop install floe
+# Update:  scoop update floe
+scoops:
+  - repository:
+      owner: jannskiee
+      name: scoop-bucket
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: "https://floe.one"
+    description: "Secure peer-to-peer file transfer CLI"
+    license: MIT
+
+# Winget (Windows, official Microsoft store).
+# Requires: fork microsoft/winget-pkgs to jannskiee/winget-pkgs (same PAT).
+# PRs are auto-validated and typically merged within a few hours.
+# Install: winget install jannskiee.floe
+# Update:  winget upgrade jannskiee.floe
+winget:
+  - name: floe
+    publisher: jannskiee
+    package_identifier: jannskiee.floe
+    license: MIT
+    homepage: "https://floe.one"
+    short_description: "Secure peer-to-peer file transfer CLI"
+    repository:
+      owner: jannskiee
+      name: winget-pkgs
+      branch: "floe-{{ .Version }}"
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+
+# Optional Tier 2: Linux native packages (.deb, .rpm, .apk).
+# Uncomment and set maintainer email to enable. No extra token needed.
+# nfpms:
+#   - package_name: floe
+#     maintainer: "jannskiee <paredesjancarlo99@gmail.com>"
+#     homepage: "https://floe.one"
+#     description: "Secure peer-to-peer file transfer CLI"
+#     license: MIT
+#     formats: [deb, rpm, apk]
+
+# Optional Tier 2: Arch Linux AUR (floe-bin).
+# Requires: AUR account, AUR_KEY secret (SSH private key registered with AUR).
+# aurs:
+#   - name: floe-bin
+#     homepage: "https://floe.one"
+#     description: "Secure peer-to-peer file transfer CLI"
+#     license: MIT
+#     maintainers: ["jannskiee <paredesjancarlo99@gmail.com>"]
+#     private_key: "{{ .Env.AUR_KEY }}"
+#     git_url: "ssh://aur@aur.archlinux.org/floe-bin.git"
+
 release:
   github:
     owner: jannskiee

--- a/README.md
+++ b/README.md
@@ -56,7 +56,33 @@ Floe provides a command-line interface for transferring files from headless devi
 
 ### Install
 
-Download the latest binary for your platform from the [Releases](https://github.com/jannskiee/floe/releases) page. No runtime or dependencies required. For package managers, checksum verification, and PATH setup, see the [installation guide](https://docs.floe.one/cli/installation).
+**macOS**
+```sh
+brew install --cask jannskiee/tap/floe
+```
+
+**Windows**
+```powershell
+winget install jannskiee.floe
+# or: scoop bucket add jannskiee https://github.com/jannskiee/scoop-bucket && scoop install floe
+```
+
+**Linux / any OS**
+```sh
+curl -fsSL https://floe.one/install.sh | sh
+# Windows PowerShell: irm https://floe.one/install.ps1 | iex
+```
+
+No runtime or dependencies required. For Go devs: `go install github.com/jannskiee/floe/cli/cmd/floe@latest`. For all install options, checksum verification, and PATH setup, see the [installation guide](https://docs.floe.one/cli/installation).
+
+### Update
+
+```sh
+floe update              # for script / manual installs
+brew upgrade floe        # Homebrew
+winget upgrade jannskiee.floe  # Winget
+scoop update floe        # Scoop
+```
 
 ### Usage
 

--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jannskiee/floe/cli/internal/code"
 	"github.com/jannskiee/floe/cli/internal/ice"
 	"github.com/jannskiee/floe/cli/internal/peer"
+	"github.com/jannskiee/floe/cli/internal/selfupdate"
 	"github.com/jannskiee/floe/cli/internal/signaling"
 	"github.com/jannskiee/floe/cli/internal/transfer"
 	"github.com/spf13/cobra"
@@ -58,6 +59,7 @@ func init() {
 	rootCmd.AddCommand(sendCmd)
 	rootCmd.AddCommand(receiveCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(updateCmd)
 
 	// Enable `floe --version` (and -v) in addition to the `version` subcommand.
 	rootCmd.Version = version
@@ -300,7 +302,71 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("floe %s\n", version)
 		fmt.Println("Docs: https://docs.floe.one")
+		if latest := selfupdate.CheckAvailable(version); latest != "" {
+			fmt.Printf("Update available: %s  run `floe update` to upgrade\n", latest)
+		}
 	},
+}
+
+// ── floe update ───────────────────────────────────────────────────────────────
+
+var flagUpdateCheck bool
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update floe to the latest release",
+	Long: `Downloads, verifies, and installs the latest floe release.
+
+If floe was installed via Homebrew, Scoop, or Winget, use your package manager
+to update instead (e.g. brew upgrade floe).
+
+Set FLOE_NO_UPDATE_CHECK=1 to suppress the update hint in 'floe version'.`,
+	RunE: runUpdate,
+}
+
+func init() {
+	updateCmd.Flags().BoolVar(&flagUpdateCheck, "check", false, "check for a newer version without installing")
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	if version == "dev" {
+		fmt.Fprintln(os.Stderr, "Cannot update a dev build.")
+		return nil
+	}
+
+	if pm := selfupdate.PMPath(); pm != "" {
+		hint := selfupdate.PMHint(pm)
+		return fmt.Errorf("installed via %s - run `%s` to update", pm, hint)
+	}
+
+	fmt.Printf("Current version: %s\n", version)
+	fmt.Print("Checking for updates... ")
+
+	latest, err := selfupdate.LatestVersion()
+	if err != nil {
+		return fmt.Errorf("failed to check for updates: %w", err)
+	}
+	fmt.Println(latest)
+
+	if selfupdate.CompareVersions(latest, version) <= 0 {
+		fmt.Printf("Already up to date (%s)\n", version)
+		return nil
+	}
+
+	fmt.Printf("Update available: %s -> %s\n", version, latest)
+
+	if flagUpdateCheck {
+		fmt.Printf("Run `floe update` to install.\n")
+		return nil
+	}
+
+	fmt.Printf("Downloading %s...\n", latest)
+	if err := selfupdate.Apply(latest); err != nil {
+		return fmt.Errorf("update failed: %w", err)
+	}
+
+	fmt.Printf("Updated to %s\n", latest)
+	return nil
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────

--- a/cli/internal/selfupdate/selfupdate.go
+++ b/cli/internal/selfupdate/selfupdate.go
@@ -1,0 +1,420 @@
+// Package selfupdate provides version-check and binary self-replacement for the
+// floe CLI. All operations use only the Go standard library.
+package selfupdate
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	apiURL   = "https://api.github.com/repos/jannskiee/floe/releases/latest"
+	baseURL  = "https://github.com/jannskiee/floe/releases/download"
+	cacheTTL = 24 * time.Hour
+)
+
+// LatestVersion fetches the latest release tag from GitHub (e.g. "v1.2.0").
+func LatestVersion() (string, error) {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+	}
+
+	var rel struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return "", err
+	}
+	if rel.TagName == "" {
+		return "", fmt.Errorf("no tag_name in GitHub API response")
+	}
+	return rel.TagName, nil
+}
+
+// CheckAvailable returns the latest version tag if it is newer than current,
+// or "" if current is already up-to-date or the check could not complete.
+// Results are cached in ~/.config/floe/update-check.json for 24 hours.
+// Always returns "" when current == "dev" or FLOE_NO_UPDATE_CHECK=1.
+func CheckAvailable(current string) string {
+	if current == "dev" || os.Getenv("FLOE_NO_UPDATE_CHECK") == "1" {
+		return ""
+	}
+
+	if cached, ok := fromCache(); ok {
+		if CompareVersions(cached, current) > 0 {
+			return cached
+		}
+		return ""
+	}
+
+	ch := make(chan string, 1)
+	go func() {
+		if v, err := LatestVersion(); err == nil {
+			writeCache(v)
+			ch <- v
+		}
+	}()
+
+	select {
+	case latest := <-ch:
+		if CompareVersions(latest, current) > 0 {
+			return latest
+		}
+	case <-time.After(1 * time.Second):
+	}
+	return ""
+}
+
+// CompareVersions returns 1 if a > b, -1 if a < b, 0 if equal.
+// Accepts "vX.Y.Z" or "X.Y.Z" format.
+func CompareVersions(a, b string) int {
+	a = strings.TrimPrefix(a, "v")
+	b = strings.TrimPrefix(b, "v")
+	pa := strings.SplitN(a, ".", 3)
+	pb := strings.SplitN(b, ".", 3)
+	for i := range 3 {
+		na, nb := 0, 0
+		if i < len(pa) {
+			na, _ = strconv.Atoi(pa[i])
+		}
+		if i < len(pb) {
+			nb, _ = strconv.Atoi(pb[i])
+		}
+		if na != nb {
+			if na > nb {
+				return 1
+			}
+			return -1
+		}
+	}
+	return 0
+}
+
+// DetectPM returns the name of the package manager that owns the binary at
+// exePath ("homebrew", "scoop", "winget"), or "" if not managed by a known PM.
+// Exported so it can be unit-tested with arbitrary paths.
+func DetectPM(exePath string) string {
+	p := filepath.ToSlash(strings.ToLower(exePath))
+	switch {
+	case strings.Contains(p, "homebrew") || strings.Contains(p, "cellar") || strings.Contains(p, "linuxbrew"):
+		return "homebrew"
+	case strings.Contains(p, "scoop"):
+		return "scoop"
+	case strings.Contains(p, "winget"):
+		return "winget"
+	}
+	return ""
+}
+
+// PMPath returns the detected package manager for the currently running binary,
+// or "" when not managed by a known package manager.
+func PMPath() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return DetectPM(exe)
+}
+
+// PMHint returns the upgrade command for the given PM name.
+func PMHint(pm string) string {
+	switch pm {
+	case "homebrew":
+		return "brew upgrade floe"
+	case "scoop":
+		return "scoop update floe"
+	case "winget":
+		return "winget upgrade jannskiee.floe"
+	}
+	return ""
+}
+
+// AssetName returns (archive filename, format string) for the given platform.
+// Exported for testing; callers within this package use assetName().
+func AssetName(version, goos, goarch string) (string, string) {
+	if goos == "windows" {
+		return fmt.Sprintf("floe_%s_%s_%s.zip", version, goos, goarch), "zip"
+	}
+	return fmt.Sprintf("floe_%s_%s_%s.tar.gz", version, goos, goarch), "tar.gz"
+}
+
+func assetName(version string) (string, string) {
+	return AssetName(version, runtime.GOOS, runtime.GOARCH)
+}
+
+// Apply downloads, verifies the SHA-256 checksum, and replaces the running
+// binary with the given version. On Windows the running executable is renamed
+// out of the way before the new binary is moved into place.
+func Apply(version string) error {
+	asset, format := assetName(version)
+	assetURL := fmt.Sprintf("%s/%s/%s", baseURL, version, asset)
+	checksumsURL := fmt.Sprintf("%s/%s/checksums.txt", baseURL, version)
+
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot locate current executable: %w", err)
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return fmt.Errorf("cannot resolve executable path: %w", err)
+	}
+
+	checksums, err := fetchText(checksumsURL)
+	if err != nil {
+		return fmt.Errorf("failed to fetch checksums: %w", err)
+	}
+
+	archiveTmp, err := downloadTemp(assetURL)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	defer os.Remove(archiveTmp)
+
+	if err := verifySHA256(archiveTmp, asset, checksums); err != nil {
+		return err
+	}
+
+	binaryTmp := exe + ".update"
+	if err := extractBinary(archiveTmp, format, binaryTmp); err != nil {
+		return fmt.Errorf("extraction failed: %w", err)
+	}
+	defer os.Remove(binaryTmp)
+
+	return replaceBinary(exe, binaryTmp)
+}
+
+// --- cache ---
+
+type cacheEntry struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Latest    string    `json:"latest"`
+}
+
+func cacheFilePath() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "floe", "update-check.json")
+}
+
+func fromCache() (string, bool) {
+	p := cacheFilePath()
+	if p == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return "", false
+	}
+	var c cacheEntry
+	if err := json.Unmarshal(data, &c); err != nil {
+		return "", false
+	}
+	if time.Since(c.CheckedAt) > cacheTTL {
+		return "", false
+	}
+	return c.Latest, true
+}
+
+func writeCache(latest string) {
+	p := cacheFilePath()
+	if p == "" {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(p), 0755)
+	data, _ := json.Marshal(cacheEntry{CheckedAt: time.Now(), Latest: latest})
+	_ = os.WriteFile(p, data, 0644)
+}
+
+// --- download & verify ---
+
+func fetchText(url string) (string, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
+	}
+	b, err := io.ReadAll(resp.Body)
+	return string(b), err
+}
+
+func downloadTemp(url string) (string, error) {
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP %d fetching %s", resp.StatusCode, url)
+	}
+
+	f, err := os.CreateTemp("", "floe-update-*")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+func verifySHA256(filePath, assetFilename, checksums string) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+
+	for line := range strings.SplitSeq(checksums, "\n") {
+		parts := strings.Fields(line)
+		if len(parts) == 2 && parts[1] == assetFilename {
+			if parts[0] == got {
+				return nil
+			}
+			return fmt.Errorf("checksum mismatch for %s:\n  expected %s\n  got      %s", assetFilename, parts[0], got)
+		}
+	}
+	return fmt.Errorf("checksum not found in checksums.txt for %s", assetFilename)
+}
+
+// --- extraction ---
+
+func extractBinary(archivePath, format, destPath string) error {
+	binaryName := "floe"
+	if runtime.GOOS == "windows" {
+		binaryName = "floe.exe"
+	}
+
+	switch format {
+	case "tar.gz":
+		f, err := os.Open(archivePath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		return extractFromTarGz(f, binaryName, destPath)
+	case "zip":
+		return extractFromZip(archivePath, binaryName, destPath)
+	default:
+		return fmt.Errorf("unknown archive format: %s", format)
+	}
+}
+
+func extractFromTarGz(r io.Reader, binaryName, destPath string) error {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if filepath.Base(hdr.Name) == binaryName {
+			return writeFile(tr, destPath)
+		}
+	}
+	return fmt.Errorf("%s not found in archive", binaryName)
+}
+
+func extractFromZip(archivePath, binaryName, destPath string) error {
+	r, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		if filepath.Base(f.Name) == binaryName {
+			rc, err := f.Open()
+			if err != nil {
+				return err
+			}
+			defer rc.Close()
+			return writeFile(rc, destPath)
+		}
+	}
+	return fmt.Errorf("%s not found in archive", binaryName)
+}
+
+func writeFile(r io.Reader, destPath string) error {
+	out, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, r)
+	closeErr := out.Close()
+	if copyErr != nil {
+		os.Remove(destPath)
+		return copyErr
+	}
+	return closeErr
+}
+
+// --- binary replacement ---
+
+func replaceBinary(exe, newBinary string) error {
+	if runtime.GOOS == "windows" {
+		// Windows disallows overwriting a running .exe but allows renaming it.
+		// Rename the old binary out of the way, then rename the new one into place.
+		bak := exe + ".bak"
+		_ = os.Remove(bak)
+		if err := os.Rename(exe, bak); err != nil {
+			return fmt.Errorf("cannot rename current binary: %w", err)
+		}
+		if err := os.Rename(newBinary, exe); err != nil {
+			_ = os.Rename(bak, exe) // attempt restore
+			return fmt.Errorf("cannot install new binary: %w", err)
+		}
+		_ = os.Remove(bak)
+		return nil
+	}
+	return os.Rename(newBinary, exe)
+}

--- a/cli/internal/selfupdate/selfupdate_test.go
+++ b/cli/internal/selfupdate/selfupdate_test.go
@@ -1,0 +1,88 @@
+package selfupdate
+
+import "testing"
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.2.0", "v1.1.0", 1},
+		{"v1.0.0", "v1.0.0", 0},
+		{"v1.0.0", "v1.1.0", -1},
+		{"v2.0.0", "v1.9.9", 1},
+		{"v1.0.1", "v1.0.0", 1},
+		{"v0.9.0", "v1.0.0", -1},
+		{"1.2.0", "v1.2.0", 0},  // no "v" prefix
+		{"v10.0.0", "v9.9.9", 1}, // double-digit major
+	}
+	for _, tt := range tests {
+		if got := CompareVersions(tt.a, tt.b); got != tt.want {
+			t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestAssetName(t *testing.T) {
+	tests := []struct {
+		goos, goarch, version string
+		wantName              string
+		wantFmt               string
+	}{
+		{"linux", "amd64", "v1.2.0", "floe_v1.2.0_linux_amd64.tar.gz", "tar.gz"},
+		{"linux", "arm64", "v1.2.0", "floe_v1.2.0_linux_arm64.tar.gz", "tar.gz"},
+		{"darwin", "amd64", "v1.2.0", "floe_v1.2.0_darwin_amd64.tar.gz", "tar.gz"},
+		{"darwin", "arm64", "v1.2.0", "floe_v1.2.0_darwin_arm64.tar.gz", "tar.gz"},
+		{"windows", "amd64", "v1.2.0", "floe_v1.2.0_windows_amd64.zip", "zip"},
+		{"windows", "arm64", "v1.2.0", "floe_v1.2.0_windows_arm64.zip", "zip"},
+	}
+	for _, tt := range tests {
+		gotName, gotFmt := AssetName(tt.version, tt.goos, tt.goarch)
+		if gotName != tt.wantName {
+			t.Errorf("AssetName(%q, %q, %q): name = %q, want %q", tt.version, tt.goos, tt.goarch, gotName, tt.wantName)
+		}
+		if gotFmt != tt.wantFmt {
+			t.Errorf("AssetName(%q, %q, %q): format = %q, want %q", tt.version, tt.goos, tt.goarch, gotFmt, tt.wantFmt)
+		}
+	}
+}
+
+func TestDetectPM(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/opt/homebrew/Cellar/floe/1.0.0/bin/floe", "homebrew"},
+		{"/usr/local/Cellar/floe/1.0.0/bin/floe", "homebrew"},
+		{"/home/linuxbrew/.linuxbrew/bin/floe", "homebrew"},
+		{"C:/Users/user/scoop/apps/floe/current/floe.exe", "scoop"},
+		{"C:/Users/user/AppData/Local/Microsoft/WinGet/Packages/jannskiee.floe/floe.exe", "winget"},
+		{"/usr/local/bin/floe", ""},
+		{"/home/user/.local/bin/floe", ""},
+		{"/home/user/bin/floe", ""},
+		{"C:/Users/user/AppData/Local/Programs/floe/floe.exe", ""},
+	}
+	for _, tt := range tests {
+		if got := DetectPM(tt.path); got != tt.want {
+			t.Errorf("DetectPM(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestPMHint(t *testing.T) {
+	tests := []struct {
+		pm   string
+		want string
+	}{
+		{"homebrew", "brew upgrade floe"},
+		{"scoop", "scoop update floe"},
+		{"winget", "winget upgrade jannskiee.floe"},
+		{"", ""},
+		{"unknown", ""},
+	}
+	for _, tt := range tests {
+		if got := PMHint(tt.pm); got != tt.want {
+			t.Errorf("PMHint(%q) = %q, want %q", tt.pm, got, tt.want)
+		}
+	}
+}

--- a/client/public/install.ps1
+++ b/client/public/install.ps1
@@ -1,0 +1,95 @@
+# Floe CLI installer for Windows
+# Usage: irm https://floe.one/install.ps1 | iex
+#        $env:FLOE_VERSION = "v1.2.0"; irm https://floe.one/install.ps1 | iex
+# Re-running upgrades an existing install in place.
+
+$ErrorActionPreference = "Stop"
+
+$Repo = "jannskiee/floe"
+$Binary = "floe.exe"
+$InstallDir = "$env:LOCALAPPDATA\Programs\floe"
+
+# Detect architecture
+$Arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+    "AMD64" { "amd64" }
+    "ARM64" { "arm64" }
+    default {
+        Write-Error "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE"
+        exit 1
+    }
+}
+
+# Resolve version
+$Version = $env:FLOE_VERSION
+if (-not $Version) {
+    Write-Host "Fetching latest version..."
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = $Release.tag_name
+}
+
+if (-not $Version) {
+    Write-Error "Could not determine latest version. Set `$env:FLOE_VERSION = 'vX.Y.Z'` to install a specific version."
+    exit 1
+}
+
+$Archive = "floe_${Version}_windows_${Arch}.zip"
+$DownloadUrl = "https://github.com/$Repo/releases/download/$Version/$Archive"
+$ChecksumsUrl = "https://github.com/$Repo/releases/download/$Version/checksums.txt"
+
+$TmpDir = New-Item -ItemType Directory -Path "$env:TEMP\floe-install-$(Get-Random)"
+
+try {
+    $ArchivePath = Join-Path $TmpDir $Archive
+
+    Write-Host "Downloading floe $Version (windows/$Arch)..."
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $ArchivePath -UseBasicParsing
+
+    # Verify SHA-256 checksum
+    Write-Host "Verifying checksum..."
+    $ChecksumsRaw = (Invoke-WebRequest -Uri $ChecksumsUrl -UseBasicParsing).Content
+    $Lines = $ChecksumsRaw -split "`r?`n"
+    $MatchLine = $Lines | Where-Object { $_ -match "\s+$([regex]::Escape($Archive))\s*$" }
+
+    if ($MatchLine) {
+        $ExpectedHash = ($MatchLine.Trim() -split "\s+")[0].ToLower()
+        $ActualHash = (Get-FileHash -Algorithm SHA256 -Path $ArchivePath).Hash.ToLower()
+        if ($ActualHash -ne $ExpectedHash) {
+            Write-Error "Checksum verification failed.`n  Expected: $ExpectedHash`n  Got:      $ActualHash"
+            exit 1
+        }
+        Write-Host "Checksum verified."
+    } else {
+        Write-Warning "Checksum not found for $Archive, skipping verification."
+    }
+
+    # Extract
+    Write-Host "Extracting..."
+    Expand-Archive -Path $ArchivePath -DestinationPath $TmpDir -Force
+
+    $ExtractedBinary = Join-Path $TmpDir $Binary
+    if (-not (Test-Path $ExtractedBinary)) {
+        Write-Error "$Binary not found in archive."
+        exit 1
+    }
+
+    # Install
+    if (-not (Test-Path $InstallDir)) {
+        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    }
+    Copy-Item -Path $ExtractedBinary -Destination (Join-Path $InstallDir $Binary) -Force
+
+    # Add install directory to user PATH (idempotent)
+    $CurrentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($CurrentPath -notlike "*$InstallDir*") {
+        $NewPath = ($CurrentPath.TrimEnd(";") + ";$InstallDir").TrimStart(";")
+        [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
+        Write-Host "Added $InstallDir to your PATH."
+    }
+
+    Write-Host ""
+    Write-Host "Installed floe $Version to $InstallDir\$Binary"
+    Write-Host "Open a new terminal, then run 'floe version' to verify."
+
+} finally {
+    Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+}

--- a/client/public/install.sh
+++ b/client/public/install.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env sh
+# Floe CLI installer for macOS and Linux
+# Usage: curl -fsSL https://floe.one/install.sh | sh
+#        FLOE_VERSION=v1.2.0 curl -fsSL https://floe.one/install.sh | sh
+# Re-running upgrades an existing install in place.
+
+set -e
+
+REPO="jannskiee/floe"
+BINARY="floe"
+
+# Detect OS
+OS="$(uname -s)"
+case "${OS}" in
+  Linux*)  GOOS="linux"  ;;
+  Darwin*) GOOS="darwin" ;;
+  *)
+    echo "Unsupported OS: ${OS}" >&2
+    echo "Download manually from https://github.com/${REPO}/releases" >&2
+    exit 1
+    ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "${ARCH}" in
+  x86_64|amd64)  GOARCH="amd64" ;;
+  arm64|aarch64) GOARCH="arm64" ;;
+  *)
+    echo "Unsupported architecture: ${ARCH}" >&2
+    echo "Download manually from https://github.com/${REPO}/releases" >&2
+    exit 1
+    ;;
+esac
+
+# Resolve version
+if [ -z "${FLOE_VERSION}" ]; then
+  printf "Fetching latest version... "
+  FLOE_VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | cut -d'"' -f4)"
+  echo "${FLOE_VERSION}"
+fi
+
+if [ -z "${FLOE_VERSION}" ]; then
+  echo "Could not determine latest version." >&2
+  echo "Set FLOE_VERSION=vX.Y.Z to install a specific version, e.g.:" >&2
+  echo "  FLOE_VERSION=v1.0.0 curl -fsSL https://floe.one/install.sh | sh" >&2
+  exit 1
+fi
+
+ARCHIVE="floe_${FLOE_VERSION}_${GOOS}_${GOARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${FLOE_VERSION}/${ARCHIVE}"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${FLOE_VERSION}/checksums.txt"
+
+# Work in a temp directory; clean up on exit
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+echo "Downloading floe ${FLOE_VERSION} (${GOOS}/${GOARCH})..."
+curl -fsSL "${DOWNLOAD_URL}" -o "${TMP_DIR}/${ARCHIVE}"
+curl -fsSL "${CHECKSUMS_URL}" -o "${TMP_DIR}/checksums.txt"
+
+# Verify SHA-256 checksum
+EXPECTED="$(grep " ${ARCHIVE}" "${TMP_DIR}/checksums.txt" | awk '{print $1}')"
+if [ -n "${EXPECTED}" ]; then
+  if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "${TMP_DIR}/${ARCHIVE}" | awk '{print $1}')"
+  elif command -v shasum >/dev/null 2>&1; then
+    ACTUAL="$(shasum -a 256 "${TMP_DIR}/${ARCHIVE}" | awk '{print $1}')"
+  else
+    echo "Warning: no sha256 tool found, skipping checksum verification." >&2
+    ACTUAL="${EXPECTED}"
+  fi
+  if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+    echo "Checksum verification failed!" >&2
+    echo "  Expected: ${EXPECTED}" >&2
+    echo "  Got:      ${ACTUAL}" >&2
+    exit 1
+  fi
+  echo "Checksum verified."
+else
+  echo "Warning: checksum not found for ${ARCHIVE}, skipping verification." >&2
+fi
+
+# Extract binary from archive
+tar xzf "${TMP_DIR}/${ARCHIVE}" -C "${TMP_DIR}"
+
+if [ ! -f "${TMP_DIR}/${BINARY}" ]; then
+  echo "Error: binary not found after extraction." >&2
+  exit 1
+fi
+
+chmod +x "${TMP_DIR}/${BINARY}"
+
+# Determine install directory
+INSTALL_DIR="/usr/local/bin"
+if [ -w "${INSTALL_DIR}" ]; then
+  mv "${TMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  echo "Installed floe ${FLOE_VERSION} to ${INSTALL_DIR}/${BINARY}"
+elif command -v sudo >/dev/null 2>&1; then
+  echo "Installing to ${INSTALL_DIR} (requires sudo)..."
+  sudo mv "${TMP_DIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+  echo "Installed floe ${FLOE_VERSION} to ${INSTALL_DIR}/${BINARY}"
+else
+  # Fall back to user-local bin
+  LOCAL_BIN="${HOME}/.local/bin"
+  mkdir -p "${LOCAL_BIN}"
+  mv "${TMP_DIR}/${BINARY}" "${LOCAL_BIN}/${BINARY}"
+  echo "Installed floe ${FLOE_VERSION} to ${LOCAL_BIN}/${BINARY}"
+  case ":${PATH}:" in
+    *":${LOCAL_BIN}:"*) ;;
+    *)
+      echo ""
+      echo "Note: ${LOCAL_BIN} is not in your PATH. Add it by running:"
+      echo "  echo 'export PATH=\"\${HOME}/.local/bin:\${PATH}\"' >> ~/.profile"
+      echo "Then reload your shell or open a new terminal."
+      ;;
+  esac
+fi
+
+echo ""
+echo "Run 'floe version' to verify the installation."

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -1,101 +1,90 @@
 ---
 title: "Installation"
-description: "Download and install the floe CLI binary."
+description: "Install the floe CLI in one command on macOS, Windows, or Linux."
 ---
 
 The `floe` CLI is a single self-contained binary with no runtime dependencies.
 
-## Download
+## Package managers
 
-Go to the [GitHub Releases page](https://github.com/jannskiee/floe/releases) and download the archive for your platform. Release archives follow this naming convention:
-
-```
-floe_<version>_<os>_<arch>.tar.gz    # macOS and Linux
-floe_<version>_<os>_<arch>.zip       # Windows
-```
-
-For example: `floe_v1.2.0_darwin_arm64.tar.gz` or `floe_v1.2.0_linux_amd64.tar.gz`.
+The fastest way to install floe. Package manager installs also get updates via the
+standard upgrade command for that tool.
 
 <Tabs>
-  <Tab title="macOS (Apple Silicon)">
-    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
-
+  <Tab title="macOS">
     ```bash
-    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_darwin_arm64.tar.gz" | tar xz
-    sudo mv floe /usr/local/bin/
+    brew install --cask jannskiee/tap/floe
     ```
 
-    Or fetch the latest version automatically:
+    Update: `brew upgrade floe`
 
-    ```bash
-    VERSION=$(curl -s https://api.github.com/repos/jannskiee/floe/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
-    curl -L "https://github.com/jannskiee/floe/releases/download/${VERSION}/floe_${VERSION}_darwin_arm64.tar.gz" | tar xz
-    sudo mv floe /usr/local/bin/
-    ```
+    First run: if macOS blocks the binary (Gatekeeper), right-click the `floe` binary in Finder
+    and choose Open, or run `xattr -dr com.apple.quarantine $(which floe)`.
   </Tab>
-  <Tab title="macOS (Intel)">
-    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
-
-    ```bash
-    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_darwin_amd64.tar.gz" | tar xz
-    sudo mv floe /usr/local/bin/
+  <Tab title="Windows (winget)">
+    ```powershell
+    winget install jannskiee.floe
     ```
 
-    Or fetch the latest version automatically:
+    Update: `winget upgrade jannskiee.floe`
 
-    ```bash
-    VERSION=$(curl -s https://api.github.com/repos/jannskiee/floe/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
-    curl -L "https://github.com/jannskiee/floe/releases/download/${VERSION}/floe_${VERSION}_darwin_amd64.tar.gz" | tar xz
-    sudo mv floe /usr/local/bin/
-    ```
+    Winget is built into Windows 10/11. The package is available after each release once
+    Microsoft's automated PR review completes (usually a few hours after the tag).
   </Tab>
-  <Tab title="Linux (amd64)">
-    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
-
-    ```bash
-    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_linux_amd64.tar.gz" | tar xz
-    sudo mv floe /usr/local/bin/
+  <Tab title="Windows (scoop)">
+    ```powershell
+    scoop bucket add jannskiee https://github.com/jannskiee/scoop-bucket
+    scoop install floe
     ```
 
-    Or fetch the latest version automatically:
+    Update: `scoop update floe`
 
-    ```bash
-    VERSION=$(curl -s https://api.github.com/repos/jannskiee/floe/releases/latest | grep '"tag_name"' | cut -d'"' -f4)
-    curl -L "https://github.com/jannskiee/floe/releases/download/${VERSION}/floe_${VERSION}_linux_amd64.tar.gz" | tar xz
-    sudo mv floe /usr/local/bin/
-    ```
-  </Tab>
-  <Tab title="Linux (arm64)">
-    Find the latest version on the [releases page](https://github.com/jannskiee/floe/releases), then replace `vX.Y.Z` below:
-
-    ```bash
-    curl -L "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/floe_vX.Y.Z_linux_arm64.tar.gz" | tar xz
-    sudo mv floe /usr/local/bin/
-    ```
-  </Tab>
-  <Tab title="Windows">
-    Download `floe_vX.Y.Z_windows_amd64.zip` from the [releases page](https://github.com/jannskiee/floe/releases). Extract the archive, then add the folder containing `floe.exe` to your `PATH` environment variable:
-
-    1. Open **System Properties** and go to **Environment Variables**.
-    2. Under **User variables**, select `Path` and click **Edit**.
-    3. Click **New** and enter the full path to the folder containing `floe.exe`.
-    4. Click **OK** to close all dialogs, then open a new terminal to pick up the change.
+    [Scoop](https://scoop.sh) can be installed with `irm get.scoop.sh | iex`.
   </Tab>
 </Tabs>
 
-## Verify the checksum (optional)
+## One-line installer
 
-Each release includes a `checksums.txt` file. To verify the integrity of your download, replace `vX.Y.Z` with your version:
+Works on macOS, Linux, and Windows without a package manager. Re-running the script
+upgrades an existing install in place.
+
+<Tabs>
+  <Tab title="macOS / Linux">
+    ```bash
+    curl -fsSL https://floe.one/install.sh | sh
+    ```
+
+    To install a specific version:
+    ```bash
+    FLOE_VERSION=v1.2.0 curl -fsSL https://floe.one/install.sh | sh
+    ```
+
+    The script detects your OS and architecture, downloads the correct archive, verifies the
+    SHA-256 checksum, and installs `floe` to `/usr/local/bin` (or `~/.local/bin` when
+    `/usr/local/bin` is not writable and `sudo` is unavailable).
+  </Tab>
+  <Tab title="Windows (PowerShell)">
+    ```powershell
+    irm https://floe.one/install.ps1 | iex
+    ```
+
+    To install a specific version:
+    ```powershell
+    $env:FLOE_VERSION = "v1.2.0"; irm https://floe.one/install.ps1 | iex
+    ```
+
+    The script downloads the correct `.zip` for your architecture, verifies the SHA-256 checksum,
+    extracts to `%LOCALAPPDATA%\Programs\floe`, and adds that directory to your user `PATH`.
+    Open a new terminal after running it.
+  </Tab>
+</Tabs>
+
+## Go install
+
+If you have Go 1.25 or later installed:
 
 ```bash
-# Download checksums
-curl -LO "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/checksums.txt"
-
-# Verify (macOS)
-shasum -a 256 --check --ignore-missing checksums.txt
-
-# Verify (Linux)
-sha256sum --check --ignore-missing checksums.txt
+go install github.com/jannskiee/floe/cli/cmd/floe@latest
 ```
 
 ## Verify the install
@@ -111,6 +100,35 @@ floe v1.x.x
 Docs: https://docs.floe.one
 ```
 
+## Verify the checksum (manual download)
+
+If you downloaded an archive directly from the [GitHub Releases page](https://github.com/jannskiee/floe/releases),
+each release includes a `checksums.txt` file. To verify:
+
+```bash
+# Download checksums
+curl -LO "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/checksums.txt"
+
+# Verify (macOS)
+shasum -a 256 --check --ignore-missing checksums.txt
+
+# Verify (Linux)
+sha256sum --check --ignore-missing checksums.txt
+```
+
+## Update
+
+For package manager installs, use the standard upgrade command (`brew upgrade floe`,
+`winget upgrade jannskiee.floe`, `scoop update floe`).
+
+For script or manual installs, run:
+
+```bash
+floe update
+```
+
+See [Updating floe](/cli/update) for details.
+
 ## Build from source
 
 Requires Go 1.25 or later.
@@ -121,4 +139,5 @@ cd floe/cli
 go build ./cmd/floe
 ```
 
-Move the resulting `floe` binary to a directory on your `PATH` (e.g. `/usr/local/bin/` on macOS and Linux).
+Move the resulting `floe` binary to a directory on your `PATH` (e.g. `/usr/local/bin` on
+macOS and Linux).

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -1,0 +1,43 @@
+---
+title: "Updating"
+description: "Keep the floe CLI up to date."
+---
+
+## Package manager installs
+
+If you installed floe via a package manager, use the standard upgrade command for that tool.
+
+| Install method | Upgrade command |
+| -------------- | --------------- |
+| Homebrew (macOS) | `brew upgrade floe` |
+| Winget (Windows) | `winget upgrade jannskiee.floe` |
+| Scoop (Windows) | `scoop update floe` |
+
+## Script and manual installs
+
+Run the built-in update command:
+
+```bash
+floe update
+```
+
+This checks the latest release on GitHub, downloads the correct archive for your OS and
+architecture, verifies the SHA-256 checksum, and replaces the running binary in place.
+
+To check for an update without installing:
+
+```bash
+floe update --check
+```
+
+To suppress the update hint shown by `floe version`, set `FLOE_NO_UPDATE_CHECK=1`.
+
+You can also re-run the original install script at any time to upgrade:
+
+```bash
+# macOS / Linux
+curl -fsSL https://floe.one/install.sh | sh
+
+# Windows
+irm https://floe.one/install.ps1 | iex
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -75,6 +75,7 @@
         "group": "CLI",
         "pages": [
           "cli/installation",
+          "cli/update",
           "cli/send",
           "cli/receive",
           "cli/version",


### PR DESCRIPTION
## Summary

Makes installing and updating the `floe` CLI a single command on every OS, matching the convenience of tools like croc. Everything below is automated on each `vX.Y.Z` tag.

### Install (new)
| OS | Command |
| --- | --- |
| macOS | `brew install --cask jannskiee/tap/floe` |
| Windows | `winget install jannskiee.floe` or `scoop bucket add jannskiee https://github.com/jannskiee/scoop-bucket && scoop install floe` |
| Any OS | `curl -fsSL https://floe.one/install.sh \| sh` / `irm https://floe.one/install.ps1 \| iex` |

### Update (new)
`brew upgrade floe` / `scoop update floe` / `winget upgrade jannskiee.floe`, or `floe update` for script/manual installs.

## Changes
- **`.goreleaser.yml`** - `homebrew_casks`, `scoops`, `winget` pipes publishing into the shared `jannskiee/homebrew-tap`, `jannskiee/scoop-bucket`, and the `jannskiee/winget-pkgs` fork. Optional Linux-native (`nfpms`/`aurs`) included commented out.
- **`.github/workflows/release.yml`** - `TAP_GITHUB_TOKEN` for publishing to the shared repos.
- **`client/public/install.sh` / `install.ps1`** - universal one-line installers (OS/arch detect, SHA-256 verify, PATH install, in-place upgrade).
- **`cli/internal/selfupdate/`** - version check, 24h-cached update notice, checksum-verified self-replace, package-manager detection (refuses to self-update a brew/scoop/winget-managed binary with a hint). Unit tested.
- **`cli/cmd/floe/main.go`** - `floe update` (with `--check`) plus an "update available" hint in `floe version`.
- **Docs / README** - package-manager-first install instructions; new `docs/cli/update.mdx`.

## Setup required before releasing
The three shared repos are already created (public). Still needed:
- [ ] Add repo secret `TAP_GITHUB_TOKEN` (PAT with Contents write on `homebrew-tap`, `scoop-bucket`, and the `winget-pkgs` fork).

## Verification
- `go vet ./...`, `go test ./...` (incl. new selfupdate tests), `go build ./cmd/floe` - all pass.
- `goreleaser check` passes; `goreleaser release --snapshot --clean` generates valid Homebrew cask, Scoop manifest, and Winget manifests with correct URLs/checksums/package id.
