### PR TITLE
feat(transfer): add protocol version negotiation

### DIFF
--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -198,7 +198,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	// 9. Send files
-	return transfer.SendFiles(dc, args)
+	return transfer.SendFiles(dc, args, version)
 }
 
 // ── floe receive ─────────────────────────────────────────────────────────────
@@ -298,7 +298,7 @@ func runReceive(cmd *cobra.Command, args []string) error {
 	fmt.Println("  Connected")
 
 	// 7. Receive files
-	return transfer.ReceiveFiles(dc, absOutput, flagAutoAccept)
+	return transfer.ReceiveFiles(dc, absOutput, flagAutoAccept, version)
 }
 
 // ── floe version ─────────────────────────────────────────────────────────────

--- a/cli/internal/transfer/loopback_test.go
+++ b/cli/internal/transfer/loopback_test.go
@@ -99,13 +99,13 @@ func runTransfer(t *testing.T, srcPaths []string) string {
 	recvErr := make(chan error, 1)
 	go func() {
 		dc := <-recvCh
-		recvErr <- ReceiveFiles(dc, outDir, true)
+		recvErr <- ReceiveFiles(dc, outDir, true, "")
 	}()
 
 	// Let the receiver register its OnMessage handler before any data is sent.
 	time.Sleep(300 * time.Millisecond)
 
-	if err := SendFiles(sender, srcPaths); err != nil {
+	if err := SendFiles(sender, srcPaths, ""); err != nil {
 		t.Fatalf("SendFiles: %v", err)
 	}
 
@@ -182,7 +182,7 @@ func TestLoopbackImmediateReceiverClose(t *testing.T) {
 
 	go func() {
 		dc := <-recvCh
-		err := ReceiveFiles(dc, outDir, true)
+		err := ReceiveFiles(dc, outDir, true, "")
 		// Close receiver immediately — this is what `defer conn.Close()` does
 		// in `runReceive`. The SCTP teardown races the final SACK to the sender.
 		dc.Close()
@@ -191,7 +191,7 @@ func TestLoopbackImmediateReceiverClose(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 
-	sendErr := SendFiles(senderDC, []string{srcPath})
+	sendErr := SendFiles(senderDC, []string{srcPath}, "")
 	closeFn() // clean up sender PC after SendFiles returns
 
 	if sendErr != nil {

--- a/cli/internal/transfer/protocol.go
+++ b/cli/internal/transfer/protocol.go
@@ -1,0 +1,85 @@
+package transfer
+
+import "fmt"
+
+// ProtocolVersion is the highest wire protocol version this build speaks.
+// MinProtocolVersion is the lowest it still supports.
+//
+// Bump policy: increment ProtocolVersion on any breaking wire change (e.g. a
+// mandatory new field old receivers cannot ignore, or a removed field they
+// require). Raise MinProtocolVersion only when deliberately dropping support
+// for an old wire format. Never tie either constant to the floe release version
+// (1.x.y) - they are independent.
+const (
+	ProtocolVersion    = 1
+	MinProtocolVersion = 1
+)
+
+// incompatibleMsg is sent by the receiver to the sender when their protocol
+// version ranges do not overlap. Sent as binary so old senders that do not
+// recognize the type treat it as a small JSON blob and drop it safely.
+type incompatibleMsg struct {
+	Type   string `json:"type"`
+	Reason string `json:"reason"`
+	Pv     int    `json:"pv"`
+	PvMin  int    `json:"pvMin"`
+	Ver    string `json:"ver,omitempty"`
+}
+
+// CheckCompat reports whether two peers can transfer files given their
+// advertised protocol version ranges [localMin, localMax] and [remoteMin,
+// remoteMax]. A zero in remoteMin or remoteMax indicates a legacy peer that
+// omitted the field; it is treated as protocol version 1.
+//
+// Returns ok=true when the ranges overlap.
+// localTooOld=true means this peer must update; false means the remote must.
+func CheckCompat(localMin, localMax, remoteMin, remoteMax int) (ok bool, localTooOld bool) {
+	if remoteMin == 0 {
+		remoteMin = 1
+	}
+	if remoteMax == 0 {
+		remoteMax = 1
+	}
+	lo := localMin
+	if remoteMin > lo {
+		lo = remoteMin
+	}
+	hi := localMax
+	if remoteMax < hi {
+		hi = remoteMax
+	}
+	if lo <= hi {
+		return true, false
+	}
+	return false, remoteMin > localMax
+}
+
+// CompatErrorMessage returns a user-facing error string for an incompatible
+// peer. localVer and remoteVer are human release strings (e.g. "v1.5.5");
+// either may be empty for legacy peers.
+func CompatErrorMessage(localTooOld bool, localVer, remoteVer string, localMin, localMax, remoteMin, remoteMax int) string {
+	localRange := fmt.Sprintf("protocol %d", localMin)
+	if localMax != localMin {
+		localRange = fmt.Sprintf("protocol %d-%d", localMin, localMax)
+	}
+	remoteRange := fmt.Sprintf("protocol %d", remoteMin)
+	if remoteMax != remoteMin {
+		remoteRange = fmt.Sprintf("protocol %d-%d", remoteMin, remoteMax)
+	}
+	if localVer != "" {
+		localRange += " (" + localVer + ")"
+	}
+	if remoteVer != "" {
+		remoteRange += " (" + remoteVer + ")"
+	}
+	if localTooOld {
+		return fmt.Sprintf(
+			"Cannot transfer: your floe is too old for this peer.\n  You: %s  Peer: %s\n  Run `floe update` to upgrade.",
+			localRange, remoteRange,
+		)
+	}
+	return fmt.Sprintf(
+		"Cannot transfer: peer's floe is too old.\n  You: %s  Peer: %s\n  Ask the other side to run `floe update`.",
+		localRange, remoteRange,
+	)
+}

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -23,12 +23,17 @@ type FileInfo struct {
 	Index      int
 	Total      int
 	TotalBytes int64
+	Pv         int    // sender's highest protocol version (0 = legacy, treat as 1)
+	PvMin      int    // sender's minimum protocol version (0 = legacy, treat as 1)
+	Ver        string // sender's human release string, e.g. "v1.5.5"
 }
 
 // ReceiveFiles handles the full receiving side of the Floe protocol.
 // It blocks until all files are received. Files are written to outputDir.
 // If autoAccept is false, the user is prompted before receiving begins.
-func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) error {
+// localVer is the human release string (e.g. "v1.5.5") embedded in the ack
+// for the optional peer-version note; pass "" for dev builds or tests.
+func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, localVer string) error {
 	// msgCh collects ALL incoming data channel messages.
 	// We use a channel so the OnMessage callback (goroutine) feeds a sequential loop.
 	msgCh := make(chan webrtc.DataChannelMessage, 256)
@@ -104,10 +109,34 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 				currentInfo = info
 				bytesReceived = 0
 
-				// On first file: show summary and optionally prompt
+				// On first file: check compat, show summary, and optionally prompt
 				if waitingForFirst {
 					waitingForFirst = false
 					start = time.Now()
+
+					// Protocol compatibility check - before creating any files or
+					// prompting the user. Send "incompatible" so the sender fails
+					// fast with a clear message rather than waiting for an ack.
+					ok, localTooOld := CheckCompat(MinProtocolVersion, ProtocolVersion, info.PvMin, info.Pv)
+					if !ok {
+						errMsg := CompatErrorMessage(localTooOld, localVer, info.Ver,
+							MinProtocolVersion, ProtocolVersion, info.PvMin, info.Pv)
+						incompat := incompatibleMsg{
+							Type:   "incompatible",
+							Reason: errMsg,
+							Pv:     ProtocolVersion,
+							PvMin:  MinProtocolVersion,
+							Ver:    localVer,
+						}
+						incompatJSON, _ := json.Marshal(incompat)
+						dc.Send([]byte(incompatJSON))
+						return fmt.Errorf("%s", errMsg)
+					}
+
+					// Optional informational note when release versions differ
+					if info.Ver != "" && localVer != "" && info.Ver != localVer {
+						fmt.Printf("  Peer version: %s\n", info.Ver)
+					}
 
 					var incomingLabel string
 					switch {
@@ -147,12 +176,19 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 				// Progress bar for this file
 				bar = newProgressBar(info.FileSize, info.Index, info.Total, info.FileName)
 
-				// Send ack as BINARY — the browser checks data.byteLength before
-				// decoding, which is only defined on ArrayBuffer/Buffer, not strings.
+				// Send ack as BINARY with protocol version fields so the sender
+				// can verify compat from its side and show the optional peer-version
+				// note. The browser checks data.byteLength before decoding, which is
+				// only defined on ArrayBuffer/Buffer, not strings.
 				ack := map[string]interface{}{
-					"type":   "ack",
-					"id":     info.ID,
+					"type":  "ack",
+					"id":    info.ID,
 					"offset": 0,
+					"pv":    ProtocolVersion,
+					"pvMin": MinProtocolVersion,
+				}
+				if localVer != "" {
+					ack["ver"] = localVer
 				}
 				ackJSON, _ := json.Marshal(ack)
 				dc.Send([]byte(ackJSON))
@@ -227,7 +263,7 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 }
 
 // classifyControl reports whether a data channel message is a Floe control
-// message and, if so, its type ("metadata" or "end").
+// message and, if so, its type.
 //
 // Control messages are JSON objects. The browser (SimplePeer) sends them as
 // strings, but depending on SCTP framing they can also arrive as small binary
@@ -236,6 +272,11 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool) err
 // as control ONLY when it parses as a JSON object whose "type" is a known
 // control type. Anything else — including a small file whose bytes happen to be
 // a JSON object — is file data and must be written, not dropped.
+//
+// The receiver only acts on "metadata" and "end". The other recognized types
+// ("ack", "received", "incompatible") flow in the opposite direction; they are
+// classified as control so they are never mistakenly written as file data if
+// they somehow arrive on this side.
 func classifyControl(data []byte, isString bool) (msgType string, isControl bool) {
 	if !isString && len(data) > 1000 {
 		return "", false
@@ -248,7 +289,8 @@ func classifyControl(data []byte, isString bool) (msgType string, isControl bool
 		return "", false
 	}
 	t, _ := base["type"].(string)
-	if t == "metadata" || t == "end" {
+	switch t {
+	case "metadata", "end", "ack", "received", "incompatible":
 		return t, true
 	}
 	return "", false
@@ -281,6 +323,9 @@ func parseMetadata(text string) (FileInfo, error) {
 		Index      int     `json:"index"`
 		Total      int     `json:"total"`
 		TotalBytes float64 `json:"totalBytes"` // absent from older senders → 0
+		Pv         int     `json:"pv"`         // absent from older senders → 0 (treated as 1)
+		PvMin      int     `json:"pvMin"`      // absent from older senders → 0 (treated as 1)
+		Ver        string  `json:"ver"`        // absent from older senders → ""
 	}
 	if err := json.Unmarshal([]byte(text), &m); err != nil {
 		return FileInfo{}, err
@@ -295,6 +340,9 @@ func parseMetadata(text string) (FileInfo, error) {
 		Index:      m.Index,
 		Total:      m.Total,
 		TotalBytes: int64(m.TotalBytes),
+		Pv:         m.Pv,
+		PvMin:      m.PvMin,
+		Ver:        m.Ver,
 	}, nil
 }
 

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -1,11 +1,17 @@
 // Package transfer implements the Floe data channel protocol for sending files.
 //
 // Protocol (same as the web app — must stay compatible for CLI↔Browser):
-//   1. Sender → Receiver: metadata JSON  (file name, size, index, total)
-//   2. Receiver → Sender: ack JSON       (confirms ready, offset for resume)
+//   1. Sender → Receiver: metadata JSON  (file name, size, index, total, pv, pvMin, ver)
+//   2. Receiver → Sender: ack JSON       (confirms ready, offset for resume, pv, pvMin, ver)
+//      OR:       incompatible JSON       (sent instead of ack when protocol ranges do not overlap)
 //   3. Sender → Receiver: binary chunks  (raw file bytes, 16 KB each)
 //   4. Sender → Receiver: end JSON       (signals end of this file)
 //   Repeat for each file.
+//
+// pv/pvMin are the protocol version range (see protocol.go). ver is the human
+// release string (e.g. "v1.5.5") used only for the optional informational note;
+// it never gates the transfer. Fields are omitted by legacy peers and default to
+// protocol version 1.
 package transfer
 
 import (
@@ -42,6 +48,9 @@ type metadataMsg struct {
 	Index      int    `json:"index"`
 	Total      int    `json:"total"`
 	TotalBytes int64  `json:"totalBytes"`
+	Pv         int    `json:"pv,omitempty"`
+	PvMin      int    `json:"pvMin,omitempty"`
+	Ver        string `json:"ver,omitempty"`
 }
 
 // ackMsg is received from the receiver confirming readiness.
@@ -49,6 +58,9 @@ type ackMsg struct {
 	Type   string `json:"type"`
 	ID     string `json:"id"`
 	Offset int64  `json:"offset"`
+	Pv     int    `json:"pv"`
+	PvMin  int    `json:"pvMin"`
+	Ver    string `json:"ver"`
 }
 
 // endMsg is sent after the last chunk of each file.
@@ -58,7 +70,9 @@ type endMsg struct {
 
 // SendFiles sends all given file paths over the open data channel.
 // Folders are walked recursively. The receiver gets each file in order.
-func SendFiles(dc *webrtc.DataChannel, paths []string) error {
+// localVer is the human release string (e.g. "v1.5.5") embedded in metadata
+// for the optional peer-version note; pass "" for dev builds or tests.
+func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
 	// Expand paths: collect all files (walk directories)
 	files, err := collectFiles(paths)
 	if err != nil {
@@ -101,7 +115,7 @@ func SendFiles(dc *webrtc.DataChannel, paths []string) error {
 	})
 
 	for i, entry := range files {
-		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files), totalBytes); err != nil {
+		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files), totalBytes, localVer); err != nil {
 			return fmt.Errorf("error sending %s: %w", entry.displayName, err)
 		}
 	}
@@ -199,7 +213,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 }
 
 // sendFile handles the full send sequence for a single file.
-func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int, totalBytes int64) error {
+func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int, totalBytes int64, localVer string) error {
 	f, err := os.Open(entry.absPath)
 	if err != nil {
 		return err
@@ -223,28 +237,66 @@ func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struc
 		Index:      index,
 		Total:      total,
 		TotalBytes: totalBytes,
+		Pv:         ProtocolVersion,
+		PvMin:      MinProtocolVersion,
+		Ver:        localVer,
 	}
 	metaJSON, _ := json.Marshal(meta)
 	if err := dc.SendText(string(metaJSON)); err != nil {
 		return fmt.Errorf("failed to send metadata: %w", err)
 	}
 
-	// Step 2: Wait for this file's ack (with 30-second timeout).
+	// Step 2: Wait for this file's ack (with 120-second timeout).
 	// Discard any stray or stale message until we see the ack whose ID matches
 	// this file — otherwise an out-of-order message could be misread as the ack
 	// (sending from offset 0) or leak into the next file's handshake.
-	var offset int64
 	// 120 s lets a human at the interactive [Y/n] receiver prompt accept without
 	// triggering a spurious timeout on the sender.
+	var offset int64
 	ackDeadline := time.After(120 * time.Second)
 ackLoop:
 	for {
 		select {
 		case raw := <-ackCh:
-			var ack ackMsg
-			if err := json.Unmarshal(raw, &ack); err == nil && ack.Type == "ack" && ack.ID == fileID {
-				offset = ack.Offset
-				break ackLoop
+			var base struct {
+				Type string `json:"type"`
+			}
+			if json.Unmarshal(raw, &base) != nil {
+				continue
+			}
+			// If the receiver found the protocol ranges incompatible it sends
+			// an "incompatible" message instead of an ack.
+			if base.Type == "incompatible" {
+				var incompat struct {
+					Reason string `json:"reason"`
+				}
+				json.Unmarshal(raw, &incompat) //nolint:errcheck
+				if incompat.Reason != "" {
+					return fmt.Errorf("%s", incompat.Reason)
+				}
+				return fmt.Errorf("peer rejected transfer: protocol incompatible")
+			}
+			if base.Type == "ack" {
+				var ack ackMsg
+				if err := json.Unmarshal(raw, &ack); err == nil && ack.ID == fileID {
+					// Defense in depth: verify protocol compat from the receiver's
+					// pv fields on the first file. The receiver already checked from
+					// its side; this catches the case where an old receiver (no pv
+					// field, treated as v1) connects to a future sender that dropped
+					// support for v1.
+					if index == 1 {
+						ok, localTooOld := CheckCompat(MinProtocolVersion, ProtocolVersion, ack.PvMin, ack.Pv)
+						if !ok {
+							return fmt.Errorf("%s", CompatErrorMessage(localTooOld, localVer, ack.Ver,
+								MinProtocolVersion, ProtocolVersion, ack.PvMin, ack.Pv))
+						}
+						if ack.Ver != "" && localVer != "" && ack.Ver != localVer {
+							fmt.Printf("  Peer version: %s\n", ack.Ver)
+						}
+					}
+					offset = ack.Offset
+					break ackLoop
+				}
 			}
 			// Not our ack — keep waiting.
 		case <-ackDeadline:

--- a/cli/internal/transfer/transfer_test.go
+++ b/cli/internal/transfer/transfer_test.go
@@ -170,6 +170,10 @@ func TestClassifyControl(t *testing.T) {
 		{"metadata string", `{"type":"metadata","id":"x","fileName":"a","fileSize":1,"index":1,"total":1}`, true, "metadata", true},
 		{"end string", `{"type":"end"}`, true, "end", true},
 		{"metadata as small binary", `{"type":"metadata","id":"x"}`, false, "metadata", true},
+		// Protocol-direction messages are control so they are never written as file data.
+		{"ack type is control", `{"type":"ack","id":"x","offset":0}`, false, "ack", true},
+		{"received type is control", `{"type":"received"}`, false, "received", true},
+		{"incompatible type is control", `{"type":"incompatible","reason":"too old"}`, false, "incompatible", true},
 		// A tiny JSON file (its own content) must be treated as DATA, not dropped.
 		{"json file content under 1KB", `{"hello":"world","n":42}`, false, "", false},
 		// A JSON object whose type is unknown is still data, not control.
@@ -194,5 +198,87 @@ func TestClassifyControl(t *testing.T) {
 	big := `{"type":"metadata",` + `"pad":"` + strings.Repeat("x", 1100) + `"}`
 	if _, isControl := classifyControl([]byte(big), false); isControl {
 		t.Errorf("classifyControl on >1000-byte binary should be data, got control")
+	}
+}
+
+// TestCheckCompat covers the full matrix of protocol version range comparisons.
+func TestCheckCompat(t *testing.T) {
+	cases := []struct {
+		name                    string
+		localMin, localMax      int
+		remoteMin, remoteMax    int
+		wantOk                  bool
+		wantLocalTooOld         bool
+	}{
+		{"equal v1", 1, 1, 1, 1, true, false},
+		{"legacy remote (zeros treated as v1)", 1, 1, 0, 0, true, false},
+		{"overlap: local 1-2 remote 2-3", 1, 2, 2, 3, true, false},
+		{"local too old: local 1-1 remote 2-2", 1, 1, 2, 2, false, true},
+		{"remote too old: local 2-2 remote 1-1", 2, 2, 1, 1, false, false},
+		{"no overlap: local 3-4 remote 1-2", 3, 4, 1, 2, false, false},
+		{"wide local range", 1, 5, 3, 3, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, localTooOld := CheckCompat(tc.localMin, tc.localMax, tc.remoteMin, tc.remoteMax)
+			if ok != tc.wantOk || localTooOld != tc.wantLocalTooOld {
+				t.Errorf("CheckCompat(%d,%d,%d,%d) = (ok=%v,localTooOld=%v), want (ok=%v,localTooOld=%v)",
+					tc.localMin, tc.localMax, tc.remoteMin, tc.remoteMax,
+					ok, localTooOld, tc.wantOk, tc.wantLocalTooOld)
+			}
+		})
+	}
+}
+
+// TestCompatErrorMessage verifies the user-facing error strings.
+func TestCompatErrorMessage(t *testing.T) {
+	// Local too old: should suggest running floe update locally
+	msg := CompatErrorMessage(true, "v1.5.5", "v2.0.0", 1, 1, 2, 2)
+	if !strings.Contains(msg, "floe update") {
+		t.Errorf("local-too-old message should mention 'floe update', got: %s", msg)
+	}
+	if !strings.Contains(msg, "v1.5.5") || !strings.Contains(msg, "v2.0.0") {
+		t.Errorf("message should contain both version strings, got: %s", msg)
+	}
+
+	// Remote too old: should ask the other side to update
+	msg2 := CompatErrorMessage(false, "v2.0.0", "v1.5.5", 2, 2, 1, 1)
+	if !strings.Contains(msg2, "other side") {
+		t.Errorf("remote-too-old message should mention 'other side', got: %s", msg2)
+	}
+
+	// Empty ver strings omitted from ranges
+	msg3 := CompatErrorMessage(true, "", "", 1, 1, 2, 2)
+	if strings.Contains(msg3, "()") {
+		t.Errorf("empty ver should not produce '()' in message, got: %s", msg3)
+	}
+}
+
+// TestParseMetadataProtocolFields verifies that pv/pvMin/ver are parsed from
+// new-format metadata, and that legacy metadata (no such fields) returns zeros.
+func TestParseMetadataProtocolFields(t *testing.T) {
+	// New sender with pv/pvMin/ver
+	withProto := `{"type":"metadata","id":"a","fileName":"f.txt","fileSize":1,"index":1,"total":1,"totalBytes":1,"pv":2,"pvMin":1,"ver":"v1.6.0"}`
+	info, err := parseMetadata(withProto)
+	if err != nil {
+		t.Fatalf("parseMetadata with proto fields error: %v", err)
+	}
+	if info.Pv != 2 || info.PvMin != 1 || info.Ver != "v1.6.0" {
+		t.Errorf("got Pv=%d PvMin=%d Ver=%q, want Pv=2 PvMin=1 Ver=v1.6.0", info.Pv, info.PvMin, info.Ver)
+	}
+
+	// Legacy sender without pv/pvMin/ver — fields default to zero/empty
+	legacy := `{"type":"metadata","id":"b","fileName":"old.txt","fileSize":10,"index":1,"total":1}`
+	info2, err := parseMetadata(legacy)
+	if err != nil {
+		t.Fatalf("parseMetadata legacy error: %v", err)
+	}
+	if info2.Pv != 0 || info2.PvMin != 0 || info2.Ver != "" {
+		t.Errorf("legacy metadata should have zero pv fields, got Pv=%d PvMin=%d Ver=%q", info2.Pv, info2.PvMin, info2.Ver)
+	}
+	// And CheckCompat treats zero as v1 — must be compatible with current build
+	ok, _ := CheckCompat(MinProtocolVersion, ProtocolVersion, info2.PvMin, info2.Pv)
+	if !ok {
+		t.Error("legacy peer (zero pv fields) must be compatible with current protocol")
 	}
 }

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -466,6 +466,10 @@ export function P2PTransfer() {
                 }
             },
             onWaiting: () => setStatus('File received. Waiting for next file'),
+            onError: (msg) => {
+                setError(msg);
+                setStatus('Transfer failed');
+            },
         });
         peer.on('data', rx.handleMessage);
         peerRef.current = peer;

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -8,6 +8,15 @@ export const READ_SLAB = 4 * 1024 * 1024;  // 4 MB — disk read slab size
 export const DEFAULT_CHUNK = 64 * 1024;    // 64 KB — fallback chunk size
 export const MAX_CHUNK = 256 * 1024;       // 256 KB — cap on adaptive chunk
 
+// ProtocolVersion is the highest wire protocol version this build speaks.
+// MinProtocolVersion is the lowest it still supports.
+//
+// Bump policy: increment ProtocolVersion on any breaking wire change. Raise
+// MinProtocolVersion only when dropping support for an old wire format. Never
+// tie either constant to the app's npm version — they are independent.
+export const PROTOCOL_VERSION = 1;
+export const MIN_PROTOCOL_VERSION = 1;
+
 // Adaptive chunk size: use the negotiated SCTP max, capped at MAX_CHUNK.
 export function chunkSize(sctpMax?: number | null): number {
     if (sctpMax && Number.isFinite(sctpMax) && sctpMax > 0) {
@@ -26,12 +35,18 @@ export interface Metadata {
     index: number;
     total: number;
     totalBytes: number;
+    pv?: number;    // sender's highest protocol version (absent on legacy peers)
+    pvMin?: number; // sender's minimum protocol version (absent on legacy peers)
+    ver?: string;   // sender's human release string, e.g. "v1.5.5"
 }
 
 export interface Ack {
     type: 'ack';
     id: string;
     offset: number;
+    pv?: number;    // receiver's highest protocol version
+    pvMin?: number; // receiver's minimum protocol version
+    ver?: string;   // receiver's human release string
 }
 
 export interface End {
@@ -45,7 +60,18 @@ export interface Received {
     type: 'received';
 }
 
-export type ControlMessage = Metadata | Ack | End | Received;
+// Sent by the receiver to the sender when their protocol version ranges do not
+// overlap. Sent as binary (Uint8Array) so old senders that don't know this
+// type can safely drop it rather than treating it as file data.
+export interface Incompatible {
+    type: 'incompatible';
+    reason: string;
+    pv?: number;
+    pvMin?: number;
+    ver?: string;
+}
+
+export type ControlMessage = Metadata | Ack | End | Received | Incompatible;
 
 // --- Message builders ---
 
@@ -55,17 +81,80 @@ export function metadataMessage(
     fileSize: number,
     index: number,
     total: number,
-    totalBytes: number
+    totalBytes: number,
+    ver?: string
 ): string {
-    return JSON.stringify({ type: 'metadata', id, fileName, fileSize, index, total, totalBytes } satisfies Metadata);
+    return JSON.stringify({
+        type: 'metadata', id, fileName, fileSize, index, total, totalBytes,
+        pv: PROTOCOL_VERSION,
+        pvMin: MIN_PROTOCOL_VERSION,
+        ver,
+    } satisfies Metadata);
 }
 
-export function ackMessage(id: string, offset: number): string {
-    return JSON.stringify({ type: 'ack', id, offset } satisfies Ack);
+export function ackMessage(id: string, offset: number, ver?: string): string {
+    return JSON.stringify({
+        type: 'ack', id, offset,
+        pv: PROTOCOL_VERSION,
+        pvMin: MIN_PROTOCOL_VERSION,
+        ver,
+    } satisfies Ack);
 }
 
 export function endMessage(): string {
     return JSON.stringify({ type: 'end' } satisfies End);
+}
+
+export function incompatibleMessage(reason: string): string {
+    return JSON.stringify({
+        type: 'incompatible', reason,
+        pv: PROTOCOL_VERSION,
+        pvMin: MIN_PROTOCOL_VERSION,
+    } satisfies Incompatible);
+}
+
+// --- Protocol compatibility ---
+
+/**
+ * Reports whether two peers can transfer files given their advertised protocol
+ * version ranges. Missing (0/undefined) remote values indicate a legacy peer
+ * and are treated as version 1.
+ */
+export function checkCompat(
+    localMin: number,
+    localMax: number,
+    remoteMin: number,
+    remoteMax: number
+): { ok: boolean; localTooOld: boolean } {
+    if (!remoteMin) remoteMin = 1;
+    if (!remoteMax) remoteMax = 1;
+    const lo = Math.max(localMin, remoteMin);
+    const hi = Math.min(localMax, remoteMax);
+    if (lo <= hi) return { ok: true, localTooOld: false };
+    return { ok: false, localTooOld: remoteMin > localMax };
+}
+
+/**
+ * Returns a user-facing error string for an incompatible peer. localVer and
+ * remoteVer are human release strings; either may be empty for legacy peers.
+ */
+export function compatErrorMessage(
+    localTooOld: boolean,
+    localVer: string,
+    remoteVer: string,
+    localMin: number,
+    localMax: number,
+    remoteMin: number,
+    remoteMax: number
+): string {
+    const localRange = localMin === localMax ? `protocol ${localMin}` : `protocol ${localMin}-${localMax}`;
+    const remoteRange = remoteMin === remoteMax ? `protocol ${remoteMin}` : `protocol ${remoteMin}-${remoteMax}`;
+    const localStr = localVer ? `${localRange} (${localVer})` : localRange;
+    const remoteStr = remoteVer ? `${remoteRange} (${remoteVer})` : remoteRange;
+    if (localTooOld) {
+        return `Cannot transfer: your browser is running an older version of Floe.\nYou: ${localStr}  Peer: ${remoteStr}\nRefresh the page to get the latest version.`;
+    }
+    return `Cannot transfer: peer's floe is too old.\nYou: ${localStr}  Peer: ${remoteStr}\nAsk the other side to run \`floe update\`.`;
 }
 
 // --- Control message classifier ---
@@ -107,5 +196,6 @@ export function classifyControl(data: ArrayBuffer | Uint8Array): ControlMessage 
     if (t === 'ack') return msg as unknown as Ack;
     if (t === 'end') return msg as unknown as End;
     if (t === 'received') return msg as unknown as Received;
+    if (t === 'incompatible') return msg as unknown as Incompatible;
     return null;
 }

--- a/client/lib/transfer/receiver.ts
+++ b/client/lib/transfer/receiver.ts
@@ -3,6 +3,11 @@
 import {
     classifyControl,
     ackMessage,
+    incompatibleMessage,
+    checkCompat,
+    compatErrorMessage,
+    PROTOCOL_VERSION,
+    MIN_PROTOCOL_VERSION,
     type Metadata,
 } from './protocol';
 
@@ -21,6 +26,7 @@ export interface ReceiverCallbacks {
     onSpeedReset?: () => void;
     onFileComplete?: (file: ReceivedFile, index: number, total: number) => void;
     onWaiting?: () => void;
+    onError?: (msg: string) => void;
 }
 
 interface PartialDownload {
@@ -44,23 +50,54 @@ interface PartialDownload {
  *       setReceivedFiles(prev => [...prev, { ...file, downloadUrl: url }]);
  *     },
  *     onWaiting: () => setStatus('File received. Waiting for next file'),
+ *     onError: (msg) => { setError(msg); setStatus('Transfer failed'); },
  *   });
  *   peer.on('data', rx.handleMessage);
  */
 export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: Uint8Array | ArrayBuffer) => void } {
     const partialDownloads = new Map<string, PartialDownload>();
     let currentMetadata: Metadata | null = null;
+    let hasCheckedCompat = false;
+    let incompatibleDetected = false;
 
     let receiveSpeedStart = performance.now();
     let receiveSpeedBytes = 0;
     let lastReceiveSpeedUpdate = 0;
 
     function handleMessage(data: Uint8Array | ArrayBuffer): void {
+        if (incompatibleDetected) return;
+
         const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
         const msg = classifyControl(buf);
 
         if (msg) {
             if (msg.type === 'metadata') {
+                // Protocol compatibility check on first file, before sending ack
+                // or accepting any file bytes.
+                if (!hasCheckedCompat) {
+                    hasCheckedCompat = true;
+                    const remotePv = msg.pv ?? 0;
+                    const remotePvMin = msg.pvMin ?? 0;
+                    const { ok, localTooOld } = checkCompat(
+                        MIN_PROTOCOL_VERSION, PROTOCOL_VERSION,
+                        remotePvMin, remotePv
+                    );
+                    if (!ok) {
+                        incompatibleDetected = true;
+                        const errMsg = compatErrorMessage(
+                            localTooOld, '', msg.ver ?? '',
+                            MIN_PROTOCOL_VERSION, PROTOCOL_VERSION,
+                            remotePvMin || 1, remotePv || 1
+                        );
+                        // Send incompatible as binary so the CLI sender's ack loop
+                        // can handle it; old senders drop unrecognized control types.
+                        const enc = new TextEncoder().encode(incompatibleMessage(errMsg));
+                        cb.send(new Uint8Array(enc));
+                        cb.onError?.(errMsg);
+                        return;
+                    }
+                }
+
                 currentMetadata = msg;
                 receiveSpeedStart = performance.now();
                 receiveSpeedBytes = 0;
@@ -76,6 +113,8 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
                     partialDownloads.set(msg.id, { chunks: [], received: 0 });
                 }
 
+                // Send ack with protocol version fields so the sender can verify
+                // compat from its side and show the optional peer-version note.
                 cb.send(ackMessage(msg.id, offset));
             } else if (msg.type === 'end') {
                 if (!currentMetadata) return;

--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -8,7 +8,12 @@ import {
     classifyControl,
     metadataMessage,
     endMessage,
+    checkCompat,
+    compatErrorMessage,
+    PROTOCOL_VERSION,
+    MIN_PROTOCOL_VERSION,
     type Ack,
+    type Incompatible,
 } from './protocol';
 
 export interface SenderCallbacks {
@@ -77,6 +82,12 @@ export async function sendFiles(
     }
 }
 
+// Result of waiting for the receiver's ack.
+type AckResult =
+    | { type: 'ack'; offset: number; pv?: number; pvMin?: number; ver?: string }
+    | { type: 'incompatible'; reason: string }
+    | { type: 'timeout' };
+
 async function sendSingleFile(
     deps: SenderDeps,
     entry: FileEntry,
@@ -95,21 +106,44 @@ async function sendSingleFile(
 
     channel.bufferedAmountLowThreshold = LOW_WATER;
 
-    // 1. Send metadata
+    // 1. Send metadata with protocol version fields
     try {
         send(metadataMessage(id, file.name, file.size, index, total, totalBytes));
     } catch {
         return;
     }
 
-    // 2. Wait for ack (15 s timeout)
-    const ackOffset = await waitForAck(onData, id);
-    if (ackOffset === null) {
+    // 2. Wait for ack (15 s timeout), handling incompatible responses
+    const ackResult = await waitForAck(onData, id);
+    if (ackResult.type === 'timeout') {
         cb.onError?.('Transfer timed out waiting for receiver. Please try again.');
         return;
     }
+    if (ackResult.type === 'incompatible') {
+        cb.onError?.(ackResult.reason);
+        return;
+    }
 
-    let offset = ackOffset;
+    // Defense in depth: verify protocol compat from the receiver's pv fields on
+    // the first file. The receiver already checked from its side; this catches
+    // the case where an old receiver (no pv field, treated as v1) connects to a
+    // future sender that dropped support for v1.
+    if (index === 1 && (ackResult.pv !== undefined || ackResult.pvMin !== undefined)) {
+        const { ok, localTooOld } = checkCompat(
+            MIN_PROTOCOL_VERSION, PROTOCOL_VERSION,
+            ackResult.pvMin ?? 0, ackResult.pv ?? 0
+        );
+        if (!ok) {
+            cb.onError?.(compatErrorMessage(
+                localTooOld, '', ackResult.ver ?? '',
+                MIN_PROTOCOL_VERSION, PROTOCOL_VERSION,
+                ackResult.pvMin ?? 1, ackResult.pv ?? 1
+            ));
+            return;
+        }
+    }
+
+    let offset = ackResult.offset;
     let speedMeasureStart = performance.now();
     let speedMeasureBytes = 0;
     let lastSpeedUpdate = 0;
@@ -195,19 +229,23 @@ async function sendSingleFile(
 function waitForAck(
     onData: (handler: (data: Uint8Array | ArrayBuffer) => void) => () => void,
     fileId: string
-): Promise<number | null> {
+): Promise<AckResult> {
     return Promise.race([
-        new Promise<number | null>((resolve) => {
+        new Promise<AckResult>((resolve) => {
             const off = onData((raw) => {
-                const msg = classifyControl(
-                    raw instanceof Uint8Array ? raw : new Uint8Array(raw)
-                );
-                if (msg && msg.type === 'ack' && (msg as Ack).id === fileId) {
+                const buf = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
+                const msg = classifyControl(buf);
+                if (!msg) return;
+                if (msg.type === 'ack' && (msg as Ack).id === fileId) {
                     off();
-                    resolve((msg as Ack).offset);
+                    const ack = msg as Ack;
+                    resolve({ type: 'ack', offset: ack.offset, pv: ack.pv, pvMin: ack.pvMin, ver: ack.ver });
+                } else if (msg.type === 'incompatible') {
+                    off();
+                    resolve({ type: 'incompatible', reason: (msg as Incompatible).reason });
                 }
             });
         }),
-        new Promise<null>((resolve) => setTimeout(() => resolve(null), 15_000)),
+        new Promise<AckResult>((resolve) => setTimeout(() => resolve({ type: 'timeout' }), 15_000)),
     ]);
 }


### PR DESCRIPTION
## Summary

- Adds a dedicated wire-protocol version (`pv`/`pvMin`) independent of the release version (1.5.x). A peer's release version being `1.5.4` vs `1.5.5` is NOT a conflict and never blocks transfer.
- Both peers exchange `pv`, `pvMin`, and `ver` fields inside the existing `metadata`/`ack` handshake with no extra round trip and full backward compatibility (absent fields are treated as protocol v1).
- If the protocol ranges genuinely don't overlap, the receiver sends an `incompatible` message before any file bytes move, and both sides print a clear role-aware update hint.
- Today every peer is protocol `1`, so the guard is a silent no-op until a future breaking wire change actually needs it.
- Covers all transfer directions: CLI-to-CLI, browser-to-CLI, CLI-to-browser.

## What changed

**CLI (`cli/internal/transfer/`)**
- `protocol.go` (new): `ProtocolVersion`/`MinProtocolVersion` constants, `CheckCompat()` range-overlap check, `CompatErrorMessage()` formatter, `incompatibleMsg` struct.
- `sender.go`: metadata now carries `pv`/`pvMin`/`ver`; ack loop handles `incompatible` response and verifies receiver's range on the first file.
- `receiver.go`: parses `pv`/`pvMin`/`ver` from metadata; checks compat before creating any files; sends `incompatible` instead of ack if ranges miss; ack now carries its own `pv`/`pvMin`/`ver`; `classifyControl` now also recognizes `ack`/`received`/`incompatible` so they are never written as file data.
- `transfer_test.go`: new table tests for `CheckCompat`, `CompatErrorMessage`, and `parseMetadata` protocol fields (including legacy-peer zero-value case).

**Browser (`client/lib/transfer/`)**
- `protocol.ts`: `PROTOCOL_VERSION`/`MIN_PROTOCOL_VERSION` constants, optional `pv?`/`pvMin?`/`ver?` on `Metadata` and `Ack`, new `Incompatible` interface and `incompatibleMessage` builder, `checkCompat()`, `compatErrorMessage()`, updated `metadataMessage`/`ackMessage` builders, `incompatible` added to `classifyControl`.
- `sender.ts`: `waitForAck` now returns a typed result (`ack`/`incompatible`/`timeout`); handles `incompatible` response and verifies receiver's range on the first file.
- `receiver.ts`: checks compat on first metadata; sends `incompatible` if ranges miss; ack carries `pv`/`pvMin`; new `onError` callback.
- `P2PTransfer.tsx`: wires `onError` into the receiver so incompatibility errors surface in the transfer UI.

## Test plan

- CLI build: `cd cli && go build ./cmd/floe && go test ./...`
- Browser build: `cd client && pnpm build` (zero TypeScript errors)
- Happy path: v1.5.4 vs v1.5.5 transfers normally (optional peer-version note, no blocking)
- Backward compat: released binary (no `pv` field) vs newly built binary transfers normally (zero fields treated as protocol 1)
- Simulated incompatibility: bump `ProtocolVersion`/`MinProtocolVersion` to 2 in one binary only; verify transfer aborts before any bytes move with the correct update hint on both the sender and the receiver sides