### PR TITLE
fix(client): align privacy policy with actual data handling

### DIFF
--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -111,11 +111,13 @@ export default function PrivacyPolicy() {
                         </h3>
                         <p>
                             Floe uses third-party infrastructure providers for
-                            hosting and network relay services. We also use
-                            Sentry for error monitoring and Umami for
-                            privacy-respecting usage analytics. Please refer to
-                            their respective privacy policies regarding data
-                            handling.
+                            hosting and network relay services. The web app is
+                            hosted on Vercel, which collects aggregate, anonymous
+                            traffic and performance metrics through Vercel Analytics
+                            and Speed Insights. We also use Sentry for error
+                            monitoring and Umami for privacy-respecting usage
+                            analytics. Please refer to their respective privacy
+                            policies regarding data handling.
                         </p>
                     </section>
 
@@ -143,15 +145,16 @@ export default function PrivacyPolicy() {
                         </h3>
                         <p>
                             Floe uses Sentry to monitor application errors
-                            and performance. When an error occurs, Sentry may capture:
+                            and performance. Sentry may capture:
                         </p>
                         <ul className="list-disc list-inside space-y-2 ml-2 text-zinc-400">
                             <li>Error stack traces and browser metadata (browser version, OS, device type)</li>
                             <li>Connection type (direct or relay) and transfer progress at time of error</li>
                             <li>
-                                <strong>Session Replay:</strong> An anonymized video-like recording of
-                                your browser session may be captured when an error occurs. Text inputs
-                                are masked. File contents are never captured.
+                                <strong>Session Replay:</strong> An anonymized, video-like recording of
+                                a small sample of browser sessions, plus any session where an error
+                                occurs. All on-screen text and media are masked, so file names and file
+                                contents are never captured.
                             </li>
                         </ul>
                         <p>

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -49,9 +49,11 @@ Sentry.init({
 
     integrations: [
         Sentry.replayIntegration({
-            // Mask text and inputs to protect user privacy
-            maskAllText: false,
-            blockAllMedia: false,
+            // Mask all text and block media so replays never capture file names,
+            // on-screen content, or previews. This upholds the Privacy Policy
+            // (Section 5): file names and file contents are never captured.
+            maskAllText: true,
+            blockAllMedia: true,
         }),
     ],
 


### PR DESCRIPTION
## What

Brings the Privacy Policy in line with what the code actually does, and tightens the Sentry replay config to honor the policy's promises.

### Changes
- **Sentry session replay** (`sentry.client.config.ts`): set `maskAllText: true` and `blockAllMedia: true` (were both `false`). With masking off, on-screen text such as file names shown in the transfer UI could appear in session replays, contradicting the policy's "Sentry does not capture file names." Masking now genuinely prevents that. (The previous `false` values also contradicted the file's own comment.)
- **Third-Party Services** (`privacy/page.tsx`, §3): disclose **Vercel Analytics & Speed Insights**, which render unconditionally in `layout.tsx` but were previously undocumented.
- **Session Replay description** (`privacy/page.tsx`, §5): corrected to state replays are captured for a sample of sessions *plus* error sessions (config samples 10% of all sessions), not only "when an error occurs."

## Why

These were the only doc/reality mismatches found in a sweep of the legal/info pages (Terms, Privacy, How It Works) and the docs site. Everything else (2 GB relay cap, Umami events, DTLS, signaling, stats opt-out, changelog) was already accurate.

## Notes
- `next-env.d.ts` was intentionally left out (pre-existing, unrelated auto-generated change).
- The Sentry config change is a code change, so the masking takes effect on the next client deploy.