### PR TITLE
docs: add missing self-hosting overview cards

### DIFF
--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -32,4 +32,10 @@ The signaling server brokers WebRTC connection setup (offer, answer, ICE candida
   <Card title="TURN Relay" href="/self-hosting/turn-relay">
     Add coturn to support peers behind strict NAT or CGNAT.
   </Card>
+  <Card title="Without Docker" href="/self-hosting/without-docker">
+    Run the stack directly with Node.js and Go instead of containers.
+  </Card>
+  <Card title="Operations" href="/self-hosting/operations">
+    Health checks, logging, updates, and monitoring.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
Adds the Without Docker and Operations cards to the self-hosting overview page. Both pages exist in the nav but were not linked from the overview card group.