### PR TITLE
docs: revert self-hosting overview cards addition

### DIFF
--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -32,10 +32,4 @@ The signaling server brokers WebRTC connection setup (offer, answer, ICE candida
   <Card title="TURN Relay" href="/self-hosting/turn-relay">
     Add coturn to support peers behind strict NAT or CGNAT.
   </Card>
-  <Card title="Without Docker" href="/self-hosting/without-docker">
-    Run the stack directly with Node.js and Go instead of containers.
-  </Card>
-  <Card title="Operations" href="/self-hosting/operations">
-    Health checks, logging, updates, and monitoring.
-  </Card>
 </CardGroup>


### PR DESCRIPTION
Removes the Without Docker and Operations cards added in #95.