### PR TITLE
fix: correct release archive filename in installers and self-update (404 fix)

### DIFF
--- a/cli/internal/selfupdate/selfupdate.go
+++ b/cli/internal/selfupdate/selfupdate.go
@@ -158,10 +158,13 @@ func PMHint(pm string) string {
 // AssetName returns (archive filename, format string) for the given platform.
 // Exported for testing; callers within this package use assetName().
 func AssetName(version, goos, goarch string) (string, string) {
+	// Release tags carry a leading "v" (e.g. v1.2.0), but GoReleaser strips it
+	// from the archive name (floe_1.2.0_...). Match the published asset name.
+	v := strings.TrimPrefix(version, "v")
 	if goos == "windows" {
-		return fmt.Sprintf("floe_%s_%s_%s.zip", version, goos, goarch), "zip"
+		return fmt.Sprintf("floe_%s_%s_%s.zip", v, goos, goarch), "zip"
 	}
-	return fmt.Sprintf("floe_%s_%s_%s.tar.gz", version, goos, goarch), "tar.gz"
+	return fmt.Sprintf("floe_%s_%s_%s.tar.gz", v, goos, goarch), "tar.gz"
 }
 
 func assetName(version string) (string, string) {

--- a/cli/internal/selfupdate/selfupdate_test.go
+++ b/cli/internal/selfupdate/selfupdate_test.go
@@ -29,12 +29,14 @@ func TestAssetName(t *testing.T) {
 		wantName              string
 		wantFmt               string
 	}{
-		{"linux", "amd64", "v1.2.0", "floe_v1.2.0_linux_amd64.tar.gz", "tar.gz"},
-		{"linux", "arm64", "v1.2.0", "floe_v1.2.0_linux_arm64.tar.gz", "tar.gz"},
-		{"darwin", "amd64", "v1.2.0", "floe_v1.2.0_darwin_amd64.tar.gz", "tar.gz"},
-		{"darwin", "arm64", "v1.2.0", "floe_v1.2.0_darwin_arm64.tar.gz", "tar.gz"},
-		{"windows", "amd64", "v1.2.0", "floe_v1.2.0_windows_amd64.zip", "zip"},
-		{"windows", "arm64", "v1.2.0", "floe_v1.2.0_windows_arm64.zip", "zip"},
+		{"linux", "amd64", "v1.2.0", "floe_1.2.0_linux_amd64.tar.gz", "tar.gz"},
+		{"linux", "arm64", "v1.2.0", "floe_1.2.0_linux_arm64.tar.gz", "tar.gz"},
+		{"darwin", "amd64", "v1.2.0", "floe_1.2.0_darwin_amd64.tar.gz", "tar.gz"},
+		{"darwin", "arm64", "v1.2.0", "floe_1.2.0_darwin_arm64.tar.gz", "tar.gz"},
+		{"windows", "amd64", "v1.2.0", "floe_1.2.0_windows_amd64.zip", "zip"},
+		{"windows", "arm64", "v1.2.0", "floe_1.2.0_windows_arm64.zip", "zip"},
+		// A bare version (no leading "v") must produce the same asset name.
+		{"linux", "amd64", "1.2.0", "floe_1.2.0_linux_amd64.tar.gz", "tar.gz"},
 	}
 	for _, tt := range tests {
 		gotName, gotFmt := AssetName(tt.version, tt.goos, tt.goarch)

--- a/client/public/install.ps1
+++ b/client/public/install.ps1
@@ -32,9 +32,21 @@ if (-not $Version) {
     exit 1
 }
 
-$Archive = "floe_${Version}_windows_${Arch}.zip"
-$DownloadUrl = "https://github.com/$Repo/releases/download/$Version/$Archive"
-$ChecksumsUrl = "https://github.com/$Repo/releases/download/$Version/checksums.txt"
+# The release tag carries a leading "v" (e.g. v1.5.2), but GoReleaser strips it
+# from the archive name (floe_1.5.2_...). Use the tag for the download path and
+# the bare version number for the filename. Tolerate FLOE_VERSION set with or
+# without the leading "v".
+if ($Version.StartsWith("v")) {
+    $Tag = $Version
+    $VersionNum = $Version.Substring(1)
+} else {
+    $Tag = "v$Version"
+    $VersionNum = $Version
+}
+
+$Archive = "floe_${VersionNum}_windows_${Arch}.zip"
+$DownloadUrl = "https://github.com/$Repo/releases/download/$Tag/$Archive"
+$ChecksumsUrl = "https://github.com/$Repo/releases/download/$Tag/checksums.txt"
 
 $TmpDir = New-Item -ItemType Directory -Path "$env:TEMP\floe-install-$(Get-Random)"
 

--- a/client/public/install.sh
+++ b/client/public/install.sh
@@ -48,9 +48,17 @@ if [ -z "${FLOE_VERSION}" ]; then
   exit 1
 fi
 
-ARCHIVE="floe_${FLOE_VERSION}_${GOOS}_${GOARCH}.tar.gz"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${FLOE_VERSION}/${ARCHIVE}"
-CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${FLOE_VERSION}/checksums.txt"
+# The release tag carries a leading "v" (e.g. v1.5.2), but GoReleaser strips it
+# from the archive name ({{ .Version }} -> 1.5.2). Normalize both forms so the
+# download path uses the tag and the filename uses the bare version number.
+case "${FLOE_VERSION}" in
+  v*) TAG="${FLOE_VERSION}"; VERSION_NUM="${FLOE_VERSION#v}" ;;
+  *)  TAG="v${FLOE_VERSION}"; VERSION_NUM="${FLOE_VERSION}" ;;
+esac
+
+ARCHIVE="floe_${VERSION_NUM}_${GOOS}_${GOARCH}.tar.gz"
+DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ARCHIVE}"
+CHECKSUMS_URL="https://github.com/${REPO}/releases/download/${TAG}/checksums.txt"
 
 # Work in a temp directory; clean up on exit
 TMP_DIR="$(mktemp -d)"

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,12 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.5.3" description="2026-06-21">
+  **Installer and self-update download fix**
+
+  - Fixed a 404 when installing or updating floe. The install scripts (`install.sh`, `install.ps1`) and the built-in `floe update` requested the release archive with a leading "v" in the version (for example `floe_v1.5.2_linux_arm64.tar.gz`), but the published asset name omits it (`floe_1.5.2_linux_arm64.tar.gz`). All download paths now use the correct filename. This affected every platform and architecture, including Raspberry Pi (linux/arm64).
+</Update>
+
 <Update label="v1.5.2" description="2026-06-17">
   **CLI stability fix**
 


### PR DESCRIPTION
## Problem

Installing or updating floe fails with a 404:

```
admin@thesis-rpi5:~ $ curl -fsSL https://floe.one/install.sh | sh
Fetching latest version... v1.5.2
Downloading floe v1.5.2 (linux/arm64)...
curl: (22) The requested URL returned error: 404
```

The install scripts and the CLI self-updater build the release asset name straight from the tag (e.g. `floe_v1.5.2_linux_arm64.tar.gz`), but GoReleaser strips the leading `v` from `{{ .Version }}`, so the published asset is `floe_1.5.2_linux_arm64.tar.gz`. The URL never matches. This affects **every platform and architecture**, not just arm64.

## Fix

- **`install.sh` / `install.ps1`**: derive the tag (with `v`, used for the release download path) and the bare version number (used for the filename) separately. Both tolerate `FLOE_VERSION` being set with or without a leading `v`.
- **`cli/internal/selfupdate`**: strip the `v` prefix in `AssetName`; update test expectations and add a bare-version case.
- **`docs/changelog.mdx`**: add the v1.5.3 entry.

## Notes

- The release tag path (`/releases/download/v1.5.2/`) keeps the `v`; only the archive filename drops it.
- Existing installs at <= v1.5.2 ship the old self-updater, so `floe update` on those will still 404. They can re-run the (now fixed) install script or download manually. New installs and v1.5.3+ self-updates work.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.