### PR TITLE
fix(docker): repair the client image build for self-hosting

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -6,13 +6,18 @@
 # image (`docker compose build client`).
 
 # ---- Builder ---------------------------------------------------------------
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
-RUN npm install -g pnpm@11
+# Pin pnpm to package.json's `packageManager` version so `--frozen-lockfile`
+# matches the lockfile exactly. pnpm 11.x requires Node 22+ (it uses the
+# node:sqlite builtin), which is why the base image is node:22, not node:20.
+RUN npm install -g pnpm@11.1.2
 WORKDIR /app
 
-# Install dependencies first for layer caching.
-COPY package.json pnpm-lock.yaml ./
+# Install dependencies first for layer caching. pnpm-workspace.yaml carries the
+# dependency `overrides` (security pins) baked into the lockfile; without it,
+# `--frozen-lockfile` aborts with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Build the standalone server. Sentry source-map upload stays disabled unless you
@@ -24,7 +29,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
 # ---- Runner ----------------------------------------------------------------
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary

`docker compose up --build` was **failing on the client image**, so the documented one-command self-host did not actually work. Found by building the stack from a clean checkout. Two separate breakages in `client/Dockerfile`, both fixed:

1. **Node base too old for pnpm.** The builder used `node:20-alpine` with `pnpm@11` (floating). Current pnpm 11.x requires Node 22.13+ (it imports the `node:sqlite` builtin), so `pnpm install` crashed with `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite`. Bumped builder and runner to `node:22-alpine`, and pinned `pnpm@11.1.2` to match `package.json`'s `packageManager` field so `--frozen-lockfile` is reproducible.
2. **Missing `pnpm-workspace.yaml`.** The dependency `overrides` (security pins for `esbuild`/`ws`/`postcss`/etc.) live in `client/pnpm-workspace.yaml` and are baked into the lockfile, but the install-stage `COPY` only copied `package.json` + `pnpm-lock.yaml`. pnpm then aborted with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Added `pnpm-workspace.yaml` to that `COPY`.

## Verification (built and ran locally, no secrets)

- `cp .env.docker.example .env && docker compose up -d --build` now builds both images and starts cleanly.
- Client: `http://localhost:3000` returns **200** with `<title>Floe</title>`.
- Server: `/health` healthy; `/api/turn-credentials` returns STUN-only (no TURN secret), `/api/stats` returns `{"totalBytes":0}` (no Redis) — graceful degradation confirmed.
- Port honored: `PORT=3999 docker compose up -d server` publishes `0.0.0.0:3999->3001` and responds.

The server image was already fine; only the client image was broken.

## Note

CI builds the client with `pnpm build` directly, not via Docker, which is why this slipped through. A follow-up could add a `docker build` smoke test to CI to prevent regressions.