### PR TITLE
docs: instruct Claude Code to omit AI co-author and attribution footer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,3 +132,12 @@ CI on docs-only changes is skipped via `paths-ignore: docs/**` in `.github/workf
 ## Writing Style
 
 Do not use em dashes (--) in any markdown files or documentation. Use periods, commas, hyphens, or parentheses instead. In `docs/`, this is enforced deterministically by Vale (`docs/.vale.ini` plus the `docs/styles/Floe/EmDash.yml` rule, surfaced as the Mintlify Grammar linter CI check) and reinforced by the weekly Apply style guide automation.
+
+## Git Conventions
+
+Do not credit Claude or any AI assistant as an author. Specifically:
+
+- Omit the `Co-Authored-By: Claude ...` trailer from commit messages.
+- Omit the `🤖 Generated with Claude Code` footer from pull request descriptions.
+
+Commit messages and PR bodies stay attribution-free. PR Summary and Test plan sections are fine, just leave out any AI footer or co-author line.


### PR DESCRIPTION
## Summary

Adds a "Git Conventions" section to `CLAUDE.md` so Claude Code sessions on this repo do not add AI authorship credit:

- no `Co-Authored-By: Claude ...` trailer on commit messages
- no "Generated with Claude Code" footer on pull request descriptions

## Test plan

Docs-only change to `CLAUDE.md`. No code paths are affected.
