### PR TITLE
refactor(client): extract TransferProgressBar from P2PTransfer

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -36,7 +36,6 @@ import {
 } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Progress } from '@/components/ui/progress';
 import {
     AlertCircle,
     AlertTriangle,
@@ -57,6 +56,7 @@ import { ConnectionStatusBadge } from '@/components/ConnectionStatusBadge';
 import { RelayFallbackToggle } from '@/components/RelayFallbackToggle';
 import { StatsContributionToggle } from '@/components/StatsContributionToggle';
 import { ShareLinkPanel } from '@/components/ShareLinkPanel';
+import { TransferProgressBar } from '@/components/TransferProgressBar';
 
 // The room id is the transfer's only secret: anyone holding it can join as the
 // receiver. It lives in the URL fragment (#room=<id>) so it never leaves the
@@ -751,31 +751,15 @@ export function P2PTransfer() {
                             )}
 
                             {progress > 0 && (
-                                <div className="space-y-2">
-                                    <div className="flex justify-between text-xs text-zinc-400 font-mono">
-                                        <span>
-                                            {isSender
-                                                ? status === 'All Files Sent!'
-                                                    ? `Upload Complete (${files.length} ${files.length === 1 ? 'File' : 'Files'})`
-                                                    : `Sending File ${currentFileIndex + 1} of ${files.length}...`
-                                                : status.includes('Receiving')
-                                                    ? status
-                                                    : 'Receiving...'}
-                                        </span>
-                                        <span className="flex items-center gap-2">
-                                            {transferSpeed && estimatedTime && progress < 100 && (
-                                                <span className="text-zinc-500">
-                                                    {transferSpeed} • {estimatedTime}
-                                                </span>
-                                            )}
-                                            <span>{progress}%</span>
-                                        </span>
-                                    </div>
-                                    <Progress
-                                        value={progress}
-                                        className="h-1 bg-zinc-800 [&>div]:bg-zinc-200"
-                                    />
-                                </div>
+                                <TransferProgressBar
+                                    isSender={isSender}
+                                    status={status}
+                                    currentFileIndex={currentFileIndex}
+                                    filesCount={files.length}
+                                    transferSpeed={transferSpeed}
+                                    estimatedTime={estimatedTime}
+                                    progress={progress}
+                                />
                             )}
 
                             {isSender && !generatedLink && (

--- a/client/components/TransferProgressBar.tsx
+++ b/client/components/TransferProgressBar.tsx
@@ -1,0 +1,54 @@
+import { Progress } from '@/components/ui/progress';
+
+interface TransferProgressBarProps {
+    isSender: boolean;
+    status: string;
+    currentFileIndex: number;
+    filesCount: number;
+    transferSpeed: string;
+    estimatedTime: string;
+    progress: number;
+}
+
+/**
+ * The active-transfer progress row: a label (sender upload / receiver download
+ * state), the speed/ETA readout, the percentage, and the bar. Rendered by
+ * P2PTransfer only while `progress > 0`. Purely presentational.
+ */
+export function TransferProgressBar({
+    isSender,
+    status,
+    currentFileIndex,
+    filesCount,
+    transferSpeed,
+    estimatedTime,
+    progress,
+}: TransferProgressBarProps) {
+    return (
+        <div className="space-y-2">
+            <div className="flex justify-between text-xs text-zinc-400 font-mono">
+                <span>
+                    {isSender
+                        ? status === 'All Files Sent!'
+                            ? `Upload Complete (${filesCount} ${filesCount === 1 ? 'File' : 'Files'})`
+                            : `Sending File ${currentFileIndex + 1} of ${filesCount}...`
+                        : status.includes('Receiving')
+                            ? status
+                            : 'Receiving...'}
+                </span>
+                <span className="flex items-center gap-2">
+                    {transferSpeed && estimatedTime && progress < 100 && (
+                        <span className="text-zinc-500">
+                            {transferSpeed} • {estimatedTime}
+                        </span>
+                    )}
+                    <span>{progress}%</span>
+                </span>
+            </div>
+            <Progress
+                value={progress}
+                className="h-1 bg-zinc-800 [&>div]:bg-zinc-200"
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

UI split, PR 5. Extracts the active-transfer progress row into a presentational component.

- New `client/components/TransferProgressBar.tsx`: the sender/receiver label, speed/ETA readout, percentage, and the bar. Props `{ isSender, status, currentFileIndex, filesCount, transferSpeed, estimatedTime, progress }`.
- `P2PTransfer.tsx` renders it inside the existing `progress > 0` guard. The `Progress` UI import moves into the new file (it was only used here) and is removed from the parent.

## Test plan

- `lint` clean (no unused-import warnings), `test` 83 passing (unchanged — presentational), `build` type-checks locally.
- CI e2e drives a real transfer and asserts progress/percentage UI, so green confirms the row renders identically for both roles.