### PR TITLE
docs: sync CONTRIBUTING env tables with current env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,7 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `NEXT_PUBLIC_SOCKET_URL` | Yes | Signaling server URL. Defaults to `https://api.floe.one`. No changes needed for UI contributions. |
+| `NEXT_PUBLIC_SITE_URL` | No | Public base URL for canonical links, Open Graph tags, and the sitemap. Defaults to `https://www.floe.one`. Set to your own domain when self-hosting. |
 | `NEXT_PUBLIC_SENTRY_DSN` | No | Your Sentry DSN for client-side error tracking. Leave empty to disable. |
 | `SENTRY_DSN` | No | Your Sentry DSN for server-side error tracking. Leave empty to disable. |
 | `SENTRY_ORG` | No | Your Sentry organization slug. |
@@ -102,6 +103,8 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 | `NODE_ENV` | No | Standard Node.js runtime flag (`development` or `production`). |
 | `TRUSTED_PROXY_COUNT` | No | Trusted reverse-proxy hop count for correct client-IP parsing and rate limiting (default: `1`). Set to `0` for direct exposure with no proxy. |
 | `MAX_CONNECTIONS_PER_IP` | No | Connection rate limit ceiling per IP per 60 seconds (default: `30`). Raise in staging or test environments. |
+| `MAX_CODE_REQUESTS_PER_IP` | No | Rate limit for the `/api/code` endpoints per IP per 60 seconds (default: `60`), shared across registering and resolving codes. Raise in CI or staging. |
+| `MAX_ACTIVE_CODES` | No | Maximum number of simultaneously-live room codes (default: `10000`). `POST /api/code` returns `503` when the cap is reached. |
 | `TURN_SECRET` | No | Shared secret for coturn HMAC credentials. Omit to use STUN-only (direct connections). |
 | `TURN_DOMAIN` | No | Your TURN relay server domain. |
 | `UPSTASH_REDIS_REST_URL` | No | Upstash Redis REST URL for the durable global transfer counter. Omit to run the counter in memory only (resets on restart). |


### PR DESCRIPTION
## Summary

Documentation accuracy audit follow-up. `CONTRIBUTING.md`'s environment-variable tables had drifted behind merged code changes: three env vars present in the `.env.example` files (and in `docs/self-hosting/configuration.mdx`) were missing here.

- Client table: add `NEXT_PUBLIC_SITE_URL` (added in #123; in `client/.env.example`).
- Server table: add `MAX_CODE_REQUESTS_PER_IP` and `MAX_ACTIVE_CODES` (added in #122; in `server/.env.example` and `server/server.js`).

Descriptions match the canonical configuration reference and the actual server defaults (60/min code limit, 10000 active-code cap → 503).

## Context

This is the only inaccuracy found in a full pass over all 34 tracked doc/`.md` files against the code (`server.js`, the CLI, and the protocol constants). Every `docs/**` page was verified accurate and needs no change. The v1.7.2 changelog entry was already merged separately (#140).

## Test plan

- Markdown-only change; no code affected. CI runs (root file is outside the `docs/**` paths-ignore) and passes unchanged.
- Verified the three vars and their defaults against `client/.env.example`, `server/.env.example`, and `server/server.js`.