### PR TITLE
chore(docs): Vale no-em-dash check and skip CI on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,25 @@ All under `cli/internal/`:
 - `ice/` - fetches STUN/TURN credentials from server
 - `code/` - registers and resolves short room codes
 
+## Documentation Site and Automations
+
+The docs live in `docs/` (Mintlify), git-synced to `main`, and deploy to docs.floe.one. The site runs on the Mintlify OSS sponsorship (10,250 credits/month). Overages are OFF and a usage alert fires at 80%, so the plan can never incur a charge.
+
+Four "require review" automations are configured in the Mintlify dashboard. Each one opens a pull request against `main`, only edits `docs/**`, and never auto-merges:
+
+| When | Automation | Job |
+|---|---|---|
+| Every Monday | Update from code changes | Keep docs accurate to merged PRs |
+| Every Friday | Apply style guide | Enforce no em dashes and voice consistency |
+| 1st of month | Fix broken links | Catch external link rot |
+| 15th of month | Audit SEO metadata | Titles, descriptions, headings, canonical tags |
+
+`docs/changelog.mdx` is written by hand. The automations are instructed (via their additional prompts) not to touch it.
+
+Intentionally OFF: Draft changelog, Draft improvements from assistant conversations, Draft improvements from user feedback (enable later once the docs have real traffic), Translate content (English only), and Fix grammar & typos (the style-guide automation already covers it).
+
+CI on docs-only changes is skipped via `paths-ignore: docs/**` in `.github/workflows/ci.yml`, so bot doc PRs do not run the client/server/CLI/e2e suite.
+
 ## Writing Style
 
-Do not use em dashes (--) in any markdown files or documentation. Use periods, commas, hyphens, or parentheses instead.
+Do not use em dashes (--) in any markdown files or documentation. Use periods, commas, hyphens, or parentheses instead. In `docs/`, this is enforced deterministically by Vale (`docs/.vale.ini` plus the `docs/styles/Floe/EmDash.yml` rule, surfaced as the Mintlify Grammar linter CI check) and reinforced by the weekly Apply style guide automation.

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -1,0 +1,9 @@
+StylesPath = styles
+MinAlertLevel = error
+
+[*.{md,mdx}]
+BasedOnStyles = Floe
+mdx = md
+; Ignore JSX components and {expressions} so Vale does not choke on MDX
+TokenIgnores = (\{[^}]*\}), (</?[A-Za-z][^>]*/?>)
+BlockIgnores = (?s) *(<[A-Z][A-Za-z]*[^>]*>.*?</[A-Z][A-Za-z]*>)

--- a/docs/styles/Floe/EmDash.yml
+++ b/docs/styles/Floe/EmDash.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Do not use em dashes. Use periods, commas, hyphens, or parentheses instead."
+level: error
+nonword: true
+tokens:
+  - '—'


### PR DESCRIPTION
## What

Repo-side setup for the new Mintlify OSS docs automations.

- **`docs/.vale.ini`** + **`docs/styles/Floe/EmDash.yml`**: a free, deterministic Vale check that flags the Unicode em dash as an error. Floe-only style with MDX/JSX-aware ignores, so no spell-check false positives. Surfaced as the Mintlify Grammar linter CI check, and complements the weekly "Apply style guide" automation.
- **`.github/workflows/ci.yml`**: adds `paths-ignore: docs/**` to both triggers so docs-only PRs (including the Mintlify review-PR automations) skip the client/server/CLI/Playwright suite. `main` has no required status checks, so docs-only PRs stay mergeable.
- **`CLAUDE.md`**: documents the Mintlify OSS pipeline and the four require-review automations (Update from code changes, Apply style guide, Fix broken links, Audit SEO metadata) with their schedules.

## Verification

- Existing `docs/**/*.mdx` content is em-dash clean, so the Grammar linter passes on current docs.
- This PR touches non-docs files, so full CI runs here (the `paths-ignore` only skips docs-only changes).
- `ci.yml` YAML validated.