### PR TITLE
docs: document receiver stats toggle and add v1.7.1 changelog entry

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,14 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.7.1" description="2026-06-22">
+  **Reliable global-counter reporting for the CLI**
+
+  - Fixed CLI transfers not always being counted in the global homepage counter. The receiver's byte-count report was sent in the background and could be cut short when the sender closed the connection and the process exited, so larger transfers (several GB and up) were frequently missed and smaller ones counted only intermittently.
+  - The report now completes before the program exits, so a successful CLI transfer of any size contributes exactly once. The report still carries only the byte count (never file names or contents), still never blocks or slows the transfer, and opting out with `--no-report` or `FLOE_NO_STATS=1` is unaffected.
+  - Browser transfers were never affected by this issue.
+</Update>
+
 <Update label="v1.7.0" description="2026-06-22">
   **Global transfer counter with opt-out**
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -28,6 +28,10 @@ description: "Send your first file in under a minute."
 </Tip>
 
 <Note>
+  The receiver view has a **Contribute to global stats** checkbox (on by default) that adds only this transfer's byte count to Floe's public homepage counter. Uncheck it to opt out. File names and contents are never sent. See [Receiving Files](/web-app/receiving#contribute-to-global-stats).
+</Note>
+
+<Note>
   The sender must keep their browser tab open for the entire duration of the transfer.
 </Note>
 
@@ -85,7 +89,7 @@ description: "Send your first file in under a minute."
       ─────────────────────────────────────────────────
     ```
 
-    Pass `-y` to auto-accept without the prompt. Omit `-o` to save to the current directory instead.
+    Pass `-y` to auto-accept without the prompt. Omit `-o` to save to the current directory instead. Pass `--no-report` (or set `FLOE_NO_STATS=1`) to skip contributing the byte count to Floe's public counter.
   </Step>
 </Steps>
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -88,7 +88,7 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
   </Accordion>
 
   <Accordion title="I am being rate limited (429 or Rate limit exceeded)">
-    The server allows 30 connections per IP per 60 seconds (Socket.IO and WebSocket) and 20 requests per IP per 60 seconds for TURN credentials. Behind a reverse proxy, set `TRUSTED_PROXY_COUNT` to the number of proxy hops so the server reads real client IPs instead of the proxy IP. See [Configuration](/self-hosting/configuration).
+    The server allows 30 connections per IP per 60 seconds (Socket.IO and WebSocket), 20 requests per IP per 60 seconds for TURN credentials, and 60 reports per IP per 60 seconds for the global stats counter. Behind a reverse proxy, set `TRUSTED_PROXY_COUNT` to the number of proxy hops so the server reads real client IPs instead of the proxy IP. See [Configuration](/self-hosting/configuration).
   </Accordion>
 
   <Accordion title="The TURN relay is not working">

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -25,6 +25,19 @@ Once the page opens, Floe negotiates the WebRTC connection. A connection indicat
 
 The transfer begins automatically once the connection is established. You do not need to click anything.
 
+## Contribute to global stats
+
+While you wait for the transfer, the receiver view shows a **Contribute to global stats** checkbox. It is on by default.
+
+Floe's homepage has a public, all-time counter of total bytes transferred across every user. When a transfer finishes, the receiving side adds only this transfer's byte count to that shared total. File names, file contents, and identifying information are never sent, and the report never slows or blocks the transfer.
+
+| Setting | Behavior |
+|---------|----------|
+| On (default) | After the transfer completes, only the byte count is added to Floe's public counter. |
+| Off | Nothing is reported. No request is made to the server. |
+
+Your choice is saved in your browser and applies to all future transfers from that device. The sender never reports, and the counter is viewable only on the homepage. See [Security and Privacy](/security-privacy#aggregate-statistics) for the full data-handling note.
+
 ## Download options
 
 When all files arrive, download options appear:


### PR DESCRIPTION
## Summary

Documentation accuracy pass for the global transfer counter and its opt-out. No code changes.

- **`web-app/receiving.mdx`** - Adds a "Contribute to global stats" section so the browser receiver toggle is documented where users look for it. This mirrors the existing "Network Relay Fallback toggle" section in the sending guide, which previously had no receiver-side counterpart.
- **`quickstart.mdx`** - Notes the receiver stats toggle in the browser flow and `--no-report` / `FLOE_NO_STATS=1` in the CLI receive step.
- **`troubleshooting.mdx`** - Adds the stats-counter rate limit (60 reports per IP per 60s) to the rate-limit list, matching the architecture reference.
- **`changelog.mdx`** - Adds the missing **v1.7.1** entry (reliable CLI counter reporting; the byte-count report now completes before the CLI exits, so large transfers are counted reliably).

## Verification

- Em-dash scan clean across all changed files (repo writing-style rule).
- All cross-reference anchors (`#contribute-to-global-stats`, `#aggregate-statistics`) resolve to real headings.
- No source/behavior changes; docs-only, deploys via Mintlify.