### PR TITLE
docs: make protocol-versioning note version-neutral

### DIFF
--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -203,7 +203,7 @@ The receiver sends this and aborts before creating any file, so the sender fails
 
 ### Protocol versioning
 
-The transfer protocol carries its own version, independent of the floe release version (1.6.x). This lets peers on different releases interoperate, while still detecting a genuine breaking wire-format change cleanly.
+The transfer protocol carries its own version, independent of the floe release version (the 1.x line). This lets peers on different releases interoperate, while still detecting a genuine breaking wire-format change cleanly.
 
 - Each peer advertises `pv` (the highest protocol version it speaks) and `pvMin` (the lowest it still supports) in its metadata and ack. Both are 1 today.
 - Two peers are compatible when their ranges overlap: `max(localMin, remoteMin) <= min(localMax, remoteMax)`. They operate at the highest common version.


### PR DESCRIPTION
## Summary
- The architecture reference's Protocol versioning section pinned the floe release line at `1.6.x`, but the current release is `1.7.x`. Reworded the parenthetical to "the 1.x line" so it stays accurate across future 1.x releases without another edit on each bump.

## Context
Part of a docs accuracy review against the current codebase. Everything else checked out: the privacy policy, terms of use, README, FAQ, CLI and self-hosting docs, the protocol constants (`PROTOCOL_VERSION`/`MIN_PROTOCOL_VERSION` both 1), rate limits, the 2 GB relay cap, the 288-word code corpus, and the analytics/Sentry references all match the current code, so no other changes were needed.

## Test plan
- Docs-only change (`docs/**`); no client/server/CLI code touched, so the app build is unaffected.
- Single-word edit inside an existing paragraph, no MDX syntax change, so Mintlify renders it unchanged apart from the wording.