### PR TITLE
docs: fix two doc inaccuracies and ignore tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # --- Next.js Build Output ---
 .next/
 out/
+*.tsbuildinfo
 
 # --- Vercel ---
 .vercel

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -5,7 +5,7 @@ description: "Complete reference for all floe CLI flags."
 
 ## Global flags
 
-Available on all commands (`send`, `receive`, `version`).
+Available on all commands (`send`, `receive`, `update`, `version`).
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/web-app/sending.mdx
+++ b/docs/web-app/sending.mdx
@@ -30,7 +30,7 @@ Turn relay off only if you need to ensure files never pass through a relay (for 
 
 ## Create the link
 
-Click **Create Secure Link and Share**. Floe connects to the signaling server, assigns a room, and generates two ways to share:
+Click **Create Secure Link & Share**. Floe connects to the signaling server, assigns a room, and generates two ways to share:
 
 - **Link** - a URL containing the room ID (e.g. `https://floe.one?room=...`). Send this via any messaging app, email, or chat.
 - **QR code** - scan it with a phone camera to open the link instantly. Useful for nearby transfers.


### PR DESCRIPTION
## Summary

Follow-up from a full documentation accuracy audit (all 33 `.mdx` pages + root markdown cross-checked against the actual client/server/CLI code, with all three test suites run and the Docker/self-host setup validated). The audit came back clean except for two trivial wording mismatches, fixed here, plus a stray untracked build artifact.

## Changes

- **`docs/web-app/sending.mdx`** - match the real UI button label **"Create Secure Link & Share"** (was "and Share"). The literal label is `Create Secure Link & Share` in `P2PTransfer.tsx`, and `quickstart.mdx` already used `&`.
- **`docs/cli/flags.mdx`** - the global flags (`--server`, `--no-relay`, `--web`) are registered as cobra persistent flags, so they are available on every subcommand. Added `update` to the list (previously listed only `send`, `receive`, `version`).
- **`.gitignore`** - ignore `*.tsbuildinfo` (TypeScript incremental build cache) so `client/tsconfig.tsbuildinfo` stops showing up as an untracked file.

## Verification

- Server tests: 25/25 pass
- CLI tests (`go test ./...`): pass
- Client tests (`vitest`): 56/56 pass
- `docker compose config` validates
- Docs only / no code paths changed