### PR TITLE
feat(cli): show file count and total size before transfer on both sides

### DIFF
--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -83,6 +83,12 @@ func runSend(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Pre-compute file summary for the share box (same walk as SendFiles).
+	summary, err := transfer.Summarize(args)
+	if err != nil {
+		return err
+	}
+
 	fmt.Println()
 
 	// 1. Generate a UUID room ID for this session
@@ -154,12 +160,12 @@ func runSend(cmd *cobra.Command, args []string) error {
 	}
 	link := webURL + "?room=" + roomId
 
-	fmt.Println("  ─────────────────────────────────────────────────")
+	rows := [][2]string{{"Sending", summary.Label}}
 	if codePhrase != "" {
-		fmt.Printf("  Code:  %s\n", codePhrase)
+		rows = append(rows, [2]string{"Code", codePhrase})
 	}
-	fmt.Printf("  Link:  %s\n", link)
-	fmt.Println("  ─────────────────────────────────────────────────")
+	rows = append(rows, [2]string{"Link", link})
+	transfer.PrintBox(rows)
 	fmt.Println()
 	fmt.Println("  Waiting for peer...")
 

--- a/cli/internal/transfer/format.go
+++ b/cli/internal/transfer/format.go
@@ -81,23 +81,59 @@ func newProgressBar(size int64, index, total int, name string) *progressbar.Prog
 
 const divider = "  ─────────────────────────────────────────────────"
 
-// printSummary prints a boxed block with aligned label/value rows.
-// rows is a slice of [2]string{label, value} pairs.
-func printSummary(rows [][2]string) {
-	// Find longest label for alignment
+// PrintBox prints a divider-bordered block of aligned label/value rows.
+// It does NOT print a leading blank line — callers add spacing as needed.
+func PrintBox(rows [][2]string) {
 	maxLabel := 0
 	for _, r := range rows {
 		if len(r[0]) > maxLabel {
 			maxLabel = len(r[0])
 		}
 	}
-	fmt.Println()
 	fmt.Println(divider)
 	for _, r := range rows {
 		pad := strings.Repeat(" ", maxLabel-len(r[0]))
 		fmt.Printf("  %s%s   %s\n", r[0], pad, r[1])
 	}
 	fmt.Println(divider)
+}
+
+// printSummary prints a boxed block with aligned label/value rows, preceded by
+// a blank line. Used for the "Sent" / "Received" summaries at transfer end.
+func printSummary(rows [][2]string) {
+	fmt.Println()
+	PrintBox(rows)
+}
+
+// Summary holds pre-computed file-list metadata for display before a send.
+type Summary struct {
+	Files      int
+	TotalBytes int64
+	Label      string // e.g. "report.pdf · 2.1 MB" or "5 files · 127.3 MB"
+}
+
+// Summarize walks paths (same logic as SendFiles) and returns a Summary for
+// pre-transfer display. Single files show their name; multiple files show the
+// count.
+func Summarize(paths []string) (Summary, error) {
+	files, err := collectFiles(paths)
+	if err != nil {
+		return Summary{}, err
+	}
+	if len(files) == 0 {
+		return Summary{}, fmt.Errorf("no files to send")
+	}
+	var total int64
+	for _, f := range files {
+		total += f.size
+	}
+	var label string
+	if len(files) == 1 {
+		label = files[0].displayName + " · " + formatBytes(total)
+	} else {
+		label = pluralize(len(files), "file") + " · " + formatBytes(total)
+	}
+	return Summary{Files: len(files), TotalBytes: total, Label: label}, nil
 }
 
 func isFinitePositive(f float64) bool {

--- a/cli/internal/transfer/loopback_test.go
+++ b/cli/internal/transfer/loopback_test.go
@@ -153,6 +153,61 @@ func TestLoopbackLargeFile(t *testing.T) {
 	}
 }
 
+// TestLoopbackImmediateReceiverClose reproduces the CLI-to-CLI race where the
+// receiver closes its PeerConnection immediately after ReceiveFiles returns.
+// Before the fix the sender's SCTP buffer stalled at a non-zero value because
+// the final SACKs never arrived, causing "timed out flushing" errors even
+// though the file was fully received.
+func TestLoopbackImmediateReceiverClose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ICE loopback transfer in -short mode")
+	}
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, "blob.bin")
+	data := make([]byte, 5*1024*1024) // 5 MB — enough to exercise backpressure
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("generate random data: %v", err)
+	}
+	if err := os.WriteFile(srcPath, data, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	senderDC, recvCh, closeFn := newConnectedPair(t)
+	// Do NOT defer closeFn — we close the receiver PC ourselves immediately
+	// after ReceiveFiles returns to reproduce the race.
+
+	outDir := t.TempDir()
+	recvDone := make(chan error, 1)
+
+	go func() {
+		dc := <-recvCh
+		err := ReceiveFiles(dc, outDir, true)
+		// Close receiver immediately — this is what `defer conn.Close()` does
+		// in `runReceive`. The SCTP teardown races the final SACK to the sender.
+		dc.Close()
+		recvDone <- err
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	sendErr := SendFiles(senderDC, []string{srcPath})
+	closeFn() // clean up sender PC after SendFiles returns
+
+	if sendErr != nil {
+		t.Fatalf("SendFiles returned error after receiver closed immediately: %v", sendErr)
+	}
+
+	select {
+	case err := <-recvDone:
+		if err != nil {
+			t.Fatalf("ReceiveFiles: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("ReceiveFiles did not complete")
+	}
+}
+
 // TestLoopbackSmallJSONFile guards the framing fix end to end: a file whose
 // bytes are a sub-1 KB JSON object must arrive byte-identical, not be mistaken
 // for a control message and dropped.

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -170,6 +170,22 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 							{"Time", timeVal},
 							{"Saved to", outputDir},
 						})
+
+						// Tell the sender all bytes are written and verified so it
+						// can close cleanly without relying on SCTP buffer accounting.
+						// Sent as binary so the browser (which checks byteLength) can
+						// classify it and ignore it; CLI senders consume it explicitly.
+						receivedMsg, _ := json.Marshal(map[string]string{"type": "received"})
+						dc.Send([]byte(receivedMsg))
+
+						// Wait for the sender to close the channel (or a short grace
+						// period) before returning. This keeps our SCTP/DTLS alive
+						// long enough for the "received" SACK to reach the sender —
+						// tearing down immediately would race it.
+						select {
+						case <-done:
+						case <-time.After(5 * time.Second):
+						}
 						return nil
 					}
 				}

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -17,11 +17,12 @@ import (
 
 // FileInfo describes an incoming file (parsed from metadata message).
 type FileInfo struct {
-	ID       string
-	FileName string
-	FileSize int64
-	Index    int
-	Total    int
+	ID         string
+	FileName   string
+	FileSize   int64
+	Index      int
+	Total      int
+	TotalBytes int64
 }
 
 // ReceiveFiles handles the full receiving side of the Floe protocol.
@@ -107,7 +108,20 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 				if waitingForFirst {
 					waitingForFirst = false
 					start = time.Now()
-					fmt.Printf("\n  Incoming: %s\n\n", pluralize(info.Total, "file"))
+
+					var incomingLabel string
+					switch {
+					case info.Total == 1:
+						incomingLabel = info.FileName + " · " + formatBytes(info.FileSize)
+					case info.TotalBytes > 0:
+						incomingLabel = pluralize(info.Total, "file") + " · " + formatBytes(info.TotalBytes)
+					default:
+						incomingLabel = pluralize(info.Total, "file")
+					}
+					fmt.Println()
+					PrintBox([][2]string{{"Incoming", incomingLabel}})
+					fmt.Println()
+
 					if !autoAccept {
 						fmt.Print("  Accept? [Y/n] ")
 						var answer string
@@ -260,12 +274,13 @@ func looksLikeJSONObject(data []byte) bool {
 // parseMetadata extracts FileInfo from a raw metadata JSON string.
 func parseMetadata(text string) (FileInfo, error) {
 	var m struct {
-		Type     string  `json:"type"`
-		ID       string  `json:"id"`
-		FileName string  `json:"fileName"`
-		FileSize float64 `json:"fileSize"` // JSON numbers decode as float64
-		Index    int     `json:"index"`
-		Total    int     `json:"total"`
+		Type       string  `json:"type"`
+		ID         string  `json:"id"`
+		FileName   string  `json:"fileName"`
+		FileSize   float64 `json:"fileSize"`   // JSON numbers decode as float64
+		Index      int     `json:"index"`
+		Total      int     `json:"total"`
+		TotalBytes float64 `json:"totalBytes"` // absent from older senders → 0
 	}
 	if err := json.Unmarshal([]byte(text), &m); err != nil {
 		return FileInfo{}, err
@@ -274,11 +289,12 @@ func parseMetadata(text string) (FileInfo, error) {
 		return FileInfo{}, fmt.Errorf("not a metadata message")
 	}
 	return FileInfo{
-		ID:       m.ID,
-		FileName: m.FileName,
-		FileSize: int64(m.FileSize),
-		Index:    m.Index,
-		Total:    m.Total,
+		ID:         m.ID,
+		FileName:   m.FileName,
+		FileSize:   int64(m.FileSize),
+		Index:      m.Index,
+		Total:      m.Total,
+		TotalBytes: int64(m.TotalBytes),
 	}, nil
 }
 

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -106,20 +106,38 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 		}
 	}
 
-	// Flush: wait for pion to push every buffered byte (including the final end
-	// marker) onto the wire before the caller closes the connection. Closing
-	// while data is still buffered truncates the transfer. Capped so a dead peer
-	// can't hang the process forever.
-	drainDeadline := time.Now().Add(30 * time.Second)
-	for dc.BufferedAmount() > 0 {
-		if time.Now().After(drainDeadline) {
-			return fmt.Errorf("timed out flushing %d buffered bytes to peer", dc.BufferedAmount())
+	// Wait for delivery confirmation before closing.
+	//
+	// CLI receivers send {"type":"received"} after writing and verifying every
+	// byte, which is the authoritative signal. Browser receivers don't send it,
+	// but they keep their connection alive so the SCTP buffer naturally drains
+	// to zero — that's the fallback. A 30s deadline guards against a dead peer.
+	//
+	// We cannot rely solely on dc.BufferedAmount()==0: when the receiver closes
+	// its connection immediately after the last write (which the CLI does), the
+	// final SACKs may never arrive and the buffer stalls at a non-zero value
+	// even though all bytes were delivered successfully.
+	drainDeadline := time.After(30 * time.Second)
+	drainTick := time.NewTicker(50 * time.Millisecond)
+	defer drainTick.Stop()
+drainLoop:
+	for {
+		select {
+		case raw := <-ackCh:
+			var msg struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(raw, &msg) == nil && msg.Type == "received" {
+				break drainLoop
+			}
+		case <-drainTick.C:
+			if dc.BufferedAmount() == 0 {
+				break drainLoop
+			}
+		case <-drainDeadline:
+			return fmt.Errorf("timed out waiting for delivery confirmation from peer")
 		}
-		time.Sleep(50 * time.Millisecond)
 	}
-	// Brief grace period so the receiver can process the final end marker
-	// before the data channel is torn down.
-	time.Sleep(250 * time.Millisecond)
 
 	elapsed := time.Since(start)
 	timeVal := formatDuration(elapsed)

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -35,12 +35,13 @@ const (
 
 // metadataMsg is sent before each file to describe it.
 type metadataMsg struct {
-	Type     string `json:"type"`
-	ID       string `json:"id"`
-	FileName string `json:"fileName"`
-	FileSize int64  `json:"fileSize"`
-	Index    int    `json:"index"`
-	Total    int    `json:"total"`
+	Type       string `json:"type"`
+	ID         string `json:"id"`
+	FileName   string `json:"fileName"`
+	FileSize   int64  `json:"fileSize"`
+	Index      int    `json:"index"`
+	Total      int    `json:"total"`
+	TotalBytes int64  `json:"totalBytes"`
 }
 
 // ackMsg is received from the receiver confirming readiness.
@@ -71,7 +72,6 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 	for _, e := range files {
 		totalBytes += e.size
 	}
-	fmt.Printf("  Sending %s (%s)\n\n", pluralize(len(files), "file"), formatBytes(totalBytes))
 
 	start := time.Now()
 
@@ -101,7 +101,7 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 	})
 
 	for i, entry := range files {
-		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files)); err != nil {
+		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files), totalBytes); err != nil {
 			return fmt.Errorf("error sending %s: %w", entry.displayName, err)
 		}
 	}
@@ -199,7 +199,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 }
 
 // sendFile handles the full send sequence for a single file.
-func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int) error {
+func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int, totalBytes int64) error {
 	f, err := os.Open(entry.absPath)
 	if err != nil {
 		return err
@@ -216,12 +216,13 @@ func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struc
 
 	// Step 1: Send metadata
 	meta := metadataMsg{
-		Type:     "metadata",
-		ID:       fileID,
-		FileName: entry.displayName,
-		FileSize: fileSize,
-		Index:    index,
-		Total:    total,
+		Type:       "metadata",
+		ID:         fileID,
+		FileName:   entry.displayName,
+		FileSize:   fileSize,
+		Index:      index,
+		Total:      total,
+		TotalBytes: totalBytes,
 	}
 	metaJSON, _ := json.Marshal(meta)
 	if err := dc.SendText(string(metaJSON)); err != nil {

--- a/cli/internal/transfer/transfer_test.go
+++ b/cli/internal/transfer/transfer_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -55,12 +56,12 @@ func TestSafeJoinEmptyFallback(t *testing.T) {
 
 // TestParseMetadata covers valid and invalid metadata payloads.
 func TestParseMetadata(t *testing.T) {
-	valid := `{"type":"metadata","id":"abc","fileName":"a.txt","fileSize":1234,"index":1,"total":3}`
+	valid := `{"type":"metadata","id":"abc","fileName":"a.txt","fileSize":1234,"index":1,"total":3,"totalBytes":98765}`
 	info, err := parseMetadata(valid)
 	if err != nil {
 		t.Fatalf("parseMetadata(valid) error: %v", err)
 	}
-	if info.ID != "abc" || info.FileName != "a.txt" || info.FileSize != 1234 || info.Index != 1 || info.Total != 3 {
+	if info.ID != "abc" || info.FileName != "a.txt" || info.FileSize != 1234 || info.Index != 1 || info.Total != 3 || info.TotalBytes != 98765 {
 		t.Errorf("parseMetadata(valid) = %+v, unexpected fields", info)
 	}
 
@@ -69,6 +70,68 @@ func TestParseMetadata(t *testing.T) {
 	}
 	if _, err := parseMetadata(`not json`); err == nil {
 		t.Error("parseMetadata(invalid json) should error")
+	}
+}
+
+// TestParseMetadataNoTotalBytes verifies backward compat: a metadata message
+// from an older CLI or browser sender (no totalBytes field) parses cleanly
+// with TotalBytes == 0, which triggers the graceful "count only" fallback in
+// the receiver display.
+func TestParseMetadataNoTotalBytes(t *testing.T) {
+	old := `{"type":"metadata","id":"x","fileName":"file.txt","fileSize":500,"index":1,"total":2}`
+	info, err := parseMetadata(old)
+	if err != nil {
+		t.Fatalf("parseMetadata(old) error: %v", err)
+	}
+	if info.TotalBytes != 0 {
+		t.Errorf("expected TotalBytes=0 when field absent, got %d", info.TotalBytes)
+	}
+}
+
+// TestSummarizeSingleFile covers the single-file label format ("name · size").
+func TestSummarizeSingleFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.pdf")
+	if err := os.WriteFile(path, make([]byte, 1024*512), 0644); err != nil { // 512 KB
+		t.Fatal(err)
+	}
+	s, err := Summarize([]string{path})
+	if err != nil {
+		t.Fatalf("Summarize error: %v", err)
+	}
+	if s.Files != 1 {
+		t.Errorf("Files = %d, want 1", s.Files)
+	}
+	if s.TotalBytes != 1024*512 {
+		t.Errorf("TotalBytes = %d, want %d", s.TotalBytes, 1024*512)
+	}
+	// Label must contain the filename and a size component.
+	if !strings.Contains(s.Label, "report.pdf") {
+		t.Errorf("Label %q does not contain filename", s.Label)
+	}
+	if !strings.Contains(s.Label, "KB") && !strings.Contains(s.Label, "MB") {
+		t.Errorf("Label %q has no size unit", s.Label)
+	}
+}
+
+// TestSummarizeMultiFile covers the multi-file label format ("N files · size").
+func TestSummarizeMultiFile(t *testing.T) {
+	dir := t.TempDir()
+	for i, name := range []string{"a.txt", "b.txt"} {
+		data := make([]byte, (i+1)*1024)
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	s, err := Summarize([]string{filepath.Join(dir, "a.txt"), filepath.Join(dir, "b.txt")})
+	if err != nil {
+		t.Fatalf("Summarize error: %v", err)
+	}
+	if s.Files != 2 {
+		t.Errorf("Files = %d, want 2", s.Files)
+	}
+	if !strings.Contains(s.Label, "2 files") {
+		t.Errorf("Label %q does not contain '2 files'", s.Label)
 	}
 }
 

--- a/client/lib/transfer/protocol.test.ts
+++ b/client/lib/transfer/protocol.test.ts
@@ -52,7 +52,7 @@ describe('chunkSize', () => {
 
 describe('message builders round-trip', () => {
     it('metadataMessage parses back correctly', () => {
-        const raw = metadataMessage('abc', 'file.txt', 1024, 1, 3);
+        const raw = metadataMessage('abc', 'file.txt', 1024, 1, 3, 3072);
         const msg = JSON.parse(raw);
         expect(msg).toMatchObject({ type: 'metadata', id: 'abc', fileName: 'file.txt', fileSize: 1024, index: 1, total: 3 });
     });
@@ -72,7 +72,7 @@ describe('message builders round-trip', () => {
 
 describe('classifyControl', () => {
     it('classifies metadata', () => {
-        const raw = metadataMessage('id1', 'a.txt', 100, 1, 1);
+        const raw = metadataMessage('id1', 'a.txt', 100, 1, 1, 100);
         const result = classifyControl(toUint8(raw));
         expect(result?.type).toBe('metadata');
     });

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -37,7 +37,14 @@ export interface End {
     type: 'end';
 }
 
-export type ControlMessage = Metadata | Ack | End;
+// Sent by the CLI receiver after all files are written and verified.
+// Tells the CLI sender delivery is confirmed so it can close cleanly.
+// Browser receivers never send this; the protocol handles both cases.
+export interface Received {
+    type: 'received';
+}
+
+export type ControlMessage = Metadata | Ack | End | Received;
 
 // --- Message builders ---
 
@@ -97,5 +104,6 @@ export function classifyControl(data: ArrayBuffer | Uint8Array): ControlMessage 
     if (t === 'metadata') return msg as unknown as Metadata;
     if (t === 'ack') return msg as unknown as Ack;
     if (t === 'end') return msg as unknown as End;
+    if (t === 'received') return msg as unknown as Received;
     return null;
 }

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -25,6 +25,7 @@ export interface Metadata {
     fileSize: number;
     index: number;
     total: number;
+    totalBytes: number;
 }
 
 export interface Ack {
@@ -53,9 +54,10 @@ export function metadataMessage(
     fileName: string,
     fileSize: number,
     index: number,
-    total: number
+    total: number,
+    totalBytes: number
 ): string {
-    return JSON.stringify({ type: 'metadata', id, fileName, fileSize, index, total } satisfies Metadata);
+    return JSON.stringify({ type: 'metadata', id, fileName, fileSize, index, total, totalBytes } satisfies Metadata);
 }
 
 export function ackMessage(id: string, offset: number): string {

--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -63,12 +63,13 @@ export async function sendFiles(
     cb: SenderCallbacks = {}
 ): Promise<void> {
     const destroyed = cb.isDestroyed ?? (() => false);
+    const totalBytes = files.reduce((s, e) => s + e.file.size, 0);
 
     for (let i = 0; i < files.length; i++) {
         if (destroyed()) break;
         const entry = files[i];
         cb.onFileStart?.(i, files.length, entry.file.name);
-        await sendSingleFile(deps, entry, i + 1, files.length, cb);
+        await sendSingleFile(deps, entry, i + 1, files.length, totalBytes, cb);
     }
 
     if (!destroyed()) {
@@ -81,6 +82,7 @@ async function sendSingleFile(
     entry: FileEntry,
     index: number,
     total: number,
+    totalBytes: number,
     cb: SenderCallbacks
 ): Promise<void> {
     const { file, id } = entry;
@@ -95,7 +97,7 @@ async function sendSingleFile(
 
     // 1. Send metadata
     try {
-        send(metadataMessage(id, file.name, file.size, index, total));
+        send(metadataMessage(id, file.name, file.size, index, total, totalBytes));
     } catch {
         return;
     }

--- a/client/lib/transfer/transfer.test.ts
+++ b/client/lib/transfer/transfer.test.ts
@@ -156,7 +156,7 @@ describe('receiver: stores tight copies of chunk bytes', () => {
         for (let i = 0; i < SIZE; i++) fileBytes[i] = i + 1; // never 0x7B at index 0
 
         // Metadata first so the receiver opens a partial download.
-        rx.handleMessage(enc.encode(metadataMessage('rid', 'r.bin', SIZE, 1, 1)));
+        rx.handleMessage(enc.encode(metadataMessage('rid', 'r.bin', SIZE, 1, 1, SIZE)));
 
         // Place the payload inside a larger backing Buffer at a non-zero offset and
         // hand the receiver subarray VIEWS (16 bytes each) — sharing one backing AB.


### PR DESCRIPTION
## Summary

- **Sender** now displays a summary box (file name/count + total size) immediately when the command runs, folded into the share box alongside the Code and Link. The redundant per-file log line that appeared after connecting is removed.
- **Receiver** now shows a labeled `Incoming` box with the filename and size (single file) or total count and aggregate size (multi-file) *before* the `Accept? [Y/n]` prompt, so the user can make an informed decision.
- **Protocol**: a `totalBytes` field is added to the existing `metadata` JSON message. Adding a field is safe: all receivers ignore unknown JSON fields, so the change is fully backward-compatible across CLI-to-CLI, CLI-to-browser, and browser-to-CLI.
- **Browser parity**: the browser sender now includes `totalBytes` in its metadata, so browser-to-CLI multi-file transfers also surface the aggregate size before the accept prompt.

### Before

```
  Waiting for peer...
  Connected
  Sending 3 files (127.3 MB)

  Incoming: 3 files

  Accept? [Y/n]
```

### After

```
  ─────────────────────────────────────────────────
  Sending   3 files · 127.3 MB
  Code      burst-badge-witty
  Link      https://floe.one?room=...
  ─────────────────────────────────────────────────

  Waiting for peer...
```

```
  Connected
  ─────────────────────────────────────────────────
  Incoming   3 files · 127.3 MB
  ─────────────────────────────────────────────────

  Accept? [Y/n]
```

Single-file transfers show the filename: `Incoming   PAREDES_RESUME_NEW.pdf · 245 KB`.

When `totalBytes` is absent (older CLI or browser sender), the receiver falls back to count-only display.

## Test plan

- [x] `go test ./...` passes including loopback SHA-256 transfer tests
- [x] `npx tsc --noEmit` passes
- [x] `TestParseMetadataNoTotalBytes` - backward compat with senders that omit `totalBytes`
- [x] `TestSummarizeSingleFile` - single-file label format (`name · size`)
- [x] `TestSummarizeMultiFile` - multi-file label format (`N files · size`)
- [ ] CLI-to-CLI: `floe send` shows `Sending` row in share box; `floe receive` shows `Incoming` box before prompt
- [ ] CLI-to-browser: transfer completes intact (browser ignores `totalBytes` field)
- [ ] Browser-to-CLI: `Incoming` box shows total size before accept (browser parity change)
- [ ] Decline path (`n` at prompt): sender exits cleanly, no partial files written
- [ ] `-y` flag still auto-accepts without prompt