### PR TITLE
refactor(client): extract useRelayConfiguration from P2PTransfer

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -22,6 +22,8 @@ import { useDownloadManager, type ReceivedFile } from '@/hooks/useDownloadManage
 import { useSignaling } from '@/hooks/useSignaling';
 import { useConnectionType } from '@/hooks/useConnectionType';
 import { useTransferAnalytics } from '@/hooks/useTransferAnalytics';
+import { useRelayConfiguration } from '@/hooks/useRelayConfiguration';
+import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate } from '@/lib/relay';
 
 import { QRCodeSVG } from 'qrcode.react';
 
@@ -87,7 +89,6 @@ export function P2PTransfer() {
     const [estimatedTime, setEstimatedTime] = useState('');
     const [showQr, setShowQr] = useState(false);
     const [showInfoTooltip, setShowInfoTooltip] = useState(false);
-    const [relayEnabled, setRelayEnabled] = useState(true);
 
     const {
         files,
@@ -117,7 +118,8 @@ export function P2PTransfer() {
 
     const { reportStatsEnabled, setReportStatsEnabled, track, reportBytes } = useTransferAnalytics();
 
-    const RELAY_SIZE_LIMIT = 2 * 1024 * 1024 * 1024; // 2 GB
+    const { relayEnabled, setRelayEnabled } = useRelayConfiguration();
+
     const isRelayOverLimit = connectionType === 'relay' && totalBytes > RELAY_SIZE_LIMIT;
 
     const peerRef = useRef<PeerInstance | null>(null);
@@ -476,12 +478,7 @@ export function P2PTransfer() {
             setStatus('Peer joined. Starting transfer');
             requestWakeLock();
 
-            const iceConfig = relayEnabled
-                ? iceServersRef.current
-                : iceServersRef.current.filter((s) => {
-                    const urls = Array.isArray(s.urls) ? s.urls : [s.urls as string];
-                    return !urls.some((u) => u.startsWith('turn:') || u.startsWith('turns:'));
-                });
+            const iceConfig = filterIceServers(iceServersRef.current, relayEnabled);
 
             const peer = new SimplePeer({
                 initiator: true,
@@ -531,7 +528,10 @@ export function P2PTransfer() {
                         data: { isRelay, totalBytes },
                     });
 
-                    if (isRelay && !relayEnabled) {
+                    const totalSize = files.reduce((s, f) => s + f.file.size, 0);
+                    const verdict = evaluateRelayGate({ isRelay, relayEnabled, totalSize });
+
+                    if (verdict.action === 'block-relay-disabled') {
                         setError('Connection failed. Enable "Network Relay" to connect across restrictive networks.');
                         setStatus('Connection failed');
                         Sentry.addBreadcrumb({
@@ -544,17 +544,17 @@ export function P2PTransfer() {
                         return;
                     }
 
-                    const totalSize = files.reduce((s, f) => s + f.file.size, 0);
-                    if (isRelay && totalSize > 2 * 1024 * 1024 * 1024) {
+                    if (verdict.action === 'block-over-limit') {
                         setStatus('Transfer blocked. Relay limit exceeded.');
                         Sentry.addBreadcrumb({
                             category: 'transfer',
                             message: 'Transfer blocked: relay size limit exceeded',
                             level: 'warning',
-                            data: { totalSize, limitBytes: 2 * 1024 * 1024 * 1024 },
+                            data: { totalSize: verdict.totalSize, limitBytes: RELAY_SIZE_LIMIT },
                         });
                         return;
                     }
+
                     sendAllFiles(peer, files);
                 }, 2000);
             });

--- a/client/hooks/useRelayConfiguration.ts
+++ b/client/hooks/useRelayConfiguration.ts
@@ -1,0 +1,11 @@
+import { useState } from 'react';
+
+/**
+ * Owns the sender's "Network Relay Fallback" toggle. Session-only state (defaults
+ * on; not persisted). The pure relay policy — the ICE-server filter and the
+ * proceed/block gate — lives in `@/lib/relay` so it can be unit-tested without React.
+ */
+export function useRelayConfiguration() {
+    const [relayEnabled, setRelayEnabled] = useState(true);
+    return { relayEnabled, setRelayEnabled };
+}

--- a/client/lib/relay.test.ts
+++ b/client/lib/relay.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+    RELAY_SIZE_LIMIT,
+    filterIceServers,
+    evaluateRelayGate,
+} from './relay';
+
+const STUN: RTCIceServer = { urls: 'stun:stun.l.google.com:19302' };
+const TURN: RTCIceServer = { urls: 'turn:turn.example.com:3478' };
+const TURNS: RTCIceServer = { urls: 'turns:turn.example.com:5349' };
+const MIXED: RTCIceServer = {
+    urls: ['stun:stun.example.com:3478', 'turn:turn.example.com:3478'],
+};
+
+describe('filterIceServers', () => {
+    it('returns the list unchanged when relay is enabled', () => {
+        const servers = [STUN, TURN, TURNS];
+        expect(filterIceServers(servers, true)).toBe(servers);
+    });
+
+    it('strips turn: and turns: servers when relay is disabled', () => {
+        expect(filterIceServers([STUN, TURN, TURNS], false)).toEqual([STUN]);
+    });
+
+    it('drops an entry whose urls array contains any turn url', () => {
+        // MIXED bundles a STUN and a TURN url; with relay off the whole entry goes.
+        expect(filterIceServers([STUN, MIXED], false)).toEqual([STUN]);
+    });
+
+    it('keeps every stun server when relay is disabled', () => {
+        const stunOnly = [STUN, { urls: 'stun:stun1.l.google.com:19302' }];
+        expect(filterIceServers(stunOnly, false)).toEqual(stunOnly);
+    });
+});
+
+describe('evaluateRelayGate', () => {
+    it('proceeds on a direct connection regardless of the other flags', () => {
+        expect(
+            evaluateRelayGate({ isRelay: false, relayEnabled: false, totalSize: RELAY_SIZE_LIMIT * 10 })
+        ).toEqual({ action: 'proceed' });
+    });
+
+    it('blocks a relayed connection when relay fallback is disabled', () => {
+        expect(
+            evaluateRelayGate({ isRelay: true, relayEnabled: false, totalSize: 1 })
+        ).toEqual({ action: 'block-relay-disabled' });
+    });
+
+    it('proceeds on a relayed connection under the size limit', () => {
+        expect(
+            evaluateRelayGate({ isRelay: true, relayEnabled: true, totalSize: RELAY_SIZE_LIMIT - 1 })
+        ).toEqual({ action: 'proceed' });
+    });
+
+    it('blocks a relayed connection over the size limit', () => {
+        expect(
+            evaluateRelayGate({ isRelay: true, relayEnabled: true, totalSize: RELAY_SIZE_LIMIT + 1 })
+        ).toEqual({ action: 'block-over-limit', totalSize: RELAY_SIZE_LIMIT + 1 });
+    });
+
+    it('proceeds at exactly the size limit (boundary is strictly greater-than)', () => {
+        expect(
+            evaluateRelayGate({ isRelay: true, relayEnabled: true, totalSize: RELAY_SIZE_LIMIT })
+        ).toEqual({ action: 'proceed' });
+    });
+});

--- a/client/lib/relay.ts
+++ b/client/lib/relay.ts
@@ -1,0 +1,45 @@
+// Pure relay-policy helpers, shared by the sender flow in P2PTransfer and the
+// useRelayConfiguration hook. Kept side-effect free so the relay gate (which the
+// e2e suite does not exercise) can be unit-tested directly.
+
+export const RELAY_SIZE_LIMIT = 2 * 1024 * 1024 * 1024; // 2 GB
+
+/**
+ * The ICE server list to hand SimplePeer. When the user keeps relay fallback on
+ * (the default), every server is offered. When they turn it off, TURN servers
+ * are stripped so the connection can only succeed as a direct path; STUN is kept.
+ */
+export function filterIceServers(
+    servers: RTCIceServer[],
+    relayEnabled: boolean
+): RTCIceServer[] {
+    if (relayEnabled) return servers;
+    return servers.filter((s) => {
+        const urls = Array.isArray(s.urls) ? s.urls : [s.urls];
+        return !urls.some((u) => u.startsWith('turn:') || u.startsWith('turns:'));
+    });
+}
+
+export type RelayGateVerdict =
+    | { action: 'proceed' }
+    | { action: 'block-relay-disabled' }
+    | { action: 'block-over-limit'; totalSize: number };
+
+/**
+ * Once the sender's connection resolves, decide whether the transfer may start.
+ * A relayed connection is blocked when the user disabled relay fallback, or when
+ * the payload exceeds the relay size cap. Direct connections always proceed.
+ * Pure: the caller owns every side effect (status, error, Sentry, peer.destroy).
+ */
+export function evaluateRelayGate(opts: {
+    isRelay: boolean;
+    relayEnabled: boolean;
+    totalSize: number;
+}): RelayGateVerdict {
+    const { isRelay, relayEnabled, totalSize } = opts;
+    if (isRelay && !relayEnabled) return { action: 'block-relay-disabled' };
+    if (isRelay && totalSize > RELAY_SIZE_LIMIT) {
+        return { action: 'block-over-limit', totalSize };
+    }
+    return { action: 'proceed' };
+}


### PR DESCRIPTION
## Summary

Step 6 of the `P2PTransfer.tsx` decomposition. Consolidates the sender's relay logic and, crucially, makes the relay-gating **unit-testable** for the first time.

- New `client/lib/relay.ts` (pure, no React): `RELAY_SIZE_LIMIT`, `filterIceServers(servers, relayEnabled)` (strips TURN when relay is off), and `evaluateRelayGate({ isRelay, relayEnabled, totalSize })` returning a tagged verdict (`proceed` / `block-relay-disabled` / `block-over-limit`).
- New `client/lib/relay.test.ts`: 9 cases covering the ICE filter and every gate branch including the size boundary.
- New `client/hooks/useRelayConfiguration.ts`: owns the session-only `relayEnabled` toggle state.
- `P2PTransfer.tsx`: the inline ICE filter becomes `filterIceServers(...)`; the sender's validation block now switches on `evaluateRelayGate(...)`. All side effects (status, error, Sentry breadcrumbs, `peer.destroy()`, `sendAllFiles`) stay inline and behave identically. Sentry stays inline (consistent with the previous step).

## Why the unit test matters

The sender's relay-validation block is **not exercised by e2e** (cli-interop uses `--no-relay`; the browser test is a direct connection). Extracting the decision into a pure function lets `relay.test.ts` cover the relay-disabled and over-limit paths that e2e cannot reach.

## Test plan

- `lint` clean, `test` 73 passing (64 + 9 new), `build` type-checks locally.
- CI e2e green confirms the direct-transfer happy path and the default relay-enabled ICE filter are preserved.
- Behavior preserved: same 2 GB cap, same block messages, `peer.destroy()` only on the relay-disabled path (not the size-limit path).