### PR TITLE
docs: clarify Upstash counter needs the read+write REST token

### DIFF
--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -18,7 +18,7 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 | `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for coturn credentials. If empty, the server returns STUN-only and no TURN is offered. Must match coturn's `static-auth-secret`. |
 | `TURN_DOMAIN` | server | No | _(none)_ | Public hostname of your TURN server (e.g. `turn.your-domain.com`). Must match coturn's `realm`. |
 | `UPSTASH_REDIS_REST_URL` | server | No | _(none)_ | REST URL of an [Upstash Redis](https://upstash.com) database, used to durably persist the global transfer counter shown on the homepage. If empty, the counter runs in memory only and resets to 0 on every restart. |
-| `UPSTASH_REDIS_REST_TOKEN` | server | No | _(none)_ | REST token that pairs with `UPSTASH_REDIS_REST_URL`. Both must be set together for durable stats. |
+| `UPSTASH_REDIS_REST_TOKEN` | server | No | _(none)_ | REST token that pairs with `UPSTASH_REDIS_REST_URL`. Both must be set together for durable stats. Use the **read+write** token (the default one in the Upstash console), not the read-only token. The server needs write access to increment the counter; with a read-only token, writes are silently rejected and the total never persists. |
 | `MAX_REPORT_BYTES` | server | No | `5497558138880` (5 TB) | Maximum bytes accepted in a single `POST /api/stats/report` request. Rejects implausibly large single-transfer reports. |
 
 ## Minimal local configuration

--- a/server/.env.example
+++ b/server/.env.example
@@ -23,7 +23,10 @@ TURN_DOMAIN=
 
 # Upstash Redis — global transfer stats counter (durable across redeploys)
 # Create a free database at https://console.upstash.com and copy the REST URL + token.
-# If omitted, the counter resets to 0 on every server restart (in-memory only).
+# IMPORTANT: use the read+write REST token (shown as the default token in the console),
+# NOT the read-only token. The server needs write access to INCRBY the counter; with the
+# read-only token, writes are silently rejected and the total never persists.
+# If omitted entirely, the counter resets to 0 on every server restart (in-memory only).
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 


### PR DESCRIPTION
## Why

The read-only Upstash REST token silently breaks the global transfer counter. The server's `INCRBY floe:bytes_total` is rejected with `NOPERM`, and because the code ignores Redis errors by design, the failure is invisible: the total only accumulates in memory and resets to 0 on every server restart. This was hit in production (the configured token was the read-only one).

## Change

Document that the **read+write** Upstash token is required:
- `server/.env.example` — inline comment on `UPSTASH_REDIS_REST_TOKEN`.
- `docs/self-hosting/configuration.mdx` — note in the variables table.

Docs only.