### PR TITLE
fix(cli): make `floe update` work for root-owned install dirs

### DIFF
--- a/cli/internal/selfupdate/selfupdate.go
+++ b/cli/internal/selfupdate/selfupdate.go
@@ -9,10 +9,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -172,8 +175,9 @@ func assetName(version string) (string, string) {
 }
 
 // Apply downloads, verifies the SHA-256 checksum, and replaces the running
-// binary with the given version. On Windows the running executable is renamed
-// out of the way before the new binary is moved into place.
+// binary with the given version. The new binary is extracted into a writable
+// temp dir, then installed in place: directly when the install dir is writable,
+// or via sudo when it is root-owned (e.g. /usr/local/bin).
 func Apply(version string) error {
 	asset, format := assetName(version)
 	assetURL := fmt.Sprintf("%s/%s/%s", baseURL, version, asset)
@@ -203,13 +207,22 @@ func Apply(version string) error {
 		return err
 	}
 
-	binaryTmp := exe + ".update"
-	if err := extractBinary(archiveTmp, format, binaryTmp); err != nil {
+	// Extract the new binary into the OS temp dir, which is always writable.
+	// The install dir itself may be root-owned (e.g. /usr/local/bin), so staging
+	// there directly would fail with "permission denied".
+	binaryTmp, err := os.CreateTemp("", "floe-update-*")
+	if err != nil {
+		return fmt.Errorf("cannot create temp file: %w", err)
+	}
+	binaryTmpPath := binaryTmp.Name()
+	_ = binaryTmp.Close()
+	defer os.Remove(binaryTmpPath)
+
+	if err := extractBinary(archiveTmp, format, binaryTmpPath); err != nil {
 		return fmt.Errorf("extraction failed: %w", err)
 	}
-	defer os.Remove(binaryTmp)
 
-	return replaceBinary(exe, binaryTmp)
+	return installBinary(exe, binaryTmpPath)
 }
 
 // --- cache ---
@@ -401,23 +414,120 @@ func writeFile(r io.Reader, destPath string) error {
 	return closeErr
 }
 
-// --- binary replacement ---
+// --- binary installation ---
 
-func replaceBinary(exe, newBinary string) error {
+// installBinary places newBinary at exe, replacing the running executable.
+// It works for user-owned install dirs (e.g. ~/.local/bin) without elevation,
+// and falls back to sudo when the install dir is root-owned (e.g. /usr/local/bin).
+func installBinary(exe, newBinary string) error {
 	if runtime.GOOS == "windows" {
-		// Windows disallows overwriting a running .exe but allows renaming it.
-		// Rename the old binary out of the way, then rename the new one into place.
-		bak := exe + ".bak"
-		_ = os.Remove(bak)
-		if err := os.Rename(exe, bak); err != nil {
-			return fmt.Errorf("cannot rename current binary: %w", err)
-		}
-		if err := os.Rename(newBinary, exe); err != nil {
-			_ = os.Rename(bak, exe) // attempt restore
-			return fmt.Errorf("cannot install new binary: %w", err)
-		}
-		_ = os.Remove(bak)
+		return windowsInstall(exe, newBinary)
+	}
+
+	// Fast path: install without elevation. Works when the install dir is
+	// writable by the current user.
+	err := unixInstall(exe, newBinary)
+	if err == nil {
 		return nil
 	}
-	return os.Rename(newBinary, exe)
+	if !errors.Is(err, fs.ErrPermission) {
+		return err
+	}
+
+	// The install dir is not writable, typically /usr/local/bin owned by root.
+	dir := filepath.Dir(exe)
+	if os.Geteuid() == 0 {
+		return fmt.Errorf("permission denied writing to %s", dir)
+	}
+	sudo, lookErr := exec.LookPath("sudo")
+	if lookErr != nil {
+		return fmt.Errorf("%s is not writable and sudo is not available; "+
+			"re-run as root, or reinstall with the install script", dir)
+	}
+	return sudoInstall(sudo, exe, newBinary)
+}
+
+// unixInstall stages a copy of newBinary alongside exe and atomically renames it
+// into place. Renaming (rather than writing over exe) is required because a
+// running executable cannot be opened for writing on Linux (ETXTBSY), and it
+// makes the swap atomic. Staging in the same directory also keeps the rename on
+// one filesystem. Returns an fs.ErrPermission error when the install dir is not
+// writable, which the caller uses to decide whether to elevate.
+func unixInstall(exe, newBinary string) error {
+	staged, err := os.CreateTemp(filepath.Dir(exe), ".floe-update-*")
+	if err != nil {
+		return err
+	}
+	stagedPath := staged.Name()
+	_ = staged.Close()
+	defer os.Remove(stagedPath)
+
+	if err := copyFile(newBinary, stagedPath, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(stagedPath, exe)
+}
+
+// sudoInstall completes the swap with elevated privileges. The download and
+// extraction already ran as the normal user; only the final move needs root.
+// It copies to a sibling (a new file, so the running binary is never opened for
+// writing -> no ETXTBSY), fixes the mode, then atomically renames it over exe,
+// all in a single sudo invocation (one password prompt).
+func sudoInstall(sudo, exe, newBinary string) error {
+	fmt.Printf("  %s is not writable; requesting sudo to install the update...\n", filepath.Dir(exe))
+	const script = `cp "$1" "$2.new" && chmod 0755 "$2.new" && mv -f "$2.new" "$2"`
+	cmd := exec.Command(sudo, "sh", "-c", script, "sh", newBinary, exe)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("sudo install failed: %w", err)
+	}
+	return nil
+}
+
+// windowsInstall stages the new binary next to exe (avoiding cross-volume
+// renames), renames the running exe out of the way, then moves the new one in.
+// Windows disallows overwriting a running .exe but allows renaming it.
+func windowsInstall(exe, newBinary string) error {
+	staged := exe + ".new"
+	_ = os.Remove(staged)
+	if err := copyFile(newBinary, staged, 0o755); err != nil {
+		return err
+	}
+	bak := exe + ".bak"
+	_ = os.Remove(bak)
+	if err := os.Rename(exe, bak); err != nil {
+		_ = os.Remove(staged)
+		return fmt.Errorf("cannot rename current binary: %w", err)
+	}
+	if err := os.Rename(staged, exe); err != nil {
+		_ = os.Rename(bak, exe) // attempt restore
+		_ = os.Remove(staged)
+		return fmt.Errorf("cannot install new binary: %w", err)
+	}
+	_ = os.Remove(bak)
+	return nil
+}
+
+// copyFile copies src to dst, creating or truncating dst with the given mode.
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+	// Ensure the mode sticks even if umask trimmed it at create time.
+	return os.Chmod(dst, mode)
 }

--- a/cli/internal/selfupdate/selfupdate_test.go
+++ b/cli/internal/selfupdate/selfupdate_test.go
@@ -1,6 +1,11 @@
 package selfupdate
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
 
 func TestCompareVersions(t *testing.T) {
 	tests := []struct {
@@ -85,6 +90,79 @@ func TestPMHint(t *testing.T) {
 	for _, tt := range tests {
 		if got := PMHint(tt.pm); got != tt.want {
 			t.Errorf("PMHint(%q) = %q, want %q", tt.pm, got, tt.want)
+		}
+	}
+}
+
+func TestInstallBinaryReplacesInPlace(t *testing.T) {
+	dir := t.TempDir()
+	exe := filepath.Join(dir, "floe")
+	if runtime.GOOS == "windows" {
+		exe += ".exe"
+	}
+	if err := os.WriteFile(exe, []byte("OLD BINARY"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The new binary is staged in the OS temp dir, exactly like Apply does.
+	newBin := filepath.Join(t.TempDir(), "floe-update")
+	if err := os.WriteFile(newBin, []byte("NEW BINARY"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installBinary(exe, newBin); err != nil {
+		t.Fatalf("installBinary: %v", err)
+	}
+
+	got, err := os.ReadFile(exe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "NEW BINARY" {
+		t.Errorf("installed content = %q, want %q", got, "NEW BINARY")
+	}
+
+	// The installed binary must be executable, even though the source was 0644.
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(exe)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("installed binary not executable: mode %v", info.Mode().Perm())
+		}
+	}
+
+	// No staging leftovers should remain in the install dir.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if e.Name() != filepath.Base(exe) {
+			t.Errorf("unexpected leftover in install dir: %s", e.Name())
+		}
+	}
+}
+
+func TestCopyFileSetsMode(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst, 0o755); err != nil {
+		t.Fatalf("copyFile: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "data" {
+		t.Errorf("content = %q, want %q", got, "data")
+	}
+	if runtime.GOOS != "windows" {
+		info, _ := os.Stat(dst)
+		if info.Mode().Perm() != 0o755 {
+			t.Errorf("mode = %v, want 0755", info.Mode().Perm())
 		}
 	}
 }

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,12 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.5.5" description="2026-06-21">
+  **`floe update` permission fix**
+
+  - Fixed `floe update` failing with "permission denied" when floe is installed in a root-owned directory such as `/usr/local/bin` on Linux and macOS. The updater now downloads and extracts as the current user, installs directly when the location is user-writable (for example `~/.local/bin`), and automatically requests sudo only for the final atomic swap when it is not. To upgrade from an older version one time, run `sudo floe update`; after that plain `floe update` works.
+</Update>
+
 <Update label="v1.5.4" description="2026-06-21">
   **CLI progress bar fix**
 


### PR DESCRIPTION
## Problem

On Linux/macOS, `floe update` fails when floe is installed in a root-owned directory (e.g. `/usr/local/bin`, the install script's default):

```
Error: update failed: extraction failed: open /usr/local/bin/floe.update: permission denied
```

The updater extracted the new binary to `<exe>.update` **inside the install dir**, which a non-root user can't write to. Even past extraction, the final rename also needs root.

## Fix

Extract into the OS temp dir (always writable), then install in place:

- **User-owned dirs** (e.g. `~/.local/bin`): stage a sibling temp file and atomically rename it over the target — no elevation.
- **Root-owned dirs**: only the final swap is elevated via a single `sudo` call — `cp` to a sibling (so the running binary is never opened for write → avoids `ETXTBSY` on Linux), `chmod`, then atomic `mv`. One password prompt.
- **No sudo / already root but denied**: clear, actionable error.

Windows keeps the rename-out-of-the-way dance, now staging in the install dir to avoid cross-volume renames.

## Notes

- The running v1.5.4 binary still has the old updater, so plain `floe update` to the fixed version will still fail; `sudo floe update` works one time to get onto it (changelog says so). After that, plain `floe update` works.

## Verification

- `go build ./... && go vet ./... && go test ./...` all pass.
- New tests `TestInstallBinaryReplacesInPlace` / `TestCopyFileSetsMode` cover the in-place swap (content replaced, executable bit set even from a 0644 source, no staging leftovers) on both Unix and Windows.