### PR TITLE
fix: raise browser sender ack timeout to 120s; correct MITM docs claim

### DIFF
--- a/client/lib/transfer/ackTimeout.test.ts
+++ b/client/lib/transfer/ackTimeout.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { sendFiles, type SenderDeps } from './sender';
+import { ackMessage, ACK_TIMEOUT_MS } from './protocol';
+
+const enc = new TextEncoder();
+
+// No-op buffer channel — backpressure is never engaged in these tests
+// (bufferedAmount stays at 0, well below HIGH_WATER).
+function makeBufferChannel() {
+    return {
+        bufferedAmount: 0,
+        bufferedAmountLowThreshold: 0,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+    };
+}
+
+// Builds SenderDeps that capture the receiver-side data handler so the test can
+// deliver (or withhold) the ack on its own schedule. `send` is a black hole:
+// the file bytes go nowhere, which is fine because we only care about the ack
+// handshake, not reassembly.
+function makeDeps() {
+    let handler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+    const deps: SenderDeps = {
+        send: () => {},
+        onData: (h) => {
+            handler = h;
+            return () => { handler = null; };
+        },
+        channel: makeBufferChannel(),
+        sctpMaxMessageSize: null,
+    };
+    return { deps, deliverAck: (id: string) => handler?.(enc.encode(ackMessage(id, 0))) };
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('sender ack timeout', () => {
+    it('proceeds when the ack arrives after 30s (slow interactive CLI accept)', async () => {
+        vi.useFakeTimers();
+        const { deps, deliverAck } = makeDeps();
+        const onError = vi.fn();
+
+        const file = new File([new Uint8Array(8)], 'x.bin');
+        const p = sendFiles(deps, [{ id: 'id-slow', file }], { onError });
+
+        // Flush the synchronous setup so metadata is sent and the ack handler is
+        // registered before any timers advance.
+        await vi.advanceTimersByTimeAsync(0);
+
+        // 30s elapses without an ack — under the 120s deadline, so no timeout yet.
+        await vi.advanceTimersByTimeAsync(30_000);
+        expect(onError).not.toHaveBeenCalled();
+
+        // Receiver finally accepts; the transfer should run to completion.
+        deliverAck('id-slow');
+        await vi.advanceTimersByTimeAsync(0);
+        await p;
+
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it('times out with the expected message when no ack ever arrives', async () => {
+        vi.useFakeTimers();
+        const { deps } = makeDeps();
+        const onError = vi.fn();
+
+        const file = new File([new Uint8Array(8)], 'x.bin');
+        const p = sendFiles(deps, [{ id: 'id-never', file }], { onError });
+
+        await vi.advanceTimersByTimeAsync(ACK_TIMEOUT_MS);
+        await p;
+
+        expect(onError).toHaveBeenCalledWith(
+            expect.stringContaining('timed out waiting for receiver')
+        );
+    });
+});

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -8,6 +8,13 @@ export const READ_SLAB = 4 * 1024 * 1024;  // 4 MB — disk read slab size
 export const DEFAULT_CHUNK = 64 * 1024;    // 64 KB — fallback chunk size
 export const MAX_CHUNK = 256 * 1024;       // 256 KB — cap on adaptive chunk
 
+// Milliseconds the sender waits for the receiver's ack before failing. Mirrors
+// the CLI sender's 120 s ack deadline (cli/engine/transfer/sender.go). It must be
+// this generous because a CLI receiver only acks after a human answers its
+// interactive "Accept? [Y/n]" prompt; a shorter timeout aborts a browser→CLI
+// transfer whenever the person at the terminal is slow to accept.
+export const ACK_TIMEOUT_MS = 120_000;
+
 // ProtocolVersion is the highest wire protocol version this build speaks.
 // MinProtocolVersion is the lowest it still supports.
 //

--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -12,6 +12,7 @@ import {
     compatErrorMessage,
     PROTOCOL_VERSION,
     MIN_PROTOCOL_VERSION,
+    ACK_TIMEOUT_MS,
     type Ack,
     type Incompatible,
 } from './protocol';
@@ -246,6 +247,6 @@ function waitForAck(
                 }
             });
         }),
-        new Promise<AckResult>((resolve) => setTimeout(() => resolve({ type: 'timeout' }), 15_000)),
+        new Promise<AckResult>((resolve) => setTimeout(() => resolve({ type: 'timeout' }), ACK_TIMEOUT_MS)),
     ]);
 }

--- a/docs/how-it-works/encryption.mdx
+++ b/docs/how-it-works/encryption.mdx
@@ -21,7 +21,7 @@ These properties hold on self-hosted instances as well. The signaling server and
 <Accordion title="Technical details">
   **DTLS for data channels:** WebRTC data channels are transported over SCTP (Stream Control Transmission Protocol) running on top of DTLS. This is distinct from DTLS-SRTP, which is used for audio/video media streams. Both provide strong encryption, but data channels specifically use SCTP over DTLS.
 
-  **Key exchange:** Each peer generates a certificate and key pair for the session. The fingerprints of these certificates are exchanged via the SDP offer and answer during signaling. DTLS verifies these fingerprints during the handshake, ensuring that even if the signaling channel is compromised, a man-in-the-middle cannot inject a different certificate.
+  **Key exchange:** Each peer generates a certificate and key pair for the session. The fingerprints of these certificates are exchanged via the SDP offer and answer during signaling. DTLS verifies these fingerprints during the handshake, so an outside attacker on the network path cannot substitute a different certificate. As in every WebRTC application, this guarantee depends on the signaling server relaying the fingerprints faithfully: a malicious server could in principle swap them to mount a man-in-the-middle attack. Self-hosting removes reliance on a third-party server for this.
 
   **Per-session keys:** Keys are ephemeral. They are generated when the connection is created and discarded when it closes. There is no key escrow, no recovery mechanism, and no persistent storage of session keys.
 </Accordion>

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -62,7 +62,7 @@ Key properties:
 - Encryption keys are generated uniquely for each transfer session.
 - Keys exist only on the two devices involved. There is no central key server.
 - Keys are ephemeral. They are discarded when the connection closes and cannot be recovered.
-- The signaling server exchanges certificate fingerprints during negotiation, so a compromised signaling channel cannot inject a different certificate (man-in-the-middle protection).
+- The DTLS handshake verifies each peer's certificate against the fingerprint exchanged during signaling, so an outside attacker on the network cannot inject a different certificate. Like every WebRTC application, Floe trusts the signaling server to relay those fingerprints faithfully. Running your own instance removes that dependency entirely (see [Self-hosted instances](#self-hosted-instances)).
 
 See [End-to-End Encryption](/how-it-works/encryption) for a deeper technical explanation.
 


### PR DESCRIPTION
## Summary

Two small correctness fixes bundled from the project analysis.

**1. Interop bug: browser sender aborted after 15s waiting for the receiver's ack.** A CLI receiver only sends its ack after a human answers the interactive `Accept? [Y/n]` prompt. If the person at the terminal took longer than 15 seconds, the browser gave up with "Transfer timed out waiting for receiver" and the browser-to-CLI transfer failed. The Go sender already allows 120s for exactly this reason (`cli/engine/transfer/sender.go`); this mirrors it with a shared `ACK_TIMEOUT_MS = 120_000` constant in `client/lib/transfer/protocol.ts` (the designated mirror of the Go wire constants).

**2. Docs overstated the MITM guarantee.** `docs/security-privacy.mdx` and `docs/how-it-works/encryption.mdx` claimed a compromised signaling channel "cannot inject a different certificate." DTLS only blocks an outside network attacker; the signaling server relays the certificate fingerprints and is therefore trusted to relay them faithfully (the code's own comments in `verify.go`/`verify.ts` say as much). Reworded to state the real guarantee and note that self-hosting removes the third-party dependency. No behavior change.

## Test plan

- New unit tests in `client/lib/transfer/ackTimeout.test.ts` (vitest fake timers):
  - ack delivered at 30s now completes without error (fails on the old 15s value)
  - a missing ack still times out with the expected message after 120s
- `corepack pnpm test` (85 tests pass), `corepack pnpm lint`, and `corepack pnpm build` all clean.
- Docs verified free of em dashes (Vale/Mintlify Grammar linter is the CI backstop).
- Manual: browser send to `floe receive ... --server http://localhost:3001`, wait ~30s at the accept prompt before pressing Y; transfer now completes instead of timing out.