### PR TITLE
refactor(client): extract useSignaling from P2PTransfer

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -10,7 +10,6 @@ if (typeof window !== 'undefined') {
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 import { useEffect, useRef, useState } from 'react';
-import io, { Socket } from 'socket.io-client';
 import SimplePeer, { Instance as PeerInstance } from 'simple-peer';
 import { v4 as uuidv4 } from 'uuid';
 import * as Sentry from '@sentry/nextjs';
@@ -20,6 +19,7 @@ import { sendFiles as sendFilesEngine } from '@/lib/transfer/sender';
 import { useWakeLock } from '@/hooks/useWakeLock';
 import { useFileManagement, type FileWithId } from '@/hooks/useFileManagement';
 import { useDownloadManager, type ReceivedFile } from '@/hooks/useDownloadManager';
+import { useSignaling } from '@/hooks/useSignaling';
 
 import { QRCodeSVG } from 'qrcode.react';
 
@@ -63,14 +63,6 @@ import {
 import { formatBytes } from '@/lib/utils';
 import { FileIcon } from '@/components/FileIcon';
 
-const socket: Socket = io(
-    process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001',
-    {
-        reconnectionDelay: 500,
-        reconnectionDelayMax: 3000,
-    }
-);
-
 // The room id is the transfer's only secret: anyone holding it can join as the
 // receiver. It lives in the URL fragment (#room=<id>) so it never leaves the
 // browser. Fragments are not sent to the server, are stripped from the Referer
@@ -89,8 +81,6 @@ function getRoomFromUrl(): string | null {
 export function P2PTransfer() {
     const [isSender, setIsSender] = useState<boolean | null>(null);
     const [status, setStatus] = useState('Idle');
-    const [isConnected, setIsConnected] = useState(false);
-    const [ping, setPing] = useState(0);
     const [generatedLink, setGeneratedLink] = useState('');
     const [currentFileIndex, setCurrentFileIndex] = useState(0);
     const [progress, setProgress] = useState(0);
@@ -142,6 +132,65 @@ export function P2PTransfer() {
     const connTypeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     const { requestWakeLock, releaseWakeLock } = useWakeLock();
+
+    const {
+        isConnected,
+        setIsConnected,
+        ping,
+        joinRoom,
+        sendSignal,
+        onUserConnected,
+        onRoomFull,
+    } = useSignaling({
+        onSignal: (data) => {
+            const peer = peerRef.current;
+            if (!peer || peer.destroyed) return;
+            const sig = data?.signal;
+            if (!sig) return;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const pc = (peer as any)._pc as RTCPeerConnection | undefined;
+            // A duplicate/late SDP answer applied after negotiation completes throws
+            // InvalidStateError ("Called in wrong state: stable"). Skip only answers.
+            // Applying an offer in `stable` is the receiver's normal first step.
+            if (pc && pc.signalingState === 'stable' && sig.type === 'answer') {
+                Sentry.addBreadcrumb({
+                    category: 'webrtc',
+                    level: 'warning',
+                    message: 'Skipped duplicate answer signal: peer already in stable state',
+                });
+                return;
+            }
+            try {
+                peer.signal(sig);
+            } catch (err) {
+                Sentry.addBreadcrumb({
+                    category: 'webrtc',
+                    level: 'warning',
+                    message: `Ignored signal in state ${pc?.signalingState}: ${(err as Error).message}`,
+                });
+            }
+        },
+        onPeerDisconnected: () => {
+            if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
+                setStatus('Transfer complete');
+            } else {
+                setStatus('Peer disconnected. Waiting for reconnection');
+            }
+            if (peerRef.current) peerRef.current.destroy();
+            releaseWakeLock();
+        },
+        onDisconnect: () => {
+            if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
+                setStatus('Transfer complete');
+            }
+        },
+        onConnectError: (err) => {
+            if (err.message === 'Rate limit exceeded') {
+                setError('Too many refreshes. Reconnecting');
+            }
+        },
+        onReconnect: () => setError(''),
+    });
 
     const fetchIceServers = async () => {
         try {
@@ -268,11 +317,7 @@ export function P2PTransfer() {
 
         setStatus('Connecting');
 
-        socket.off('room-full');
-
-        socket.emit('join-room', roomId);
-
-        socket.on('room-full', () => {
+        onRoomFull(() => {
             if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
                 setStatus('Transfer complete');
                 return;
@@ -280,6 +325,8 @@ export function P2PTransfer() {
             setError('Link Expired or Busy');
             setStatus('Access Denied');
         });
+
+        joinRoom(roomId);
 
         const peer = new SimplePeer({
             initiator: false,
@@ -290,7 +337,7 @@ export function P2PTransfer() {
         });
 
         peer.on('signal', (signal) =>
-            socket.emit('signal', { target: null, roomId, signal })
+            sendSignal({ target: null, roomId, signal })
         );
         peer.on('connect', () => {
             setIsConnected(true);
@@ -442,86 +489,8 @@ export function P2PTransfer() {
             fetchIceServers();
         }
 
-        if (socket.connected) queueMicrotask(() => setIsConnected(true));
-        socket.on('connect', () => setIsConnected(true));
-        socket.on('disconnect', () => {
-            setIsConnected(false);
-            setPing(0);
-            if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
-                setStatus('Transfer complete');
-            }
-        });
-
-        socket.on('connect_error', (err) => {
-            setIsConnected(false);
-            if (err.message === 'Rate limit exceeded') {
-                setError('Too many refreshes. Reconnecting');
-            }
-        });
-
-        socket.io.on('reconnect', () => {
-            setError('');
-        });
-
-        const pingInterval = setInterval(() => {
-            const start = performance.now();
-            socket.emit('ping', () => {
-                const duration = performance.now() - start;
-                setPing(Number(duration.toFixed(2)));
-            });
-        }, 2000);
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        socket.on('signal', (data: any) => {
-            const peer = peerRef.current;
-            if (!peer || peer.destroyed) return;
-            const sig = data?.signal;
-            if (!sig) return;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const pc = (peer as any)._pc as RTCPeerConnection | undefined;
-            // A duplicate/late SDP answer applied after negotiation completes throws
-            // InvalidStateError ("Called in wrong state: stable"). Skip only answers.
-            // Applying an offer in `stable` is the receiver's normal first step.
-            if (pc && pc.signalingState === 'stable' && sig.type === 'answer') {
-                Sentry.addBreadcrumb({
-                    category: 'webrtc',
-                    level: 'warning',
-                    message: 'Skipped duplicate answer signal: peer already in stable state',
-                });
-                return;
-            }
-            try {
-                peer.signal(sig);
-            } catch (err) {
-                Sentry.addBreadcrumb({
-                    category: 'webrtc',
-                    level: 'warning',
-                    message: `Ignored signal in state ${pc?.signalingState}: ${(err as Error).message}`,
-                });
-            }
-        });
-
-        socket.on('peer-disconnected', () => {
-            if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
-                setStatus('Transfer complete');
-            } else {
-                setStatus('Peer disconnected. Waiting for reconnection');
-            }
-            if (peerRef.current) peerRef.current.destroy();
-            releaseWakeLock();
-        });
-
         return () => {
-            clearInterval(pingInterval);
             if (connTypeIntervalRef.current) clearInterval(connTypeIntervalRef.current);
-            socket.off('signal');
-            socket.off('user-connected');
-            socket.off('connect');
-            socket.off('disconnect');
-            socket.off('room-full');
-            socket.off('peer-disconnected');
-            socket.off('connect_error');
-            socket.io.off('reconnect');
             releaseWakeLock();
             peerRef.current?.destroy();
             receivedFilesRef.current.forEach((f) => URL.revokeObjectURL(f.downloadUrl));
@@ -557,11 +526,10 @@ export function P2PTransfer() {
         const newRoomId = uuidv4();
         const link = `${window.location.protocol}//${window.location.host}/#room=${newRoomId}`;
         setGeneratedLink(link);
-        socket.emit('join-room', newRoomId);
+        joinRoom(newRoomId);
         setStatus('Waiting for peer');
 
-        socket.off('user-connected');
-        socket.on('user-connected', (userId: string) => {
+        onUserConnected((userId: string) => {
             if (peerRef.current && !peerRef.current.destroyed) {
                 peerRef.current.destroy();
             }
@@ -584,7 +552,7 @@ export function P2PTransfer() {
             });
 
             peer.on('signal', (signal) =>
-                socket.emit('signal', { target: userId, signal })
+                sendSignal({ target: userId, signal })
             );
             peer.on('connect', () => {
                 setIsConnected(true);

--- a/client/hooks/useSignaling.ts
+++ b/client/hooks/useSignaling.ts
@@ -1,0 +1,127 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import io, { Socket } from 'socket.io-client';
+
+// Module-level singleton: created once when this module is first imported.
+// Keep this the ONLY io() call in the app so the whole client shares one socket.
+// P2PTransfer (the only importer) therefore holds no direct socket reference.
+const socket: Socket = io(
+    process.env.NEXT_PUBLIC_SOCKET_URL || 'http://localhost:3001',
+    {
+        reconnectionDelay: 500,
+        reconnectionDelayMax: 3000,
+    }
+);
+
+export interface SignalPayload {
+    target: string | null;
+    roomId?: string;
+    signal: unknown; // peer-agnostic; the component passes SimplePeer.SignalData
+}
+
+export interface UseSignalingCallbacks {
+    // Inbound signal: the component validates against its peer and calls peer.signal().
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onSignal: (data: any) => void;
+    // The remote peer left the room (transfer-aware status + peer teardown).
+    onPeerDisconnected: () => void;
+    // Socket dropped. isConnected/ping are already cleared; the component sets a
+    // transfer-aware status.
+    onDisconnect: () => void;
+    // Socket connect failed (e.g. rate limit).
+    onConnectError: (err: Error) => void;
+    // Socket reconnected (the component clears the error banner).
+    onReconnect: () => void;
+}
+
+/**
+ * Owns the Socket.IO transport only: online status, round-trip ping, joining a
+ * room, and relaying WebRTC signals. It is peer- and transfer-agnostic — every
+ * event whose handling depends on peer/transfer state is delegated to a callback
+ * supplied by the component. (Peer/WebRTC creation lives in the component until
+ * the usePeerConnection extraction.)
+ */
+export function useSignaling(callbacks: UseSignalingCallbacks) {
+    const [isConnected, setIsConnected] = useState(false);
+    const [ping, setPing] = useState(0);
+
+    // Listeners are registered once (deps []), but always invoke the component's
+    // current callbacks via this latest-ref, so no handler can go stale. The ref
+    // is updated in an effect (not during render) to satisfy react-hooks/refs;
+    // socket events are async, so the ref is always current by the time they fire.
+    const cbRef = useRef(callbacks);
+    useEffect(() => {
+        cbRef.current = callbacks;
+    });
+
+    useEffect(() => {
+        if (socket.connected) queueMicrotask(() => setIsConnected(true));
+
+        socket.on('connect', () => setIsConnected(true));
+        socket.on('disconnect', () => {
+            setIsConnected(false);
+            setPing(0);
+            cbRef.current.onDisconnect();
+        });
+        socket.on('connect_error', (err) => {
+            setIsConnected(false);
+            cbRef.current.onConnectError(err);
+        });
+        // `reconnect` is a Manager-level event — note the `.io` namespace.
+        socket.io.on('reconnect', () => cbRef.current.onReconnect());
+
+        const pingInterval = setInterval(() => {
+            const start = performance.now();
+            socket.emit('ping', () => {
+                const duration = performance.now() - start;
+                setPing(Number(duration.toFixed(2)));
+            });
+        }, 2000);
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        socket.on('signal', (data: any) => cbRef.current.onSignal(data));
+        socket.on('peer-disconnected', () => cbRef.current.onPeerDisconnected());
+
+        return () => {
+            clearInterval(pingInterval);
+            socket.off('signal');
+            socket.off('user-connected');
+            socket.off('connect');
+            socket.off('disconnect');
+            socket.off('room-full');
+            socket.off('peer-disconnected');
+            socket.off('connect_error');
+            socket.io.off('reconnect');
+        };
+    }, []);
+
+    const joinRoom = useCallback((roomId: string) => {
+        socket.emit('join-room', roomId);
+    }, []);
+
+    const sendSignal = useCallback((payload: SignalPayload) => {
+        socket.emit('signal', payload);
+    }, []);
+
+    // Dynamic, per-action registrations (sender on create-link, receiver on join).
+    // The handler closes over current state, so it is replaced (off then on) each
+    // time rather than memoized.
+    const onUserConnected = useCallback((handler: (userId: string) => void) => {
+        socket.off('user-connected');
+        socket.on('user-connected', handler);
+    }, []);
+
+    const onRoomFull = useCallback((handler: () => void) => {
+        socket.off('room-full');
+        socket.on('room-full', handler);
+    }, []);
+
+    return {
+        isConnected,
+        setIsConnected,
+        ping,
+        joinRoom,
+        sendSignal,
+        onUserConnected,
+        onRoomFull,
+    };
+}


### PR DESCRIPTION
## Summary

Third step of decomposing `client/components/P2PTransfer.tsx` into focused hooks (follows #124 `useFileManagement`, #125 `useDownloadManager`). This extracts the **Socket.IO transport** — the most coupled seam so far — as a deliberately **thin** hook, leaving peer/WebRTC creation in the component for the next step (`usePeerConnection`).

Moved into `client/hooks/useSignaling.ts` (incl. the relocated `socket = io(...)` singleton):
- `isConnected` + `ping` state and the 2s ping loop
- the mount-time socket listeners: `connect`, `disconnect`, `connect_error`, `socket.io.on('reconnect')`, `signal`, `peer-disconnected`, and their cleanup

The hook is peer-/transfer-agnostic. It returns `{ isConnected, setIsConnected, ping, joinRoom, sendSignal, onUserConnected, onRoomFull }` and takes callbacks (`onSignal`, `onPeerDisconnected`, `onDisconnect`, `onConnectError`, `onReconnect`) for the transfer-aware bodies, which stay in the component. The component now holds **zero** direct `socket` references; every `socket.emit/on` became a hook call. A latest-callbacks ref keeps the once-registered listeners current.

Pure refactor: **no behavior change, no wire-protocol change.** Component 1429 → 1397 lines; new hook ~127 lines.

## Test plan

- `corepack pnpm lint` - clean (caught + fixed a `react-hooks/refs` issue: the latest-callbacks ref is updated in an effect, not during render)
- `corepack pnpm test` - 64 pass
- `corepack pnpm build` - type-checks and builds
- **E2E (CI) is the real guard:** `transfer.spec.ts` (browser↔browser 50 MB SHA-256) + `cli-interop.spec.ts` (CLI↔browser both directions) exercise the full `join-room`/`signal`/`user-connected`/`room-full` flow. Green E2E proves the socket wiring is unchanged and still matches the Go CLI.

## Next

`usePeerConnection` (SimplePeer create + ICE/relay + connection-type), which will consume `sendSignal` and own the `onSignal`/`onUserConnected` bodies.