### PR TITLE
docs: massive documentation overhaul - accuracy fixes, 6 new pages, changelog

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -20,6 +20,10 @@ CLIENT_URL=http://localhost:3000
 # parsing for rate limiting). 0 = direct, 1 = behind one proxy (Render/Fly/Nginx).
 TRUSTED_PROXY_COUNT=1
 
+# Optional: override the connection rate limit ceiling (default: 30 per IP per 60s).
+# Raise this in staging or testing environments that drive many connections from one IP.
+MAX_CONNECTIONS_PER_IP=30
+
 # --- Optional TURN relay (coturn) -------------------------------------------
 # Leave both empty for STUN-only (direct connections). Fill them in AND start the
 # coturn service (`docker compose --profile turn up -d`) to enable relay for users

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Floe** is a browser-native, peer-to-peer file transfer app built on WebRTC. Three components work together:
 
-- **`client/`** — Next.js 15 (React 19) web app
-- **`server/`** — Node.js signaling server (Express + Socket.IO + WebSocket)
-- **`cli/`** — Go CLI (`floe`) for headless transfers
+- **`client/`** - Next.js 16 (React 19) web app
+- **`server/`** - Node.js signaling server (Express + Socket.IO + WebSocket)
+- **`cli/`** - Go CLI (`floe`) for headless transfers
 
-File data never touches the server — WebRTC data channels carry it directly between peers. The server only brokers WebRTC signaling (offer/answer/ICE candidates) and optionally issues TURN relay credentials.
+File data never touches the server. WebRTC data channels carry it directly between peers. The server only brokers WebRTC signaling (offer/answer/ICE candidates) and optionally issues TURN relay credentials.
 
 ## Commands
 
@@ -42,7 +42,7 @@ The CLI uses GoReleaser for cross-platform distribution; version is injected via
 
 ## Environment Setup
 
-**Server** — copy `server/.env.example` to `server/.env`:
+**Server** - copy `server/.env.example` to `server/.env`:
 ```
 CLIENT_URL=http://localhost:3000
 PORT=3001
@@ -50,7 +50,7 @@ TURN_SECRET=       # optional Coturn HMAC secret
 TURN_DOMAIN=       # optional TURN server hostname
 ```
 
-**Client** — copy `client/.env.example` to `client/.env.local`:
+**Client** - copy `client/.env.example` to `client/.env.local`:
 ```
 NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
 NEXT_PUBLIC_SENTRY_DSN=    # optional
@@ -62,9 +62,9 @@ NEXT_PUBLIC_SENTRY_DSN=    # optional
 1. A peer joins a room (`join-room` event) → server assigns role: **sender** (first) or **receiver** (second).
 2. When both peers are present, server emits `user-connected` to the sender.
 3. Peers exchange WebRTC `signal` messages (offer → answer → ICE candidates) via the server.
-4. Once WebRTC connects, the data channel is used directly — server is out of the loop.
+4. Once WebRTC connects, the data channel is used directly (server is out of the loop).
 
-Browser peers communicate via **Socket.IO**; CLI peers communicate via **WebSocket at `/ws`**. Both share the same `rooms` registry on the server (`Map<roomId, [peer, peer]>`), so browser↔CLI transfers work transparently.
+Browser peers communicate via **Socket.IO**; CLI peers communicate via **WebSocket at `/ws`**. Both share the same `rooms` registry on the server (`Map<roomId, [peer, peer]>`), so browser-to-CLI transfers work transparently.
 
 ### Room Codes
 `POST /api/code` registers a short human-readable phrase (e.g. `olive-tiger-castle`) mapping to a room ID with 10-min TTL. `GET /api/code/:code` resolves it. Words come from `server/words.json`.
@@ -79,17 +79,17 @@ Two independent per-IP limiters, each over a 60s window, tracked in plain `Map`s
 `next.config.mjs` sets `reactStrictMode: false`. Strict Mode's double-mount breaks Socket.IO connections and `simple-peer` instances. All socket/peer logic uses refs and cleanup functions to handle component lifecycle correctly.
 
 ### Key Client Modules
-- `client/components/P2PTransfer.tsx` — entire transfer UI (role detection, file selection, progress, download)
-- `client/hooks/useWakeLock.ts` — Screen Wake Lock API wrapper (prevents device sleep during transfers)
-- `client/lib/transferUtils.ts` — `formatSpeed()` and `formatETA()` used by the progress display
+- `client/components/P2PTransfer.tsx` - entire transfer UI (role detection, file selection, progress, download)
+- `client/hooks/useWakeLock.ts` - Screen Wake Lock API wrapper (prevents device sleep during transfers)
+- `client/lib/transferUtils.ts` - `formatSpeed()` and `formatETA()` used by the progress display
 
 ### CLI Internal Packages
 All under `cli/internal/`:
-- `signaling/` — WebSocket client for the `/ws` endpoint
-- `peer/` — WebRTC peer setup via Pion
-- `transfer/sender.go` / `transfer/receiver.go` — binary protocol over the data channel
-- `ice/` — fetches STUN/TURN credentials from server
-- `code/` — registers and resolves short room codes
+- `signaling/` - WebSocket client for the `/ws` endpoint
+- `peer/` - WebRTC peer setup via Pion
+- `transfer/sender.go` / `transfer/receiver.go` - binary protocol over the data channel
+- `ice/` - fetches STUN/TURN credentials from server
+- `code/` - registers and resolves short room codes
 
 ## Writing Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,17 @@ go build ./cmd/floe
 go test ./...
 ```
 
+### Documentation (Only needed if you're changing docs)
+
+The documentation site lives in `docs/` and is built with [Mintlify](https://mintlify.com).
+
+```bash
+cd floe/docs
+npx mintlify dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to preview the docs locally.
+
 ### Full stack with Docker (no local toolchain needed)
 
 To run the client and signaling server together in containers (without installing Node, pnpm, or Go locally), use the Docker Compose setup:
@@ -90,6 +101,7 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 | `PORT` | No | Signaling server port (default: `3001`) |
 | `NODE_ENV` | No | Standard Node.js runtime flag (`development` or `production`). |
 | `TRUSTED_PROXY_COUNT` | No | Trusted reverse-proxy hop count for correct client-IP parsing and rate limiting (default: `1`). Set to `0` for direct exposure with no proxy. |
+| `MAX_CONNECTIONS_PER_IP` | No | Connection rate limit ceiling per IP per 60 seconds (default: `30`). Raise in staging or test environments. |
 | `TURN_SECRET` | No | Shared secret for coturn HMAC credentials. Omit to use STUN-only (direct connections). |
 | `TURN_DOMAIN` | No | Your TURN relay server domain. |
 
@@ -103,7 +115,9 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 2. Make your changes
 3. Ensure the build passes: `pnpm build` (in `client/`)
 4. Run the linter: `pnpm lint` (in `client/`)
-5. Submit a pull request with a clear title and description
+5. Run client tests: `pnpm test` (in `client/`)
+6. Run CLI tests: `go test ./...` (in `cli/`)
+7. Submit a pull request with a clear title and description
 
 ---
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,0 +1,75 @@
+---
+title: "Changelog"
+description: "Release history for Floe."
+---
+
+<Update label="v1.5.2" description="2026-06-17">
+  **CLI stability fix**
+
+  - Fixed a rare concurrent-write panic in the CLI signaling client. Rapid ICE candidate negotiation could trigger simultaneous WebSocket writes from separate goroutines; all writes are now serialized.
+</Update>
+
+<Update label="v1.5.1" description="2026-06-17">
+  **CLI output improvement**
+
+  - The `Sending` summary line (file name and total size) now appears above the sharing box, so you can see what is being sent before the peer connects.
+</Update>
+
+<Update label="v1.5.0" description="2026-06-17">
+  **File summary on both sides**
+
+  - Both the sender and the receiver now see a file count and total size before and after the transfer. Example: `Sending   3 files · 11.8 MB` on the sender side and `Incoming   3 files · 11.8 MB` on the receiver side.
+</Update>
+
+<Update label="v1.4.0" description="2026-06-17">
+  **CLI-to-CLI transfer fix**
+
+  - Fixed an error reported by the CLI sender after a successful CLI-to-CLI transfer. The transfer completed correctly but the sender exited with an error code. It now exits cleanly.
+</Update>
+
+<Update label="v1.3.0" description="2026-06-17">
+  **One-command install and self-update**
+
+  - `floe update` now works on all platforms (script installs, manual installs). It downloads, verifies, and replaces the running binary in one step.
+  - Re-running the install script (`curl -fsSL https://floe.one/install.sh | sh` or `irm https://floe.one/install.ps1 | iex`) also upgrades an existing install in place.
+  - If floe was installed via Homebrew, Scoop, or Winget, `floe update` detects this and prints the correct package manager command instead.
+  - Security: updated `ws`, `esbuild`, and `postcss` transitive dependencies to address published advisories.
+</Update>
+
+<Update label="v1.2.0" description="2026-06-16">
+  **Rich transfer summary**
+
+  - At the end of each transfer, the CLI now prints a boxed summary with the total data transferred, elapsed time, and average speed. Example:
+
+    ```
+      ─────────────────────────────────────────────────
+      Sent   3 files (11.8 MB)
+      Time   8s · avg 1.4 MB/s
+      ─────────────────────────────────────────────────
+    ```
+
+  - The receiver summary also includes the `Saved to` path.
+</Update>
+
+<Update label="v1.1.0" description="2026-06-16">
+  **Transfer reliability and browser fixes**
+
+  - Fixed several CLI transfer sync bugs that could cause stalled or incomplete transfers, especially in CLI-to-CLI sessions. Added cross-implementation loopback tests to prevent regressions.
+  - Fixed a browser receiver bug where a `Buffer` view was retained across chunk boundaries instead of being copied, which could corrupt received data.
+  - Fixed an issue where the in-app browser detection could steal the receiver slot from a legitimate peer, preventing the transfer from starting.
+  - Fixed duplicate WebRTC signal handling that could break transfers after a reconnect.
+  - Redesigned the in-app browser warning page for clarity.
+  - Upgraded the CLI to Pion WebRTC v4 (includes Pion DTLS v3).
+  - Performance: improved browser-to-browser transfer throughput with better backpressure tuning.
+</Update>
+
+<Update label="v1.0.0" description="2026-06-14">
+  **Initial public release**
+
+  - Browser-based peer-to-peer file transfer at [floe.one](https://floe.one). No account, no installation, no file storage.
+  - `floe` CLI for macOS, Linux, and Windows. Fully interoperable with the browser client.
+  - End-to-end DTLS encryption on all transfers, direct and relayed.
+  - Optional TURN relay fallback for peers behind strict firewalls or carrier-grade NAT (capped at 2 GB per session).
+  - Self-hosting support via Docker Compose. See [Self-Hosting](/self-hosting/overview).
+  - Mintlify documentation site at [docs.floe.one](https://docs.floe.one).
+</Update>

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -40,28 +40,34 @@ floe receive olive-tiger-castle -y
 Running `floe receive olive-tiger-castle -o ~/Downloads`:
 
 ```
-Connecting to sender...
-Connected
-
-  Incoming: 2 file(s)
+  Connecting to sender...
+  Connected
+  ─────────────────────────────────────────────────
+  Incoming   2 files · 2.3 MB
+  ─────────────────────────────────────────────────
 
   Accept? [Y/n] y
 
   [1/2] photo.jpg  [████████████████] 2.3 MB/2.3 MB
-
   [2/2] notes.txt  [████████████████] 14 KB/14 KB
 
-  Done. 2 file(s) received in ~/Downloads
+  ─────────────────────────────────────────────────
+  Received   2 files (2.3 MB)
+  Time       5s · avg 468.0 KB/s
+  Saved to   /home/user/Downloads
+  ─────────────────────────────────────────────────
 ```
 
 With no `-o` flag, files save to the current directory.
 
 ## Confirmation prompt
 
-When the first file's metadata arrives, Floe shows how many files are incoming and asks for confirmation:
+When the first file's metadata arrives, Floe shows a summary of what is incoming and asks for confirmation:
 
 ```
-  Incoming: N file(s)
+  ─────────────────────────────────────────────────
+  Incoming   N files · X MB
+  ─────────────────────────────────────────────────
 
   Accept? [Y/n]
 ```

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -31,25 +31,32 @@ floe send ./project
 
 ## Output
 
-After running `floe send`, you will see a sharing panel with a short code and a browser link:
+After running `floe send`, Floe shows a summary of what will be sent, then prints a sharing panel:
 
 ```
-─────────────────────────────────────────────────
-Code:  olive-tiger-castle
-Link:  https://floe.one?room=...
-─────────────────────────────────────────────────
+  Sending   3 files · 11.8 MB
+  ─────────────────────────────────────────────────
+  Code   olive-tiger-castle
+  Link   https://floe.one?room=...
+  ─────────────────────────────────────────────────
 
-Waiting for peer...
-Connecting...
-Connected
+  Waiting for peer...
+```
 
-  Sending 3 file(s)...
+Once the recipient connects, Floe negotiates the WebRTC connection and streams each file with a live progress bar:
 
-  [1/3] report.pdf     [████████████░░░] 8.1 MB/9.5 MB
-  [2/3] photo.jpg      [████████████████] 2.3 MB/2.3 MB
-  [3/3] notes.txt      [████████████████] 14 KB/14 KB
+```
+  Connecting...
+  Connected
 
-  All files sent.
+  [1/3] report.pdf              [████████░░░░░░░] 8.1 MB/9.5 MB
+  [2/3] photo.jpg               [████████████████] 2.3 MB/2.3 MB
+  [3/3] notes.txt               [████████████████] 14 KB/14 KB
+
+  ─────────────────────────────────────────────────
+  Sent   3 files (11.8 MB)
+  Time   8s · avg 1.4 MB/s
+  ─────────────────────────────────────────────────
 ```
 
 Share the **code** with CLI recipients or the **link** with browser recipients. The short code is valid for 10 minutes. The room link stays active until the session ends or you press `Ctrl+C`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -69,7 +69,14 @@
     "groups": [
       {
         "group": "Getting Started",
-        "pages": ["introduction", "quickstart", "troubleshooting"]
+        "pages": ["introduction", "quickstart", "faq", "troubleshooting"]
+      },
+      {
+        "group": "Web App",
+        "pages": [
+          "web-app/sending",
+          "web-app/receiving"
+        ]
       },
       {
         "group": "CLI",
@@ -104,6 +111,14 @@
           "how-it-works/relay-connection",
           "how-it-works/2gb-limit",
           "how-it-works/encryption"
+        ]
+      },
+      {
+        "group": "Reference",
+        "pages": [
+          "changelog",
+          "security-privacy",
+          "reference/architecture"
         ]
       }
     ]

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,0 +1,113 @@
+---
+title: "FAQ"
+description: "Answers to the most common questions about Floe."
+---
+
+## Files and transfers
+
+<AccordionGroup>
+  <Accordion title="Where do my files go?">
+    Your files go directly to the recipient's device. In most cases they never touch a server at all. When a direct path cannot be found (strict corporate firewalls, carrier-grade NAT), Floe automatically falls back to an encrypted TURN relay. Even through a relay, the server sees only encrypted packets and cannot read your files.
+
+    See [How It Works](/how-it-works/signaling) for a full explanation.
+  </Accordion>
+
+  <Accordion title="Is there a file size limit?">
+    Direct connections have no size limit. Files transfer directly between the two devices and no server bandwidth is consumed.
+
+    Relay connections are capped at **2 GB per session** to keep the service free. Most home and mobile network transfers connect directly and have no limit. See [The 2 GB Relay Limit](/how-it-works/2gb-limit) for details and tips on obtaining a direct connection.
+  </Accordion>
+
+  <Accordion title="Can I send multiple files or a whole folder?">
+    Yes. In the browser, select multiple files in the file picker. In the CLI, pass multiple files or folder paths to `floe send`:
+
+    ```bash
+    floe send file1.pdf file2.jpg notes/
+    ```
+
+    Folder transfers preserve the directory structure. The recipient receives files at the same relative paths.
+  </Accordion>
+
+  <Accordion title="How fast is it?">
+    Transfer speed is limited only by the slower of the two connections involved. There is no artificial throttling. Direct transfers run at your internet connection speed. Relay transfers may be slightly slower depending on server load and network conditions, but the encryption overhead is minimal.
+  </Accordion>
+
+  <Accordion title="How long does the sender have to stay connected?">
+    For the full duration of the transfer. Files stream directly from the sender's device, so the browser tab or CLI process must remain open and active. If the sender closes the tab or cancels mid-transfer, the session ends and any partially received files are incomplete.
+  </Accordion>
+
+  <Accordion title="Are my files stored anywhere?">
+    No. Files are never stored on any server. They travel directly between the two devices in real time. Once the session closes, nothing about your transfer is retained.
+  </Accordion>
+</AccordionGroup>
+
+## Browser
+
+<AccordionGroup>
+  <Accordion title="Which browsers are supported?">
+    Any modern browser with WebRTC support works: Chrome, Firefox, Safari, Edge, and most Chromium-based browsers. A secure context (HTTPS or localhost) is required.
+
+    WebRTC is not available in some in-app browsers (the web views embedded in Facebook, Instagram, TikTok, and similar apps). Floe detects these and prompts you to open the page in Chrome or Safari instead.
+  </Accordion>
+
+  <Accordion title="I'm on iOS. Why are downloads behaving oddly?">
+    On iOS, use **Download ZIP** rather than downloading files individually. This is the most reliable option on Safari and iOS web views. Individual file downloads can behave inconsistently on iOS due to browser sandboxing.
+  </Accordion>
+
+  <Accordion title="What does the connection indicator color mean?">
+    The indicator in the corner of the page shows connection state:
+
+    - **Green (Direct):** Files transfer directly between devices. No server involved. No size limit.
+    - **Amber (Relay):** Files route through the encrypted TURN relay. The 2 GB cap applies.
+    - **Connecting:** Negotiating the WebRTC connection. This usually takes a few seconds.
+
+    If the connection stays in "Connecting" for more than 30 seconds, see [Troubleshooting](/troubleshooting).
+  </Accordion>
+
+  <Accordion title="Can I enter a short code in the browser to receive?">
+    No. The browser UI does not have a code entry field. To receive in the browser, the recipient must open the full link (or scan the QR code). Short codes are for the CLI only: `floe receive olive-tiger-castle`.
+  </Accordion>
+</AccordionGroup>
+
+## Accounts and privacy
+
+<AccordionGroup>
+  <Accordion title="Do I need an account?">
+    No. Floe requires no account, no sign-up, and no registration. Open [floe.one](https://floe.one) or run the CLI and share the link or short code with your recipient.
+  </Accordion>
+
+  <Accordion title="Does Floe collect any data?">
+    The signaling server tracks room IDs and connection metadata only for the duration of the session. No file content, file names, or transfer records are stored. Room state is discarded once both peers disconnect. See [Security and Privacy](/security-privacy) for details.
+  </Accordion>
+
+  <Accordion title="Is Floe open source?">
+    Yes. The full source for the client, server, and CLI is available on [GitHub](https://github.com/jannskiee/floe) under the MIT license. You can also [self-host](/self-hosting/overview) your own instance on your own infrastructure.
+  </Accordion>
+</AccordionGroup>
+
+## CLI
+
+<AccordionGroup>
+  <Accordion title="How do I install the CLI?">
+    See [CLI Installation](/cli/installation) for platform-specific steps. The quick version:
+
+    ```bash
+    # macOS
+    brew install --cask jannskiee/tap/floe
+
+    # Windows (winget)
+    winget install jannskiee.floe
+
+    # Linux / any OS
+    curl -fsSL https://floe.one/install.sh | sh
+    ```
+  </Accordion>
+
+  <Accordion title="Can a CLI sender transfer to a browser receiver (or vice versa)?">
+    Yes. Browser and CLI clients are fully interoperable. The CLI sender prints a browser link that any recipient can open, and the browser sender's link can be passed directly to `floe receive`. See the [cross-platform transfers table](/quickstart#cross-platform-transfers).
+  </Accordion>
+
+  <Accordion title="How do I keep the CLI up to date?">
+    Run `floe update` for script and manual installs. For package manager installs, use `brew upgrade floe`, `winget upgrade jannskiee.floe`, or `scoop update floe`. See [Updating](/cli/update).
+  </Accordion>
+</AccordionGroup>

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -49,7 +49,7 @@ The signaling server never touches file data, never stores anything about your t
   **Data-channel transfer protocol:** Once the WebRTC data channel opens, the sender runs this sequence for each file:
   1. Sends a JSON `metadata` message with the filename, size in bytes, and the file's index and total count in the batch.
   2. Waits for the receiver to reply with a JSON `ack` message. The ack carries a byte offset, so a transfer can resume mid-file.
-  3. Streams the file as 16 KB binary chunks until the whole file is sent. Both the CLI and the browser use 16 KB chunks; the browser sender adds backpressure-based flow control, pausing when the data channel's send buffer fills.
+  3. Streams the file as binary chunks until the whole file is sent. The CLI uses 16 KB chunks. The browser sender uses larger adaptive chunks and adds backpressure-based flow control, pausing when the data channel's send buffer fills.
   4. Sends a JSON `end` message to signal completion.
 
   For multi-file transfers, this four-step sequence repeats for each file in order.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -27,29 +27,7 @@ Floe transfers files directly between devices using WebRTC. Files are end-to-end
 
 ## Common questions
 
-<AccordionGroup>
-  <Accordion title="Where do my files go?">
-    Your files go directly to the recipient's device. In most cases they never touch a server at all. When a direct path cannot be found (strict corporate firewalls, carrier-grade NAT), Floe automatically falls back to an encrypted TURN relay. Even then, the relay server sees only encrypted packets and cannot read your files.
-  </Accordion>
-  <Accordion title="Is there a file size limit?">
-    Direct connections have no size limit. Relay connections are capped at 2 GB per session to keep the service free. See [Why the 2 GB Limit?](/how-it-works/2gb-limit) for details. Most home and mobile network transfers connect directly and have no limit.
-  </Accordion>
-  <Accordion title="Do I need an account?">
-    No. Floe requires no account, no sign-up, and no registration. Open the site or run the CLI and share the link or short code with your recipient.
-  </Accordion>
-  <Accordion title="How fast is it?">
-    Transfer speed is limited only by the slower of the two connections involved. There is no artificial throttling. Direct transfers are as fast as your internet connection allows. Relay transfers may be slightly slower depending on server load, but encryption overhead is minimal.
-  </Accordion>
-  <Accordion title="Which browsers are supported?">
-    Any modern browser with WebRTC support works: Chrome, Firefox, Safari, Edge, and most Chromium-based browsers. A secure context (HTTPS or localhost) is required. WebRTC is not available in some in-app browsers (such as those embedded in Facebook, Instagram, or TikTok). If this affects you, Floe will prompt you to open the page in Chrome or Safari instead.
-  </Accordion>
-  <Accordion title="Can I use the terminal instead of the browser?">
-    Yes. The `floe` CLI is a self-contained binary for macOS, Linux, and Windows. It connects to the same infrastructure as the web app, and is fully compatible with browser clients. A CLI sender can transfer to a browser receiver, and vice versa. See [CLI Installation](/cli/installation) to get started.
-  </Accordion>
-  <Accordion title="Is Floe open source?">
-    Yes. The full source for the client, server, and CLI is available on [GitHub](https://github.com/jannskiee/floe) under the MIT license. You can also [self-host](/self-hosting/overview) your own instance.
-  </Accordion>
-</AccordionGroup>
+Common questions about file size, browser support, in-app browsers, iOS, speed, and accounts are answered in the [FAQ](/faq).
 
 ## Self-hosting
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -47,12 +47,13 @@ description: "Send your first file in under a minute."
     Floe connects, registers a short code, and prints a sharing panel:
 
     ```
-    ─────────────────────────────────────────────────
-    Code:  olive-tiger-castle
-    Link:  https://floe.one?room=...
-    ─────────────────────────────────────────────────
+      Sending   photo.jpg · 6.0 MB
+      ─────────────────────────────────────────────────
+      Code   olive-tiger-castle
+      Link   https://floe.one?room=...
+      ─────────────────────────────────────────────────
 
-    Waiting for peer...
+      Waiting for peer...
     ```
 
     Share the **code** (CLI recipients) or the **link** (browser recipients). The short code is valid for 10 minutes.
@@ -64,19 +65,24 @@ description: "Send your first file in under a minute."
     floe receive olive-tiger-castle -o ~/Downloads
     ```
 
-    Or they can open the link in any browser. Once connected, the CLI shows a confirmation prompt and then a live progress bar:
+    Or they can open the link in any browser. Once connected, the CLI shows an incoming summary, a confirmation prompt, and then a live progress bar:
 
     ```
-    Connecting to sender...
-    Connected
-
-      Incoming: 1 file(s)
+      Connecting to sender...
+      Connected
+      ─────────────────────────────────────────────────
+      Incoming   photo.jpg · 6.0 MB
+      ─────────────────────────────────────────────────
 
       Accept? [Y/n] y
 
       [1/1] photo.jpg  [████████░░░░░░░] 4.2 MB/6.0 MB
 
-      Done. 1 file(s) received in ~/Downloads
+      ─────────────────────────────────────────────────
+      Received   1 file (6.0 MB)
+      Time       5s · avg 1.2 MB/s
+      Saved to   /home/user/Downloads
+      ─────────────────────────────────────────────────
     ```
 
     Pass `-y` to auto-accept without the prompt. Omit `-o` to save to the current directory instead.

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -1,0 +1,188 @@
+---
+title: "Architecture Reference"
+description: "Signaling protocol, HTTP endpoints, WebSocket events, and the data-channel binary protocol."
+---
+
+This page is a technical reference for contributors and advanced self-hosters. For a plain-language overview, see [How It Works](/how-it-works/signaling).
+
+## Components
+
+| Component | Runtime | Port | Purpose |
+|-----------|---------|------|---------|
+| Client | Next.js 16 (React 19) | 3000 | Browser UI, WebRTC peer (via simple-peer) |
+| Server | Node.js (Express 5, Socket.IO 4, ws 8) | 3001 | Signaling broker, TURN credential issuer |
+| CLI | Go 1.25 (Pion WebRTC v4) | - | Headless sender/receiver |
+| coturn | coturn (optional) | 3478, 5349 | TURN relay server |
+
+File data never passes through the server or coturn. All file bytes travel over encrypted WebRTC data channels between peers.
+
+## Signaling transports
+
+The server exposes two transports. Both share the same `rooms` registry (`Map<roomId, [peer, peer]>`) so browser-to-CLI transfers work transparently.
+
+| Transport | Path | Used by |
+|-----------|------|---------|
+| Socket.IO | `/socket.io/` | Browser (web app) |
+| WebSocket | `/ws` | CLI |
+
+## HTTP endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/` | Status check. Returns `{ "status": "ok", "timestamp": "..." }`. |
+| `GET` | `/health` | Liveness probe. Returns `{ "status": "healthy", "uptime": <seconds> }`. |
+| `GET` | `/api/turn-credentials` | Returns ICE server list. With `TURN_SECRET` set, includes coturn credentials. Without it, returns Google STUN servers only. Rate-limited to 20 requests per IP per 60 s. |
+| `POST` | `/api/code` | Registers a short code for a room ID. Body: `{ "roomId": "<uuid>" }`. Response: `{ "code": "word-word-word" }`. TTL: 10 minutes. |
+| `GET` | `/api/code/:code` | Resolves a short code to a room ID. Response: `{ "roomId": "<uuid>" }`. Returns 404 if expired or not found. |
+
+### TURN credentials response
+
+When `TURN_SECRET` and `TURN_DOMAIN` are set:
+
+```json
+[
+  { "urls": "stun:turn.your-domain.com:3478" },
+  { "urls": "turn:turn.your-domain.com:3478", "username": "...", "credential": "..." },
+  { "urls": "turns:turn.your-domain.com:5349", "username": "...", "credential": "..." }
+]
+```
+
+When `TURN_SECRET` is unset:
+
+```json
+[
+  { "urls": "stun:stun.l.google.com:19302" },
+  { "urls": "stun:stun1.l.google.com:19302" }
+]
+```
+
+Credentials use HMAC-SHA1: `username = "{expiry_unix}:floeuser"`, `credential = base64(HMAC-SHA1(TURN_SECRET, username))`. Expiry is 24 hours from issuance.
+
+## Socket.IO events (browser)
+
+### Client to server
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `join-room` | `roomId: string` | Join a room. UUID format required. |
+| `signal` | `{ signal, target?, roomId? }` | Forward a WebRTC signal (SDP or ICE candidate) to the other peer. |
+| `ping` | callback function | Keepalive. Server invokes the callback immediately. |
+
+### Server to client
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `room-joined` | `{ role: "sender" \| "receiver" }` | Confirms room join and assigns role. |
+| `user-connected` | `peerId: string` | Notifies the sender that the receiver joined. |
+| `signal` | `{ signal, sender: peerId }` | Delivers a WebRTC signal from the other peer. |
+| `peer-disconnected` | `{}` | The other peer left the room. |
+| `room-full` | `{}` | Room already has two peers. |
+| `error` | `{ message: string }` | Server error. |
+
+## WebSocket messages (CLI, path `/ws`)
+
+All messages are JSON objects with a `type` field.
+
+### Client to server
+
+| `type` | Other fields | Description |
+|--------|-------------|-------------|
+| `join-room` | `roomId: string` | Join a room. |
+| `signal` | `signal, roomId: string` | Forward a WebRTC signal. |
+| `ping` | - | Keepalive. Server responds with `{ "type": "pong" }`. |
+
+### Server to client
+
+| `type` | Other fields | Description |
+|--------|-------------|-------------|
+| `room-joined` | `role: "sender" \| "receiver"` | Role assignment. |
+| `user-connected` | `id: string` | Receiver joined. |
+| `signal` | `signal, sender: string` | WebRTC signal from the other peer. |
+| `peer-disconnected` | - | Other peer disconnected. |
+| `room-full` | - | Room already full. |
+| `pong` | - | Response to client `ping`. |
+| `error` | `message: string` | Server error. |
+
+## Rate limiting
+
+| Limit | Value | Applies to |
+|-------|-------|-----------|
+| Connection rate | 30 per IP per 60 s (configurable via `MAX_CONNECTIONS_PER_IP`) | Socket.IO connections and WebSocket `/ws` connections, shared |
+| TURN credential rate | 20 per IP per 60 s | `GET /api/turn-credentials` |
+
+Counters are tracked in memory (`Map<ip, timestamp[]>`) and cleaned every 60 seconds.
+
+## Signaling flow
+
+1. Sender calls `POST /api/code` with a UUID room ID to register a short code.
+2. Sender joins the room via `join-room`. Server assigns role `sender`.
+3. Sender prints the code and link and waits.
+4. Receiver joins the same room via `join-room`. Server assigns role `receiver` and emits `user-connected` to the sender.
+5. Sender creates a WebRTC offer and sends it via `signal`.
+6. Receiver receives the offer, creates an answer, and sends it back via `signal`.
+7. Both peers exchange ICE candidates via `signal` (trickle ICE).
+8. WebRTC data channel opens. Signaling server plays no further part.
+
+## Data-channel transfer protocol
+
+Once the WebRTC data channel is open, the sender runs the following sequence for each file. The CLI and browser use the same protocol and are fully interoperable.
+
+### Message types
+
+**Metadata (JSON, sender to receiver)**
+
+```json
+{
+  "type": "metadata",
+  "id": "<uuid>",
+  "fileName": "photo.jpg",
+  "fileSize": 6291456,
+  "index": 1,
+  "total": 3,
+  "totalBytes": 11800000
+}
+```
+
+**Ack (JSON, receiver to sender)**
+
+```json
+{
+  "type": "ack",
+  "id": "<uuid>",
+  "offset": 0
+}
+```
+
+`offset` supports mid-file resume. In normal operation it is always 0.
+
+**Binary chunks (raw bytes)**
+
+The CLI sends 16 KB chunks. The browser sender sends larger adaptive chunks.
+
+**End marker (JSON, sender to receiver)**
+
+```json
+{ "type": "end" }
+```
+
+**Received confirmation (JSON, receiver to sender)**
+
+After all files are complete, the CLI receiver sends:
+
+```json
+{ "type": "received" }
+```
+
+This lets the sender exit cleanly instead of polling the SCTP buffer. Browser receivers do not send this; the sender waits for the data channel buffer to drain to zero.
+
+### Backpressure
+
+The sender pauses when the SCTP send buffer reaches the high-water mark (8 MB) and resumes when it drains below the low-water mark (4 MB). This prevents buffer overflow on large or slow transfers.
+
+### Multi-file transfers
+
+The four-step sequence (metadata, ack, binary chunks, end) repeats for each file in order. The receiver processes files sequentially.
+
+## Room codes
+
+Codes are three random words joined by hyphens (e.g. `olive-tiger-castle`), sampled from a 288-word corpus in `server/words.json`. On collision (extremely rare), a fourth word is appended. Codes expire 10 minutes after registration.

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -1,0 +1,57 @@
+---
+title: "Security and Privacy"
+description: "What Floe's servers can and cannot see, and how your files are protected."
+---
+
+## The short version
+
+Your files travel directly between devices, encrypted end-to-end. Floe's servers broker the connection but never see your file data. The relay server (when used) forwards encrypted packets it cannot read.
+
+## What the signaling server does
+
+The signaling server at `api.floe.one` handles one task: helping two devices find each other so they can connect directly.
+
+It:
+- Assigns each peer a role (sender or receiver) within a room.
+- Relays the WebRTC offer, answer, and ICE candidates that the two devices exchange to establish a connection.
+- Issues short-lived TURN credentials when a TURN server is configured.
+- Registers short codes (e.g. `olive-tiger-castle`) that map to room IDs with a 10-minute TTL.
+
+It never:
+- Receives, stores, or inspects file data.
+- Persist room or peer information after the session ends.
+- Log what you transfer or to whom.
+
+Once the WebRTC data channel is established, the signaling server plays no further part.
+
+## What the TURN relay sees
+
+When a direct connection cannot be established (strict firewalls, carrier-grade NAT), Floe routes traffic through a TURN relay server. The relay server acts as a forwarding intermediary.
+
+The relay sees: encrypted DTLS packets.
+
+It does not see: the plaintext contents of those packets. File data is encrypted before it reaches the relay, and decrypted only on the recipient's device. The relay cannot read, store, or inspect your files.
+
+See [Relay Connection](/how-it-works/relay-connection) for more detail.
+
+## End-to-end encryption
+
+Every WebRTC data channel is encrypted using **DTLS** (Datagram TLS), which is built into the WebRTC standard.
+
+Key properties:
+- Encryption keys are generated uniquely for each transfer session.
+- Keys exist only on the two devices involved. There is no central key server.
+- Keys are ephemeral. They are discarded when the connection closes and cannot be recovered.
+- The signaling server exchanges certificate fingerprints during negotiation, so a compromised signaling channel cannot inject a different certificate (man-in-the-middle protection).
+
+See [End-to-End Encryption](/how-it-works/encryption) for a deeper technical explanation.
+
+## Self-hosted instances
+
+All of the above applies to self-hosted instances as well. The signaling server and TURN relay are architecturally incapable of receiving plaintext file data regardless of who operates them. If you run your own instance, you get the same encryption guarantees, and you control the infrastructure entirely.
+
+See [Self-Hosting](/self-hosting/overview) to run your own instance.
+
+## Reporting a vulnerability
+
+If you discover a security issue in Floe, please report it privately via [GitHub Security Advisories](https://github.com/jannskiee/floe/security/advisories/new) or the contact listed in [SECURITY.md](https://github.com/jannskiee/floe/blob/main/SECURITY.md). Do not open a public issue, as that may expose the vulnerability before a fix is available.

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -14,6 +14,7 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 | `NODE_ENV` | server | No | `production` | Standard Node.js runtime flag. The server Docker image sets this to `production`. |
 | `CLIENT_URL` | server | Yes (prod) | _(none)_ | Frontend origin allowed by CORS. Set to your client's public URL (e.g. `https://app.your-domain.com`). |
 | `TRUSTED_PROXY_COUNT` | server | No | `1` | Number of trusted reverse-proxy hops in front of the server, used for correct `X-Forwarded-For` parsing and per-IP rate limiting. Defaults to `1` (behind one proxy such as Render, Fly, or Vercel). Set to `0` only for direct exposure with no proxy. |
+| `MAX_CONNECTIONS_PER_IP` | server | No | `30` | Maximum new connections allowed per IP per 60-second window, shared across Socket.IO and WebSocket. Raise this in staging or test environments that drive many connections from a single IP. |
 | `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for coturn credentials. If empty, the server returns STUN-only and no TURN is offered. Must match coturn's `static-auth-secret`. |
 | `TURN_DOMAIN` | server | No | _(none)_ | Public hostname of your TURN server (e.g. `turn.your-domain.com`). Must match coturn's `realm`. |
 

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -1,0 +1,67 @@
+---
+title: "Receiving Files"
+description: "How to receive files in the Floe web app."
+---
+
+When someone sends you files via Floe, they share a link (e.g. `https://floe.one?room=...`) or a QR code. Open it in any modern browser to receive.
+
+## Open the link
+
+Click the link or scan the QR code. The page connects to the signaling server and joins the sender's room automatically. No account or installation is needed.
+
+<Note>
+  Some in-app browsers (embedded in Facebook, Instagram, TikTok, and similar apps) do not support WebRTC. If you open the link inside one of these, Floe detects it and prompts you to open the page in Chrome, Safari, or your default browser instead.
+</Note>
+
+## Connection
+
+Once the page opens, Floe negotiates the WebRTC connection. A connection indicator appears in the corner:
+
+| Color | Meaning |
+|-------|---------|
+| Connecting | Establishing the WebRTC connection (usually a few seconds). |
+| Green - Direct | Connected directly, peer-to-peer. No server involved. |
+| Amber - Relay | Connected via the encrypted TURN relay. |
+
+The transfer begins automatically once the connection is established. You do not need to click anything.
+
+## Download options
+
+When all files arrive, download options appear:
+
+| Option | Behavior |
+|--------|---------|
+| **Download** (per file) | Downloads each file individually. Available for every file. |
+| **Download All** | Triggers individual downloads for every file in the batch. |
+| **Download ZIP** | Bundles all files into a single `.zip` archive and downloads it. |
+
+<Tip>
+  On iOS, use **Download ZIP**. Individual file downloads can behave inconsistently on Safari and iOS web views due to browser sandboxing.
+</Tip>
+
+## The sender must stay connected
+
+Files stream directly from the sender's device. If the sender closes their browser tab or the CLI process before the transfer completes, the connection drops and you will need to ask them to start a new session.
+
+## Receiving with the CLI instead
+
+If you prefer the terminal, paste the full link into `floe receive`:
+
+```bash
+floe receive "https://floe.one?room=abc123..."
+```
+
+Or use the short code if the sender shares one:
+
+```bash
+floe receive olive-tiger-castle
+```
+
+See [floe receive](/cli/receive) for details and flags.
+
+## If the link does not work
+
+- **"Room not found" or "expired":** Short codes expire after 10 minutes. Full links stay valid as long as the sender's tab is open. Ask the sender to start a new session.
+- **Stuck connecting:** The sender may be behind a strict network. Both peers need to be on compatible networks for a direct connection. Make sure relay fallback is enabled on the sender's side.
+
+See [Troubleshooting](/troubleshooting) for more help.

--- a/docs/web-app/sending.mdx
+++ b/docs/web-app/sending.mdx
@@ -1,0 +1,70 @@
+---
+title: "Sending Files"
+description: "How to send files from the Floe web app at floe.one."
+---
+
+Open [floe.one](https://floe.one) in any modern browser. No account or installation required.
+
+## Add files
+
+Drop files directly onto the page, or click the drop zone to open the file picker. You can add:
+- A single file of any type.
+- Multiple files at once (the picker accepts multi-select).
+
+There is no file size limit on direct connections. Relay connections are capped at 2 GB per session. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+
+<Note>
+  Folder transfers are a CLI-only feature. To send a folder from the browser, either zip it first or use `floe send ./folder` from the terminal.
+</Note>
+
+## Network Relay Fallback toggle
+
+Below the drop zone is a **Network Relay Fallback** toggle. It is on by default and recommended for most users.
+
+| Setting | Behavior |
+|---------|----------|
+| On (default) | Floe attempts a direct connection first. If that fails, it automatically falls back to the encrypted TURN relay. |
+| Off | Only direct connections are attempted. If a direct path cannot be established, the transfer fails. |
+
+Turn relay off only if you need to ensure files never pass through a relay (for example, for compliance reasons or to transfer very large files over a direct connection).
+
+## Create the link
+
+Click **Create Secure Link and Share**. Floe connects to the signaling server, assigns a room, and generates two ways to share:
+
+- **Link** - a URL containing the room ID (e.g. `https://floe.one?room=...`). Send this via any messaging app, email, or chat.
+- **QR code** - scan it with a phone camera to open the link instantly. Useful for nearby transfers.
+
+The link is valid for as long as your browser tab stays open.
+
+## Connection indicator
+
+Once you share the link, a small connection indicator appears in the corner of the page. Its color tells you what is happening:
+
+| Color | Meaning |
+|-------|---------|
+| Pulsing (no color) | Waiting for the recipient to open the link. |
+| Green - Direct | Connected directly. Files travel peer-to-peer, no server involved. No size limit. |
+| Amber - Relay | Connected via the encrypted TURN relay. The 2 GB cap applies. |
+
+## Transfer
+
+The transfer starts automatically the moment the recipient opens the link. You do not need to click anything.
+
+Keep the browser tab open and active for the entire transfer. If you close or navigate away from the tab, the session ends immediately and the recipient loses the connection.
+
+## Short code
+
+The sender always sees a short code in the share panel (e.g. `olive-tiger-castle`). This code can be used by a **CLI recipient** to join without opening the link:
+
+```bash
+floe receive olive-tiger-castle
+```
+
+The code expires 10 minutes after the link is created. Browser recipients must use the full link.
+
+## Tips
+
+- On mobile, keep the browser in the foreground. Background tabs may be throttled and slow the transfer.
+- If the connection indicator stays in "Connecting" for more than 30 seconds, see [Troubleshooting](/troubleshooting).
+- For large files on a corporate or university network, try a personal mobile hotspot to get a direct connection instead of relay.

--- a/server/.env.example
+++ b/server/.env.example
@@ -11,6 +11,10 @@ NODE_ENV=development
 # Controls how X-Forwarded-For is parsed for rate limiting.
 TRUSTED_PROXY_COUNT=1
 
+# Optional: Override the connection rate limit ceiling (default: 30).
+# Raise this in staging or testing environments that drive many connections from one IP.
+MAX_CONNECTIONS_PER_IP=30
+
 # Optional: TURN relay server
 # Without these, the server falls back to Google public STUN servers.
 # Direct connections still work on most home and mobile networks.


### PR DESCRIPTION
## Summary

- **Accuracy fixes** verified against source code: stale CLI terminal output samples corrected in `send.mdx`, `receive.mdx`, and `quickstart.mdx` to match the current `Sending` line-above-box format and the boxed `Received/Time/Saved to` summary; browser chunk size description fixed in `signaling.mdx`; `MAX_CONNECTIONS_PER_IP` documented everywhere it was missing (server `.env.example`, `.env.docker.example`, `configuration.mdx`, `CONTRIBUTING.md`); `CLAUDE.md` Next.js version corrected (15 to 16) and em dashes removed per writing style rule
- **6 new pages:** `faq.mdx` (standalone FAQ), `changelog.mdx` (v1.0.0-v1.5.2 with Mintlify `<Update>` components), `security-privacy.mdx` (user-facing trust/threat-model), `web-app/sending.mdx`, `web-app/receiving.mdx` (in-depth browser guides), `reference/architecture.mdx` (full developer/self-hoster protocol reference)
- **Navigation** updated in `docs.json`: FAQ added to Getting Started, new Web App group, new Reference group
- **CONTRIBUTING.md** gains a "Working on the Docs" setup section and `pnpm test`/`go test ./...` in the PR checklist

## Test plan

- [ ] `npx mintlify dev` in `docs/` - all 29 pages render, new sidebar groups appear
- [ ] New pages load without broken-link errors (FAQ, Changelog, Security, Web App, Architecture)
- [ ] CLI output samples in `send.mdx`, `receive.mdx`, and `quickstart.mdx` match actual `floe send`/`floe receive` terminal output
- [ ] `grep` for em dash character across all touched `.md`/`.mdx` files returns zero hits
- [ ] `server/.env.example`, `.env.docker.example`, `configuration.mdx`, and `CONTRIBUTING.md` all list `MAX_CONNECTIONS_PER_IP`