### PR TITLE
docs: align all md/mdx with the Cloudflare TURN migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,10 @@ The CLI uses GoReleaser for cross-platform distribution; version is injected via
 ```
 CLIENT_URL=http://localhost:3000
 PORT=3001
-TURN_SECRET=                 # optional Coturn HMAC secret
-TURN_DOMAIN=                 # optional TURN server hostname
+CLOUDFLARE_TURN_KEY_ID=      # optional, managed Cloudflare Realtime TURN (takes precedence)
+CLOUDFLARE_TURN_KEY_API_TOKEN= # optional, pairs with the key ID above
+TURN_SECRET=                 # optional coturn HMAC secret (used when Cloudflare vars unset)
+TURN_DOMAIN=                 # optional coturn hostname
 UPSTASH_REDIS_REST_URL=      # optional, durable global stats counter
 UPSTASH_REDIS_REST_TOKEN=    # optional, pairs with the URL above
 MAX_REPORT_BYTES=            # optional, per-report cap (default 5 TB)
@@ -76,7 +78,7 @@ The data-channel transfer protocol carries its own version, independent of the r
 `POST /api/code` registers a short human-readable phrase (e.g. `olive-tiger-castle`) mapping to a room ID with 10-min TTL. `GET /api/code/:code` resolves it. Words come from `server/words.json`.
 
 ### TURN Credentials
-`GET /api/turn-credentials` issues short-lived (24h) Coturn HMAC-SHA1 credentials. Called by both client and CLI before connecting. If `TURN_SECRET` is unset, only STUN is returned.
+`GET /api/turn-credentials` returns the ICE server list; called by both client and CLI before connecting. Precedence: **Cloudflare Realtime TURN** when `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN` are set (what floe.one runs; short-lived credentials minted from Cloudflare's `generate-ice-servers` API, cached in memory ~12h, with STUN and TURN returned as separate entries so the client's relay-off filter can strip TURN while keeping STUN), then self-hosted **coturn** HMAC-SHA1 credentials (24h) when `TURN_SECRET` / `TURN_DOMAIN` are set, otherwise Google STUN only.
 
 ### Global Stats Counter
 A public, all-time counter of total bytes transferred across every Floe user, shown on the homepage (`client/components/GlobalStats.tsx`) with a NumberFlow odometer animation. Because Floe is P2P and file bytes never reach the server, the **receiver** peer reports the byte count out-of-band over HTTP after a completed transfer. Only the receiver reports (browser receiver in `P2PTransfer.tsx`, CLI receiver in `cli/internal/transfer/receiver.go`), so each transfer is counted exactly once. The sender never reports. The data-channel protocol is unchanged, so no `ProtocolVersion` bump is needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,10 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 | `MAX_CONNECTIONS_PER_IP` | No | Connection rate limit ceiling per IP per 60 seconds (default: `30`). Raise in staging or test environments. |
 | `MAX_CODE_REQUESTS_PER_IP` | No | Rate limit for the `/api/code` endpoints per IP per 60 seconds (default: `60`), shared across registering and resolving codes. Raise in CI or staging. |
 | `MAX_ACTIVE_CODES` | No | Maximum number of simultaneously-live room codes (default: `10000`). `POST /api/code` returns `503` when the cap is reached. |
-| `TURN_SECRET` | No | Shared secret for coturn HMAC credentials. Omit to use STUN-only (direct connections). |
-| `TURN_DOMAIN` | No | Your TURN relay server domain. |
+| `CLOUDFLARE_TURN_KEY_ID` | No | Turn Token ID of a Cloudflare Realtime TURN key. With the API token below, enables managed TURN with no extra infrastructure. Takes precedence over the coturn variables. |
+| `CLOUDFLARE_TURN_KEY_API_TOKEN` | No | API token that pairs with `CLOUDFLARE_TURN_KEY_ID`. Keep it secret. |
+| `TURN_SECRET` | No | Shared secret for self-hosted coturn HMAC credentials, used only when the Cloudflare variables are unset. Omit both options to use STUN-only (direct connections). |
+| `TURN_DOMAIN` | No | Your self-hosted TURN relay server domain. |
 | `UPSTASH_REDIS_REST_URL` | No | Upstash Redis REST URL for the durable global transfer counter. Omit to run the counter in memory only (resets on restart). |
 | `UPSTASH_REDIS_REST_TOKEN` | No | Upstash Redis REST token, paired with the URL above. |
 | `MAX_REPORT_BYTES` | No | Max bytes accepted per `/api/stats/report` call (default: 5 TB). |

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -32,7 +32,8 @@ Everything is set in the `.env` file you copied above. The values that matter mo
 | `NEXT_PUBLIC_SITE_URL` | Public URL of your client (canonical links, share previews, sitemap). |
 | `PORT` | Host port the server is published on. |
 | `CLIENT_URL` | Your client's origin, allowed by the server's CORS. |
-| `TURN_SECRET` / `TURN_DOMAIN` | Optional relay credentials (see below). |
+| `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN` | Optional managed TURN via Cloudflare (see below). |
+| `TURN_SECRET` / `TURN_DOMAIN` | Optional self-hosted coturn credentials (see below). |
 
 ### Build-time variables (important)
 
@@ -48,9 +49,14 @@ docker compose build client && docker compose up -d
 
 - **STUN only (default).** Works for most networks. Peers connect directly and no
   file data passes through your server. Nothing extra to configure.
-- **TURN relay (optional).** Needed when both peers are behind strict NAT / CGNAT
-  and cannot connect directly. Set `TURN_SECRET` and `TURN_DOMAIN`, then start the
-  bundled coturn service:
+- **Managed TURN via Cloudflare (recommended).** Needed when both peers are behind
+  strict NAT / CGNAT and cannot connect directly. Create a TURN key in the
+  Cloudflare dashboard (Realtime > TURN Server), then set
+  `CLOUDFLARE_TURN_KEY_ID` and `CLOUDFLARE_TURN_KEY_API_TOKEN`. No public IP,
+  extra ports, or TLS certificates needed. These take precedence over the coturn
+  variables below.
+- **Self-hosted TURN relay (coturn).** Prefer to run the relay yourself? Set
+  `TURN_SECRET` and `TURN_DOMAIN`, then start the bundled coturn service:
 
   ```bash
   docker compose --profile turn up -d

--- a/docs/how-it-works/direct-connection.mdx
+++ b/docs/how-it-works/direct-connection.mdx
@@ -25,7 +25,7 @@ Strict corporate firewalls, university networks, and carrier-grade NAT can block
 <Accordion title="Technical details">
   **ICE (Interactive Connectivity Establishment):** WebRTC uses the ICE protocol to find a usable network path. Each peer gathers a list of "candidates" (IP/port combinations it might be reachable on), including local addresses, server-reflexive addresses from STUN, and relay addresses from TURN. Peers exchange their candidates via the signaling server and try each pair until one works.
 
-  **STUN servers used:** `stun.l.google.com:19302` and `stun1.l.google.com:19302` as fallbacks. When connected to a self-hosted instance with TURN configured, the signaling server's TURN endpoints also double as STUN.
+  **STUN servers used:** On floe.one, `stun.cloudflare.com:3478` (with an alternate on port 53) from the Cloudflare ICE list. `stun.l.google.com:19302` and `stun1.l.google.com:19302` serve as the fallback when no TURN service is configured. On a self-hosted instance with coturn, the TURN endpoints also double as STUN.
 
   **Trickle ICE:** Candidates are sent incrementally as they are gathered rather than waiting for the full list. This reduces connection time significantly.
 

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -44,7 +44,7 @@ The signaling server never touches file data, never stores your files or any rec
 
   **Short codes:** Registered via `POST /api/code` with a room UUID. The server picks three random words from a 288-word list using a cryptographically secure random source (`crypto.randomInt`, not `Math.random`), because the code phrase is the only secret guarding a transfer, and maps them to the room ID with a 10-minute TTL. `GET /api/code/:code` resolves a code back to its room UUID.
 
-  **TURN credentials:** Issued via `GET /api/turn-credentials`. Credentials use HMAC-SHA1 with a 24-hour expiry. If `TURN_SECRET` is not set, the endpoint returns STUN servers only.
+  **TURN credentials:** Issued via `GET /api/turn-credentials`. On floe.one the server mints short-lived credentials (up to 24 hours) from Cloudflare's Realtime TURN service. Self-hosted instances can instead use coturn with HMAC-SHA1 credentials via `TURN_SECRET`, or skip TURN entirely, in which case the endpoint returns public STUN servers only.
 
   **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint; 60 requests per IP per 60 seconds shared across `POST /api/code` and `GET /api/code/:code`; 60 reports per IP per 60 seconds for the stats endpoint. The signaling server also caps the number of simultaneously-live room codes (10000 by default); `POST /api/code` returns `503` when that cap is hit.
 

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -46,7 +46,7 @@ Share links use a URL fragment (`https://floe.one/#room=...`), not a query strin
 
 ## What the TURN relay sees
 
-When a direct connection cannot be established (strict firewalls, carrier-grade NAT), Floe routes traffic through a TURN relay server. The relay server acts as a forwarding intermediary.
+When a direct connection cannot be established (strict firewalls, carrier-grade NAT), Floe routes traffic through a TURN relay server. The relay server acts as a forwarding intermediary. On floe.one, the relay is Cloudflare's Realtime TURN network; self-hosted instances can run their own coturn relay instead.
 
 The relay sees: encrypted DTLS packets.
 

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -18,8 +18,10 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 | `MAX_CONNECTIONS_PER_IP` | server | No | `30` | Maximum new connections allowed per IP per 60-second window, shared across Socket.IO and WebSocket. Raise this in staging or test environments that drive many connections from a single IP. |
 | `MAX_CODE_REQUESTS_PER_IP` | server | No | `60` | Maximum requests per IP per 60-second window against the room-code endpoints, shared across `POST /api/code` and `GET /api/code/:code`. Requests over the cap get `429`. Raise this in CI or staging suites that mint many codes from one IP. |
 | `MAX_ACTIVE_CODES` | server | No | `10000` | Maximum number of simultaneously-live room codes. Once this cap is reached, `POST /api/code` returns `503` until existing codes expire (10-minute TTL) or are consumed. Bounds memory use of the code registry; raise it only if you legitimately expect more than ten thousand pending transfers at once. |
-| `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for coturn credentials. If empty, the server returns STUN-only and no TURN is offered. Must match coturn's `static-auth-secret`. |
-| `TURN_DOMAIN` | server | No | _(none)_ | Public hostname of your TURN server (e.g. `turn.your-domain.com`). Must match coturn's `realm`. |
+| `CLOUDFLARE_TURN_KEY_ID` | server | No | _(none)_ | Turn Token ID of a [Cloudflare Realtime TURN](https://developers.cloudflare.com/realtime/turn/) key. With the API token below, the server mints short-lived TURN credentials from Cloudflare's managed network, so you need no public IP, extra ports, or TLS certificates. Takes precedence over the coturn variables. |
+| `CLOUDFLARE_TURN_KEY_API_TOKEN` | server | No | _(none)_ | API token that pairs with `CLOUDFLARE_TURN_KEY_ID`. Keep it secret. |
+| `TURN_SECRET` | server | No | _(none)_ | Shared HMAC secret for self-hosted coturn credentials, used only when the Cloudflare variables are unset. If no TURN option is configured, the server returns STUN-only and no relay is offered. Must match coturn's `static-auth-secret`. |
+| `TURN_DOMAIN` | server | No | _(none)_ | Public hostname of your self-hosted TURN server (e.g. `turn.your-domain.com`). Must match coturn's `realm`. |
 | `UPSTASH_REDIS_REST_URL` | server | No | _(none)_ | REST URL of an [Upstash Redis](https://upstash.com) database, used to durably persist the global transfer counter shown on the homepage. If empty, the counter runs in memory only and resets to 0 on every restart. |
 | `UPSTASH_REDIS_REST_TOKEN` | server | No | _(none)_ | REST token that pairs with `UPSTASH_REDIS_REST_URL`. Both must be set together for durable stats. Use the **read+write** token (the default one in the Upstash console), not the read-only token. The server needs write access to increment the counter; with a read-only token, writes are silently rejected and the total never persists. |
 | `MAX_REPORT_BYTES` | server | No | `5497558138880` (5 TB) | Maximum bytes accepted in a single `POST /api/stats/report` request. Rejects implausibly large single-transfer reports. |
@@ -42,8 +44,14 @@ A typical production `.env` for a deployment with HTTPS and TURN:
 NEXT_PUBLIC_SOCKET_URL=https://api.your-domain.com
 CLIENT_URL=https://app.your-domain.com
 TRUSTED_PROXY_COUNT=1
-TURN_SECRET=your-strong-random-secret
-TURN_DOMAIN=turn.your-domain.com
+
+# Managed TURN via Cloudflare (recommended)
+CLOUDFLARE_TURN_KEY_ID=your-turn-token-id
+CLOUDFLARE_TURN_KEY_API_TOKEN=your-api-token
+
+# Or self-hosted coturn instead:
+# TURN_SECRET=your-strong-random-secret
+# TURN_DOMAIN=turn.your-domain.com
 ```
 
 See [Production Deployment](/self-hosting/production) for the full setup.

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -15,7 +15,7 @@ The signaling server brokers WebRTC connection setup (offer, answer, ICE candida
 |-----------|-------------|
 | `client` | Next.js web app, served on port 3000 |
 | `server` | Node.js signaling server, on port 3001 |
-| `coturn` | Optional TURN relay (profile-gated in Docker Compose) |
+| `coturn` | Optional self-hosted TURN relay (profile-gated in Docker Compose). Alternatively, use managed Cloudflare Realtime TURN with no extra container. |
 
 ## Contents
 
@@ -30,6 +30,6 @@ The signaling server brokers WebRTC connection setup (offer, answer, ICE candida
     HTTPS, reverse proxy, and domain setup.
   </Card>
   <Card title="TURN Relay" href="/self-hosting/turn-relay">
-    Add coturn to support peers behind strict NAT or CGNAT.
+    Use Cloudflare's managed TURN or add coturn to support peers behind strict NAT or CGNAT.
   </Card>
 </CardGroup>

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -92,7 +92,11 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
   </Accordion>
 
   <Accordion title="The TURN relay is not working">
-    The bundled coturn service uses host networking, so it runs on a **Linux host** with a public IP, a domain, and TLS certificates. On macOS or Windows with Docker Desktop, run coturn separately or on a Linux VM. Confirm that `TURN_SECRET` and `TURN_DOMAIN` in `.env` match coturn's `static-auth-secret` and `realm`, then start the stack with `docker compose --profile turn up -d --build`. See [TURN Relay](/self-hosting/turn-relay).
+    First check which relay option your instance uses.
+
+    **Managed Cloudflare TURN:** confirm both `CLOUDFLARE_TURN_KEY_ID` and `CLOUDFLARE_TURN_KEY_API_TOKEN` are set in `.env`, then run `curl http://localhost:3001/api/turn-credentials`. A working setup returns `turn.cloudflare.com` entries with a username and credential. If it returns STUN servers only, one of the two variables is missing or the API token is invalid (roll it in the Cloudflare dashboard under Realtime, then TURN Server).
+
+    **Self-hosted coturn:** the bundled coturn service uses host networking, so it runs on a **Linux host** with a public IP, a domain, and TLS certificates. On macOS or Windows with Docker Desktop, run coturn separately or on a Linux VM. Confirm that `TURN_SECRET` and `TURN_DOMAIN` in `.env` match coturn's `static-auth-secret` and `realm`, then start the stack with `docker compose --profile turn up -d --build`. See [TURN Relay](/self-hosting/turn-relay).
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary

Full accuracy audit of all 34 tracked md/mdx files after the infrastructure migration (Azure signaling + Cloudflare Realtime TURN, PRs #145/#146). Eight files still described the pre-migration world; this PR brings them in line with the shipped `/api/turn-credentials` precedence (Cloudflare, then coturn, then Google STUN), plus one consistency note.

- `CLAUDE.md`: env block gains `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN`; TURN Credentials section rewritten to the three-tier precedence (Cloudflare creds cached ~12h, STUN/TURN split for the relay-off filter; coturn HMAC for self-hosters; STUN fallback).
- `CONTRIBUTING.md`, `docs/self-hosting/configuration.mdx`: env tables gain the two Cloudflare rows; `TURN_SECRET` rows note they apply only when the Cloudflare vars are unset. Production example shows Cloudflare as the recommended TURN config with coturn as the commented alternative.
- `SELF_HOSTING.md`, `docs/self-hosting/overview.mdx`: connectivity/components sections present managed Cloudflare TURN (recommended) alongside self-hosted coturn.
- `docs/how-it-works/signaling.mdx`: technical accordion no longer claims "if TURN_SECRET is not set, STUN only"; describes floe.one's Cloudflare-minted credentials with the coturn and STUN-only alternatives.
- `docs/how-it-works/direct-connection.mdx`: STUN section now lists `stun.cloudflare.com` as production STUN with Google STUN as the no-TURN fallback.
- `docs/troubleshooting.mdx`: "TURN relay is not working" split into managed-Cloudflare checks (env vars, expected `turn.cloudflare.com` response) and the existing coturn guidance.
- `docs/security-privacy.mdx`: names Cloudflare as floe.one's relay operator, matching the updated privacy policy.

Deliberately unchanged: `docs/changelog.mdx` (hand-written), `docs/self-hosting/turn-relay.mdx` and `docs/reference/architecture.mdx` (already updated), README/faq/encryption/2gb-limit and the remaining pages (verified accurate as-is). coturn stays fully documented as the self-hosting option throughout.

## Test plan

- `grep -rn "TURN_SECRET is unset|TURN_SECRET is not set"` over md/mdx: no matches.
- `grep -rn "turn.floe.one"`: no matches.
- No em dashes introduced (Vale EmDash rule).
- Mintlify deployment + Grammar linter checks green on this PR.