### PR TITLE
fix(self-hosting): forward stats/limit env vars in docker-compose

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -8,7 +8,7 @@
 # ---- Builder ---------------------------------------------------------------
 FROM node:20-alpine AS builder
 
-RUN npm install -g pnpm@10
+RUN npm install -g pnpm@11
 WORKDIR /app
 
 # Install dependencies first for layer caching.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,18 @@ services:
       - "${PORT:-3001}:3001"
     environment:
       # The server always listens on 3001 inside the container; the host port above
-      # is what changes. CLIENT_URL / TRUSTED_PROXY_COUNT / TURN_* come from .env.
+      # is what changes. Everything else is interpolated from .env.
       PORT: 3001
       CLIENT_URL: ${CLIENT_URL:-http://localhost:3000}
       TRUSTED_PROXY_COUNT: ${TRUSTED_PROXY_COUNT:-1}
+      MAX_CONNECTIONS_PER_IP: ${MAX_CONNECTIONS_PER_IP:-30}
       TURN_SECRET: ${TURN_SECRET:-}
       TURN_DOMAIN: ${TURN_DOMAIN:-}
+      # Durable global-stats counter (optional). Without these the counter is
+      # in-memory only and resets on restart. MAX_REPORT_BYTES caps one report.
+      UPSTASH_REDIS_REST_URL: ${UPSTASH_REDIS_REST_URL:-}
+      UPSTASH_REDIS_REST_TOKEN: ${UPSTASH_REDIS_REST_TOKEN:-}
+      MAX_REPORT_BYTES: ${MAX_REPORT_BYTES:-}
 
   client:
     build:

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -51,4 +51,4 @@ For a deployment accessible beyond a single machine, follow these steps.
 
 ## CORS note
 
-The server's allow-list also includes the official `floe.one` origins. Your `CLIENT_URL` is added on top of these, so browser clients on your domain and on floe.one can both reach your server. If you are running a private fork and want a strict allow-list, remove the hard-coded entries from `server/server.js`.
+The server's allow-list also includes the official `floe.one` origins (`https://floe.one` and `https://www.floe.one`) plus `http://localhost:3000` for local development. Your `CLIENT_URL` is added on top of these, so browser clients on your domain and on floe.one can both reach your server. If you are running a private fork and want a strict allow-list, remove the hard-coded entries from `server/server.js`.


### PR DESCRIPTION
## Summary

Found during a full documentation/markdown accuracy audit. The docs were overwhelmingly accurate; this fixes the one real defect plus two minor consistency nits.

### The bug (docker-compose env forwarding)
`docker-compose.yml` only forwarded `PORT`, `CLIENT_URL`, `TRUSTED_PROXY_COUNT`, and `TURN_*` to the server container. It silently dropped four env vars that `server.js` reads and that both `.env.docker.example` and `docs/self-hosting/configuration.mdx` tell self-hosters to set:

- `UPSTASH_REDIS_REST_URL`
- `UPSTASH_REDIS_REST_TOKEN`
- `MAX_REPORT_BYTES`
- `MAX_CONNECTIONS_PER_IP`

Effect: following the documented Docker flow (`cp .env.docker.example .env`, set Upstash creds, `docker compose up`), durable global-stats never worked. The counter reset to 0 on every restart, and the two override knobs were inert. This forwards all four, so the documented behavior now actually works. No doc prose had to change.

### Minor consistency fixes
- `client/Dockerfile`: bump `pnpm@10` → `pnpm@11` to match `packageManager: pnpm@11.1.2`.
- `docs/self-hosting/production.mdx`: note that the CORS allow-list also includes `http://localhost:3000` (matches `server.js`).

## Verification
- `docker compose config` confirms all four vars now resolve into the server container (`MAX_CONNECTIONS_PER_IP: "30"`; the optional ones empty, which the server treats as unset and a real `.env` value overrides).
- No CLI/app/server runtime code changed, so no release tag is warranted.

## Notes
- `client/next-env.d.ts` was left out of this PR (auto-generated, unrelated local change).