### PR TITLE
refactor(client): extract ShareLinkPanel from P2PTransfer

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -26,8 +26,6 @@ import { useRelayConfiguration } from '@/hooks/useRelayConfiguration';
 import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate } from '@/lib/relay';
 import { classifyPeerError } from '@/lib/peerErrors';
 
-import { QRCodeSVG } from 'qrcode.react';
-
 import {
     Card,
     CardContent,
@@ -43,15 +41,11 @@ import {
     AlertCircle,
     AlertTriangle,
     ArrowRight,
-    Check,
     CheckCircle2,
-    Copy,
     Download,
     Infinity,
     Loader2,
-    QrCode,
     Radio,
-    Share2,
     ShieldCheck,
     UploadCloud,
     FileArchive,
@@ -62,6 +56,7 @@ import { FileIcon } from '@/components/FileIcon';
 import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge';
 import { RelayFallbackToggle } from '@/components/RelayFallbackToggle';
 import { StatsContributionToggle } from '@/components/StatsContributionToggle';
+import { ShareLinkPanel } from '@/components/ShareLinkPanel';
 
 // The room id is the transfer's only secret: anyone holding it can join as the
 // receiver. It lives in the URL fragment (#room=<id>) so it never leaves the
@@ -835,86 +830,15 @@ export function P2PTransfer() {
 
 
                                         {generatedLink && (
-                                            <div className="rounded-lg bg-black/40 p-4 border border-zinc-800 mb-4">
-                                                <div className="group">
-                                                    <p className="text-[10px] uppercase text-zinc-500 mb-1 font-bold tracking-wider">
-                                                        Share Link
-                                                    </p>
-                                                    <div>
-                                                        <code className="block break-all rounded bg-zinc-950 p-3 text-xs text-zinc-300 font-mono border border-zinc-800 group-hover:border-zinc-600 transition leading-relaxed">
-                                                            {generatedLink}
-                                                        </code>
-                                                        <div className="flex items-center justify-center gap-2 mt-2.5">
-                                                            <button
-                                                                onClick={handleCopy}
-                                                                className="w-20 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md bg-zinc-800/80 hover:bg-zinc-700 border border-zinc-700 text-zinc-400 hover:text-white text-xs font-medium transition-all"
-                                                                aria-label="Copy link"
-                                                            >
-                                                                {copied ? (
-                                                                    <>
-                                                                        <Check className="h-3.5 w-3.5 text-green-500" />
-                                                                        <span className="text-green-500">Copied</span>
-                                                                    </>
-                                                                ) : (
-                                                                    <>
-                                                                        <Copy className="h-3.5 w-3.5" />
-                                                                        Copy
-                                                                    </>
-                                                                )}
-                                                            </button>
-                                                            <button
-                                                                onClick={() => setShowQr((v) => !v)}
-                                                                className={`w-24 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md border text-xs font-medium transition-all ${showQr
-                                                                        ? 'bg-zinc-700 border-zinc-600 text-white'
-                                                                        : 'bg-zinc-800/80 hover:bg-zinc-700 border-zinc-700 text-zinc-400 hover:text-white'
-                                                                    }`}
-                                                                aria-label="Toggle QR code"
-                                                            >
-                                                                <QrCode className="h-3.5 w-3.5" />
-                                                                {showQr ? 'Hide QR' : 'Show QR'}
-                                                            </button>
-                                                            {typeof navigator !== 'undefined' && !!navigator.share && (
-                                                                <button
-                                                                    onClick={handleShare}
-                                                                    className="w-20 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md bg-zinc-800/80 hover:bg-zinc-700 border border-zinc-700 text-zinc-400 hover:text-white text-xs font-medium transition-all"
-                                                                    aria-label="Share link"
-                                                                >
-                                                                    <Share2 className="h-3.5 w-3.5" />
-                                                                    Share
-                                                                </button>
-                                                            )}
-                                                        </div>
-                                                    </div>
-                                                </div>
-
-                                                {showQr && (
-                                                    <div className="mt-3 flex flex-col items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-200">
-                                                        <div className="rounded-2xl bg-white p-4 shadow-lg ring-1 ring-white/10">
-                                                            <QRCodeSVG
-                                                                value={generatedLink}
-                                                                size={156}
-                                                                bgColor="#ffffff"
-                                                                fgColor="#09090b"
-                                                                level="M"
-                                                            />
-                                                        </div>
-                                                        <p className="text-[10px] uppercase tracking-widest text-zinc-600 font-bold">Scan to receive files</p>
-                                                    </div>
-                                                )}
-
-                                                <div className="mt-3 flex w-full items-center justify-center gap-2 text-xs transition-colors duration-300">
-                                                    {status === 'All Files Sent!' || status.includes('Transfer complete') ? (
-                                                        <CheckCircle2 className="h-3 w-3 shrink-0 text-green-400" />
-                                                    ) : (
-                                                        <Loader2 className="h-3 w-3 shrink-0 animate-spin text-zinc-500" />
-                                                    )}
-                                                    <span
-                                                        className={`truncate max-w-[200px] sm:max-w-[280px] ${status === 'All Files Sent!' || status.includes('Transfer complete') ? 'text-green-400 font-medium' : 'text-zinc-500'}`}
-                                                    >
-                                                        {status}
-                                                    </span>
-                                                </div>
-                                            </div>
+                                            <ShareLinkPanel
+                                                generatedLink={generatedLink}
+                                                copied={copied}
+                                                onCopy={handleCopy}
+                                                onShare={handleShare}
+                                                showQr={showQr}
+                                                onToggleQr={() => setShowQr((v) => !v)}
+                                                status={status}
+                                            />
                                         )}
 
                                         <div

--- a/client/components/ShareLinkPanel.tsx
+++ b/client/components/ShareLinkPanel.tsx
@@ -1,0 +1,112 @@
+import { QRCodeSVG } from 'qrcode.react';
+import { Check, CheckCircle2, Copy, Loader2, QrCode, Share2 } from 'lucide-react';
+
+interface ShareLinkPanelProps {
+    generatedLink: string;
+    copied: boolean;
+    onCopy: () => void;
+    onShare: () => void;
+    showQr: boolean;
+    onToggleQr: () => void;
+    status: string;
+}
+
+/**
+ * Sender-side share panel shown once a link exists: the link text, the
+ * Copy/QR/Share buttons, the optional QR code, and the live transfer status line.
+ * Purely presentational; all state and handlers live in P2PTransfer.
+ */
+export function ShareLinkPanel({
+    generatedLink,
+    copied,
+    onCopy,
+    onShare,
+    showQr,
+    onToggleQr,
+    status,
+}: ShareLinkPanelProps) {
+    const isComplete = status === 'All Files Sent!' || status.includes('Transfer complete');
+
+    return (
+        <div className="rounded-lg bg-black/40 p-4 border border-zinc-800 mb-4">
+            <div className="group">
+                <p className="text-[10px] uppercase text-zinc-500 mb-1 font-bold tracking-wider">
+                    Share Link
+                </p>
+                <div>
+                    <code className="block break-all rounded bg-zinc-950 p-3 text-xs text-zinc-300 font-mono border border-zinc-800 group-hover:border-zinc-600 transition leading-relaxed">
+                        {generatedLink}
+                    </code>
+                    <div className="flex items-center justify-center gap-2 mt-2.5">
+                        <button
+                            onClick={onCopy}
+                            className="w-20 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md bg-zinc-800/80 hover:bg-zinc-700 border border-zinc-700 text-zinc-400 hover:text-white text-xs font-medium transition-all"
+                            aria-label="Copy link"
+                        >
+                            {copied ? (
+                                <>
+                                    <Check className="h-3.5 w-3.5 text-green-500" />
+                                    <span className="text-green-500">Copied</span>
+                                </>
+                            ) : (
+                                <>
+                                    <Copy className="h-3.5 w-3.5" />
+                                    Copy
+                                </>
+                            )}
+                        </button>
+                        <button
+                            onClick={onToggleQr}
+                            className={`w-24 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md border text-xs font-medium transition-all ${showQr
+                                    ? 'bg-zinc-700 border-zinc-600 text-white'
+                                    : 'bg-zinc-800/80 hover:bg-zinc-700 border-zinc-700 text-zinc-400 hover:text-white'
+                                }`}
+                            aria-label="Toggle QR code"
+                        >
+                            <QrCode className="h-3.5 w-3.5" />
+                            {showQr ? 'Hide QR' : 'Show QR'}
+                        </button>
+                        {typeof navigator !== 'undefined' && !!navigator.share && (
+                            <button
+                                onClick={onShare}
+                                className="w-20 inline-flex items-center justify-center gap-1.5 py-1.5 rounded-md bg-zinc-800/80 hover:bg-zinc-700 border border-zinc-700 text-zinc-400 hover:text-white text-xs font-medium transition-all"
+                                aria-label="Share link"
+                            >
+                                <Share2 className="h-3.5 w-3.5" />
+                                Share
+                            </button>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {showQr && (
+                <div className="mt-3 flex flex-col items-center gap-2 animate-in fade-in slide-in-from-top-2 duration-200">
+                    <div className="rounded-2xl bg-white p-4 shadow-lg ring-1 ring-white/10">
+                        <QRCodeSVG
+                            value={generatedLink}
+                            size={156}
+                            bgColor="#ffffff"
+                            fgColor="#09090b"
+                            level="M"
+                        />
+                    </div>
+                    <p className="text-[10px] uppercase tracking-widest text-zinc-600 font-bold">Scan to receive files</p>
+                </div>
+            )}
+
+            <div className="mt-3 flex w-full items-center justify-center gap-2 text-xs transition-colors duration-300">
+                {isComplete ? (
+                    <CheckCircle2 className="h-3 w-3 shrink-0 text-green-400" />
+                ) : (
+                    <Loader2 className="h-3 w-3 shrink-0 animate-spin text-zinc-500" />
+                )}
+                <span
+                    className={`truncate max-w-[200px] sm:max-w-[280px] ${isComplete ? 'text-green-400 font-medium' : 'text-zinc-500'}`}
+                >
+                    {status}
+                </span>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

UI split, PR 4. Extracts the sender's share panel (shown once a link exists) into a presentational component.

- New `client/components/ShareLinkPanel.tsx`: the link text + Copy/QR/Share buttons + optional QR code + live status line. Props `{ generatedLink, copied, onCopy, onShare, showQr, onToggleQr, status }`.
- Moves the `QRCodeSVG` import and the `Check`/`Copy`/`QrCode`/`Share2` icon imports into the new file; removes them from `P2PTransfer` (now unused there). `CheckCircle2`/`Loader2` stay in the parent (used elsewhere).
- The repeated `status === 'All Files Sent!' || status.includes('Transfer complete')` check is computed once as a local `isComplete` inside the component (same logic, no behavior change).

## Test plan

- `lint` clean (no unused-import warnings), `test` 83 passing (unchanged — presentational), `build` type-checks locally.
- CI e2e drives the sender flow and asserts the post-link status text, so green confirms the panel renders identically.