### PR TITLE
perf(cli): size send chunks to the negotiated SCTP max (up to 256 KB)

### DIFF
--- a/cli/internal/transfer/chunk_test.go
+++ b/cli/internal/transfer/chunk_test.go
@@ -1,0 +1,33 @@
+package transfer
+
+import "testing"
+
+// TestChunkSizeFor verifies the adaptive send-chunk sizing: cap at maxChunkSize,
+// never exceed the negotiated SCTP ceiling (so dc.Send can't return
+// ErrOutboundPacketTooLarge), and fall back to the default when the max is unknown.
+func TestChunkSizeFor(t *testing.T) {
+	cases := []struct {
+		name    string
+		sctpMax uint32
+		want    int
+	}{
+		{"unknown falls back to default", 0, defaultChunkSize},
+		{"unset ceiling (65535) is respected exactly", 65535, 65535},
+		{"chrome 256KB caps at max", 262144, maxChunkSize},
+		{"cli 1GB patch caps at max", 1073741824, maxChunkSize},
+		{"tiny ceiling is respected", 100, 100},
+		{"exactly at max", maxChunkSize, maxChunkSize},
+		{"one below max", maxChunkSize - 1, maxChunkSize - 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := chunkSizeFor(c.sctpMax); got != c.want {
+				t.Fatalf("chunkSizeFor(%d) = %d, want %d", c.sctpMax, got, c.want)
+			}
+			// Invariant: the chosen chunk must never exceed the negotiated ceiling.
+			if c.sctpMax != 0 && chunkSizeFor(c.sctpMax) > int(c.sctpMax) {
+				t.Fatalf("chunkSizeFor(%d) exceeds the SCTP ceiling", c.sctpMax)
+			}
+		})
+	}
+}

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -4,7 +4,8 @@
 //   1. Sender → Receiver: metadata JSON  (file name, size, index, total, pv, pvMin, ver)
 //   2. Receiver → Sender: ack JSON       (confirms ready, offset for resume, pv, pvMin, ver)
 //      OR:       incompatible JSON       (sent instead of ack when protocol ranges do not overlap)
-//   3. Sender → Receiver: binary chunks  (raw file bytes, 16 KB each)
+//   3. Sender → Receiver: binary chunks  (raw file bytes; chunk size adapts to
+//      the negotiated SCTP max-message-size, capped at 256 KB — see chunkSizeFor)
 //   4. Sender → Receiver: end JSON       (signals end of this file)
 //   Repeat for each file.
 //
@@ -26,7 +27,30 @@ import (
 	"github.com/pion/webrtc/v4"
 )
 
-const chunkSize = 16 * 1024
+const (
+	// defaultChunkSize is the safe fallback used when the negotiated SCTP
+	// max-message-size is unavailable (0). It matches the historical value.
+	defaultChunkSize = 16 * 1024
+	// maxChunkSize caps the adaptive chunk. Mirrors MAX_CHUNK in the browser
+	// sender (client/lib/transfer/protocol.ts).
+	maxChunkSize = 256 * 1024
+)
+
+// chunkSizeFor returns the send chunk size for a connection whose negotiated
+// SCTP max-message-size is sctpMax (read from dc.Transport().GetCapabilities()).
+// It caps at maxChunkSize and never exceeds the negotiated ceiling, so dc.Send
+// can never return ErrOutboundPacketTooLarge (pion/sctp enforces the limit on
+// send). A zero sctpMax (capabilities not yet available) falls back to the
+// proven default. Mirrors chunkSize() in client/lib/transfer/protocol.ts.
+func chunkSizeFor(sctpMax uint32) int {
+	if sctpMax == 0 {
+		return defaultChunkSize
+	}
+	if int(sctpMax) < maxChunkSize {
+		return int(sctpMax)
+	}
+	return maxChunkSize
+}
 
 // Backpressure watermarks mirror the browser sender (P2PTransfer.tsx): pause
 // sending once pion's SCTP send buffer reaches the high-water mark, resume once
@@ -114,8 +138,17 @@ func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
 		}
 	})
 
+	// Size chunks to the connection's negotiated SCTP max-message-size (capped
+	// at maxChunkSize), matching the browser sender. Larger chunks mean far fewer
+	// dc.Send calls per file — the main throughput lever on fast links.
+	var sctpMax uint32
+	if t := dc.Transport(); t != nil {
+		sctpMax = t.GetCapabilities().MaxMessageSize
+	}
+	chunk := chunkSizeFor(sctpMax)
+
 	for i, entry := range files {
-		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files), totalBytes, localVer); err != nil {
+		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files), totalBytes, localVer, chunk); err != nil {
 			return fmt.Errorf("error sending %s: %w", entry.displayName, err)
 		}
 	}
@@ -213,7 +246,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 }
 
 // sendFile handles the full send sequence for a single file.
-func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int, totalBytes int64, localVer string) error {
+func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int, totalBytes int64, localVer string, chunk int) error {
 	f, err := os.Open(entry.absPath)
 	if err != nil {
 		return err
@@ -315,7 +348,7 @@ ackLoop:
 	bar := newProgressBar(fileSize, index, total, entry.displayName)
 	bar.Set64(offset)
 
-	buf := make([]byte, chunkSize)
+	buf := make([]byte, chunk)
 	for {
 		n, err := f.Read(buf)
 		if n > 0 {


### PR DESCRIPTION
## Summary

The CLI sender sent every file in fixed **16 KB** chunks, while the browser sender already sizes each chunk to the negotiated SCTP max-message-size, capped at 256 KB (`client/lib/transfer/protocol.ts`, `chunkSize()` + `MAX_CHUNK`). Each `dc.Send` carries fixed SCTP framing and per-call overhead, so the small chunk means ~16x more sends than 256 KB for the same file and caps throughput on fast links (LAN, direct connections).

This change reads the negotiated ceiling from `dc.Transport().GetCapabilities().MaxMessageSize` and caps the chunk at `min(256 KB, ceiling)`, mirroring the browser exactly. It is a **local send-buffer sizing change only** — no wire-protocol change, no `ProtocolVersion` bump, full browser↔CLI compatibility preserved.

### Why capping at the ceiling is safe
`pion/sctp` enforces the max message size on send (`stream.go` returns `ErrOutboundPacketTooLarge` for any payload above `association.MaxMessageSize()`), and that ceiling is the remote peer's advertised `a=max-message-size`:
- Browser receiver (Chrome): advertises `262144` (256 KB) → we send 256 KB.
- CLI receiver: patches its answer to `1073741824` (1 GB) → we cap at 256 KB.
- A peer that advertises nothing → `65535` default → we send 65535, still valid.
- Capabilities unavailable (`0`) → fall back to the historical 16 KB.

Since the chunk is always `<= ceiling`, `dc.Send` can never trip the pion limit.

## Test plan

- New table-driven unit test `TestChunkSizeFor` (`cli/internal/transfer/chunk_test.go`): `0→16384`, `65535→65535`, `262144→256KB`, `1GB→256KB`, `100→100`, plus the exact-boundary cases, asserting the chunk never exceeds the ceiling.
- The existing `TestLoopbackLargeFile` (20 MB, sha256-verified, real pion ICE pair) now sends larger chunks and validates the adaptive path byte-for-byte; `TestLoopbackImmediateReceiverClose` and `TestLoopbackSmallJSONFile` stay green.
- `go build ./cmd/floe`, `go vet ./...`, and `go test ./...` all pass locally (transfer suite runs the real-ICE loopbacks, ~14s).
- CI: `client/e2e/cli-interop.spec.ts` covers browser↔CLI interop.

Touches only `cli/`, so full CI runs.