### PR TITLE
feat(server): add Cloudflare Realtime TURN with coturn fallback

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -31,9 +31,15 @@ TRUSTED_PROXY_COUNT=1
 # Raise this in staging or testing environments that drive many connections from one IP.
 MAX_CONNECTIONS_PER_IP=30
 
-# --- Optional TURN relay (coturn) -------------------------------------------
-# Leave both empty for STUN-only (direct connections). Fill them in AND start the
-# coturn service (`docker compose --profile turn up -d`) to enable relay for users
+# --- Optional TURN relay ----------------------------------------------------
+# Managed TURN via Cloudflare Realtime (recommended, no public IP needed). Create a
+# TURN key at https://dash.cloudflare.com (Realtime > TURN Server) and paste the
+# Turn Token ID + API token. These take precedence over the coturn vars below.
+CLOUDFLARE_TURN_KEY_ID=
+CLOUDFLARE_TURN_KEY_API_TOKEN=
+
+# Self-hosted coturn (used only if the Cloudflare vars above are unset). Fill both
+# in AND start the coturn service (`docker compose --profile turn up -d`) for peers
 # behind strict NAT / CGNAT. TURN_SECRET must match `static-auth-secret` in
 # coturn/turnserver.conf. See SELF_HOSTING.md.
 TURN_SECRET=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,9 @@ services:
       CLIENT_URL: ${CLIENT_URL:-http://localhost:3000}
       TRUSTED_PROXY_COUNT: ${TRUSTED_PROXY_COUNT:-1}
       MAX_CONNECTIONS_PER_IP: ${MAX_CONNECTIONS_PER_IP:-30}
+      # Managed TURN via Cloudflare Realtime (takes precedence over coturn below).
+      CLOUDFLARE_TURN_KEY_ID: ${CLOUDFLARE_TURN_KEY_ID:-}
+      CLOUDFLARE_TURN_KEY_API_TOKEN: ${CLOUDFLARE_TURN_KEY_API_TOKEN:-}
       TURN_SECRET: ${TURN_SECRET:-}
       TURN_DOMAIN: ${TURN_DOMAIN:-}
       # Durable global-stats counter (optional). Without these the counter is

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -1,11 +1,35 @@
 ---
-title: "TURN Relay (coturn)"
+title: "TURN Relay"
 description: "Add a TURN server to support peers behind strict NAT or CGNAT."
 ---
 
 A TURN server relays the (still end-to-end encrypted) stream when two peers cannot reach each other directly. This is common with symmetric NAT or carrier-grade NAT. Without TURN, those specific transfers fail. All other transfers still work over direct connections.
 
-## Infrastructure requirements
+You have two options: a managed TURN service (recommended) or a self-hosted coturn relay.
+
+## Managed TURN via Cloudflare (recommended)
+
+Cloudflare's Realtime TURN service runs on Cloudflare's global anycast network. It needs no public IP, no UDP port range, and no TLS certificates on your side, and it includes a generous free tier.
+
+<Steps>
+  <Step title="Create a TURN key">
+    In the [Cloudflare dashboard](https://dash.cloudflare.com), open **Realtime > TURN Server** and create a key. Copy the **Turn Token ID** and its **API token** (the token is shown only once).
+  </Step>
+  <Step title="Set the server environment">
+    In `.env`:
+
+    ```env
+    CLOUDFLARE_TURN_KEY_ID=<your Turn Token ID>
+    CLOUDFLARE_TURN_KEY_API_TOKEN=<your API token>
+    ```
+
+    The signaling server mints short-lived ICE credentials from Cloudflare and caches them. These variables take precedence over the coturn variables below, so you do not need to run coturn.
+  </Step>
+</Steps>
+
+## Self-hosting with coturn
+
+Prefer to run the relay yourself? Leave the Cloudflare variables unset and configure coturn instead.
 
 TURN requires a **public IP address**, a **domain name**, and **TLS certificates**. The bundled `coturn` service uses host networking and is intended for a Linux host with a public IP.
 
@@ -72,7 +96,7 @@ When TURN is configured, the response contains `turn:` and `turns:` entries, plu
 ]
 ```
 
-When `TURN_SECRET` and `TURN_DOMAIN` are unset, the endpoint instead returns the Google public STUN servers only.
+With Cloudflare configured, the response instead contains `turn.cloudflare.com` entries. When neither the Cloudflare variables nor `TURN_SECRET` / `TURN_DOMAIN` are set, the endpoint returns the Google public STUN servers only.
 
 ## How credentials work
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -23,8 +23,15 @@ MAX_CODE_REQUESTS_PER_IP=60
 # POST /api/code returns 503 once this many codes are active, bounding memory.
 MAX_ACTIVE_CODES=10000
 
-# Optional: TURN relay server
-# Without these, the server falls back to Google public STUN servers.
+# Optional: managed TURN via Cloudflare Realtime (recommended, no public IP needed).
+# Create a TURN key at https://dash.cloudflare.com (Realtime > TURN Server) and paste
+# the Turn Token ID + its API token below. These take precedence over the coturn vars.
+# The API token is a secret — keep it out of version control.
+CLOUDFLARE_TURN_KEY_ID=
+CLOUDFLARE_TURN_KEY_API_TOKEN=
+
+# Optional: self-hosted TURN relay (coturn), used only when the Cloudflare vars above
+# are unset. Without any of these, the server falls back to Google public STUN servers.
 # Direct connections still work on most home and mobile networks.
 TURN_SECRET=
 TURN_DOMAIN=

--- a/server/server.js
+++ b/server/server.js
@@ -120,7 +120,71 @@ function generateCoturnCredentials() {
     ];
 }
 
-app.get('/api/turn-credentials', (req, res) => {
+// ---------------------------------------------------------------------------
+// Cloudflare Realtime TURN
+//
+// When CLOUDFLARE_TURN_KEY_ID / CLOUDFLARE_TURN_KEY_API_TOKEN are set, mint
+// short-lived ICE servers from Cloudflare's global anycast TURN network. The
+// credentials are not per-user, so cache one set in memory and refresh well
+// before the 24h TTL instead of calling the API on every request. STUN and TURN
+// are returned as separate entries so the client's relay-off filter
+// (filterIceServers) can drop TURN while keeping STUN.
+// ---------------------------------------------------------------------------
+
+const CLOUDFLARE_TURN_KEY_ID = process.env.CLOUDFLARE_TURN_KEY_ID;
+const CLOUDFLARE_TURN_KEY_API_TOKEN = process.env.CLOUDFLARE_TURN_KEY_API_TOKEN;
+const CF_TURN_TTL = 24 * 3600;         // credential lifetime requested from Cloudflare (seconds)
+const CF_CACHE_MS = 12 * 3600 * 1000;  // refresh our cached copy every 12h (well within the TTL)
+
+let cfIceCache = { servers: null, expires: 0 };
+
+async function generateCloudflareIceServers() {
+    if (!CLOUDFLARE_TURN_KEY_ID || !CLOUDFLARE_TURN_KEY_API_TOKEN) return null;
+    if (cfIceCache.servers && Date.now() < cfIceCache.expires) return cfIceCache.servers;
+    try {
+        const resp = await fetch(
+            `https://rtc.live.cloudflare.com/v1/turn/keys/${CLOUDFLARE_TURN_KEY_ID}/credentials/generate-ice-servers`,
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: `Bearer ${CLOUDFLARE_TURN_KEY_API_TOKEN}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ ttl: CF_TURN_TTL }),
+            }
+        );
+        if (!resp.ok) return cfIceCache.servers; // serve last good copy on a transient failure
+        const { iceServers } = await resp.json();
+        if (!iceServers) return cfIceCache.servers;
+
+        // Cloudflare returns one object with all URLs and a single credential.
+        // Split STUN from TURN so the client can strip TURN while keeping STUN
+        // when the user disables relay fallback.
+        const raw = Array.isArray(iceServers) ? iceServers : [iceServers];
+        const stunUrls = [];
+        const turnUrls = [];
+        let username;
+        let credential;
+        for (const s of raw) {
+            const urls = Array.isArray(s.urls) ? s.urls : [s.urls];
+            for (const u of urls) {
+                (u.startsWith('stun:') ? stunUrls : turnUrls).push(u);
+            }
+            if (s.username) { username = s.username; credential = s.credential; }
+        }
+        const servers = [];
+        if (stunUrls.length) servers.push({ urls: stunUrls });
+        if (turnUrls.length) servers.push({ urls: turnUrls, username, credential });
+        if (!servers.length) return cfIceCache.servers;
+
+        cfIceCache = { servers, expires: Date.now() + CF_CACHE_MS };
+        return servers;
+    } catch {
+        return cfIceCache.servers; // network hiccup: last good copy (may be null, then we fall through)
+    }
+}
+
+app.get('/api/turn-credentials', async (req, res) => {
     const ip = req.ip;  // Express resolves this correctly via trust proxy
     const now = Date.now();
 
@@ -130,7 +194,8 @@ app.get('/api/turn-credentials', (req, res) => {
     timestamps.push(now);
     turnRateLimits.set(ip, timestamps);
 
-    const credentials = generateCoturnCredentials();
+    // Prefer Cloudflare's managed TURN, then self-hosted coturn, then public STUN.
+    const credentials = (await generateCloudflareIceServers()) || generateCoturnCredentials();
     res.json(credentials || STUN_FALLBACK);
 });
 


### PR DESCRIPTION
## Summary

Adds managed TURN via Cloudflare Realtime as the preferred TURN backend for the signaling server, ahead of the existing self-hosted coturn path. This supports moving Floe's infra off the DigitalOcean droplet (which self-hosted coturn) to a signaling-only Azure VM plus Cloudflare's global anycast TURN network.

- `/api/turn-credentials` mints short-lived ICE servers from Cloudflare when `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN` are set, caches one set in memory (12h refresh, well within the 24h TTL), and splits STUN from TURN so the client relay-off filter (`filterIceServers`) still drops TURN while keeping STUN.
- Precedence: Cloudflare, then self-hosted coturn (`TURN_SECRET` / `TURN_DOMAIN`), then public STUN fallback. Self-hosters are unaffected.
- Client (`client/lib/relay.ts`) and CLI (`cli/internal/ice/credentials.go`) consume the ICE list generically, so they need no changes.
- Env examples and docs updated: `server/.env.example`, `.env.docker.example`, `docker-compose.yml`, `docs/self-hosting/turn-relay.mdx`.

## Test plan

- `npm test` in `server/` (37 pass).
- Post-merge, validated on the Azure host: `/api/turn-credentials` returns `turn.cloudflare.com` entries and a real relayed transfer completes.