### PR TITLE
fix(cli): serialize WebSocket writes to prevent concurrent-write panic

### DIFF
--- a/cli/internal/signaling/client.go
+++ b/cli/internal/signaling/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -30,6 +31,13 @@ type Message struct {
 type Client struct {
 	conn   *websocket.Conn
 	roomId string
+
+	// writeMu serializes all writes to the WebSocket. gorilla/websocket permits
+	// only one concurrent writer; without this, an ICE candidate sent from pion's
+	// OnICECandidate callback can race the offer/answer sent from the main
+	// goroutine, tripping gorilla's "concurrent write" panic or corrupting a
+	// frame (which silently breaks ICE and aborts the transfer).
+	writeMu sync.Mutex
 
 	// Role receives "sender" or "receiver" after joining a room.
 	Role chan string
@@ -99,16 +107,27 @@ func (c *Client) SendSignal(signal interface{}) error {
 
 // Close gracefully closes the WebSocket connection.
 func (c *Client) Close() {
+	// WriteControl shares the write path with writeJSON, so hold writeMu to
+	// avoid racing an in-flight signal write (e.g. a late trickle-ICE candidate).
+	c.writeMu.Lock()
 	c.conn.WriteControl(
 		websocket.CloseMessage,
 		websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
 		time.Now().Add(time.Second),
 	)
+	c.writeMu.Unlock()
 	c.conn.Close()
 }
 
 // writeJSON marshals v to JSON and writes it to the WebSocket.
+//
+// All writes funnel through here so writeMu is the single serialization point
+// for the connection: the main goroutine (join-room, offer/answer) and pion's
+// OnICECandidate callback goroutine (trickle ICE) both reach the socket via
+// writeJSON, and gorilla/websocket only allows one writer at a time.
 func (c *Client) writeJSON(v interface{}) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	c.conn.SetWriteDeadline(time.Now().Add(10 * time.Second))
 	return c.conn.WriteJSON(v)
 }


### PR DESCRIPTION
## Summary

- Add `writeMu sync.Mutex` to the signaling `Client` and hold it in `writeJSON` and `Close`, serializing all WebSocket writes through a single point.
- Fixes the flaky `Direction 2: browser send -> CLI receive` E2E test that was failing in CI with exit code 2 (panic) on first attempt and exit code 1 (error) on retry.

## Root cause

gorilla/websocket only allows one concurrent writer and panics with `"concurrent write to websocket connection"` when violated. The signaling client was writing from two goroutines without any lock:

- **Main goroutine** -- `JoinRoom`, and `SetupAsReceiver`'s `SendSignal(answer)`
- **pion's `OnICECandidate` callback goroutine** -- fires repeatedly during trickle ICE, each calling `SendSignal(candidate)`

On a fast dev machine the race is rare (couldn't reproduce across 4 local runs). On a slow 2-core CI runner it was frequent enough to either panic (exit 2) or corrupt a WebSocket frame, silently breaking ICE negotiation and aborting the transfer mid-stream (exit 1). The **receiver** role (Direction 2) is the exposed side because it sends its answer after receiving the offer, by which point its own ICE gathering is already emitting candidates concurrently.

## Test plan

- `go build ./...` and `go test ./...` pass (including the CLI-to-CLI loopback integration test).
- Ran `cli-interop` Playwright spec against the rebuilt binary with live servers: both directions passed (2 passed, 18.1s).
- CI E2E job should now pass for the `Direction 2: browser send -> CLI receive` test.