### PR TITLE
docs: enable light/dark appearance toggle

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -20,7 +20,7 @@
   },
   "appearance": {
     "default": "dark",
-    "strict": true
+    "strict": false
   },
   "seo": {
     "metatags": {


### PR DESCRIPTION
## What

Enables the light/dark mode toggle button in the docs navbar (docs.floe.one).

## Why

`appearance.strict` was set to `true` in `docs/docs.json`, which locks Mintlify to a single theme and hides the theme toggle entirely. That's why there was no dark/light button. Setting it to `false` (Mintlify's default) restores the sun/moon toggle in the top-right navbar cluster, next to the `floe.one` and `jannskiee/floe` links.

## Details

- Default theme stays `dark`.
- Light/dark logo variants (`/logo/light.svg`, `/logo/dark.svg`) and both `colors.light` / `colors.dark` are already defined, so light mode renders correctly. Safe and deployable.
- Mintlify positions the toggle automatically in the top navbar; there is no per-side placement option.

## Change

```diff
 "appearance": {
   "default": "dark",
-  "strict": true
+  "strict": false
 },
```