### PR TITLE
fix(cli): sender no longer errors after successful CLI-to-CLI transfer

### DIFF
--- a/cli/internal/transfer/loopback_test.go
+++ b/cli/internal/transfer/loopback_test.go
@@ -153,6 +153,61 @@ func TestLoopbackLargeFile(t *testing.T) {
 	}
 }
 
+// TestLoopbackImmediateReceiverClose reproduces the CLI-to-CLI race where the
+// receiver closes its PeerConnection immediately after ReceiveFiles returns.
+// Before the fix the sender's SCTP buffer stalled at a non-zero value because
+// the final SACKs never arrived, causing "timed out flushing" errors even
+// though the file was fully received.
+func TestLoopbackImmediateReceiverClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ICE loopback transfer in -short mode")
+	}
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "blob.bin")
+	data := make([]byte, 5*1024*1024) // 5 MB — enough to exercise backpressure
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("generate random data: %v", err)
+	}
+	if err := os.WriteFile(srcPath, data, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	senderDC, recvCh, closeFn := newConnectedPair(t)
+	// Do NOT defer closeFn — we close the receiver PC ourselves immediately
+	// after ReceiveFiles returns to reproduce the race.
+
+	outDir := t.TempDir()
+	recvDone := make(chan error, 1)
+
+	go func() {
+		dc := <-recvCh
+		err := ReceiveFiles(dc, outDir, true)
+		// Close receiver immediately — this is what `defer conn.Close()` does
+		// in `runReceive`. The SCTP teardown races the final SACK to the sender.
+		dc.Close()
+		recvDone <- err
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	sendErr := SendFiles(senderDC, []string{srcPath})
+	closeFn() // clean up sender PC after SendFiles returns
+
+	if sendErr != nil {
+		t.Fatalf("SendFiles returned error after receiver closed immediately: %v", sendErr)
+	}
+
+	select {
+	case err := <-recvDone:
+		if err != nil {
+			t.Fatalf("ReceiveFiles: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("ReceiveFiles did not complete")
+	}
+}
+
 // TestLoopbackSmallJSONFile guards the framing fix end to end: a file whose
 // bytes are a sub-1 KB JSON object must arrive byte-identical, not be mistaken
 // for a control message and dropped.

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -170,6 +170,22 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 							{"Time", timeVal},
 							{"Saved to", outputDir},
 						})
+
+						// Tell the sender all bytes are written and verified so it
+						// can close cleanly without relying on SCTP buffer accounting.
+						// Sent as binary so the browser (which checks byteLength) can
+						// classify it and ignore it; CLI senders consume it explicitly.
+						receivedMsg, _ := json.Marshal(map[string]string{"type": "received"})
+						dc.Send([]byte(receivedMsg))
+
+						// Wait for the sender to close the channel (or a short grace
+						// period) before returning. This keeps our SCTP/DTLS alive
+						// long enough for the "received" SACK to reach the sender —
+						// tearing down immediately would race it.
+						select {
+						case <-done:
+						case <-time.After(5 * time.Second):
+						}
 						return nil
 					}
 				}

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -106,20 +106,38 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 		}
 	}
 
-	// Flush: wait for pion to push every buffered byte (including the final end
-	// marker) onto the wire before the caller closes the connection. Closing
-	// while data is still buffered truncates the transfer. Capped so a dead peer
-	// can't hang the process forever.
-	drainDeadline := time.Now().Add(30 * time.Second)
-	for dc.BufferedAmount() > 0 {
-		if time.Now().After(drainDeadline) {
-			return fmt.Errorf("timed out flushing %d buffered bytes to peer", dc.BufferedAmount())
+	// Wait for delivery confirmation before closing.
+	//
+	// CLI receivers send {"type":"received"} after writing and verifying every
+	// byte, which is the authoritative signal. Browser receivers don't send it,
+	// but they keep their connection alive so the SCTP buffer naturally drains
+	// to zero — that's the fallback. A 30s deadline guards against a dead peer.
+	//
+	// We cannot rely solely on dc.BufferedAmount()==0: when the receiver closes
+	// its connection immediately after the last write (which the CLI does), the
+	// final SACKs may never arrive and the buffer stalls at a non-zero value
+	// even though all bytes were delivered successfully.
+	drainDeadline := time.After(30 * time.Second)
+	drainTick := time.NewTicker(50 * time.Millisecond)
+	defer drainTick.Stop()
+drainLoop:
+	for {
+		select {
+		case raw := <-ackCh:
+			var msg struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(raw, &msg) == nil && msg.Type == "received" {
+				break drainLoop
+			}
+		case <-drainTick.C:
+			if dc.BufferedAmount() == 0 {
+				break drainLoop
+			}
+		case <-drainDeadline:
+			return fmt.Errorf("timed out waiting for delivery confirmation from peer")
 		}
-		time.Sleep(50 * time.Millisecond)
 	}
-	// Brief grace period so the receiver can process the final end marker
-	// before the data channel is torn down.
-	time.Sleep(250 * time.Millisecond)
 
 	elapsed := time.Since(start)
 	timeVal := formatDuration(elapsed)

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -37,7 +37,14 @@ export interface End {
     type: 'end';
 }
 
-export type ControlMessage = Metadata | Ack | End;
+// Sent by the CLI receiver after all files are written and verified.
+// Tells the CLI sender delivery is confirmed so it can close cleanly.
+// Browser receivers never send this; the protocol handles both cases.
+export interface Received {
+    type: 'received';
+}
+
+export type ControlMessage = Metadata | Ack | End | Received;
 
 // --- Message builders ---
 
@@ -97,5 +104,6 @@ export function classifyControl(data: ArrayBuffer | Uint8Array): ControlMessage 
     if (t === 'metadata') return msg as unknown as Metadata;
     if (t === 'ack') return msg as unknown as Ack;
     if (t === 'end') return msg as unknown as End;
+    if (t === 'received') return msg as unknown as Received;
     return null;
 }


### PR DESCRIPTION
## Summary

- **Root cause:** After `ReceiveFiles` returned, the CLI receiver immediately called `conn.Close()`, which tore down SCTP/DTLS before the final SACKs reached the sender. The sender's `BufferedAmount` poll stalled at a non-zero value (e.g. 1134 bytes) and hit the 30s deadline, printing a false "timed out flushing" error — even though the file arrived intact on the receiver side.
- **Fix:** Added an application-level completion handshake. The CLI receiver sends `{"type":"received"}` after all bytes are written and verified, then lingers up to 5s waiting for the sender to close first. The sender breaks its drain loop the moment it sees that message, with `BufferedAmount==0` kept as a silent fallback for browser receivers (which stay alive and SACK normally).
- **Protocol:** `{"type":"received"}` is added to `client/lib/transfer/protocol.ts` so browser peers recognize and discard it rather than treat it as file data.

## Test plan

- [x] `TestLoopbackImmediateReceiverClose` (new) — closes the receiver data channel immediately after `ReceiveFiles` returns, reproducing the exact race; asserts `SendFiles` returns `nil`
- [x] `TestLoopbackLargeFile` — existing 20 MB end-to-end test still passes
- [x] `TestLoopbackSmallJSONFile` — existing JSON framing regression still passes
- [x] `go vet ./...` — clean
- [x] `pnpm lint` (client) — clean
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)