### PR TITLE
fix(cli): ensure stats report completes before program exits

### DIFF
--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -248,9 +248,6 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 						receivedMsg, _ := json.Marshal(map[string]string{"type": "received"})
 						dc.Send([]byte(receivedMsg))
 
-						// Report total bytes to the global stats counter.
-						go reportBytesToServer(serverURL, totalReceived)
-
 						// Wait for the sender to close the channel (or a short grace
 						// period) before returning. This keeps our SCTP/DTLS alive
 						// long enough for the "received" SACK to reach the sender —
@@ -259,6 +256,12 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 						case <-done:
 						case <-time.After(5 * time.Second):
 						}
+
+						// Report total bytes to the global stats counter. Called
+						// synchronously AFTER the grace wait so the program does not
+						// exit before the HTTP POST completes. reportBytesToServer
+						// has its own 5 s timeout and is fire-and-forget on error.
+						reportBytesToServer(serverURL, totalReceived)
 						return nil
 					}
 				}


### PR DESCRIPTION
## Root cause

`reportBytesToServer` was launched as a goroutine *before* the grace-period `select` in `receiver.go`. The race:

1. Receiver sends `"received"` to the CLI sender
2. `go reportBytesToServer(...)` starts — begins HTTP POST to `api.floe.one`
3. CLI sender immediately calls `dc.Close()` on receiving `"received"`
4. `done` fires, `select` returns instantly
5. `ReceiveFiles` returns, `runReceive` returns, program exits
6. Goroutine is killed mid-HTTP-request — report never lands

This is why 400 MB occasionally worked (lucky timing) but 4.66 GB never did — the channel closes faster once the final SCTP ACKs flush on large transfers.

## Fix

Move `reportBytesToServer` to after the grace-period `select`, called synchronously. It has its own 5s HTTP timeout so it cannot hang indefinitely.

```go
// before (race)
go reportBytesToServer(serverURL, totalReceived)
select { case <-done: case <-time.After(5 * time.Second): }
return nil

// after (correct)
select { case <-done: case <-time.After(5 * time.Second): }
reportBytesToServer(serverURL, totalReceived)
return nil
```

## Test plan

- [x] `go build ./cmd/floe` -- compiles clean
- [x] `go test ./...` -- all pass
- [ ] CLI-to-CLI transfer of 4+ GB -- counter should increment reliably after `floe update`