### PR TITLE
docs: point production TURN references at Cloudflare

### DIFF
--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -18,7 +18,7 @@ export default function PrivacyPolicy() {
                     <h1 className="text-4xl font-bold tracking-tight text-white">
                         Privacy Policy
                     </h1>
-                    <p className="text-zinc-400">Last updated: June 2026</p>
+                    <p className="text-zinc-400">Last updated: July 2026</p>
                 </div>
 
                 <div className="p-6 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-4">
@@ -113,7 +113,9 @@ export default function PrivacyPolicy() {
                         <p>
                             Floe uses third-party infrastructure providers for
                             hosting and network relay services. The web app is
-                            hosted on Vercel. For usage analytics we use only
+                            hosted on Vercel, the signaling server runs on Microsoft
+                            Azure, and when a relay is needed, encrypted file data
+                            passes through Cloudflare&apos;s TURN network. For usage analytics we use only
                             Umami, which is cookieless and does not track you
                             across sites, and we optionally use Sentry for error
                             monitoring. The link you share carries its room id in
@@ -134,15 +136,15 @@ export default function PrivacyPolicy() {
                         </h3>
                         <p>
                             When a direct connection cannot be established, file data
-                            is routed through our TURN relay server (
+                            is routed through Cloudflare&apos;s TURN relay network (
                             <code className="text-xs bg-zinc-800 px-1.5 py-0.5 rounded text-zinc-300">
-                                turn.floe.one
+                                turn.cloudflare.com
                             </code>
-                            ). This server processes encrypted data packets in transit
+                            ). The relay processes encrypted data packets in transit
                             and does not store, decrypt, or inspect any file contents.
                             Relay sessions are limited to 2 GB per session. Connection
                             metadata (timestamps, IP addresses) may be logged by the
-                            hosting provider for security purposes.
+                            infrastructure provider for security purposes.
                         </p>
                     </section>
 

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -17,7 +17,7 @@ Some networks make it impossible for two devices to connect directly. This happe
 
 ## TURN fallback
 
-When a direct connection fails, Floe automatically routes through a **TURN server** (`turn.floe.one`). A TURN server acts as a secure bridge. Your data travels through it on the way to the recipient, like a courier carrying a locked box it cannot open.
+When a direct connection fails, Floe automatically routes through a **TURN server** on Cloudflare's global anycast network. A TURN server acts as a secure bridge. Your data travels through it on the way to the recipient, like a courier carrying a locked box it cannot open.
 
 ## Encryption
 
@@ -43,9 +43,9 @@ With relay disabled, the transfer fails if a direct path cannot be established.
 <Accordion title="Technical details">
   **TURN (Traversal Using Relays around NAT):** When ICE negotiation produces only `relay` candidates, both peers connect to the TURN server and the server forwards packets between them. The data is still DTLS-encrypted end-to-end before it reaches the TURN server.
 
-  **Credentials:** The signaling server issues time-limited HMAC-SHA1 credentials for coturn (`username: {expiry}:floeuser`, `password: base64(HMAC-SHA1(secret, username))`). Credentials are valid for 24 hours.
+  **Credentials:** The signaling server mints short-lived credentials from Cloudflare's Realtime TURN service and hands them to peers via `/api/turn-credentials`. Credentials are valid for up to 24 hours. (Self-hosted deployments can instead use coturn with time-limited HMAC-SHA1 credentials; see the self-hosting guide.)
 
-  **Endpoints:** `turn:turn.floe.one:3478` (STUN/TURN over UDP and TCP) and `turns:turn.floe.one:5349` (TURN over TLS).
+  **Endpoints:** `turn:turn.cloudflare.com:3478` (STUN/TURN over UDP and TCP) and `turns:turn.cloudflare.com:5349` (TURN over TLS), plus TCP fallbacks on ports 80 and 443.
 
   **Relay detection:** The browser polls `RTCStatsReport` every 5 seconds and examines the nominated candidate pair. If either candidate is of type `relay`, the connection indicator shows amber.
 </Accordion>

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -12,9 +12,9 @@ This page is a technical reference for contributors and advanced self-hosters. F
 | Client | Next.js 16 (React 19) | 3000 | Browser UI, WebRTC peer (via simple-peer) |
 | Server | Node.js (Express 5, Socket.IO 4, ws 8) | 3001 | Signaling broker, TURN credential issuer |
 | CLI | Go 1.25 (Pion WebRTC v4) | - | Headless sender/receiver |
-| coturn | coturn (optional) | 3478, 5349 | TURN relay server |
+| TURN relay | Cloudflare Realtime TURN (floe.one) or self-hosted coturn | 3478, 5349 | Relays encrypted packets when a direct path fails |
 
-File data never passes through the server or coturn. All file bytes travel over encrypted WebRTC data channels between peers.
+File data never passes through the signaling server, and only end-to-end-encrypted packets ever transit the TURN relay. All file bytes travel over encrypted WebRTC data channels between peers.
 
 ## Signaling transports
 
@@ -31,7 +31,7 @@ The server exposes two transports. Both share the same `rooms` registry (`Map<ro
 |--------|------|-------------|
 | `GET` | `/` | Status check. Returns `{ "status": "ok", "timestamp": "..." }`. |
 | `GET` | `/health` | Liveness probe. Returns `{ "status": "healthy", "uptime": <seconds> }`. |
-| `GET` | `/api/turn-credentials` | Returns ICE server list. With `TURN_SECRET` set, includes coturn credentials. Without it, returns Google STUN servers only. Rate-limited to 20 requests per IP per 60 s. |
+| `GET` | `/api/turn-credentials` | Returns ICE server list. Prefers Cloudflare Realtime TURN when `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN` are set, then self-hosted coturn when `TURN_SECRET` is set, otherwise Google STUN only. Rate-limited to 20 requests per IP per 60 s. |
 | `POST` | `/api/code` | Registers a short code for a room ID. Body: `{ "roomId": "<uuid>" }`. Response: `{ "code": "word-word-word" }`. TTL: 10 minutes. Rate-limited to 60 requests per IP per 60 s (shared with `GET /api/code/:code`, configurable via `MAX_CODE_REQUESTS_PER_IP`). Returns `503` when the live-code count hits `MAX_ACTIVE_CODES` (default 10000). |
 | `GET` | `/api/code/:code` | Resolves a short code to a room ID. Response: `{ "roomId": "<uuid>" }`. Returns 404 if expired or not found. Rate-limited to 60 requests per IP per 60 s (shared with `POST /api/code`, configurable via `MAX_CODE_REQUESTS_PER_IP`). |
 | `GET` | `/api/stats` | Returns the all-time global transfer counter: `{ "totalBytes": <integer> }`. Served from an in-memory cache (no Redis read per request). |
@@ -39,7 +39,7 @@ The server exposes two transports. Both share the same `rooms` registry (`Map<ro
 
 ### TURN credentials response
 
-When `TURN_SECRET` and `TURN_DOMAIN` are set:
+On floe.one the endpoint returns short-lived Cloudflare Realtime TURN credentials (`turn.cloudflare.com`). For a self-hosted coturn relay, when `TURN_SECRET` and `TURN_DOMAIN` are set it returns:
 
 ```json
 [
@@ -58,7 +58,7 @@ When `TURN_SECRET` is unset:
 ]
 ```
 
-Credentials use HMAC-SHA1: `username = "{expiry_unix}:floeuser"`, `credential = base64(HMAC-SHA1(TURN_SECRET, username))`. Expiry is 24 hours from issuance.
+For self-hosted coturn, credentials use HMAC-SHA1: `username = "{expiry_unix}:floeuser"`, `credential = base64(HMAC-SHA1(TURN_SECRET, username))`. Expiry is 24 hours from issuance.
 
 ## Socket.IO events (browser)
 


### PR DESCRIPTION
## Summary

Production `floe.one` now relays through **Cloudflare Realtime TURN**, not the old self-hosted coturn at `turn.floe.one` (which is being decommissioned along with the DigitalOcean droplet). This updates the user- and contributor-facing docs that still named the old relay, so nothing points at a hostname that is about to disappear.

- **Privacy policy** (`client/app/privacy/page.tsx`): relay section now names Cloudflare's TURN network (`turn.cloudflare.com`); third-party section notes the signaling server runs on Microsoft Azure and relay data transits Cloudflare; "Last updated" bumped to July 2026.
- **Relay connection** (`docs/how-it-works/relay-connection.mdx`): TURN server and endpoints now reference Cloudflare; credential note describes the Cloudflare-issued short-lived creds, with coturn kept as the self-host path.
- **Architecture reference** (`docs/reference/architecture.mdx`): component table, `/api/turn-credentials` description, and credentials section reflect Cloudflare-first precedence, coturn documented as the self-hosting option.

Self-hosting docs (`docs/self-hosting/*`, `docker-compose.yml`, `.env.example`) intentionally keep coturn, since it remains a supported self-host relay. No `turn.floe.one` references remain in the repo.

## Test plan
- `grep -r turn.floe.one` returns nothing.
- CI (build + lint + e2e) green.