### PR TITLE
fix(cli): keep transfer progress bar on a single line

### DIFF
--- a/cli/internal/transfer/format.go
+++ b/cli/internal/transfer/format.go
@@ -68,7 +68,16 @@ func newProgressBar(size int64, index, total int, name string) *progressbar.Prog
 		progressbar.OptionSetDescription(
 			fmt.Sprintf("  [%d/%d] %s", index, total, truncateName(name, 30)),
 		),
-		progressbar.OptionSetWidth(30),
+		// Size the bar to the terminal width so the whole line always fits.
+		// A fixed width could overflow a narrow window; on Windows the library
+		// clears with a bare "\r", so a wrapped line scrolls a new row on every
+		// redraw (one line per percentage). Full width keeps it on one line and
+		// falls back to an 80-column layout when stdout is not a TTY.
+		progressbar.OptionFullWidth(),
+		// Default throttle is 0, so the bar re-renders (and fsyncs) on every
+		// chunk. Cap redraws to keep the display smooth and cut I/O; the final
+		// 100% still renders because render() bypasses the throttle at max.
+		progressbar.OptionThrottle(65*time.Millisecond),
 		progressbar.OptionShowBytes(true),
 		progressbar.OptionSetTheme(progressbar.Theme{
 			Saucer:        "█",

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,12 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.5.4" description="2026-06-21">
+  **CLI progress bar fix**
+
+  - Fixed the transfer progress bar printing a new line for every percentage on narrow or Windows terminals. The bar now sizes itself to the terminal width so the line never wraps, and it updates in place on a single line per file.
+</Update>
+
 <Update label="v1.5.3" description="2026-06-21">
   **Installer and self-update download fix**
 


### PR DESCRIPTION
## Problem

In `floe send` / `floe receive`, the progress bar prints a **new line for every percentage** instead of updating one line in place:

```
[1/1] test-file.dat   7% [██░░...]
[1/1] test-file.dat   8% [██░░...] (41 MB/s) [8s:1m53s]
...
```

## Cause

`newProgressBar` (`cli/internal/transfer/format.go`) used a fixed `OptionSetWidth(30)`. The full line (description + 30-char bar + speed/ETA) runs ~85 columns. On any terminal narrower than that the line wraps onto a second physical row, and because `schollz/progressbar/v3` clears with a bare `\r` on Windows, each redraw only returns to the start of the current physical row, scrolling a new line every tick.

## Fix

- Replace `OptionSetWidth(30)` with `OptionFullWidth()`, which sizes the bar from the terminal width each render so the line always fits (and falls back to an 80-column layout when stdout is not a TTY, so loopback tests / CI are unaffected).
- Add `OptionThrottle(65ms)` so the bar no longer re-renders and fsyncs on every chunk.

One change in the shared `newProgressBar`, so it fixes both sender and receiver.

## Verification

- `go build ./... && go vet ./... && go test ./...` all pass (transfer/loopback tests run for real).
- Width measurement with the production options and a 30-char filename: old config emits an **85-col** line (overflows 80 -> wraps -> bug); `OptionFullWidth` emits **79 cols** (fits the 80 fallback, smaller on narrower real terminals).