### PR TITLE
fix(client): recover from stale-bundle errors and cut Sentry noise

### DIFF
--- a/client/instrumentation-client.ts
+++ b/client/instrumentation-client.ts
@@ -2,4 +2,17 @@
 // Next.js 15+ runs this file in the browser before hydration.
 // This is the correct entry point for client-side Sentry initialization
 // in the App Router. The server-side configs are handled by instrumentation.ts.
+import * as Sentry from '@sentry/nextjs';
 import './sentry.client.config';
+import { registerStaleBundleReload } from './lib/staleBundle';
+
+// Auto-recover from "stale bundle" errors after a redeploy by reloading the
+// page once. Registered here (before hydration) so it catches chunk-load
+// failures that happen during the very first client-side navigation.
+registerStaleBundleReload();
+
+// Required by @sentry/nextjs to trace client-side App Router navigations.
+// Without it, navigation transactions (e.g. moving between /privacy and /terms)
+// are not instrumented, so errors that surface during navigation lack trace
+// context. The build emits an "ACTION REQUIRED" warning until this is exported.
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/client/lib/staleBundle.test.ts
+++ b/client/lib/staleBundle.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isStaleBundleError } from './staleBundle';
+
+describe('isStaleBundleError', () => {
+    it('returns false for empty/nullish input', () => {
+        expect(isStaleBundleError(undefined)).toBe(false);
+        expect(isStaleBundleError(null)).toBe(false);
+        expect(isStaleBundleError('')).toBe(false);
+    });
+
+    it('detects the Turbopack stale module-factory error (FLOE-C)', () => {
+        expect(
+            isStaleBundleError(
+                'Module 74891 was instantiated because it was required from module 88178, but the module factory is not available.'
+            )
+        ).toBe(true);
+    });
+
+    it('detects Webpack chunk-load failures', () => {
+        expect(isStaleBundleError('Loading chunk 537 failed.')).toBe(true);
+        expect(isStaleBundleError('Loading chunk app-pages failed')).toBe(true);
+        expect(isStaleBundleError('ChunkLoadError: Loading chunk 12 failed')).toBe(true);
+    });
+
+    it('detects native ESM dynamic-import failures across browser wording', () => {
+        expect(isStaleBundleError('Failed to fetch dynamically imported module: https://x/a.js')).toBe(true);
+        expect(isStaleBundleError('error loading dynamically imported module')).toBe(true);
+        expect(isStaleBundleError('Importing a module script failed.')).toBe(true);
+    });
+
+    it('ignores unrelated application errors', () => {
+        expect(isStaleBundleError('TypeError: Cannot read properties of undefined')).toBe(false);
+        expect(isStaleBundleError('Ice connection failed.')).toBe(false);
+        expect(
+            isStaleBundleError(
+                "Failed to execute 'setRemoteDescription' on 'RTCPeerConnection': Called in wrong state: stable"
+            )
+        ).toBe(false);
+    });
+});

--- a/client/lib/staleBundle.ts
+++ b/client/lib/staleBundle.ts
@@ -1,0 +1,98 @@
+/**
+ * Stale-bundle recovery.
+ *
+ * When a new version is deployed, a browser tab that loaded the previous
+ * version still references the old JavaScript chunks. The moment that tab
+ * tries to load a chunk on client-side navigation, the bundler throws because
+ * the chunk (or the module factory inside it) no longer exists. With Turbopack
+ * this surfaces as:
+ *
+ *   "Module 12345 was instantiated because it was required from module 67890,
+ *    but the module factory is not available."
+ *
+ * Webpack throws the equivalent "Loading chunk N failed" / "ChunkLoadError",
+ * and native ESM throws "Failed to fetch dynamically imported module". None of
+ * these are application bugs - they are expected churn after a deploy, and the
+ * fix is always the same: reload so the browser fetches the current bundle.
+ */
+
+const STALE_BUNDLE_PATTERNS: RegExp[] = [
+    // Turbopack: stale module graph after a redeploy
+    /module factory is not available/i,
+    // Webpack: classic chunk-load failure
+    /Loading chunk [\w-]+ failed/i,
+    /ChunkLoadError/i,
+    // Native ESM dynamic import (Safari / Firefox / Chrome wording variants)
+    /Failed to fetch dynamically imported module/i,
+    /error loading dynamically imported module/i,
+    /Importing a module script failed/i,
+];
+
+/** True when an error message looks like a stale-deploy bundle/chunk failure. */
+export function isStaleBundleError(message: string | undefined | null): boolean {
+    if (!message) return false;
+    return STALE_BUNDLE_PATTERNS.some((re) => re.test(message));
+}
+
+// sessionStorage key holding the timestamp of the last auto-reload. Used to
+// break reload loops: if a fresh bundle *still* fails, the error is not stale
+// and we must not keep reloading.
+const RELOAD_KEY = 'floe:stale-bundle-reloaded-at';
+
+// If a reload happened within this window and we hit another stale-bundle
+// error, treat it as a genuine failure and stop reloading. Long enough to
+// cover a full reload + hydrate, short enough that a *later* deploy still
+// recovers.
+const RELOAD_DEBOUNCE_MS = 10_000;
+
+function messageOf(value: unknown): string | undefined {
+    if (typeof value === 'string') return value;
+    if (value instanceof Error) return value.message;
+    if (value && typeof value === 'object' && 'message' in value) {
+        const m = (value as { message?: unknown }).message;
+        if (typeof m === 'string') return m;
+    }
+    return undefined;
+}
+
+/**
+ * Reload the page once if `message` is a stale-bundle error. Guarded against
+ * reload loops via a sessionStorage debounce. Returns true if a reload was
+ * triggered.
+ */
+export function reloadIfStaleBundle(message: string | undefined): boolean {
+    if (typeof window === 'undefined') return false;
+    if (!isStaleBundleError(message)) return false;
+
+    let last = 0;
+    try {
+        last = Number(window.sessionStorage.getItem(RELOAD_KEY)) || 0;
+    } catch {
+        // sessionStorage can throw in private/restricted contexts - ignore.
+    }
+    if (Date.now() - last < RELOAD_DEBOUNCE_MS) return false;
+
+    try {
+        window.sessionStorage.setItem(RELOAD_KEY, String(Date.now()));
+    } catch {
+        // Non-fatal: worst case we lose loop protection in a restricted context.
+    }
+    window.location.reload();
+    return true;
+}
+
+/**
+ * Register global listeners that auto-recover from stale-bundle errors.
+ * Safe to call once at client startup (see instrumentation-client.ts).
+ */
+export function registerStaleBundleReload(): void {
+    if (typeof window === 'undefined') return;
+
+    window.addEventListener('error', (event: ErrorEvent) => {
+        reloadIfStaleBundle(event.message || messageOf(event.error));
+    });
+
+    window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+        reloadIfStaleBundle(messageOf(event.reason));
+    });
+}

--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -29,13 +29,16 @@ export default withSentryConfig(nextConfig, {
         reactComponentAnnotation: {
             enabled: true,
         },
+        // Strip Sentry debug logging from the production bundle. Replaces the
+        // deprecated top-level `disableLogger`. This is webpack-only; Turbopack
+        // builds ignore it, which is fine as debug logging is already disabled.
+        treeshake: {
+            removeDebugLogging: true,
+        },
     },
 
     // Hide Sentry source maps from the browser bundle
     hideSourceMaps: true,
-
-    // Remove Sentry debug logging from the production bundle
-    disableLogger: true,
 
     // Source map uploads require SENTRY_AUTH_TOKEN env var.
     // Add it to Vercel project settings to enable detailed stack traces.

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
+import { isStaleBundleError } from './lib/staleBundle';
 
 Sentry.init({
     // Set NEXT_PUBLIC_SENTRY_DSN in your environment to enable error tracking.
@@ -18,8 +19,29 @@ Sentry.init({
         'ResizeObserver loop',
     ],
 
-    // Capture 100% of transactions in production — adjust to 0.1 at scale
-    tracesSampleRate: 1.0,
+    // Sample 10% of transactions. Tracing every page load (1.0) flooded the
+    // performance detectors with low-signal "Degraded HTTP Operation" issues on
+    // slow first/cold loads and added per-session overhead. 10% keeps enough
+    // signal to spot real regressions without the noise.
+    tracesSampleRate: 0.1,
+
+    // Stale-bundle/chunk-load errors are expected deploy churn, not bugs: an old
+    // tab requests chunks a new deploy removed. The browser auto-reloads onto the
+    // current bundle (see lib/staleBundle.ts). Collapse every wording variant into
+    // one warning-level issue instead of a flood of distinct, non-actionable errors.
+    beforeSend(event, hint) {
+        const message =
+            (hint?.originalException as Error | undefined)?.message ??
+            event.exception?.values?.[0]?.value;
+
+        if (isStaleBundleError(message)) {
+            event.level = 'warning';
+            event.fingerprint = ['stale-bundle-chunk-load'];
+            event.tags = { ...event.tags, stale_bundle: true, auto_recovered: true };
+        }
+
+        return event;
+    },
 
     // Session replay: capture 10% of sessions, 100% of sessions with errors
     replaysSessionSampleRate: 0.1,


### PR DESCRIPTION
## Summary

Fixes three production Sentry issues (and one build warning) in the Next.js client. All are deploy-time / instrumentation problems rather than transfer-logic bugs.

| Sentry | Problem | Fix |
|---|---|---|
| **FLOE-C** | `Module ... factory is not available` (Turbopack stale-bundle error after a redeploy, broke client navigation between `/privacy` and `/terms`) | Detect stale-bundle/chunk-load failures and auto-reload once onto the fresh bundle |
| **FLOE-B** | `Degraded HTTP Operation` (low-signal perf-detector noise, amplified by tracing every page load) | `tracesSampleRate` 1.0 -> 0.1 |
| build warning | Sentry `ACTION REQUIRED`: navigations not instrumented | Export `onRouterTransitionStart` |
| deprecation | `disableLogger` deprecated in `@sentry/nextjs` | Migrate to `webpack.treeshake.removeDebugLogging` |

`FLOE-A` (`setRemoteDescription ... wrong state: stable`) was already fixed and resolved, so it is untouched.

## Changes

- **`client/lib/staleBundle.ts`** (new) — shared detection for Turbopack `module factory is not available`, Webpack `ChunkLoadError` / `Loading chunk N failed`, and native-ESM dynamic-import failures, plus `reloadIfStaleBundle()` / `registerStaleBundleReload()`. The reload is debounced via `sessionStorage` (10s) so a genuinely broken bundle never reload-loops, while a later deploy can still recover.
- **`client/instrumentation-client.ts`** — register the recovery listeners before hydration (so the very first client-side navigation is covered) and export `onRouterTransitionStart`.
- **`client/sentry.client.config.ts`** — `beforeSend` collapses every stale-bundle wording variant into one `warning`-level issue (`fingerprint: stale-bundle-chunk-load`, tagged `stale_bundle` / `auto_recovered`), keeping deploy-health signal without a flood of distinct errors; lower `tracesSampleRate` to 0.1.
- **`client/next.config.mjs`** — replace deprecated `disableLogger` with `webpack.treeshake.removeDebugLogging`.
- **`client/lib/staleBundle.test.ts`** (new) — 5 cases covering each error wording and false-positive guards.

## Verification

- `vitest run` — 56/56 pass (5 new).
- `eslint` — clean.
- `tsc --noEmit` — clean.
- `next build` — succeeds; the Sentry `ACTION REQUIRED` and `disableLogger` deprecation warnings are both gone.

## Notes

- Merging with `Fixes FLOE-C` in the squash/commit message will auto-close FLOE-C in Sentry.
- After this deploys, FLOE-B can be safely resolved/ignored (super-low actionability noise).
