### PR TITLE
fix(client): restore space after "Aggregate Transfer Total:" label

### DIFF
--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -80,7 +80,8 @@ export default function PrivacyPolicy() {
                                 is not stored permanently.
                             </li>
                             <li>
-                                <strong>Aggregate Transfer Total:</strong> When a
+                                <strong>Aggregate Transfer Total:</strong>{' '}
+                                When a
                                 transfer completes, the receiving side reports only
                                 the number of bytes it received. We add this to one
                                 shared, all-time counter of total bytes transferred,


### PR DESCRIPTION
## Summary
- The "Information We Collect" list on `/privacy` rendered `Aggregate Transfer Total:When a transfer...` with no space after the colon. Verified against the live DOM: the text node after `</strong>` started with `When` (no leading space), while the other three items (`Files:`, `Metadata:`, `IP Addresses:`) correctly started with a space.
- The literal same-line space was not surviving the build for this item even though the source matched the other three. Replaced it with an explicit `{' '}` token (the same idiom already used for the `--no-report` / `FLOE_NO_STATS=1` `<code>` spans in this list item), so the space is preserved by construction.

## Test plan
- After deploy, confirm `/privacy` renders `Aggregate Transfer Total: When a transfer...` with the space, matching the other list items.