### PR TITLE
fix(client): ignore browser-extension promise rejection in Sentry

### DIFF
--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -13,6 +13,10 @@ Sentry.init({
         "Failed to execute 'removeChild' on 'Node'",
         "Failed to execute 'insertBefore' on 'Node'",
         "The node to be removed is not a child of this node",
+        // Privacy/anti-fingerprint extensions bridge to native desktop software and
+        // reject a promise with a plain object when that bridge is not ready. Surfaces
+        // as "Object Not Found Matching Id:N, MethodName:..., ParamCount:N". Not our code.
+        'Object Not Found Matching Id',
         // Clipboard blocked in restricted browsers (already handled with fallback)
         'Write permission denied',
         // Safari/iOS ResizeObserver noise


### PR DESCRIPTION
## What

Add the `"Object Not Found Matching Id"` signature to the Sentry client `ignoreErrors` list so it is filtered before being sent.

## Why

Sentry issue [FLOE-D](https://jannskiee.sentry.io/issues/FLOE-D) fired an `UnhandledRejection`:

> Non-Error promise rejection captured with value: Object Not Found Matching Id:1, MethodName:update, ParamCount:4

This is **not Floe code**. It comes from a visitor's privacy / anti-fingerprint browser extension that bridges to native desktop software and rejects a promise with a plain object when that bridge is not ready. Evidence:

- No stack trace into our bundle (caught by the global `onunhandledrejection` handler).
- Breadcrumb just before it: `antifingerprint not defined yet. will try and handle event after its ready...` (injected by the extension, not by us).
- 0 users affected, single event, no crash or data exposure.

It only adds alert noise. The existing issue has already been resolved in Sentry; this change stops future occurrences at the SDK so it does not regress.

## Approach

Used the narrow, unique `"Object Not Found Matching Id"` string rather than the broad `"Non-Error promise rejection captured"`, so genuine object-valued promise rejections in our own code still report. Slotted into the existing browser-extension block in `client/sentry.client.config.ts`.

## Notes

- No protocol or behavior change; client-only.
- Takes effect on the next Vercel deploy of the client.
