### PR TITLE
docs: document protocol version negotiation (v1.6.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,9 @@ NEXT_PUBLIC_SENTRY_DSN=    # optional
 
 Browser peers communicate via **Socket.IO**; CLI peers communicate via **WebSocket at `/ws`**. Both share the same `rooms` registry on the server (`Map<roomId, [peer, peer]>`), so browser-to-CLI transfers work transparently.
 
+### Transfer Protocol Versioning
+The data-channel transfer protocol carries its own version, independent of the release version (1.x.y). Peers exchange `pv` (highest protocol version), `pvMin` (lowest supported), and `ver` (release string) inside the existing `metadata` and `ack` messages. Compatibility is a range-overlap check; if the ranges miss, the receiver sends an `incompatible` message before any file bytes move and both sides print a "run `floe update`" hint. Constants: `ProtocolVersion` / `MinProtocolVersion` in `cli/internal/transfer/protocol.go`, mirrored as `PROTOCOL_VERSION` / `MIN_PROTOCOL_VERSION` in `client/lib/transfer/protocol.ts`. Both are 1 today. Bump `ProtocolVersion` only on a breaking wire change; keep the two implementations in sync. Peers omitting the fields (pre-1.6.0) are treated as protocol 1.
+
 ### Room Codes
 `POST /api/code` registers a short human-readable phrase (e.g. `olive-tiger-castle`) mapping to a room ID with 10-min TTL. `GET /api/code/:code` resolves it. Words come from `server/words.json`.
 

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -181,11 +181,11 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 				// note. The browser checks data.byteLength before decoding, which is
 				// only defined on ArrayBuffer/Buffer, not strings.
 				ack := map[string]interface{}{
-					"type":  "ack",
-					"id":    info.ID,
+					"type":   "ack",
+					"id":     info.ID,
 					"offset": 0,
-					"pv":    ProtocolVersion,
-					"pvMin": MinProtocolVersion,
+					"pv":     ProtocolVersion,
+					"pvMin":  MinProtocolVersion,
 				}
 				if localVer != "" {
 					ack["ver"] = localVer
@@ -319,7 +319,7 @@ func parseMetadata(text string) (FileInfo, error) {
 		Type       string  `json:"type"`
 		ID         string  `json:"id"`
 		FileName   string  `json:"fileName"`
-		FileSize   float64 `json:"fileSize"`   // JSON numbers decode as float64
+		FileSize   float64 `json:"fileSize"` // JSON numbers decode as float64
 		Index      int     `json:"index"`
 		Total      int     `json:"total"`
 		TotalBytes float64 `json:"totalBytes"` // absent from older senders → 0

--- a/cli/internal/transfer/transfer_test.go
+++ b/cli/internal/transfer/transfer_test.go
@@ -204,11 +204,11 @@ func TestClassifyControl(t *testing.T) {
 // TestCheckCompat covers the full matrix of protocol version range comparisons.
 func TestCheckCompat(t *testing.T) {
 	cases := []struct {
-		name                    string
-		localMin, localMax      int
-		remoteMin, remoteMax    int
-		wantOk                  bool
-		wantLocalTooOld         bool
+		name                 string
+		localMin, localMax   int
+		remoteMin, remoteMax int
+		wantOk               bool
+		wantLocalTooOld      bool
 	}{
 		{"equal v1", 1, 1, 1, 1, true, false},
 		{"legacy remote (zeros treated as v1)", 1, 1, 0, 0, true, false},

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.6.0" description="2026-06-22">
+  **Protocol version negotiation**
+
+  - Added a wire protocol version that the sender and receiver exchange when a transfer starts. It is separate from the release version (1.6.x), so peers on different releases still transfer normally. A patch or minor difference such as v1.5.4 and v1.5.5 is never a conflict and is never blocked.
+  - If a future release ever changes the wire format in a breaking way, the two sides now detect it before any file data moves and print a clear "your floe is too old, run `floe update`" message (or "ask the other side to update") instead of failing with a confusing error or a corrupt file.
+  - Works in every direction: CLI-to-CLI, browser-to-CLI, and CLI-to-browser. Older peers that predate this change are treated as the baseline protocol and stay fully compatible.
+</Update>
+
 <Update label="v1.5.5" description="2026-06-21">
   **`floe update` permission fix**
 

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -41,3 +41,7 @@ curl -fsSL https://floe.one/install.sh | sh
 # Windows
 irm https://floe.one/install.ps1 | iex
 ```
+
+## Version compatibility
+
+You do not need to match versions with the person on the other end. Floe peers on different releases interoperate, so a small version difference is never a problem. In the rare case a release changes the transfer protocol in a breaking way, Floe detects it before any data moves and tells whichever side is older to update. See [Protocol versioning](/reference/architecture#protocol-versioning) for the details.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -110,4 +110,10 @@ description: "Answers to the most common questions about Floe."
   <Accordion title="How do I keep the CLI up to date?">
     Run `floe update` for script and manual installs. For package manager installs, use `brew upgrade floe`, `winget upgrade jannskiee.floe`, or `scoop update floe`. See [Updating](/cli/update).
   </Accordion>
+
+  <Accordion title="Do both peers need the same version?">
+    No. Floe peers on different versions interoperate, so you do not need to coordinate updates with the person on the other end. A patch or minor difference (for example v1.5.4 sending to v1.5.5) transfers normally.
+
+    Floe negotiates a transfer protocol version separate from the release version. The only time a transfer is blocked is the rare case where a release changes the wire format in a breaking way and the two versions cannot bridge it. If that happens, Floe tells you before any data moves and points whichever side is older to `floe update`. See the [Protocol versioning](/reference/architecture#protocol-versioning) reference for how this works.
+  </Accordion>
 </AccordionGroup>

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -139,9 +139,14 @@ Once the WebRTC data channel is open, the sender runs the following sequence for
   "fileSize": 6291456,
   "index": 1,
   "total": 3,
-  "totalBytes": 11800000
+  "totalBytes": 11800000,
+  "pv": 1,
+  "pvMin": 1,
+  "ver": "v1.6.0"
 }
 ```
+
+`pv`, `pvMin`, and `ver` carry the protocol version range and release string (see [Protocol versioning](#protocol-versioning)). They were added in v1.6.0 and are absent on older peers, which are treated as protocol version 1.
 
 **Ack (JSON, receiver to sender)**
 
@@ -149,11 +154,14 @@ Once the WebRTC data channel is open, the sender runs the following sequence for
 {
   "type": "ack",
   "id": "<uuid>",
-  "offset": 0
+  "offset": 0,
+  "pv": 1,
+  "pvMin": 1,
+  "ver": "v1.6.0"
 }
 ```
 
-`offset` supports mid-file resume. In normal operation it is always 0.
+`offset` supports mid-file resume. In normal operation it is always 0. The ack carries the receiver's own `pv`, `pvMin`, and `ver` so the sender can verify compatibility from its side.
 
 **Binary chunks (raw bytes)**
 
@@ -174,6 +182,33 @@ After all files are complete, the CLI receiver sends:
 ```
 
 This lets the sender exit cleanly instead of polling the SCTP buffer. Browser receivers do not send this; the sender waits for the data channel buffer to drain to zero.
+
+**Incompatible (JSON, receiver to sender)**
+
+Sent in place of the ack when the two peers' protocol version ranges do not overlap (see [Protocol versioning](#protocol-versioning)). It carries a human-readable `reason` plus the receiver's own version range:
+
+```json
+{
+  "type": "incompatible",
+  "reason": "Cannot transfer: your floe is too old for this peer. ...",
+  "pv": 1,
+  "pvMin": 1
+}
+```
+
+The receiver sends this and aborts before creating any file, so the sender fails fast with a clear message instead of waiting for an ack that never arrives. Older senders that predate this message type ignore it safely.
+
+### Protocol versioning
+
+The transfer protocol carries its own version, independent of the floe release version (1.6.x). This lets peers on different releases interoperate, while still detecting a genuine breaking wire-format change cleanly.
+
+- Each peer advertises `pv` (the highest protocol version it speaks) and `pvMin` (the lowest it still supports) in its metadata and ack. Both are 1 today.
+- Two peers are compatible when their ranges overlap: `max(localMin, remoteMin) <= min(localMax, remoteMax)`. They operate at the highest common version.
+- A peer that omits the fields (any release before v1.6.0) is treated as protocol version 1, so all existing peers stay compatible.
+- When the ranges do not overlap, the receiver sends an `incompatible` message and both sides print an actionable message: the older peer is told to run `floe update`, or to ask the other side to update.
+- `ver` is the human release string (for example `v1.6.0`). It is informational only, used for the optional peer-version note, and never gates a transfer.
+
+The constants live in `cli/internal/transfer/protocol.go` (`ProtocolVersion`, `MinProtocolVersion`) and `client/lib/transfer/protocol.ts` (`PROTOCOL_VERSION`, `MIN_PROTOCOL_VERSION`). Bump `ProtocolVersion` only on a breaking wire change; raise `MinProtocolVersion` only when deliberately dropping support for an old wire format.
 
 ### Backpressure
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -54,6 +54,19 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
   <Accordion title="A browser recipient cannot join my CLI transfer">
     A browser can only join by opening the link, not by entering a short code (there is no code field in the web UI). Share the **link** printed by `floe send` with browser recipients, and the **code** with CLI recipients.
   </Accordion>
+
+  <Accordion title="The CLI says the version is incompatible">
+    Peers on different floe versions normally transfer fine, so a small version difference (for example v1.5.4 and v1.5.5) is never a problem. This message only appears if a release changed the transfer protocol in a way the two versions cannot bridge. Whichever side is older should update:
+
+    ```bash
+    floe update              # script / manual installs
+    brew upgrade floe        # Homebrew
+    winget upgrade jannskiee.floe  # Winget
+    scoop update floe        # Scoop
+    ```
+
+    If you are receiving from a browser, refresh the page to load the latest web client. See [Updating](/cli/update).
+  </Accordion>
 </AccordionGroup>
 
 ## Self-hosting


### PR DESCRIPTION
Documents the v1.6.0 protocol version negotiation feature (#100) across the docs site and project files, plus minor alignment cleanup in the code that feature added.

## Docs

- **changelog**: new v1.6.0 entry explaining that different release versions still interoperate, and that a genuine breaking wire change now surfaces a clear "run `floe update`" message instead of a confusing failure.
- **reference/architecture**: the data-channel protocol section is the only doc that specs the wire format, and it was stale. Added `pv`/`pvMin`/`ver` to the metadata and ack examples, documented the new `incompatible` message, and added a **Protocol versioning** subsection (range-overlap rule, legacy-peer handling, where the constants live).
- **troubleshooting**: new CLI accordion for the incompatible-version error.
- **faq**: new "Do both peers need the same version?" entry.
- **cli/update**: new "Version compatibility" note linking to the architecture reference.
- **CLAUDE.md**: short "Transfer Protocol Versioning" note so future work keeps the two implementations in sync.

## Cleanup (no behavior change)

- gofmt alignment in the `receiver.go` ack map literal and the `parseMetadata` struct comment.
- gofmt alignment in the `TestCheckCompat` struct in `transfer_test.go`.

No test files were deleted: every existing test still exercises a live code path, so removing any would only cut coverage.

## Test plan

- `cd cli && go build ./... && go test ./internal/transfer/... -count=1` (pass)
- `go vet ./...` (clean)
- Verified no em dashes in the edited markdown (repo writing-style rule).
- Docs deploy via Mintlify from `main`; no new release tag needed (docs and formatting only).