### PR TITLE
feat: add opt-out for global transfer counter (CLI + browser)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,11 +79,17 @@ The data-channel transfer protocol carries its own version, independent of the r
 `GET /api/turn-credentials` issues short-lived (24h) Coturn HMAC-SHA1 credentials. Called by both client and CLI before connecting. If `TURN_SECRET` is unset, only STUN is returned.
 
 ### Global Stats Counter
-A public, all-time counter of total bytes transferred across every Floe user, shown on the homepage (`client/components/GlobalStats.tsx`) with a NumberFlow odometer animation. Because Floe is P2P and file bytes never reach the server, the **receiver** peer reports the byte count out-of-band over HTTP after a completed transfer. Only the receiver reports (browser receiver in `P2PTransfer.tsx`, CLI receiver in `cli/internal/transfer/receiver.go`), so each transfer is counted exactly once. The data-channel protocol is unchanged, so no `ProtocolVersion` bump is needed.
+A public, all-time counter of total bytes transferred across every Floe user, shown on the homepage (`client/components/GlobalStats.tsx`) with a NumberFlow odometer animation. Because Floe is P2P and file bytes never reach the server, the **receiver** peer reports the byte count out-of-band over HTTP after a completed transfer. Only the receiver reports (browser receiver in `P2PTransfer.tsx`, CLI receiver in `cli/internal/transfer/receiver.go`), so each transfer is counted exactly once. The sender never reports. The data-channel protocol is unchanged, so no `ProtocolVersion` bump is needed.
+
+The global total is viewable only in the browser (the `GlobalStats` component on the homepage). The CLI receiver contributes to the counter but never fetches or displays it.
 
 - `GET /api/stats` returns `{ totalBytes }` straight from an in-memory `cachedTotal`, so homepage polling (every 10s) never touches Redis.
 - `POST /api/stats/report` body `{ bytes }`: validates a positive integer `<= MAX_REPORT_BYTES` (`validateReportBytes`), rate-limits per IP (`statsRateLimits`, 60/min), increments `cachedTotal`, then fires `INCRBY floe:bytes_total` to Upstash without awaiting (a Redis hiccup never fails the response).
 - Durability is Upstash Redis over its REST API via native `fetch` (no SDK). `initStats()` seeds `cachedTotal` from Redis on startup. If `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are unset, the counter degrades gracefully to in-memory only (resets to 0 on restart). This is a best-effort vanity metric with lightweight guardrails, not a tamper-proof figure.
+
+**Opt-out:** Both the browser and the CLI receiver support opting out of reporting.
+- Browser: a "Contribute to global stats" toggle on the receiver view (persisted in `localStorage['floe:report-stats']`). When unchecked, neither the `POST /api/stats/report` call nor the optimistic `floe:bytes-reported` event fires.
+- CLI: pass `--no-report` to `floe receive`, or set `FLOE_NO_STATS=1` in the environment. Both gate the report by passing an empty `statsURL` to `ReceiveFiles`, which hits the existing `if serverURL == "" { return }` guard in `reportBytesToServer` (`receiver.go:36-39`). No change to `ReceiveFiles` signature or `receiver.go` logic.
 
 ### Rate Limiting
 Three independent per-IP limiters, each over a 60s window, tracked in plain `Map`s and cleaned every 60s. Connection limiter: 30 per IP (configurable via `MAX_CONNECTIONS_PER_IP`), shared across Socket.IO and WebSocket connections (`checkRateLimit`). TURN endpoint: a separate 20 requests per IP for `GET /api/turn-credentials` (`turnRateLimits`). Stats endpoint: a separate 60 reports per IP for `POST /api/stats/report` (`statsRateLimits`).

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ floe receive olive-tiger-castle
 
 The sender's terminal will display a room code and a browser link. The receiver can join using either the code (CLI) or the link (browser).
 
+After a successful transfer, the receiver reports only the total byte count to Floe's signaling server to power the public "transferred globally" counter on the homepage. No file names or contents are included. The sender never reports. To opt out:
+
+```sh
+floe receive olive-tiger-castle --no-report   # single transfer
+FLOE_NO_STATS=1 floe receive ...              # permanent (add to shell profile)
+```
+
+The global total is visible only in the browser. The CLI contributes to it but never displays it.
+
 For all commands, flags, and advanced usage, see the [documentation](https://docs.floe.one).
 
 ## Self-Hosting

--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -206,13 +206,20 @@ func runSend(cmd *cobra.Command, args []string) error {
 var (
 	flagOutput     string
 	flagAutoAccept bool
+	flagNoReport   bool
 )
 
 var receiveCmd = &cobra.Command{
 	Use:   "receive <code | link>",
 	Short: "Receive files from a peer",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runReceive,
+	Long: `Receive files from a peer using a code or link.
+
+After a successful transfer the receiver posts only the total byte count to
+Floe's signaling server to power the public global-transfer counter. No file
+names, contents, or identities are included. To opt out of this report, use
+--no-report or set FLOE_NO_STATS=1 in your environment.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runReceive,
 }
 
 func init() {
@@ -220,6 +227,8 @@ func init() {
 		"directory to save received files")
 	receiveCmd.Flags().BoolVarP(&flagAutoAccept, "yes", "y", false,
 		"auto-accept incoming files without confirmation")
+	receiveCmd.Flags().BoolVar(&flagNoReport, "no-report", false,
+		"do not report transferred bytes to Floe's public global counter")
 }
 
 func runReceive(cmd *cobra.Command, args []string) error {
@@ -298,7 +307,11 @@ func runReceive(cmd *cobra.Command, args []string) error {
 	fmt.Println("  Connected")
 
 	// 7. Receive files
-	return transfer.ReceiveFiles(dc, absOutput, flagAutoAccept, version, flagServer)
+	statsURL := flagServer
+	if flagNoReport || os.Getenv("FLOE_NO_STATS") == "1" {
+		statsURL = "" // reportBytesToServer no-ops on empty URL
+	}
+	return transfer.ReceiveFiles(dc, absOutput, flagAutoAccept, version, statsURL)
 }
 
 // ── floe version ─────────────────────────────────────────────────────────────

--- a/cli/internal/transfer/transfer_test.go
+++ b/cli/internal/transfer/transfer_test.go
@@ -1,6 +1,10 @@
 package transfer
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -281,4 +285,49 @@ func TestParseMetadataProtocolFields(t *testing.T) {
 	if !ok {
 		t.Error("legacy peer (zero pv fields) must be compatible with current protocol")
 	}
+}
+
+// TestReportBytesToServer verifies the stats report is posted correctly and
+// that passing an empty serverURL skips the request entirely (the opt-out path).
+func TestReportBytesToServer(t *testing.T) {
+	t.Run("posts byte count when URL is set", func(t *testing.T) {
+		var got int64
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/stats/report" || r.Method != http.MethodPost {
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			var payload map[string]int64
+			if err := json.Unmarshal(body, &payload); err != nil {
+				t.Errorf("body is not valid JSON: %v", err)
+			}
+			got = payload["bytes"]
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		reportBytesToServer(srv.URL, 12345)
+
+		if got != 12345 {
+			t.Errorf("reported bytes = %d, want 12345", got)
+		}
+	})
+
+	t.Run("skips request when URL is empty (opt-out)", func(t *testing.T) {
+		called := false
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		// Empty URL is the opt-out signal; the real server URL is irrelevant.
+		reportBytesToServer("", 99999)
+
+		if called {
+			t.Error("reportBytesToServer should not make any request when serverURL is empty")
+		}
+	})
 }

--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -43,7 +43,8 @@ export default function PrivacyPolicy() {
                         in transit but is never stored or inspected. The only thing we
                         keep is a single anonymous number: the running total of bytes
                         transferred across all users, shown by the counter on our
-                        homepage.
+                        homepage. You can opt out of contributing to this counter at
+                        any time.
                     </p>
                 </div>
 
@@ -83,9 +84,16 @@ export default function PrivacyPolicy() {
                                 transfer completes, the receiving side reports only
                                 the number of bytes it received. We add this to one
                                 shared, all-time counter of total bytes transferred,
-                                shown on our homepage. We do not store file names,
-                                file contents, individual transfer records, or any
-                                link between this number and you.
+                                shown on our homepage. The sender never reports.
+                                We do not store file names, file contents, individual
+                                transfer records, or any link between this number and
+                                you. You can opt out of this report: uncheck
+                                &quot;Contribute to global stats&quot; on the receiver
+                                view in the browser, or use{' '}
+                                <code className="text-xs bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-300">--no-report</code>
+                                {' '}(or set{' '}
+                                <code className="text-xs bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-300">FLOE_NO_STATS=1</code>
+                                ) when using the CLI.
                             </li>
                             <li>
                                 <strong>IP Addresses:</strong> Like all web

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -107,6 +107,8 @@ export function P2PTransfer() {
     const [showQr, setShowQr] = useState(false);
     const [showInfoTooltip, setShowInfoTooltip] = useState(false);
     const [relayEnabled, setRelayEnabled] = useState(true);
+    const [reportStatsEnabled, setReportStatsEnabled] = useState(true);
+    const reportStatsEnabledRef = useRef(true);
 
     const RELAY_SIZE_LIMIT = 2 * 1024 * 1024 * 1024; // 2 GB
     const totalBytes = files.reduce((sum, f) => sum + f.file.size, 0);
@@ -164,6 +166,25 @@ export function P2PTransfer() {
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setIsSender(!new URLSearchParams(window.location.search).has('room'));
     }, []);
+
+    useEffect(() => {
+        try {
+            const stored = localStorage.getItem('floe:report-stats');
+            if (stored !== null) {
+                const val = stored !== 'false';
+                // eslint-disable-next-line react-hooks/set-state-in-effect
+                setReportStatsEnabled(val);
+                reportStatsEnabledRef.current = val;
+            }
+        } catch { }
+    }, []);
+
+    useEffect(() => {
+        reportStatsEnabledRef.current = reportStatsEnabled;
+        try {
+            localStorage.setItem('floe:report-stats', String(reportStatsEnabled));
+        } catch { }
+    }, [reportStatsEnabled]);
 
     useEffect(() => {
         const timer = setTimeout(() => {
@@ -470,18 +491,20 @@ export function P2PTransfer() {
                 });
                 // Report the transfer's total bytes to the global counter (fire-and-forget).
                 // keepalive lets the report survive if the tab closes right after the
-                // last file lands.
-                const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
-                fetch(`${socketUrl}/api/stats/report`, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ bytes: totalBytes }),
-                    keepalive: true,
-                }).catch(() => {});
-                // Optimistic local bump for an instant, single footer animation.
-                window.dispatchEvent(
-                    new CustomEvent('floe:bytes-reported', { detail: { bytes: totalBytes } })
-                );
+                // last file lands. Skipped when the user has opted out.
+                if (reportStatsEnabledRef.current) {
+                    const socketUrl = process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001';
+                    fetch(`${socketUrl}/api/stats/report`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ bytes: totalBytes }),
+                        keepalive: true,
+                    }).catch(() => {});
+                    // Optimistic local bump for an instant, single footer animation.
+                    window.dispatchEvent(
+                        new CustomEvent('floe:bytes-reported', { detail: { bytes: totalBytes } })
+                    );
+                }
             },
             onWaiting: () => setStatus('File received. Waiting for next file'),
             onError: (msg) => {
@@ -1335,6 +1358,47 @@ export function P2PTransfer() {
 
                             {!isSender && (
                                 <div className="space-y-3 pt-2">
+                                    {/* Contribute to global stats toggle — visible while waiting, before any file arrives */}
+                                    {receivedFiles.length === 0 && (
+                                        <div className="mb-1 rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
+                                            <label className="flex items-start gap-3 cursor-pointer group/report select-none">
+                                                <div className="relative flex-shrink-0 mt-0.5">
+                                                    <input
+                                                        type="checkbox"
+                                                        checked={reportStatsEnabled}
+                                                        onChange={(e) => setReportStatsEnabled(e.target.checked)}
+                                                        className="sr-only"
+                                                    />
+                                                    <div className={`h-4 w-4 rounded-sm border transition-all duration-150 flex items-center justify-center ${reportStatsEnabled
+                                                            ? 'bg-white border-white'
+                                                            : 'bg-transparent border-zinc-600 group-hover/report:border-zinc-400'
+                                                        }`}>
+                                                        {reportStatsEnabled && (
+                                                            <svg viewBox="0 0 10 8" fill="none" className="h-2.5 w-2.5">
+                                                                <path d="M1 4l2.5 2.5L9 1" stroke="#09090b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                                                            </svg>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                                <div className="space-y-1.5">
+                                                    <p className="text-sm font-medium text-zinc-200 leading-none">Contribute to global stats</p>
+                                                    <p className="text-xs text-zinc-500 leading-relaxed">
+                                                        Adds only this transfer&apos;s byte count to Floe&apos;s public total. File names and contents are never sent.{' '}
+                                                        <a
+                                                            href="/privacy"
+                                                            target="_blank"
+                                                            rel="noreferrer"
+                                                            onClick={(e) => e.stopPropagation()}
+                                                            className="text-zinc-400 hover:text-white underline underline-offset-2 transition-colors"
+                                                        >
+                                                            Learn more
+                                                        </a>
+                                                    </p>
+                                                </div>
+                                            </label>
+                                        </div>
+                                    )}
+
                                     {receivedFiles.length === 0 &&
                                         !status.includes('Receiving') && (
                                             <div className="text-center text-sm text-zinc-500 py-8">

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -4,10 +4,12 @@ description: "Release history for Floe."
 ---
 
 <Update label="v1.7.0" description="2026-06-22">
-  **Global transfer counter**
+  **Global transfer counter with opt-out**
 
   - Added a public, all-time counter of total bytes transferred across every Floe user, shown on the homepage with a rolling-number animation. The number rolls up from zero on each visit and ticks higher as transfers complete worldwide.
-  - The counter is fed without ever touching your files. After a transfer finishes, the receiving side reports only the byte count (never file names or contents). The stored value is a single anonymous total, not linked to any user, transfer, or IP address. See [Security and Privacy](/security-privacy) for the full data-handling note.
+  - The counter is fed without ever touching your files. After a transfer finishes, only the receiving side reports the byte count (never file names or contents). The sender never reports. The stored value is a single anonymous total, not linked to any user, transfer, or IP address. See [Security and Privacy](/security-privacy) for the full data-handling note.
+  - The CLI receiver now contributes to the global counter. The total is viewable only in the browser; the CLI never fetches or displays it.
+  - Both the browser receiver and the CLI receiver support opting out. Browser: uncheck "Contribute to global stats" on the receiver view (saved to your browser). CLI: pass `--no-report` to `floe receive`, or set `FLOE_NO_STATS=1` in your environment for a permanent opt-out. The transfer is unaffected either way.
   - Self-hosters can opt in by pointing the server at a free [Upstash Redis](https://upstash.com) database (`UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`). Without it, the counter still works but resets on restart. See [Configuration](/self-hosting/configuration).
 </Update>
 

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -21,6 +21,26 @@ Specific to the `receive` command.
 |------|-------|---------|-------------|
 | `--output <dir>` | `-o` | `.` | Directory to save received files. Created automatically if it does not exist. |
 | `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
+| `--no-report` | | `false` | Do not report the transferred byte count to Floe's public global counter. See [Opting out of the global counter](#opting-out-of-the-global-counter) below. |
+
+## Opting out of the global counter
+
+After a successful transfer, the **receiver** sends only the total byte count to Floe's signaling server to power the public "transferred globally" counter on the homepage. No file names, contents, or identity are included, and reporting is always fire-and-forget (it never blocks or slows a transfer). The **sender** never reports.
+
+To opt out for a single transfer, pass `--no-report`:
+
+```bash
+floe receive olive-tiger-castle --no-report
+```
+
+To opt out permanently, set `FLOE_NO_STATS=1` in your environment (for example in your shell profile):
+
+```bash
+export FLOE_NO_STATS=1
+floe receive olive-tiger-castle
+```
+
+When opted out, no request is sent to the server and the global counter is not incremented for that transfer. The transfer itself is unaffected.
 
 ## Examples
 

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -83,8 +83,9 @@ Pass `-y` to skip this prompt and accept automatically.
 |------|-------|---------|-------------|
 | `--output` | `-o` | `.` (current directory) | Directory to save received files. Created automatically if it does not exist. |
 | `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
+| `--no-report` | | `false` | Do not report the transferred byte count to Floe's public global counter. Set `FLOE_NO_STATS=1` to opt out permanently. |
 
-See [Flags Reference](/cli/flags) for global flags (`--server`, `--no-relay`).
+See [Flags Reference](/cli/flags) for global flags (`--server`, `--no-relay`) and full opt-out documentation.
 
 ## Notes
 
@@ -92,3 +93,4 @@ See [Flags Reference](/cli/flags) for global flags (`--server`, `--no-relay`).
 - Directory structure is preserved when the sender sends a folder. Files land at the same relative paths inside your output directory.
 - Press `Ctrl+C` to cancel the transfer at any time.
 - Short codes expire 10 minutes after the sender starts the session. After that, only the full link works (and only while the sender is still connected).
+- After the transfer completes, the receiver posts only the total byte count to the signaling server for the public global counter. No file names or contents are included. Use `--no-report` or `FLOE_NO_STATS=1` to skip this. The sender never reports.

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -80,3 +80,4 @@ See [Flags Reference](/cli/flags) for `--server`, `--no-relay`, and `--web`.
 - Press `Ctrl+C` at any time to cancel the transfer and close the session.
 - If the short code cannot be registered (for example, the signaling server is unreachable), Floe prints a warning and continues with the link only.
 - Files are streamed in the order they are listed. For multiple files, progress is shown per file.
+- The sender never reports to the global transfer counter. Only the receiver does. To opt out on the receiving side, the receiver uses `--no-report` or sets `FLOE_NO_STATS=1`.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -84,6 +84,26 @@ description: "Answers to the most common questions about Floe."
 
   <Accordion title="What is the counter on the homepage?">
     It is a public, all-time total of how many bytes Floe has helped move across all users. When a transfer finishes, the receiving side reports just the size (never the file name or contents), and that size is added to one shared total. The figure is an honest best-effort metric, not an audited count, and reporting it never slows or blocks your transfer.
+
+    The counter is viewable only in the browser. The CLI receiver contributes to it but never fetches or displays the total. The sender (browser or CLI) never reports.
+  </Accordion>
+
+  <Accordion title="Can I opt out of the transfer counter?">
+    Yes. The byte-count report is on by default but can be turned off on the receiving side.
+
+    **Browser:** Uncheck "Contribute to global stats" on the receiver view before the transfer completes. The preference is saved in your browser and applies to all future transfers from that device.
+
+    **CLI - single transfer:**
+    ```bash
+    floe receive olive-tiger-castle --no-report
+    ```
+
+    **CLI - permanent (add to your shell profile):**
+    ```bash
+    export FLOE_NO_STATS=1
+    ```
+
+    When opted out, no request is sent to Floe's server and the global counter is not incremented for that transfer. The transfer itself is unaffected.
   </Accordion>
 
   <Accordion title="Is Floe open source?">

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -48,7 +48,7 @@ The signaling server never touches file data, never stores your files or any rec
 
   **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint; 60 reports per IP per 60 seconds for the stats endpoint.
 
-  **Global stats counter:** After a transfer completes, the receiver sends `POST /api/stats/report` with just the byte count. The server keeps a single anonymous running total (cached in memory, optionally persisted to Upstash Redis) and serves it from `GET /api/stats` for the homepage counter. No file names, contents, or per-transfer records are stored. See the [architecture reference](/reference/architecture#global-statistics-counter) for details.
+  **Global stats counter:** After a transfer completes, the receiver sends `POST /api/stats/report` with just the byte count. The sender never reports. The server keeps a single anonymous running total (cached in memory, optionally persisted to Upstash Redis) and serves it from `GET /api/stats` for the homepage counter. No file names, contents, or per-transfer records are stored. The total is viewable only in the browser; the CLI receiver contributes but never displays it. Both the browser receiver and CLI receiver can opt out (browser: "Contribute to global stats" toggle; CLI: `--no-report` flag or `FLOE_NO_STATS=1`). See the [architecture reference](/reference/architecture#global-statistics-counter) for details.
 
   **Data-channel transfer protocol:** Once the WebRTC data channel opens, the sender runs this sequence for each file:
   1. Sends a JSON `metadata` message with the filename, size in bytes, and the file's index and total count in the batch.

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -229,6 +229,8 @@ Codes are three random words joined by hyphens (e.g. `olive-tiger-castle`), samp
 
 The homepage shows a public, all-time counter of total bytes transferred across every Floe user. Because file data never reaches the server, the counter is fed out-of-band: after a transfer completes, the **receiver** reports the number of bytes it received via `POST /api/stats/report`. Only the receiver reports (the browser receiver and the CLI receiver), so each transfer is counted exactly once. The sender never reports, and the data-channel protocol is unchanged.
 
+The global total is **viewable only in the browser** (`GlobalStats.tsx` on the homepage, polling `GET /api/stats` every 10 seconds). The CLI receiver contributes to the counter but never fetches or displays it.
+
 The server keeps the running total in two places:
 
 - **In-memory cache (`cachedTotal`).** Every `GET /api/stats` is answered from this value, so homepage polling never incurs a Redis read.
@@ -237,3 +239,8 @@ The server keeps the running total in two places:
 If `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are not configured, the counter runs in memory only and resets to 0 on restart. The endpoint never blocks a transfer: reports are fire-and-forget on the client, and a Redis write failure is swallowed rather than surfaced.
 
 Guardrails are deliberately lightweight. A per-IP rate limit (60 reports per 60 s) and a per-report cap (`MAX_REPORT_BYTES`, default 5 TB) reject abuse and implausible values, but the figure is an honest best-effort metric, not a tamper-proof audited count. The stored value is a single anonymous integer: it carries no file names, no per-transfer records, and no link to any user or IP.
+
+**Opt-out:** Both clients support opting out of the byte-count report. The opt-out is enforced on the receiver side before the HTTP request is made; the server has no role in it.
+
+- Browser: a "Contribute to global stats" toggle on the receiver view, persisted in `localStorage['floe:report-stats']`. When unchecked, the `fetch` to `/api/stats/report` and the optimistic `floe:bytes-reported` event are both skipped.
+- CLI: `--no-report` flag on `floe receive`, or `FLOE_NO_STATS=1` environment variable. Both gate the report by passing an empty `statsURL` into `ReceiveFiles`, which hits the existing `if serverURL == "" { return }` guard in `reportBytesToServer`.

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -27,13 +27,18 @@ Once the WebRTC data channel is established, the signaling server plays no furth
 
 ## Aggregate statistics
 
-Floe's homepage shows a public, all-time counter of total bytes transferred across all users. To feed it, the receiving side reports the number of bytes it received after a transfer completes.
+Floe's homepage shows a public, all-time counter of total bytes transferred across all users. To feed it, the receiving side reports the number of bytes it received after a transfer completes. The sender never reports. The global total is shown only in the browser; the CLI receiver contributes to it but never fetches or displays it.
 
 What is recorded: a single cumulative integer (total bytes, the sum across everyone). Nothing else.
 
 What is not recorded: file names, file contents, per-transfer records, who sent or received, or any link to your identity or IP address. The reported figure is just a size, added to one global running total.
 
 The counter is an honest best-effort metric protected by lightweight guardrails (a per-IP rate limit and a per-report size cap). It is not a tamper-proof audited figure, and reporting never blocks or slows a transfer. Self-hosted instances can leave this disabled, in which case nothing is recorded at all.
+
+**Opting out:** Both the browser receiver and the CLI receiver support opting out.
+
+- Browser: uncheck "Contribute to global stats" on the receiver view before the transfer completes. The preference is saved in your browser and applies to all future transfers from that device.
+- CLI: pass `--no-report` to `floe receive` for a single transfer, or set `FLOE_NO_STATS=1` in your environment to opt out permanently. When opted out, no request is made to the server and the counter is not incremented.
 
 ## What the TURN relay sees
 


### PR DESCRIPTION
## Summary

- **CLI opt-out:** `--no-report` flag on `floe receive` and `FLOE_NO_STATS=1` env var. Both pass an empty `statsURL` into `ReceiveFiles`, hitting the existing `if serverURL == "" { return }` guard in `reportBytesToServer` -- no change to `ReceiveFiles` signature or `receiver.go` logic.
- **Browser opt-out:** a "Contribute to global stats" toggle on the receiver view, styled identically to the relay fallback choicebox card. Persisted in `localStorage['floe:report-stats']`. Both the `POST /api/stats/report` call and the optimistic `floe:bytes-reported` event are gated via a ref so the `onAllComplete` callback always reads the latest toggle value.
- **CLI display boundary:** the CLI receiver contributes to the counter but never fetches or displays the global total. The sender (browser or CLI) never reports. This was already true and is now explicitly documented.
- **Test:** added `TestReportBytesToServer` using `httptest` -- covers the normal POST path and the empty-URL opt-out no-op path.
- **Docs:** changelog (v1.7.0 updated), flags reference (new `--no-report` section), `receive.mdx`, `send.mdx`, FAQ (new opt-out Q&A), `security-privacy.mdx`, `architecture.mdx`, `signaling.mdx`, privacy page (`client/app/privacy/page.tsx`), README, and CLAUDE.md.

## Behaviour

| Scenario | Reports? |
|---|---|
| Browser receiver, toggle ON (default) | Yes |
| Browser receiver, toggle OFF | No |
| CLI receiver, no flags | Yes (from v1.7.0) |
| CLI receiver, `--no-report` | No |
| CLI receiver, `FLOE_NO_STATS=1` | No |
| Any sender (browser or CLI) | Never |

## Test plan

- [x] `cd cli && go build ./cmd/floe` -- compiles clean
- [x] `cd cli && go test ./...` -- all pass including new `TestReportBytesToServer`
- [x] `cd client && npm run lint` -- no errors
- [x] `cd client && npm run build` -- builds clean, all 9 pages static
- [ ] Manual browser: open receiver view, confirm toggle appears, toggle off, complete a transfer, verify no `POST /api/stats/report` in Network tab and footer counter does not bump; toggle on and verify it does
- [ ] Manual CLI: `floe receive <code> --no-report` and `FLOE_NO_STATS=1 floe receive <code>` -- verify `GET /api/stats` total is unchanged after transfer

## Release

This PR contains the first tagged release of CLI receiver reporting. After merge, tag `v1.7.0` to trigger GoReleaser and publish cross-platform binaries + homebrew-tap/scoop-bucket/winget packages.