### PR TITLE
docs: document the global transfer counter feature

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -31,3 +31,12 @@ MAX_CONNECTIONS_PER_IP=30
 # coturn/turnserver.conf. See SELF_HOSTING.md.
 TURN_SECRET=
 TURN_DOMAIN=
+
+# --- Optional global transfer counter ---------------------------------------
+# Durable storage for the public "bytes transferred" counter on the homepage.
+# Create a free Redis database at https://console.upstash.com and paste its REST
+# URL + token. Leave both empty to run the counter in memory only (it resets to 0
+# on every restart). MAX_REPORT_BYTES caps a single report (default 5 TB).
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+MAX_REPORT_BYTES=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,11 @@ The CLI uses GoReleaser for cross-platform distribution; version is injected via
 ```
 CLIENT_URL=http://localhost:3000
 PORT=3001
-TURN_SECRET=       # optional Coturn HMAC secret
-TURN_DOMAIN=       # optional TURN server hostname
+TURN_SECRET=                 # optional Coturn HMAC secret
+TURN_DOMAIN=                 # optional TURN server hostname
+UPSTASH_REDIS_REST_URL=      # optional, durable global stats counter
+UPSTASH_REDIS_REST_TOKEN=    # optional, pairs with the URL above
+MAX_REPORT_BYTES=            # optional, per-report cap (default 5 TB)
 ```
 
 **Client** - copy `client/.env.example` to `client/.env.local`:
@@ -75,8 +78,15 @@ The data-channel transfer protocol carries its own version, independent of the r
 ### TURN Credentials
 `GET /api/turn-credentials` issues short-lived (24h) Coturn HMAC-SHA1 credentials. Called by both client and CLI before connecting. If `TURN_SECRET` is unset, only STUN is returned.
 
+### Global Stats Counter
+A public, all-time counter of total bytes transferred across every Floe user, shown on the homepage (`client/components/GlobalStats.tsx`) with a NumberFlow odometer animation. Because Floe is P2P and file bytes never reach the server, the **receiver** peer reports the byte count out-of-band over HTTP after a completed transfer. Only the receiver reports (browser receiver in `P2PTransfer.tsx`, CLI receiver in `cli/internal/transfer/receiver.go`), so each transfer is counted exactly once. The data-channel protocol is unchanged, so no `ProtocolVersion` bump is needed.
+
+- `GET /api/stats` returns `{ totalBytes }` straight from an in-memory `cachedTotal`, so homepage polling (every 10s) never touches Redis.
+- `POST /api/stats/report` body `{ bytes }`: validates a positive integer `<= MAX_REPORT_BYTES` (`validateReportBytes`), rate-limits per IP (`statsRateLimits`, 60/min), increments `cachedTotal`, then fires `INCRBY floe:bytes_total` to Upstash without awaiting (a Redis hiccup never fails the response).
+- Durability is Upstash Redis over its REST API via native `fetch` (no SDK). `initStats()` seeds `cachedTotal` from Redis on startup. If `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are unset, the counter degrades gracefully to in-memory only (resets to 0 on restart). This is a best-effort vanity metric with lightweight guardrails, not a tamper-proof figure.
+
 ### Rate Limiting
-Two independent per-IP limiters, each over a 60s window, tracked in plain `Map`s and cleaned every 60s. Connection limiter: 30 per IP, shared across Socket.IO and WebSocket connections (`checkRateLimit`). TURN endpoint: a separate 20 requests per IP for `GET /api/turn-credentials` (`turnRateLimits`).
+Three independent per-IP limiters, each over a 60s window, tracked in plain `Map`s and cleaned every 60s. Connection limiter: 30 per IP (configurable via `MAX_CONNECTIONS_PER_IP`), shared across Socket.IO and WebSocket connections (`checkRateLimit`). TURN endpoint: a separate 20 requests per IP for `GET /api/turn-credentials` (`turnRateLimits`). Stats endpoint: a separate 60 reports per IP for `POST /api/stats/report` (`statsRateLimits`).
 
 ### React Strict Mode is intentionally disabled
 `next.config.mjs` sets `reactStrictMode: false`. Strict Mode's double-mount breaks Socket.IO connections and `simple-peer` instances. All socket/peer logic uses refs and cleanup functions to handle component lifecycle correctly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,9 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 | `MAX_CONNECTIONS_PER_IP` | No | Connection rate limit ceiling per IP per 60 seconds (default: `30`). Raise in staging or test environments. |
 | `TURN_SECRET` | No | Shared secret for coturn HMAC credentials. Omit to use STUN-only (direct connections). |
 | `TURN_DOMAIN` | No | Your TURN relay server domain. |
+| `UPSTASH_REDIS_REST_URL` | No | Upstash Redis REST URL for the durable global transfer counter. Omit to run the counter in memory only (resets on restart). |
+| `UPSTASH_REDIS_REST_TOKEN` | No | Upstash Redis REST token, paired with the URL above. |
+| `MAX_REPORT_BYTES` | No | Max bytes accepted per `/api/stats/report` call (default: 5 TB). |
 
 > **Note:** TURN is optional. Without it, only direct connections work. This is fine for local development and most home networks.
 

--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -18,7 +18,7 @@ export default function PrivacyPolicy() {
                     <h1 className="text-4xl font-bold tracking-tight text-white">
                         Privacy Policy
                     </h1>
-                    <p className="text-zinc-400">Last updated: May 2026</p>
+                    <p className="text-zinc-400">Last updated: June 2026</p>
                 </div>
 
                 <div className="p-6 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-4">
@@ -40,8 +40,10 @@ export default function PrivacyPolicy() {
                         </strong>{' '}
                         In direct connections, files never touch our servers. In relay
                         connections, encrypted file data passes through our TURN server
-                        in transit but is never stored or inspected. We do not operate
-                        a database.
+                        in transit but is never stored or inspected. The only thing we
+                        keep is a single anonymous number: the running total of bytes
+                        transferred across all users, shown by the counter on our
+                        homepage.
                     </p>
                 </div>
 
@@ -75,6 +77,15 @@ export default function PrivacyPolicy() {
                                 process filenames and sizes during the signaling
                                 phase to display them to the receiver. This data
                                 is not stored permanently.
+                            </li>
+                            <li>
+                                <strong>Aggregate Transfer Total:</strong> When a
+                                transfer completes, the receiving side reports only
+                                the number of bytes it received. We add this to one
+                                shared, all-time counter of total bytes transferred,
+                                shown on our homepage. We do not store file names,
+                                file contents, individual transfer records, or any
+                                link between this number and you.
                             </li>
                             <li>
                                 <strong>IP Addresses:</strong> Like all web

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.7.0" description="2026-06-22">
+  **Global transfer counter**
+
+  - Added a public, all-time counter of total bytes transferred across every Floe user, shown on the homepage with a rolling-number animation. The number rolls up from zero on each visit and ticks higher as transfers complete worldwide.
+  - The counter is fed without ever touching your files. After a transfer finishes, the receiving side reports only the byte count (never file names or contents). The stored value is a single anonymous total, not linked to any user, transfer, or IP address. See [Security and Privacy](/security-privacy) for the full data-handling note.
+  - Self-hosters can opt in by pointing the server at a free [Upstash Redis](https://upstash.com) database (`UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`). Without it, the counter still works but resets on restart. See [Configuration](/self-hosting/configuration).
+</Update>
+
 <Update label="v1.6.0" description="2026-06-22">
   **Protocol version negotiation**
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -77,7 +77,13 @@ description: "Answers to the most common questions about Floe."
   </Accordion>
 
   <Accordion title="Does Floe collect any data?">
-    The signaling server tracks room IDs and connection metadata only for the duration of the session. No file content, file names, or transfer records are stored. Room state is discarded once both peers disconnect. See [Security and Privacy](/security-privacy) for details.
+    The signaling server tracks room IDs and connection metadata only for the duration of the session. No file content, file names, or transfer records are stored. Room state is discarded once both peers disconnect.
+
+    The one persistent value Floe keeps is a single anonymous total of bytes transferred across all users, shown by the counter on the homepage. It is a plain running number with no file names, no per-transfer records, and no link to you. See [Security and Privacy](/security-privacy) for details.
+  </Accordion>
+
+  <Accordion title="What is the counter on the homepage?">
+    It is a public, all-time total of how many bytes Floe has helped move across all users. When a transfer finishes, the receiving side reports just the size (never the file name or contents), and that size is added to one shared total. The figure is an honest best-effort metric, not an audited count, and reporting it never slows or blocks your transfer.
   </Accordion>
 
   <Accordion title="Is Floe open source?">

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -5,7 +5,7 @@ description: "How Floe brokers the initial connection between two peers."
 
 When you create a transfer in Floe, a unique room is created on the signaling server. The sender shares a code or link. When the recipient joins, the two devices introduce themselves through the server and exchange the information they need to connect directly. Once that handshake is complete, the server steps aside.
 
-The signaling server never touches file data, never stores anything about your transfer, and plays no part once the WebRTC connection is established.
+The signaling server never touches file data, never stores your files or any record of what you send, and plays no part once the WebRTC connection is established. The only thing it keeps is a single anonymous running total of bytes transferred, used for the public counter on the homepage (see below).
 
 ## Connection lifecycle
 
@@ -22,11 +22,13 @@ The signaling server never touches file data, never stores anything about your t
 - Relays WebRTC negotiation messages: the initial offer, the answer, and ICE candidates.
 - Issues short-lived TURN credentials when a TURN server is configured.
 - Registers short human-readable codes (e.g. `olive-tiger-castle`) that map to room IDs.
+- Adds the size of each completed transfer to one anonymous global byte total, for the public homepage counter.
 
 ## What the signaling server never does
 
 - Handle file data of any kind.
-- Store files, transfer content, or logs of what you send or receive.
+- Store files, file names, transfer content, or logs of what you send or receive.
+- Link the byte total to you. The counter is a single shared number with no per-user or per-transfer records.
 - Persist room or peer information after the session ends.
 
 <Accordion title="Technical details">
@@ -44,7 +46,9 @@ The signaling server never touches file data, never stores anything about your t
 
   **TURN credentials:** Issued via `GET /api/turn-credentials`. Credentials use HMAC-SHA1 with a 24-hour expiry. If `TURN_SECRET` is not set, the endpoint returns STUN servers only.
 
-  **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint.
+  **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint; 60 reports per IP per 60 seconds for the stats endpoint.
+
+  **Global stats counter:** After a transfer completes, the receiver sends `POST /api/stats/report` with just the byte count. The server keeps a single anonymous running total (cached in memory, optionally persisted to Upstash Redis) and serves it from `GET /api/stats` for the homepage counter. No file names, contents, or per-transfer records are stored. See the [architecture reference](/reference/architecture#global-statistics-counter) for details.
 
   **Data-channel transfer protocol:** Once the WebRTC data channel opens, the sender runs this sequence for each file:
   1. Sends a JSON `metadata` message with the filename, size in bytes, and the file's index and total count in the batch.

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -34,6 +34,8 @@ The server exposes two transports. Both share the same `rooms` registry (`Map<ro
 | `GET` | `/api/turn-credentials` | Returns ICE server list. With `TURN_SECRET` set, includes coturn credentials. Without it, returns Google STUN servers only. Rate-limited to 20 requests per IP per 60 s. |
 | `POST` | `/api/code` | Registers a short code for a room ID. Body: `{ "roomId": "<uuid>" }`. Response: `{ "code": "word-word-word" }`. TTL: 10 minutes. |
 | `GET` | `/api/code/:code` | Resolves a short code to a room ID. Response: `{ "roomId": "<uuid>" }`. Returns 404 if expired or not found. |
+| `GET` | `/api/stats` | Returns the all-time global transfer counter: `{ "totalBytes": <integer> }`. Served from an in-memory cache (no Redis read per request). |
+| `POST` | `/api/stats/report` | Receiver peers report bytes after a completed transfer. Body: `{ "bytes": <positive integer> }`. Response: `{ "totalBytes": <integer> }`. Rate-limited to 60 requests per IP per 60 s; rejects values that are not positive integers or exceed `MAX_REPORT_BYTES` (default 5 TB). |
 
 ### TURN credentials response
 
@@ -109,6 +111,7 @@ All messages are JSON objects with a `type` field.
 |-------|-------|-----------|
 | Connection rate | 30 per IP per 60 s (configurable via `MAX_CONNECTIONS_PER_IP`) | Socket.IO connections and WebSocket `/ws` connections, shared |
 | TURN credential rate | 20 per IP per 60 s | `GET /api/turn-credentials` |
+| Stats report rate | 60 per IP per 60 s | `POST /api/stats/report` |
 
 Counters are tracked in memory (`Map<ip, timestamp[]>`) and cleaned every 60 seconds.
 
@@ -221,3 +224,16 @@ The four-step sequence (metadata, ack, binary chunks, end) repeats for each file
 ## Room codes
 
 Codes are three random words joined by hyphens (e.g. `olive-tiger-castle`), sampled from a 288-word corpus in `server/words.json`. On collision (extremely rare), a fourth word is appended. Codes expire 10 minutes after registration.
+
+## Global statistics counter
+
+The homepage shows a public, all-time counter of total bytes transferred across every Floe user. Because file data never reaches the server, the counter is fed out-of-band: after a transfer completes, the **receiver** reports the number of bytes it received via `POST /api/stats/report`. Only the receiver reports (the browser receiver and the CLI receiver), so each transfer is counted exactly once. The sender never reports, and the data-channel protocol is unchanged.
+
+The server keeps the running total in two places:
+
+- **In-memory cache (`cachedTotal`).** Every `GET /api/stats` is answered from this value, so homepage polling never incurs a Redis read.
+- **Upstash Redis (durable).** Each accepted report fires an atomic `INCRBY floe:bytes_total` over the Upstash REST API. On startup the server seeds `cachedTotal` from this key, so the total survives restarts and redeploys.
+
+If `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are not configured, the counter runs in memory only and resets to 0 on restart. The endpoint never blocks a transfer: reports are fire-and-forget on the client, and a Redis write failure is swallowed rather than surfaced.
+
+Guardrails are deliberately lightweight. A per-IP rate limit (60 reports per 60 s) and a per-report cap (`MAX_REPORT_BYTES`, default 5 TB) reject abuse and implausible values, but the figure is an honest best-effort metric, not a tamper-proof audited count. The stored value is a single anonymous integer: it carries no file names, no per-transfer records, and no link to any user or IP.

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -16,13 +16,24 @@ It:
 - Relays the WebRTC offer, answer, and ICE candidates that the two devices exchange to establish a connection.
 - Issues short-lived TURN credentials when a TURN server is configured.
 - Registers short codes (e.g. `olive-tiger-castle`) that map to room IDs with a 10-minute TTL.
+- Keeps a single anonymous running total of bytes transferred, for the public counter on the homepage (see [Aggregate statistics](#aggregate-statistics) below).
 
 It never:
 - Receives, stores, or inspects file data.
-- Persist room or peer information after the session ends.
-- Log what you transfer or to whom.
+- Persists room or peer information after the session ends.
+- Logs what you transfer, your file names, or to whom.
 
 Once the WebRTC data channel is established, the signaling server plays no further part.
+
+## Aggregate statistics
+
+Floe's homepage shows a public, all-time counter of total bytes transferred across all users. To feed it, the receiving side reports the number of bytes it received after a transfer completes.
+
+What is recorded: a single cumulative integer (total bytes, the sum across everyone). Nothing else.
+
+What is not recorded: file names, file contents, per-transfer records, who sent or received, or any link to your identity or IP address. The reported figure is just a size, added to one global running total.
+
+The counter is an honest best-effort metric protected by lightweight guardrails (a per-IP rate limit and a per-report size cap). It is not a tamper-proof audited figure, and reporting never blocks or slows a transfer. Self-hosted instances can leave this disabled, in which case nothing is recorded at all.
 
 ## What the TURN relay sees
 

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -17,6 +17,9 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 | `MAX_CONNECTIONS_PER_IP` | server | No | `30` | Maximum new connections allowed per IP per 60-second window, shared across Socket.IO and WebSocket. Raise this in staging or test environments that drive many connections from a single IP. |
 | `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for coturn credentials. If empty, the server returns STUN-only and no TURN is offered. Must match coturn's `static-auth-secret`. |
 | `TURN_DOMAIN` | server | No | _(none)_ | Public hostname of your TURN server (e.g. `turn.your-domain.com`). Must match coturn's `realm`. |
+| `UPSTASH_REDIS_REST_URL` | server | No | _(none)_ | REST URL of an [Upstash Redis](https://upstash.com) database, used to durably persist the global transfer counter shown on the homepage. If empty, the counter runs in memory only and resets to 0 on every restart. |
+| `UPSTASH_REDIS_REST_TOKEN` | server | No | _(none)_ | REST token that pairs with `UPSTASH_REDIS_REST_URL`. Both must be set together for durable stats. |
+| `MAX_REPORT_BYTES` | server | No | `5497558138880` (5 TB) | Maximum bytes accepted in a single `POST /api/stats/report` request. Rejects implausibly large single-transfer reports. |
 
 ## Minimal local configuration
 


### PR DESCRIPTION
## Summary

Documents the new public, all-time **global transfer counter** (shipped in #103) across the technical, self-hosting, and user-facing privacy docs. Formal, detailed, and transparent about exactly what is and is not recorded. No code changes.

## Technical / contributor docs
- **`CLAUDE.md`** — new Global Stats Counter architecture section; Rate Limiting updated to three limiters; Upstash/cap env vars added to the server env block.
- **`docs/reference/architecture.mdx`** — `/api/stats` and `/api/stats/report` added to the endpoints table, a stats rate-limit row, and a dedicated "Global statistics counter" section.
- **`docs/self-hosting/configuration.mdx`**, **`CONTRIBUTING.md`**, **`.env.docker.example`** — `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `MAX_REPORT_BYTES` (default 5 TB) documented.
- **`docs/changelog.mdx`** — v1.7.0 entry.

## Transparency / privacy
- **`docs/security-privacy.mdx`** — corrected the "never logs" list; added an "Aggregate statistics" section.
- **`docs/how-it-works/signaling.mdx`** — counter added to "what it does / never does" plus a technical note.
- **`docs/faq.mdx`** — updated the data-collection answer; added "What is the counter on the homepage?".
- **`client/app/privacy/page.tsx`** — fixed the now-inaccurate "no database" line, added an "Aggregate Transfer Total" disclosure, bumped the date to June 2026.

The recorded value is disclosed everywhere as a single anonymous cumulative integer (total bytes) with no file names, contents, per-transfer records, or link to any user or IP.

## Verification
- Numbers cross-checked against `server/server.js` (5 TB cap, 60/IP/60s stats rate, request/response shapes).
- `pnpm lint` passes (privacy page is the only client change). No em dashes introduced (repo writing style).