### PR TITLE
fix(client): define xs breakpoint and use dvh for mobile viewport height

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -4,6 +4,8 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+    /* Custom breakpoint: enables xs: variants (e.g. xs:grid-cols-2) for larger phones */
+    --breakpoint-xs: 30rem;
     --color-background: var(--background);
     --color-foreground: var(--foreground);
     --font-sans: var(--font-geist-sans);

--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 
 export default function HowItWorks() {
     return (
-        <div className="min-h-screen bg-zinc-950 text-zinc-100 font-sans p-6 md:p-12">
+        <div className="min-h-dvh bg-zinc-950 text-zinc-100 font-sans p-6 md:p-12">
             <div className="max-w-3xl mx-auto space-y-8">
                 <div className="space-y-4">
                     <Link

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -9,7 +9,7 @@ import { InAppBrowserGuard } from '@/components/InAppBrowserGuard';
 
 export default function Home() {
     return (
-        <div className="flex min-h-screen flex-col items-center bg-zinc-950 font-sans text-zinc-100 p-4 sm:p-6 pt-28 sm:pt-32">
+        <div className="flex min-h-dvh flex-col items-center bg-zinc-950 font-sans text-zinc-100 p-4 sm:p-6 pt-28 sm:pt-32">
             <Navbar />
 
             <div className="mx-auto max-w-3xl text-center mb-8 space-y-4">

--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 
 export default function PrivacyPolicy() {
     return (
-        <div className="min-h-screen bg-zinc-950 text-zinc-100 font-sans p-6 md:p-12">
+        <div className="min-h-dvh bg-zinc-950 text-zinc-100 font-sans p-6 md:p-12">
             <div className="max-w-3xl mx-auto space-y-8">
                 <div className="space-y-4">
                     <Link

--- a/client/app/terms/page.tsx
+++ b/client/app/terms/page.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 
 export default function TermsOfUse() {
     return (
-        <div className="min-h-screen bg-zinc-950 text-zinc-100 font-sans p-6 md:p-12">
+        <div className="min-h-dvh bg-zinc-950 text-zinc-100 font-sans p-6 md:p-12">
             <div className="max-w-3xl mx-auto space-y-8">
                 <div className="space-y-4">
                     <Link


### PR DESCRIPTION
## What

Fixes a mobile responsiveness bug found in a layout audit, plus a related viewport-height correctness improvement. Both changes are CSS-only and DOM-neutral.

### 1. Dead `xs:` breakpoint (the bug)
The receiver's "Download All" / "Download ZIP" buttons use `xs:grid-cols-2`, but `xs` was never defined as a Tailwind v4 breakpoint (no `tailwind.config.*`; the theme lives in `globals.css`). Tailwind v4 silently drops unknown variants, so the class was inert and the buttons stayed stacked in one column until the `sm` (640px) breakpoint.

Defining `--breakpoint-xs: 30rem` registers the variant, so the two-column layout now applies on larger phones (480px+) as the markup intended. Confirmed in the build output:

```
@media (min-width:30rem){.xs\:grid-cols-2{grid-template-columns:repeat(2,minmax(0,1fr))}}
```

### 2. `min-h-screen` to `min-h-dvh`
The homepage and the how-it-works, privacy, and terms pages used `min-h-screen` (= `100vh`), which ignores mobile browser chrome. Swapped to `min-h-dvh` (dynamic viewport height) so the minimum page height tracks the real visible viewport on mobile.

## Testing
- `pnpm lint` clean
- `pnpm test` (58 unit tests) pass
- `pnpm build` succeeds; verified both new utilities are emitted in the built CSS
- DOM-neutral, so the Playwright e2e suite (which selects file inputs, the Create Secure Link button, room codes, and download links) is unaffected

## Scope notes
Navbar clipping on sub-320px screens and sub-44px nav tap targets were also flagged in the audit but intentionally left out of this PR.
