### PR TITLE
fix(client): report global counter once per transfer, not per file

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -456,25 +456,32 @@ export function P2PTransfer() {
                     return updated;
                 });
                 transferCompleteRef.current = true;
-                if (typeof window !== 'undefined') {
-                    (window as UmamiWindow).umami?.track('transfer-received', {
-                        files: receivedFilesRef.current.length,
-                        bytes: file.fileSize,
-                        connection: connectionType ?? 'unknown',
-                        role: 'receiver',
-                    });
-                    // Report bytes to global counter — fire-and-forget
-                    const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
-                    fetch(`${socketUrl}/api/stats/report`, {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ bytes: file.fileSize }),
-                    }).catch(() => {});
-                    // Optimistic local bump for instant footer animation
-                    window.dispatchEvent(
-                        new CustomEvent('floe:bytes-reported', { detail: { bytes: file.fileSize } })
-                    );
-                }
+            },
+            onAllComplete: (totalBytes, fileCount) => {
+                // Per-transfer side effects: fire once for the whole transfer (not per
+                // file) so analytics and the global counter stay accurate and the footer
+                // animates a single time. Mirrors the sender's onAllSent.
+                if (typeof window === 'undefined') return;
+                (window as UmamiWindow).umami?.track('transfer-received', {
+                    files: fileCount,
+                    bytes: totalBytes,
+                    connection: connectionType ?? 'unknown',
+                    role: 'receiver',
+                });
+                // Report the transfer's total bytes to the global counter (fire-and-forget).
+                // keepalive lets the report survive if the tab closes right after the
+                // last file lands.
+                const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+                fetch(`${socketUrl}/api/stats/report`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ bytes: totalBytes }),
+                    keepalive: true,
+                }).catch(() => {});
+                // Optimistic local bump for an instant, single footer animation.
+                window.dispatchEvent(
+                    new CustomEvent('floe:bytes-reported', { detail: { bytes: totalBytes } })
+                );
             },
             onWaiting: () => setStatus('File received. Waiting for next file'),
             onError: (msg) => {

--- a/client/lib/transfer/receiver.ts
+++ b/client/lib/transfer/receiver.ts
@@ -25,6 +25,13 @@ export interface ReceiverCallbacks {
     onSpeed?: (bytesPerSec: number, etaSeconds: number) => void;
     onSpeedReset?: () => void;
     onFileComplete?: (file: ReceivedFile, index: number, total: number) => void;
+    /**
+     * Fires exactly once when the final file of a transfer completes (index === total),
+     * carrying the summed bytes and file count for the whole transfer. Use this for
+     * per-transfer side effects (analytics, the global byte counter) so they run once
+     * instead of once per file. Mirrors the sender's `onAllSent`.
+     */
+    onAllComplete?: (totalBytes: number, fileCount: number) => void;
     onWaiting?: () => void;
     onError?: (msg: string) => void;
 }
@@ -59,6 +66,7 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
     let currentMetadata: Metadata | null = null;
     let hasCheckedCompat = false;
     let incompatibleDetected = false;
+    let sessionBytes = 0; // accumulated across all files of the current transfer
 
     let receiveSpeedStart = performance.now();
     let receiveSpeedBytes = 0;
@@ -131,6 +139,15 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
 
                 partialDownloads.delete(currentMetadata.id);
                 cb.onFileComplete?.(completed, currentMetadata.index, currentMetadata.total);
+
+                // Accumulate for the per-transfer callback, then fire once on the
+                // last file so reporting happens a single time per transfer.
+                sessionBytes += fileData.received;
+                if (currentMetadata.index === currentMetadata.total) {
+                    cb.onAllComplete?.(sessionBytes, currentMetadata.total);
+                    sessionBytes = 0; // reset for a possible subsequent transfer
+                }
+
                 cb.onWaiting?.();
                 cb.onProgress?.(0, 0, 0);
                 cb.onSpeedReset?.();

--- a/client/lib/transfer/transfer.test.ts
+++ b/client/lib/transfer/transfer.test.ts
@@ -175,6 +175,56 @@ describe('receiver: stores tight copies of chunk bytes', () => {
     });
 });
 
+describe('receiver: onAllComplete fires once per transfer', () => {
+    // Guards the global-counter fix: per-transfer side effects (stats report,
+    // analytics, optimistic footer bump) must run exactly once with the summed
+    // bytes — never once per file — so multi-file transfers are counted correctly
+    // and are not partially dropped by the server's per-IP report rate limit.
+    function feedFile(
+        rx: { handleMessage: (d: Uint8Array | ArrayBuffer) => void },
+        id: string,
+        size: number,
+        index: number,
+        total: number,
+    ) {
+        rx.handleMessage(enc.encode(metadataMessage(id, `${id}.bin`, size, index, total, 0)));
+        const chunk = new Uint8Array(size);
+        for (let i = 0; i < size; i++) chunk[i] = (i + 1) % 256; // never starts with '{'
+        if (size > 0) rx.handleMessage(chunk);
+        rx.handleMessage(enc.encode(endMessage()));
+    }
+
+    it('fires a single time with the total bytes and file count for a 3-file transfer', () => {
+        const calls: { totalBytes: number; fileCount: number }[] = [];
+        const rx = createReceiver({
+            send: () => { /* ack — ignored */ },
+            onAllComplete: (totalBytes, fileCount) => calls.push({ totalBytes, fileCount }),
+        });
+
+        feedFile(rx, 'a', 100, 1, 3);
+        expect(calls).toHaveLength(0); // not after the first file
+        feedFile(rx, 'b', 200, 2, 3);
+        expect(calls).toHaveLength(0); // not after the second file
+        feedFile(rx, 'c', 300, 3, 3);
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toEqual({ totalBytes: 600, fileCount: 3 });
+    });
+
+    it('fires once for a single-file transfer (index === total === 1)', () => {
+        const calls: { totalBytes: number; fileCount: number }[] = [];
+        const rx = createReceiver({
+            send: () => {},
+            onAllComplete: (totalBytes, fileCount) => calls.push({ totalBytes, fileCount }),
+        });
+
+        feedFile(rx, 'only', 512, 1, 1);
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0]).toEqual({ totalBytes: 512, fileCount: 1 });
+    });
+});
+
 describe('loopback: small binary framing guard', () => {
     it('does not misclassify a 999-byte binary chunk starting with 0x7B ({) as a control message', async () => {
         // Build a file whose first 999 bytes start with '{' — the byteLength guard must


### PR DESCRIPTION
## Problem

On multi-file transfers the global counter badly under-counted. A 1000-file / 450 MB transfer persisted only ~87 MB; the receiver briefly showed 450 MB then dropped to 87 MB on refresh.

**Root cause:** the browser receiver reported bytes **per file** (`onFileComplete`), firing one `POST /api/stats/report` per file. The server rate-limits that endpoint to **60 reports per IP per 60 s**, so ~80% of the 1000 reports got a 429 and were dropped. The 450 MB on screen was only the local optimistic sum (`floe:bytes-reported`), which evaporates on refresh when `GET /api/stats` returns the true persisted value.

## Fix

Make the browser symmetric with the CLI, which already reports `totalReceived` exactly once (`cli/internal/transfer/receiver.go`).

- **`client/lib/transfer/receiver.ts`** — new `onAllComplete(totalBytes, fileCount)` callback. The engine accumulates `sessionBytes` and fires it once when the last file lands (`index === total`), then resets. Mirrors the sender's `onAllSent`.
- **`client/components/P2PTransfer.tsx`** — `onFileComplete` now only builds the download list. The stats report, `transfer-received` analytics, and the optimistic footer bump moved into `onAllComplete`, so they run once per transfer with the true aggregate. The single `fetch` adds `keepalive: true` to survive a tab close right after the last file.
- **`client/lib/transfer/transfer.test.ts`** — regression tests asserting `onAllComplete` fires exactly once with the summed bytes / file count (multi-file and single-file).

## Result

One request and one odometer animation per transfer, no rate-limit drops, accurate persisted total, correct value after refresh. No server or CLI changes needed.

## Verification
- `pnpm test` (58 pass, +2 new), `pnpm lint`, `pnpm build` all green.