### PR TITLE
refactor(client): extract useConnectionType from P2PTransfer

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -20,6 +20,7 @@ import { useWakeLock } from '@/hooks/useWakeLock';
 import { useFileManagement, type FileWithId } from '@/hooks/useFileManagement';
 import { useDownloadManager, type ReceivedFile } from '@/hooks/useDownloadManager';
 import { useSignaling } from '@/hooks/useSignaling';
+import { useConnectionType } from '@/hooks/useConnectionType';
 
 import { QRCodeSVG } from 'qrcode.react';
 
@@ -89,7 +90,6 @@ export function P2PTransfer() {
     const [error, setError] = useState('');
     const [transferSpeed, setTransferSpeed] = useState('');
     const [estimatedTime, setEstimatedTime] = useState('');
-    const [connectionType, setConnectionType] = useState<'direct' | 'relay' | null>(null);
     const [showQr, setShowQr] = useState(false);
     const [showInfoTooltip, setShowInfoTooltip] = useState(false);
     const [relayEnabled, setRelayEnabled] = useState(true);
@@ -115,6 +115,13 @@ export function P2PTransfer() {
         handleDownloadZip,
     } = useDownloadManager(receivedFiles, setError);
 
+    const {
+        connectionType,
+        startPolling: startConnectionTypePolling,
+        stopPolling: stopConnectionTypePolling,
+        reset: resetConnectionType,
+    } = useConnectionType();
+
     const RELAY_SIZE_LIMIT = 2 * 1024 * 1024 * 1024; // 2 GB
     const isRelayOverLimit = connectionType === 'relay' && totalBytes > RELAY_SIZE_LIMIT;
 
@@ -129,7 +136,6 @@ export function P2PTransfer() {
         { urls: 'stun:stun.l.google.com:19302' },
         { urls: 'stun:stun1.l.google.com:19302' },
     ]);
-    const connTypeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     const { requestWakeLock, releaseWakeLock } = useWakeLock();
 
@@ -204,25 +210,6 @@ export function P2PTransfer() {
         } catch {
 
         }
-    };
-
-    const checkConnectionType = async (peer: PeerInstance) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const pc = (peer as any)._pc as RTCPeerConnection | undefined;
-        if (!pc) return;
-        try {
-            const stats = await pc.getStats();
-            stats.forEach((report) => {
-                if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
-                    const localCandidate = stats.get(report.localCandidateId);
-                    const remoteCandidate = stats.get(report.remoteCandidateId);
-                    const isRelay =
-                        localCandidate?.candidateType === 'relay' ||
-                        remoteCandidate?.candidateType === 'relay';
-                    setConnectionType(isRelay ? 'relay' : 'direct');
-                }
-            });
-        } catch { }
     };
 
     useEffect(() => {
@@ -342,9 +329,7 @@ export function P2PTransfer() {
         peer.on('connect', () => {
             setIsConnected(true);
             requestWakeLock();
-            checkConnectionType(peer);
-            if (connTypeIntervalRef.current) clearInterval(connTypeIntervalRef.current);
-            connTypeIntervalRef.current = setInterval(() => checkConnectionType(peer), 5000);
+            startConnectionTypePolling(peer);
             Sentry.addBreadcrumb({
                 category: 'webrtc',
                 message: 'Receiver peer connected',
@@ -353,8 +338,8 @@ export function P2PTransfer() {
         });
         peer.on('close', () => {
             releaseWakeLock();
-            setConnectionType(null);
-            if (connTypeIntervalRef.current) clearInterval(connTypeIntervalRef.current);
+            resetConnectionType();
+            stopConnectionTypePolling();
             Sentry.addBreadcrumb({
                 category: 'webrtc',
                 message: 'Receiver peer connection closed',
@@ -490,7 +475,7 @@ export function P2PTransfer() {
         }
 
         return () => {
-            if (connTypeIntervalRef.current) clearInterval(connTypeIntervalRef.current);
+            stopConnectionTypePolling();
             releaseWakeLock();
             peerRef.current?.destroy();
             receivedFilesRef.current.forEach((f) => URL.revokeObjectURL(f.downloadUrl));
@@ -556,9 +541,7 @@ export function P2PTransfer() {
             );
             peer.on('connect', () => {
                 setIsConnected(true);
-                checkConnectionType(peer);
-                if (connTypeIntervalRef.current) clearInterval(connTypeIntervalRef.current);
-                connTypeIntervalRef.current = setInterval(() => checkConnectionType(peer), 5000);
+                startConnectionTypePolling(peer);
 
                 Sentry.addBreadcrumb({
                     category: 'webrtc',
@@ -622,8 +605,8 @@ export function P2PTransfer() {
             });
             peer.on('close', () => {
                 releaseWakeLock();
-                setConnectionType(null);
-                if (connTypeIntervalRef.current) clearInterval(connTypeIntervalRef.current);
+                resetConnectionType();
+                stopConnectionTypePolling();
                 Sentry.addBreadcrumb({
                     category: 'webrtc',
                     message: 'Sender peer connection closed',

--- a/client/hooks/useConnectionType.ts
+++ b/client/hooks/useConnectionType.ts
@@ -1,0 +1,47 @@
+import { useState, useRef } from 'react';
+import type { Instance as PeerInstance } from 'simple-peer';
+
+/**
+ * Detects and tracks whether the active WebRTC connection is direct or routed
+ * through a TURN relay, by polling the peer's ICE candidate-pair stats every 5s.
+ * Pure connection-quality detection: it only drives the "Direct/Relay" badge and
+ * has no effect on the transfer itself.
+ */
+export function useConnectionType() {
+    const [connectionType, setConnectionType] = useState<'direct' | 'relay' | null>(null);
+    const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+    const checkConnectionType = async (peer: PeerInstance) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const pc = (peer as any)._pc as RTCPeerConnection | undefined;
+        if (!pc) return;
+        try {
+            const stats = await pc.getStats();
+            stats.forEach((report) => {
+                if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
+                    const localCandidate = stats.get(report.localCandidateId);
+                    const remoteCandidate = stats.get(report.remoteCandidateId);
+                    const isRelay =
+                        localCandidate?.candidateType === 'relay' ||
+                        remoteCandidate?.candidateType === 'relay';
+                    setConnectionType(isRelay ? 'relay' : 'direct');
+                }
+            });
+        } catch { }
+    };
+
+    // Check immediately, then re-check every 5s (replacing any prior interval).
+    const startPolling = (peer: PeerInstance) => {
+        checkConnectionType(peer);
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        intervalRef.current = setInterval(() => checkConnectionType(peer), 5000);
+    };
+
+    const stopPolling = () => {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+
+    const reset = () => setConnectionType(null);
+
+    return { connectionType, startPolling, stopPolling, reset };
+}


### PR DESCRIPTION
## Summary

Fourth step of decomposing `client/components/P2PTransfer.tsx` into focused hooks (follows #124/#125/#128). This takes the clean, low-risk slice of the peer-connection concern: the **direct-vs-relay detection** that drives the "Direct/Relay" status badge.

Moved into `client/hooks/useConnectionType.ts`:
- `connectionType` state and its 5s polling interval (was `connTypeIntervalRef`)
- `checkConnectionType(peer)` (reads `peer._pc.getStats()` for the nominated candidate pair) — moved verbatim

The hook returns `{ connectionType, startPolling, stopPolling, reset }`. The two peer `connect` handlers now call `startPolling(peer)`, the two `close` handlers call `reset()` + `stopPolling()`, and the mount cleanup calls `stopPolling()` — all 1:1 replacements of the previous inline interval bookkeeping. Every `connectionType` read (badge, `isRelayOverLimit`, Sentry/Umami, `floe-connection-status` dispatch) is unchanged.

**Deliberately untouched:** the sender's *separate* inline `getStats()` relay-fallback validation (block on forced-off relay + 2 GB cap) inside `peer.on('connect')` — a different concern that the e2e suite does not cover, so it was left exactly as-is. The bigger peer-creation extraction is deferred until later hooks de-clutter the peer handlers.

Pure refactor: no behavior change. Component 1397 → 1380 lines; new hook ~46 lines.

## Test plan

- `corepack pnpm lint` - clean
- `corepack pnpm test` - 64 pass
- `corepack pnpm build` - type-checks and builds
- E2E (CI): browser↔browser + CLI↔browser transfers; a green run confirms the detection/badge path still works (the logic is moved 1:1).

## Next

`useTransferAnalytics` (Sentry/Umami/stats) and `useRelayConfiguration` (relay toggle + the relay-fallback validation), which de-bloat the peer handlers — then `usePeerConnection` becomes a small, safe extraction.