### PR TITLE
refactor(client): extract RelayFallbackToggle from P2PTransfer

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -60,6 +60,7 @@ import {
 import { formatBytes } from '@/lib/utils';
 import { FileIcon } from '@/components/FileIcon';
 import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge';
+import { RelayFallbackToggle } from '@/components/RelayFallbackToggle';
 
 // The room id is the transfer's only secret: anyone holding it can join as the
 // receiver. It lives in the URL fragment (#room=<id>) so it never leaves the
@@ -819,52 +820,7 @@ export function P2PTransfer() {
                                     <div className="mt-4">
                                         {files.length > 0 && !generatedLink && (
                                             <>
-                                                {/* Network Relay Fallback toggle */}
-                                                <div className="mb-4 rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
-                                                    <label className="flex items-start gap-3 cursor-pointer group/relay select-none">
-                                                        <div className="relative flex-shrink-0 mt-0.5">
-                                                            <input
-                                                                type="checkbox"
-                                                                checked={relayEnabled}
-                                                                onChange={(e) => setRelayEnabled(e.target.checked)}
-                                                                className="sr-only"
-                                                            />
-                                                            <div className={`h-4 w-4 rounded-sm border transition-all duration-150 flex items-center justify-center ${relayEnabled
-                                                                    ? 'bg-white border-white'
-                                                                    : 'bg-transparent border-zinc-600 group-hover/relay:border-zinc-400'
-                                                                }`}>
-                                                                {relayEnabled && (
-                                                                    <svg viewBox="0 0 10 8" fill="none" className="h-2.5 w-2.5">
-                                                                        <path d="M1 4l2.5 2.5L9 1" stroke="#09090b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                                                                    </svg>
-                                                                )}
-                                                            </div>
-                                                        </div>
-                                                        <div className="space-y-1.5">
-                                                            <p className="text-sm font-medium text-zinc-200 leading-none">Network Relay Fallback</p>
-                                                            <p className="text-xs text-zinc-500 leading-relaxed">
-                                                                Uses a relay server when a direct connection is unavailable. Recommended for mobile data and private networks. 2 GB limit per session.{' '}
-                                                                <a
-                                                                    href="/how-it-works"
-                                                                    target="_blank"
-                                                                    rel="noreferrer"
-                                                                    onClick={(e) => e.stopPropagation()}
-                                                                    className="text-zinc-400 hover:text-white underline underline-offset-2 transition-colors"
-                                                                >
-                                                                    Learn more
-                                                                </a>
-                                                            </p>
-                                                        </div>
-                                                    </label>
-                                                    {!relayEnabled && (
-                                                        <div className="mt-3 bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 flex items-start gap-2.5">
-                                                            <AlertTriangle className="h-4 w-4 text-amber-400 flex-shrink-0 mt-0.5" />
-                                                            <p className="text-xs text-amber-300 leading-relaxed">
-                                                                Relay fallback is disabled. Transfers may fail if either device is on mobile data or a restricted network and a direct connection cannot be established.
-                                                            </p>
-                                                        </div>
-                                                    )}
-                                                </div>
+                                                <RelayFallbackToggle relayEnabled={relayEnabled} onChange={setRelayEnabled} />
 
                                                 <Button
                                                     onClick={handleCreateLink}

--- a/client/components/RelayFallbackToggle.tsx
+++ b/client/components/RelayFallbackToggle.tsx
@@ -1,0 +1,61 @@
+import { AlertTriangle } from 'lucide-react';
+
+interface RelayFallbackToggleProps {
+    relayEnabled: boolean;
+    onChange: (enabled: boolean) => void;
+}
+
+/**
+ * Sender-side "Network Relay Fallback" checkbox card, shown after files are
+ * picked but before the share link is created. Purely presentational; the
+ * relayEnabled state lives in P2PTransfer (via useRelayConfiguration).
+ */
+export function RelayFallbackToggle({ relayEnabled, onChange }: RelayFallbackToggleProps) {
+    return (
+        <div className="mb-4 rounded-xl border border-zinc-800 bg-zinc-900/60 p-4">
+            <label className="flex items-start gap-3 cursor-pointer group/relay select-none">
+                <div className="relative flex-shrink-0 mt-0.5">
+                    <input
+                        type="checkbox"
+                        checked={relayEnabled}
+                        onChange={(e) => onChange(e.target.checked)}
+                        className="sr-only"
+                    />
+                    <div className={`h-4 w-4 rounded-sm border transition-all duration-150 flex items-center justify-center ${relayEnabled
+                            ? 'bg-white border-white'
+                            : 'bg-transparent border-zinc-600 group-hover/relay:border-zinc-400'
+                        }`}>
+                        {relayEnabled && (
+                            <svg viewBox="0 0 10 8" fill="none" className="h-2.5 w-2.5">
+                                <path d="M1 4l2.5 2.5L9 1" stroke="#09090b" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                        )}
+                    </div>
+                </div>
+                <div className="space-y-1.5">
+                    <p className="text-sm font-medium text-zinc-200 leading-none">Network Relay Fallback</p>
+                    <p className="text-xs text-zinc-500 leading-relaxed">
+                        Uses a relay server when a direct connection is unavailable. Recommended for mobile data and private networks. 2 GB limit per session.{' '}
+                        <a
+                            href="/how-it-works"
+                            target="_blank"
+                            rel="noreferrer"
+                            onClick={(e) => e.stopPropagation()}
+                            className="text-zinc-400 hover:text-white underline underline-offset-2 transition-colors"
+                        >
+                            Learn more
+                        </a>
+                    </p>
+                </div>
+            </label>
+            {!relayEnabled && (
+                <div className="mt-3 bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 flex items-start gap-2.5">
+                    <AlertTriangle className="h-4 w-4 text-amber-400 flex-shrink-0 mt-0.5" />
+                    <p className="text-xs text-amber-300 leading-relaxed">
+                        Relay fallback is disabled. Transfers may fail if either device is on mobile data or a restricted network and a direct connection cannot be established.
+                    </p>
+                </div>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

UI split, PR 2. Extracts the sender's "Network Relay Fallback" checkbox card into a presentational component.

- New `client/components/RelayFallbackToggle.tsx`: the checkbox card + its "disabled" amber warning. Props `{ relayEnabled, onChange }`.
- `P2PTransfer.tsx` renders `<RelayFallbackToggle relayEnabled={relayEnabled} onChange={setRelayEnabled} />`. State stays in the parent (via `useRelayConfiguration`). `AlertTriangle` stays imported in the parent (still used by the over-limit banner).

## Test plan

- `lint` clean, `test` 83 passing (unchanged — presentational), `build` type-checks locally.
- CI e2e drives the sender flow (selects files, creates link), which renders this card, so green confirms the DOM is unchanged.