### PR TITLE
feat: global transfer counter with rolling-number animation

### DIFF
--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -298,7 +298,7 @@ func runReceive(cmd *cobra.Command, args []string) error {
 	fmt.Println("  Connected")
 
 	// 7. Receive files
-	return transfer.ReceiveFiles(dc, absOutput, flagAutoAccept, version)
+	return transfer.ReceiveFiles(dc, absOutput, flagAutoAccept, version, flagServer)
 }
 
 // ── floe version ─────────────────────────────────────────────────────────────

--- a/cli/internal/transfer/loopback_test.go
+++ b/cli/internal/transfer/loopback_test.go
@@ -99,7 +99,7 @@ func runTransfer(t *testing.T, srcPaths []string) string {
 	recvErr := make(chan error, 1)
 	go func() {
 		dc := <-recvCh
-		recvErr <- ReceiveFiles(dc, outDir, true, "")
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
 	}()
 
 	// Let the receiver register its OnMessage handler before any data is sent.
@@ -182,7 +182,7 @@ func TestLoopbackImmediateReceiverClose(t *testing.T) {
 
 	go func() {
 		dc := <-recvCh
-		err := ReceiveFiles(dc, outDir, true, "")
+		err := ReceiveFiles(dc, outDir, true, "", "")
 		// Close receiver immediately — this is what `defer conn.Close()` does
 		// in `runReceive`. The SCTP teardown races the final SACK to the sender.
 		dc.Close()

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -3,8 +3,10 @@
 package transfer
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,12 +30,30 @@ type FileInfo struct {
 	Ver        string // sender's human release string, e.g. "v1.5.5"
 }
 
+// reportBytesToServer posts the received byte count to the server's stats
+// endpoint after a successful transfer. Fire-and-forget: errors are silently
+// ignored so a network hiccup never affects the transfer outcome.
+func reportBytesToServer(serverURL string, byteCount int64) {
+	if serverURL == "" {
+		return
+	}
+	payload, _ := json.Marshal(map[string]int64{"bytes": byteCount})
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Post(serverURL+"/api/stats/report", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
 // ReceiveFiles handles the full receiving side of the Floe protocol.
 // It blocks until all files are received. Files are written to outputDir.
 // If autoAccept is false, the user is prompted before receiving begins.
 // localVer is the human release string (e.g. "v1.5.5") embedded in the ack
 // for the optional peer-version note; pass "" for dev builds or tests.
-func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, localVer string) error {
+// serverURL is the signaling server base URL used to report transfer stats;
+// pass "" to skip reporting (e.g. in tests).
+func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, localVer string, serverURL string) error {
 	// msgCh collects ALL incoming data channel messages.
 	// We use a channel so the OnMessage callback (goroutine) feeds a sequential loop.
 	msgCh := make(chan webrtc.DataChannelMessage, 256)
@@ -227,6 +247,9 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 						// classify it and ignore it; CLI senders consume it explicitly.
 						receivedMsg, _ := json.Marshal(map[string]string{"type": "received"})
 						dc.Send([]byte(receivedMsg))
+
+						// Report total bytes to the global stats counter.
+						go reportBytesToServer(serverURL, totalReceived)
 
 						// Wait for the sender to close the channel (or a short grace
 						// period) before returning. This keeps our SCTP/DTLS alive

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
-import { Heart } from 'lucide-react';
 import { Navbar } from '@/components/layout/Navbar';
 import { AboutSection } from '@/components/layout/AboutSection';
 import { FAQSection } from '@/components/layout/FAQSection';
+import { Footer } from '@/components/layout/Footer';
+import { GlobalStats } from '@/components/GlobalStats';
 import { P2PTransfer } from '@/components/P2PTransfer';
 import { InAppBrowserGuard } from '@/components/InAppBrowserGuard';
 
@@ -27,50 +26,11 @@ export default function Home() {
             <InAppBrowserGuard>
                 <P2PTransfer />
             </InAppBrowserGuard>
+            <GlobalStats />
             <AboutSection />
             <FAQSection />
 
-            <footer className="mt-24 mb-12 w-full max-w-md flex flex-col items-center space-y-6 border-t border-white/5 pt-8">
-                <div className="flex items-center gap-6">
-                    <a
-                        href="https://github.com/jannskiee/floe"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex items-center gap-2 text-sm text-zinc-400 hover:text-white transition-colors"
-                    >
-                        <Image
-                            src="/github-mark-white.png"
-                            alt="GitHub"
-                            width={16}
-                            height={16}
-                            className="opacity-80 hover:opacity-100 transition-opacity"
-                        />
-                        <span className="font-medium">Open Source</span>
-                    </a>
-                    <a
-                        href="https://ko-fi.com/jannskiee"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex items-center gap-2 text-sm text-zinc-400 hover:text-[#FF5E5B] transition-colors"
-                    >
-                        <Heart className="h-4 w-4" />
-                        <span className="font-medium">Support on Ko-fi</span>
-                    </a>
-                </div>
-                <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[10px] text-zinc-500 uppercase tracking-wide">
-                    <Link href="/how-it-works" className="whitespace-nowrap hover:text-white transition-colors">How It Works</Link>
-                    <span>•</span>
-                    <a href="https://docs.floe.one" target="_blank" rel="noreferrer" className="whitespace-nowrap hover:text-white transition-colors">Docs</a>
-                    <span>•</span>
-                    <Link href="/privacy" className="whitespace-nowrap hover:text-white transition-colors">Privacy Policy</Link>
-                    <span>•</span>
-                    <Link href="/terms" className="whitespace-nowrap hover:text-white transition-colors">Terms of Use</Link>
-                </div>
-                <p className="text-xs text-zinc-600 text-center">
-                    &copy; {new Date().getFullYear()} Floe. Built with Next.js,
-                    WebRTC, and Socket.io.
-                </p>
-            </footer>
+            <Footer />
         </div>
     );
 }

--- a/client/components/GlobalStats.tsx
+++ b/client/components/GlobalStats.tsx
@@ -39,29 +39,23 @@ export function GlobalStats() {
         };
     }, []);
 
+    // Render at 0 until loaded so NumberFlow rolls up from 0 on every refresh
+    // (it only animates on value *changes* after mount, not on its first paint).
     const { value, unit } = splitBytes(totalBytes ?? 0);
 
     return (
-        <div className="mt-6 mb-2 w-full max-w-sm mx-auto">
-            <div className="flex flex-col items-center gap-2 px-6 py-4 rounded-2xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm">
-                <p className="text-[10px] text-zinc-600 uppercase tracking-[0.2em] font-medium select-none">
-                    Transferred globally
-                </p>
-                {totalBytes === null ? (
-                    <div className="h-8 w-40 rounded-lg bg-white/5 animate-pulse" />
-                ) : (
-                    <NumberFlow
-                        value={value}
-                        format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
-                        suffix={' ' + unit}
-                        plugins={[continuous]}
-                        className="text-[1.75rem] leading-none font-mono font-semibold text-white tracking-tight tabular-nums"
-                    />
-                )}
-                <p className="text-[10px] text-zinc-700 select-none">
-                    across all users, all time
-                </p>
-            </div>
+        <div className="mt-6 mb-2 flex items-center justify-center gap-2 text-sm select-none">
+            <NumberFlow
+                value={value}
+                format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+                suffix={' ' + unit}
+                plugins={[continuous]}
+                spinTiming={{ duration: 900, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
+                transformTiming={{ duration: 750, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
+                opacityTiming={{ duration: 350, easing: 'ease-out' }}
+                className="font-mono font-medium text-zinc-300 tabular-nums"
+            />
+            <span className="text-zinc-600">transferred globally</span>
         </div>
     );
 }

--- a/client/components/GlobalStats.tsx
+++ b/client/components/GlobalStats.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import NumberFlow, { continuous } from '@number-flow/react';
+import { splitBytes } from '@/lib/utils';
+
+export function GlobalStats() {
+    const [totalBytes, setTotalBytes] = useState<number | null>(null);
+
+    useEffect(() => {
+        const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+
+        const fetchStats = async () => {
+            try {
+                const res = await fetch(`${socketUrl}/api/stats`);
+                if (!res.ok) return;
+                const { totalBytes: raw } = await res.json();
+                const n = Number(raw) || 0;
+                setTotalBytes((prev) => (prev === null ? n : Math.max(prev, n)));
+            } catch {
+                // Server unreachable — keep current display
+            }
+        };
+
+        fetchStats();
+        const interval = setInterval(fetchStats, 10_000);
+
+        const handleBytesReported = (e: Event) => {
+            const bytes = (e as CustomEvent<{ bytes: number }>).detail?.bytes;
+            if (typeof bytes === 'number' && bytes > 0) {
+                setTotalBytes((prev) => (prev ?? 0) + bytes);
+            }
+        };
+        window.addEventListener('floe:bytes-reported', handleBytesReported);
+
+        return () => {
+            clearInterval(interval);
+            window.removeEventListener('floe:bytes-reported', handleBytesReported);
+        };
+    }, []);
+
+    const { value, unit } = splitBytes(totalBytes ?? 0);
+
+    return (
+        <div className="mt-6 mb-2 w-full max-w-sm mx-auto">
+            <div className="flex flex-col items-center gap-2 px-6 py-4 rounded-2xl border border-white/[0.06] bg-white/[0.02] backdrop-blur-sm">
+                <p className="text-[10px] text-zinc-600 uppercase tracking-[0.2em] font-medium select-none">
+                    Transferred globally
+                </p>
+                {totalBytes === null ? (
+                    <div className="h-8 w-40 rounded-lg bg-white/5 animate-pulse" />
+                ) : (
+                    <NumberFlow
+                        value={value}
+                        format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
+                        suffix={' ' + unit}
+                        plugins={[continuous]}
+                        className="text-[1.75rem] leading-none font-mono font-semibold text-white tracking-tight tabular-nums"
+                    />
+                )}
+                <p className="text-[10px] text-zinc-700 select-none">
+                    across all users, all time
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -463,6 +463,17 @@ export function P2PTransfer() {
                         connection: connectionType ?? 'unknown',
                         role: 'receiver',
                     });
+                    // Report bytes to global counter — fire-and-forget
+                    const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+                    fetch(`${socketUrl}/api/stats/report`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ bytes: file.fileSize }),
+                    }).catch(() => {});
+                    // Optimistic local bump for instant footer animation
+                    window.dispatchEvent(
+                        new CustomEvent('floe:bytes-reported', { detail: { bytes: file.fileSize } })
+                    );
                 }
             },
             onWaiting: () => setStatus('File received. Waiting for next file'),

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Heart } from 'lucide-react';
+
+export function Footer() {
+    return (
+        <footer className="mt-24 mb-12 w-full max-w-md flex flex-col items-center space-y-6 border-t border-white/5 pt-8">
+            <div className="flex items-center gap-6">
+                <a
+                    href="https://github.com/jannskiee/floe"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-2 text-sm text-zinc-400 hover:text-white transition-colors"
+                >
+                    <Image
+                        src="/github-mark-white.png"
+                        alt="GitHub"
+                        width={16}
+                        height={16}
+                        className="opacity-80 hover:opacity-100 transition-opacity"
+                    />
+                    <span className="font-medium">Open Source</span>
+                </a>
+                <a
+                    href="https://ko-fi.com/jannskiee"
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex items-center gap-2 text-sm text-zinc-400 hover:text-[#FF5E5B] transition-colors"
+                >
+                    <Heart className="h-4 w-4" />
+                    <span className="font-medium">Support on Ko-fi</span>
+                </a>
+            </div>
+            <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[10px] text-zinc-500 uppercase tracking-wide">
+                <Link href="/how-it-works" className="whitespace-nowrap hover:text-white transition-colors">How It Works</Link>
+                <span>•</span>
+                <a href="https://docs.floe.one" target="_blank" rel="noreferrer" className="whitespace-nowrap hover:text-white transition-colors">Docs</a>
+                <span>•</span>
+                <Link href="/privacy" className="whitespace-nowrap hover:text-white transition-colors">Privacy Policy</Link>
+                <span>•</span>
+                <Link href="/terms" className="whitespace-nowrap hover:text-white transition-colors">Terms of Use</Link>
+            </div>
+            <p className="text-xs text-zinc-600 text-center">
+                &copy; {new Date().getFullYear()} Floe. Built with Next.js,
+                WebRTC, and Socket.io.
+            </p>
+        </footer>
+    );
+}

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -12,3 +12,16 @@ export const formatBytes = (bytes: number) => {
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 };
+
+// splitBytes returns the numeric value and unit separately so NumberFlow can
+// animate the number while keeping the unit stable as a suffix.
+export const splitBytes = (bytes: number): { value: number; unit: string } => {
+    if (bytes === 0) return { value: 0, unit: 'Bytes' };
+    const k = 1024;
+    const units = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), units.length - 1);
+    return {
+        value: parseFloat((bytes / Math.pow(k, i)).toFixed(2)),
+        unit: units[i],
+    };
+};

--- a/client/next-env.d.ts
+++ b/client/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@number-flow/react": "^0.6.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
@@ -34,7 +35,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
-    "vitest": "^3.2.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
@@ -45,6 +45,7 @@
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.0"
   }
 }

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
 
   .:
     dependencies:
+      '@number-flow/react':
+        specifier: ^0.6.0
+        version: 0.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -664,6 +667,12 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@number-flow/react@0.6.0':
+    resolution: {integrity: sha512-77Yfc9+zkV2UDSP8phhZzxJGuwxi/Tt1TikmipL+1r3e9GFKEYDZ1XwInj67NoSt3OnOB0KLvvcl3lfPZgBHVQ==}
+    peerDependencies:
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
 
   '@opentelemetry/api-logs@0.214.0':
     resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
@@ -2073,6 +2082,9 @@ packages:
       jiti:
         optional: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2693,6 +2705,9 @@ packages:
   node-releases@2.0.47:
     resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
     engines: {node: '>=18'}
+
+  number-flow@0.6.0:
+    resolution: {integrity: sha512-K8flNq2Wqus53vjp/btVo3qXFkagF8dIdYavreBfE7hlvFFG/b1HMGEH6nZL+mlrJ+4lbLP9OmPv3t2rmRkpSQ==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -3816,6 +3831,13 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@number-flow/react@0.6.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      esm-env: 1.2.2
+      number-flow: 0.6.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@opentelemetry/api-logs@0.214.0':
     dependencies:
@@ -5315,6 +5337,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   espree@10.4.0:
     dependencies:
       acorn: 8.17.0
@@ -5882,6 +5906,10 @@ snapshots:
       whatwg-url: 5.0.0
 
   node-releases@2.0.47: {}
+
+  number-flow@0.6.0:
+    dependencies:
+      esm-env: 1.2.2
 
   object-assign@4.1.1: {}
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -20,3 +20,13 @@ MAX_CONNECTIONS_PER_IP=30
 # Direct connections still work on most home and mobile networks.
 TURN_SECRET=
 TURN_DOMAIN=
+
+# Upstash Redis — global transfer stats counter (durable across redeploys)
+# Create a free database at https://console.upstash.com and copy the REST URL + token.
+# If omitted, the counter resets to 0 on every server restart (in-memory only).
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# Max bytes accepted in a single /api/stats/report request (default: 5 TB).
+# Rejects implausibly large single-transfer reports.
+MAX_REPORT_BYTES=

--- a/server/server.js
+++ b/server/server.js
@@ -70,6 +70,11 @@ const turnRateLimits = new Map();
 const TURN_RATE_WINDOW = 60000;
 const TURN_MAX_REQUESTS = 20;
 
+const statsRateLimits = new Map();
+const STATS_RATE_WINDOW = 60000;
+const STATS_MAX_REPORTS = 60; // per IP per minute
+const MAX_REPORT_BYTES = parseInt(process.env.MAX_REPORT_BYTES || '', 10) || (5 * 1024 * 1024 * 1024 * 1024); // 5 TB
+
 function generateCoturnCredentials() {
     const turnSecret = process.env.TURN_SECRET;
     const turnDomain = process.env.TURN_DOMAIN;
@@ -142,6 +147,76 @@ app.get('/api/code/:code', (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
+// Global stats — Upstash Redis (durable) + fast in-memory read cache
+//
+// GET /api/stats  — served from cachedTotal; zero Redis reads per poll request.
+// POST /api/stats/report — receiver peers report bytes after a completed transfer.
+//   Validates, increments cachedTotal, then fires INCRBY to Upstash (no-await).
+//   Gracefully degrades to in-memory-only when UPSTASH_* env vars are absent.
+// ---------------------------------------------------------------------------
+
+const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL;
+const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+const STATS_KEY = 'floe:bytes_total';
+
+let cachedTotal = 0;
+
+async function upstashPost(command) {
+    if (!UPSTASH_URL || !UPSTASH_TOKEN) return null;
+    try {
+        const resp = await fetch(UPSTASH_URL, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${UPSTASH_TOKEN}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(command),
+        });
+        if (!resp.ok) return null;
+        const { result } = await resp.json();
+        return result;
+    } catch {
+        return null;
+    }
+}
+
+async function initStats() {
+    const val = await upstashPost(['GET', STATS_KEY]);
+    if (val !== null) cachedTotal = Number(val) || 0;
+}
+
+function validateReportBytes(bytes, maxBytes) {
+    return Number.isInteger(bytes) && bytes > 0 && bytes <= maxBytes;
+}
+
+app.get('/api/stats', (_req, res) => {
+    res.json({ totalBytes: cachedTotal });
+});
+
+app.post('/api/stats/report', (req, res) => {
+    const ip = req.ip;
+    const now = Date.now();
+
+    if (!statsRateLimits.has(ip)) statsRateLimits.set(ip, []);
+    const timestamps = statsRateLimits.get(ip).filter(t => now - t < STATS_RATE_WINDOW);
+    if (timestamps.length >= STATS_MAX_REPORTS) {
+        return res.status(429).json({ error: 'Too many reports' });
+    }
+    timestamps.push(now);
+    statsRateLimits.set(ip, timestamps);
+
+    const { bytes } = req.body || {};
+    if (!validateReportBytes(bytes, MAX_REPORT_BYTES)) {
+        return res.status(400).json({ error: 'Invalid byte count' });
+    }
+
+    cachedTotal += bytes;
+    upstashPost(['INCRBY', STATS_KEY, bytes]);
+
+    res.json({ totalBytes: cachedTotal });
+});
+
+// ---------------------------------------------------------------------------
 // Rate limiting (Socket.IO connections + WebSocket connections share this map)
 // ---------------------------------------------------------------------------
 
@@ -175,6 +250,11 @@ const cleanupInterval = setInterval(() => {
         const valid = timestamps.filter(t => now - t < TURN_RATE_WINDOW);
         if (valid.length === 0) turnRateLimits.delete(ip);
         else turnRateLimits.set(ip, valid);
+    }
+    for (const [ip, timestamps] of statsRateLimits.entries()) {
+        const valid = timestamps.filter(t => now - t < STATS_RATE_WINDOW);
+        if (valid.length === 0) statsRateLimits.delete(ip);
+        else statsRateLimits.set(ip, valid);
     }
     for (const [code, entry] of codeToRoom.entries()) {
         if (now > entry.expires) codeToRoom.delete(code);
@@ -447,6 +527,7 @@ function shutdown() {
 
 if (require.main === module) {
     server.listen(PORT);
+    initStats().catch(() => {}); // seed cachedTotal from Redis on startup
     process.on('SIGTERM', shutdown);
     process.on('SIGINT', shutdown);
 }
@@ -463,4 +544,6 @@ module.exports = {
     codeToRoom,
     connectionCounts,
     turnRateLimits,
+    validateReportBytes,
+    statsRateLimits,
 };

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -17,6 +17,8 @@ const {
     rooms,
     codeToRoom,
     connectionCounts,
+    validateReportBytes,
+    statsRateLimits,
 } = require('./server');
 
 // ---------------------------------------------------------------------------
@@ -274,6 +276,56 @@ describe('handleDisconnect', () => {
         const p = makePeer('lone');
         handleDisconnect(p); // should not throw
         assert.equal(p.msgs.length, 0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Stats reporting — validateReportBytes
+// ---------------------------------------------------------------------------
+
+describe('validateReportBytes', () => {
+    const MAX = 5 * 1024 ** 4; // 5 TB
+
+    it('accepts a valid byte count', () => {
+        assert.equal(validateReportBytes(1024, MAX), true);
+    });
+
+    it('accepts exactly the maximum', () => {
+        assert.equal(validateReportBytes(MAX, MAX), true);
+    });
+
+    it('rejects zero', () => {
+        assert.equal(validateReportBytes(0, MAX), false);
+    });
+
+    it('rejects a negative number', () => {
+        assert.equal(validateReportBytes(-1, MAX), false);
+    });
+
+    it('rejects a float', () => {
+        assert.equal(validateReportBytes(1.5, MAX), false);
+    });
+
+    it('rejects a value above the cap', () => {
+        assert.equal(validateReportBytes(MAX + 1, MAX), false);
+    });
+
+    it('rejects non-numeric input', () => {
+        assert.equal(validateReportBytes('1000', MAX), false);
+        assert.equal(validateReportBytes(null, MAX), false);
+        assert.equal(validateReportBytes(undefined, MAX), false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Stats rate limiter cleanup
+// ---------------------------------------------------------------------------
+
+describe('statsRateLimits', () => {
+    beforeEach(() => { statsRateLimits.clear(); });
+
+    it('is exported and starts empty', () => {
+        assert.equal(statsRateLimits.size, 0);
     });
 });
 


### PR DESCRIPTION
## Summary

Adds a public, all-time **global counter** of bytes transferred across all Floe users, shown on the homepage between the transfer card and the features section, rendered as a single clean line with a smooth NumberFlow odometer roll.

Floe is P2P (file bytes never reach the server), so the **receiving** peer reports the byte count out-of-band over HTTP. Each transfer is counted exactly once (only the receiver reports, never the sender). The data-channel transfer protocol is unchanged, so no `ProtocolVersion` bump.

## Changes

**Server (`server/server.js`)**
- `GET /api/stats` returns `{ totalBytes }` from an in-memory cache (zero Redis reads per poll).
- `POST /api/stats/report` validates `{ bytes }` (positive integer, capped by `MAX_REPORT_BYTES`), increments the cache, and persists to Upstash Redis via `INCRBY` over REST. Per-IP rate limit (60/min) reusing the existing windowed-Map pattern.
- Durable across redeploys via Upstash; degrades gracefully to in-memory if the env vars are unset (no Upstash needed for local dev).
- New env: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `MAX_REPORT_BYTES`.

**Client**
- New `GlobalStats` component: polls `/api/stats` every 10s, plus an optimistic bump on the user's own transfer via a `floe:bytes-reported` CustomEvent. Single centered line, mounts at 0 so the count-up animation plays on load.
- `splitBytes` util in `lib/utils.ts` splits raw bytes into `{ value, unit }` so only the number rolls and the unit is a stable suffix.
- `P2PTransfer` receiver path reports `file.fileSize` on completion.

**CLI (`cli/internal/transfer/receiver.go`)**
- Receiver POSTs `totalReceived` to `/api/stats/report` (fire-and-forget, errors ignored so stats never break a transfer). Sender does not report.

## Tests
- `validateReportBytes` unit suite + rate-limit export test in `server.test.js` (all server tests pass).
- `go test ./...` passes; CLI loopback tests updated for the new `ReceiveFiles` signature.
- `pnpm build` passes.

## Notes
- Best-effort vanity metric with lightweight guardrails (rate limit + per-report cap); not tamper-proof by design.
- Server side is already live on the droplet; merging this deploys the client UI via Vercel.