### PR TITLE
refactor(client): extract classifyPeerError from P2PTransfer

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -24,6 +24,7 @@ import { useConnectionType } from '@/hooks/useConnectionType';
 import { useTransferAnalytics } from '@/hooks/useTransferAnalytics';
 import { useRelayConfiguration } from '@/hooks/useRelayConfiguration';
 import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate } from '@/lib/relay';
+import { classifyPeerError } from '@/lib/peerErrors';
 
 import { QRCodeSVG } from 'qrcode.react';
 
@@ -335,10 +336,7 @@ export function P2PTransfer() {
             // "Ice connection failed." / "Connection failed." — relay likely disabled on sender
             // "User-Initiated Abort" — sender closed the tab or peer was destroyed
             // Log a breadcrumb but do NOT send to Sentry.
-            const isExpected =
-                err.message === 'Ice connection failed.' ||
-                err.message === 'Connection failed.' ||
-                (err.message?.includes('User-Initiated Abort') ?? false);
+            const { isExpected, reason } = classifyPeerError(err.message);
 
             if (isExpected) {
                 Sentry.addBreadcrumb({
@@ -362,13 +360,7 @@ export function P2PTransfer() {
                 setError(`Connection error: ${err.message}`);
             }
             // Track failed connection attempt
-            track('transfer-failed', {
-                reason: err.message?.includes('User-Initiated Abort') ? 'abort'
-                    : err.message === 'Ice connection failed.' ? 'ice-failed'
-                        : err.message === 'Connection failed.' ? 'conn-failed'
-                            : 'unknown',
-                role: 'receiver',
-            });
+            track('transfer-failed', { reason, role: 'receiver' });
             setStatus('Connection failed');
         });
 
@@ -575,11 +567,7 @@ export function P2PTransfer() {
                     return;
                 }
 
-                const isExpected =
-                    !relayEnabled ||
-                    err.message === 'Ice connection failed.' ||
-                    err.message === 'Connection failed.' ||
-                    (err.message?.includes('User-Initiated Abort') ?? false);
+                const { isExpected, reason } = classifyPeerError(err.message, { relayEnabled });
 
                 if (isExpected) {
                     Sentry.addBreadcrumb({
@@ -608,11 +596,7 @@ export function P2PTransfer() {
                     setError(`Connection error: ${err.message}`);
                 }
                 track('transfer-failed', {
-                    reason: !relayEnabled ? 'relay-disabled'
-                        : err.message?.includes('User-Initiated Abort') ? 'abort'
-                            : err.message === 'Ice connection failed.' ? 'ice-failed'
-                                : err.message === 'Connection failed.' ? 'conn-failed'
-                                    : 'unknown',
+                    reason,
                     role: 'sender',
                     files: files.length,
                     bytes: totalBytes,

--- a/client/lib/peerErrors.test.ts
+++ b/client/lib/peerErrors.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { classifyPeerError } from './peerErrors';
+
+describe('classifyPeerError', () => {
+    describe('receiver (relayEnabled defaulted to true)', () => {
+        it('treats an ICE failure as expected', () => {
+            expect(classifyPeerError('Ice connection failed.')).toEqual({
+                isExpected: true,
+                reason: 'ice-failed',
+            });
+        });
+
+        it('treats a generic connection failure as expected', () => {
+            expect(classifyPeerError('Connection failed.')).toEqual({
+                isExpected: true,
+                reason: 'conn-failed',
+            });
+        });
+
+        it('treats a user-initiated abort (substring match) as expected', () => {
+            expect(classifyPeerError('Error: User-Initiated Abort, reason=x')).toEqual({
+                isExpected: true,
+                reason: 'abort',
+            });
+        });
+
+        it('treats any other message as an unexpected bug', () => {
+            expect(classifyPeerError('RTCDataChannel send queue full')).toEqual({
+                isExpected: false,
+                reason: 'unknown',
+            });
+        });
+
+        it('treats an undefined message as unexpected', () => {
+            expect(classifyPeerError(undefined)).toEqual({
+                isExpected: false,
+                reason: 'unknown',
+            });
+        });
+
+        it('never reports relay-disabled when relay is not a concern', () => {
+            expect(classifyPeerError('Ice connection failed.', { relayEnabled: true }).reason).toBe(
+                'ice-failed'
+            );
+        });
+    });
+
+    describe('sender with relay forced off', () => {
+        it('marks every error expected and attributes it to relay-disabled', () => {
+            expect(classifyPeerError('Ice connection failed.', { relayEnabled: false })).toEqual({
+                isExpected: true,
+                reason: 'relay-disabled',
+            });
+        });
+
+        it('attributes even an otherwise-unknown error to relay-disabled', () => {
+            expect(classifyPeerError('weird internal error', { relayEnabled: false })).toEqual({
+                isExpected: true,
+                reason: 'relay-disabled',
+            });
+        });
+    });
+
+    describe('sender with relay enabled', () => {
+        it('classifies like the receiver does', () => {
+            expect(classifyPeerError('Connection failed.', { relayEnabled: true })).toEqual({
+                isExpected: true,
+                reason: 'conn-failed',
+            });
+        });
+
+        it('captures an unexpected error', () => {
+            expect(classifyPeerError('boom', { relayEnabled: true })).toEqual({
+                isExpected: false,
+                reason: 'unknown',
+            });
+        });
+    });
+});

--- a/client/lib/peerErrors.ts
+++ b/client/lib/peerErrors.ts
@@ -1,0 +1,45 @@
+// Pure classification of WebRTC peer errors, shared by the sender and receiver
+// error handlers in P2PTransfer. Kept side-effect free so the branchy
+// "expected vs unexpected" decision and the analytics reason mapping (which the
+// e2e suite cannot reliably trigger) can be unit-tested directly. The caller
+// owns every side effect (Sentry, setError, track, setStatus).
+
+export type PeerErrorReason =
+    | 'relay-disabled'
+    | 'abort'
+    | 'ice-failed'
+    | 'conn-failed'
+    | 'unknown';
+
+/**
+ * Decide whether a peer error is an expected outcome (logged as a breadcrumb,
+ * never sent to Sentry) versus a real bug to capture, and map it to the reason
+ * label reported to analytics.
+ *
+ * `relayEnabled` is a sender-only concern: when the sender forced relay off, any
+ * connection failure is expected and attributed to `relay-disabled`. The receiver
+ * has no relay toggle, so it omits the option and the default (`true`) neutralizes
+ * that term, matching the receiver's original behavior.
+ */
+export function classifyPeerError(
+    message: string | undefined,
+    { relayEnabled = true }: { relayEnabled?: boolean } = {}
+): { isExpected: boolean; reason: PeerErrorReason } {
+    const isAbort = message?.includes('User-Initiated Abort') ?? false;
+    const isIceFailed = message === 'Ice connection failed.';
+    const isConnFailed = message === 'Connection failed.';
+
+    const isExpected = !relayEnabled || isIceFailed || isConnFailed || isAbort;
+
+    const reason: PeerErrorReason = !relayEnabled
+        ? 'relay-disabled'
+        : isAbort
+            ? 'abort'
+            : isIceFailed
+                ? 'ice-failed'
+                : isConnFailed
+                    ? 'conn-failed'
+                    : 'unknown';
+
+    return { isExpected, reason };
+}


### PR DESCRIPTION
## Summary

A surgical follow-up to the hook-extraction series. The sender and receiver `peer.on('error')` handlers each duplicated the same branchy "expected vs unexpected" check and the analytics `reason` mapping. This pulls that pure decision into one tested function and leaves all side effects inline.

- New `client/lib/peerErrors.ts`: `classifyPeerError(message, { relayEnabled })` returns `{ isExpected, reason }`. `relayEnabled` is a sender-only concern (forced-off relay makes any failure expected and attributes it to `relay-disabled`); it defaults to `true` so the receiver call site omits it and behaves exactly as before.
- New `client/lib/peerErrors.test.ts`: 10 cases covering the ICE/conn/abort/unknown mapping, undefined messages, and the relay-disabled override.
- `P2PTransfer.tsx`: both error handlers now call `classifyPeerError(...)`; the Sentry breadcrumbs/capture, `setError` messages, `track()` payloads, and `setStatus` stay inline and unchanged.

## Why

The peer error handlers run on connection failures the e2e suite can't reliably trigger, and the `reason` ternary was duplicated and easy to drift. Extracting the pure decision gives it direct unit coverage and removes the duplication, with zero behavior change.

## Test plan

- `lint` clean, `test` 83 passing (73 + 10 new), `build` type-checks locally.
- Behavior preserved: identical `isExpected` results, identical `reason` labels for both roles (including the sender's `relay-disabled` precedence), identical messages and analytics payloads.