### PR TITLE
fix(cli): skip link-local interfaces during ICE gathering, add opt-in --iface

### DIFF
--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -34,6 +34,7 @@ var (
 	flagServer  string
 	flagNoRelay bool
 	flagWebURL  string
+	flagIface   []string
 )
 
 // ── Root command ─────────────────────────────────────────────────────────────
@@ -55,6 +56,8 @@ func init() {
 		"disable TURN relay (direct connections only)")
 	rootCmd.PersistentFlags().StringVar(&flagWebURL, "web", "",
 		"web app URL shown in the browser link (auto-detected if not set)")
+	rootCmd.PersistentFlags().StringSliceVar(&flagIface, "iface", nil,
+		"restrict WebRTC to network interfaces matching these names (repeatable, e.g. --iface Ethernet); use when a VPN/VM adapter slows connection setup")
 
 	rootCmd.AddCommand(sendCmd)
 	rootCmd.AddCommand(receiveCmd)
@@ -184,7 +187,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 	_ = peerId // used internally by signaling routing
 
 	// 8. Set up WebRTC as the initiator (sender creates offer + data channel)
-	conn, err := peer.New(iceServers, sc)
+	conn, err := peer.New(iceServers, sc, peer.WithInterfaceAllowlist(flagIface))
 	if err != nil {
 		return fmt.Errorf("failed to create peer connection: %w", err)
 	}
@@ -295,7 +298,7 @@ func runReceive(cmd *cobra.Command, args []string) error {
 	fmt.Println("  Connecting to sender...")
 
 	// 6. Set up WebRTC as the responder (receiver waits for offer)
-	conn, err := peer.New(iceServers, sc)
+	conn, err := peer.New(iceServers, sc, peer.WithInterfaceAllowlist(flagIface))
 	if err != nil {
 		return fmt.Errorf("failed to create peer connection: %w", err)
 	}

--- a/cli/internal/peer/connection.go
+++ b/cli/internal/peer/connection.go
@@ -5,12 +5,26 @@ package peer
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 	"sync"
 
 	"github.com/jannskiee/floe/cli/internal/signaling"
 	"github.com/pion/webrtc/v4"
 )
+
+// keepICEIP reports whether an interface IP should be used for ICE candidate
+// gathering. It drops link-local addresses (IPv4 169.254.0.0/16 and IPv6
+// fe80::/10), which are handed out by virtual and VPN adapters (Hyper-V, WSL,
+// VMware, Tailscale) and by APIPA auto-config when DHCP fails. Such addresses
+// never form a working peer-to-peer path, but pion would otherwise gather a host
+// candidate on each and spend 20-30s running connectivity checks that fail with
+// "socket operation attempted to an unreachable host" before settling on the
+// real interface (often falling back to the relay). Filtering by the link-local
+// IP class is unambiguous and safe: it never removes a routable interface.
+func keepICEIP(ip net.IP) bool {
+	return !ip.IsLinkLocalUnicast()
+}
 
 // signalPayload is the JSON structure for WebRTC signals sent over the
 // signaling channel. It can be either an SDP (offer/answer) or an ICE candidate.
@@ -53,6 +67,9 @@ func New(iceServers []webrtc.ICEServer, sc *signaling.Client) (*Connection, erro
 	// browser-to-CLI transfers to stall after the small metadata arrives.
 	se := webrtc.SettingEngine{}
 	se.SetSCTPMaxReceiveBufferSize(16 * 1024 * 1024) // 16 MB total receive buffer
+	// Skip link-local interfaces when gathering ICE candidates so virtual/VPN
+	// adapters (Hyper-V, WSL, Tailscale, APIPA) don't stall connection setup.
+	se.SetIPFilter(keepICEIP)
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
 
 	pc, err := api.NewPeerConnection(config)

--- a/cli/internal/peer/connection.go
+++ b/cli/internal/peer/connection.go
@@ -26,6 +26,49 @@ func keepICEIP(ip net.IP) bool {
 	return !ip.IsLinkLocalUnicast()
 }
 
+// makeInterfaceAllowFilter builds an ICE interface filter that keeps only the
+// interfaces whose name contains one of the given substrings (case-insensitive).
+// It is used for the opt-in `--iface` flag so power users on machines with many
+// virtual/VPN adapters (VMware, WSL, Tailscale) can pin ICE to their real NIC,
+// e.g. `--iface Ethernet`. The link-local IP filter above already handles the
+// common case; this is the manual override for the rest. Returns nil (no filter)
+// for an empty allowlist so the default behavior is unchanged.
+func makeInterfaceAllowFilter(names []string) func(string) bool {
+	var wanted []string
+	for _, n := range names {
+		n = strings.ToLower(strings.TrimSpace(n))
+		if n != "" {
+			wanted = append(wanted, n)
+		}
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+	return func(ifName string) bool {
+		lower := strings.ToLower(ifName)
+		for _, w := range wanted {
+			if strings.Contains(lower, w) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// Option configures a Connection created by New.
+type Option func(*settings)
+
+type settings struct {
+	ifaceAllowlist []string
+}
+
+// WithInterfaceAllowlist restricts ICE candidate gathering to network interfaces
+// whose name contains one of the given substrings (case-insensitive). Empty or
+// nil leaves the default (gather on all non-link-local interfaces).
+func WithInterfaceAllowlist(names []string) Option {
+	return func(s *settings) { s.ifaceAllowlist = names }
+}
+
 // signalPayload is the JSON structure for WebRTC signals sent over the
 // signaling channel. It can be either an SDP (offer/answer) or an ICE candidate.
 type signalPayload struct {
@@ -58,7 +101,12 @@ type Connection struct {
 
 // New creates a pion RTCPeerConnection with the given ICE servers and starts
 // the signal dispatcher. Call SetupAsSender or SetupAsReceiver next.
-func New(iceServers []webrtc.ICEServer, sc *signaling.Client) (*Connection, error) {
+func New(iceServers []webrtc.ICEServer, sc *signaling.Client, opts ...Option) (*Connection, error) {
+	var cfg settings
+	for _, o := range opts {
+		o(&cfg)
+	}
+
 	config := webrtc.Configuration{ICEServers: iceServers}
 
 	// Configure SCTP to accept large messages from browsers.
@@ -70,6 +118,10 @@ func New(iceServers []webrtc.ICEServer, sc *signaling.Client) (*Connection, erro
 	// Skip link-local interfaces when gathering ICE candidates so virtual/VPN
 	// adapters (Hyper-V, WSL, Tailscale, APIPA) don't stall connection setup.
 	se.SetIPFilter(keepICEIP)
+	// Opt-in `--iface` override: pin ICE to specific interfaces by name.
+	if f := makeInterfaceAllowFilter(cfg.ifaceAllowlist); f != nil {
+		se.SetInterfaceFilter(f)
+	}
 	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
 
 	pc, err := api.NewPeerConnection(config)

--- a/cli/internal/peer/icefilter_test.go
+++ b/cli/internal/peer/icefilter_test.go
@@ -5,6 +5,40 @@ import (
 	"testing"
 )
 
+// TestMakeInterfaceAllowFilter verifies the opt-in --iface allowlist: an empty
+// list disables the filter (nil), and a non-empty list keeps only interfaces
+// whose name contains an allowed substring (case-insensitive).
+func TestMakeInterfaceAllowFilter(t *testing.T) {
+	if makeInterfaceAllowFilter(nil) != nil {
+		t.Fatal("empty allowlist must return a nil filter (default behavior)")
+	}
+	if makeInterfaceAllowFilter([]string{"", "  "}) != nil {
+		t.Fatal("blank-only allowlist must return a nil filter")
+	}
+
+	f := makeInterfaceAllowFilter([]string{"Ethernet", "wi-fi"})
+	if f == nil {
+		t.Fatal("non-empty allowlist must return a filter")
+	}
+	cases := []struct {
+		ifName string
+		keep   bool
+	}{
+		{"Ethernet", true},
+		{"Ethernet 2", true},       // substring match
+		{"ethernet", true},         // case-insensitive
+		{"Wi-Fi", true},            // case-insensitive match of "wi-fi"
+		{"Tailscale", false},       // not in the allowlist
+		{"VMware Network Adapter VMnet1", false},
+		{"vEthernet (WSL)", true},  // contains "ethernet" -> matched by "Ethernet" entry
+	}
+	for _, c := range cases {
+		if got := f(c.ifName); got != c.keep {
+			t.Errorf("filter(%q) = %v, want %v", c.ifName, got, c.keep)
+		}
+	}
+}
+
 // TestKeepICEIP verifies the ICE gathering filter drops link-local addresses
 // (the virtual/VPN/APIPA junk that stalls connection setup) while keeping every
 // routable address a real transfer needs.

--- a/cli/internal/peer/icefilter_test.go
+++ b/cli/internal/peer/icefilter_test.go
@@ -1,0 +1,37 @@
+package peer
+
+import (
+	"net"
+	"testing"
+)
+
+// TestKeepICEIP verifies the ICE gathering filter drops link-local addresses
+// (the virtual/VPN/APIPA junk that stalls connection setup) while keeping every
+// routable address a real transfer needs.
+func TestKeepICEIP(t *testing.T) {
+	cases := []struct {
+		name string
+		ip   string
+		keep bool
+	}{
+		{"IPv4 APIPA link-local dropped", "169.254.83.107", false},
+		{"IPv6 link-local dropped", "fe80::1", false},
+		{"private LAN kept", "192.168.5.38", true},
+		{"virtual-adapter private IP kept", "192.168.160.1", true}, // not link-local; only names would flag it, which we avoid
+		{"other RFC1918 kept", "10.0.0.5", true},
+		{"public IP kept", "112.201.205.40", true},
+		{"loopback kept", "127.0.0.1", true},
+		{"IPv6 global kept", "2606:4700::1111", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ip := net.ParseIP(c.ip)
+			if ip == nil {
+				t.Fatalf("bad test IP %q", c.ip)
+			}
+			if got := keepICEIP(ip); got != c.keep {
+				t.Fatalf("keepICEIP(%s) = %v, want %v", c.ip, got, c.keep)
+			}
+		})
+	}
+}

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -12,6 +12,7 @@ Available on all commands (`send`, `receive`, `update`, `version`).
 | `--server <url>` | `https://api.floe.one` | Signaling server URL. Use `http://localhost:3001` for local testing or your self-hosted server URL. |
 | `--no-relay` | `false` | Disable the TURN relay. Only direct (STUN) connections are attempted. The transfer fails if a direct path cannot be established. Useful for ensuring files never pass through a relay. |
 | `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: the production server defaults to `https://floe.one`, and `localhost:3001` defaults to `http://localhost:3000`. |
+| `--iface <name>` | _(all interfaces)_ | Restrict WebRTC to network interfaces whose name contains this value (case-insensitive). Repeatable. Use when a VPN or virtual-machine adapter (Tailscale, VMware, WSL, Hyper-V) slows connection setup, for example `--iface Ethernet`. See [Troubleshooting](/troubleshooting). |
 
 ## `floe receive` flags
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -55,6 +55,18 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
     A browser can only join by opening the link, not by entering a short code (there is no code field in the web UI). Share the **link** printed by `floe send` with browser recipients, and the **code** with CLI recipients.
   </Accordion>
 
+  <Accordion title="The CLI is slow to connect when a VPN or virtual machine is running">
+    A VPN (such as Tailscale) or virtualization software (VMware, VirtualBox, WSL, Hyper-V) adds extra network interfaces. The CLI probes each one while establishing the connection, so a machine with several of them can spend longer on "Connecting..." before settling on the working path. The transfer still completes, and the browser app is unaffected.
+
+    The CLI already skips dead auto-config interfaces automatically. If you still see slow connects, pin the CLI to your real interface by name:
+
+    ```bash
+    floe receive olive-tiger-castle --iface Ethernet   # or --iface Wi-Fi
+    ```
+
+    Pass `--iface` more than once to allow several interfaces. Temporarily quitting the VPN during a transfer also resolves it.
+  </Accordion>
+
   <Accordion title="The CLI says the version is incompatible">
     Peers on different floe versions normally transfer fine, so a small version difference (for example v1.5.4 and v1.5.5) is never a problem. This message only appears if a release changed the transfer protocol in a way the two versions cannot bridge. Whichever side is older should update:
 


### PR DESCRIPTION
## Summary

Two related changes to speed up CLI connection setup on machines with virtual/VPN network adapters (Tailscale, VMware, WSL, Hyper-V, APIPA). The browser was never affected; this is a pion/CLI-only issue.

### 1. Skip link-local interfaces during ICE gathering
On affected machines, pion gathered an ICE host candidate on every link-local interface (`169.254.0.0/16`, `fe80::/10`) and spent 20-30s running connectivity checks that fail ("socket operation attempted to an unreachable host") before settling on the real interface. Diagnosed from `PION_LOG_DEBUG=all` logs showing repeated `wsasendto: unreachable` from `169.254.x` sources. Fix: a `SettingEngine.SetIPFilter` (`keepICEIP`) that drops link-local addresses. Filtering by the link-local IP class is unambiguous and never removes a routable interface. **Verified on a real affected machine:** after the fix, the `169.254.x` candidates are gone from the logs.

### 2. Opt-in `--iface` flag
The link-local filter does not cover non-link-local junk like Tailscale's `100.64.0.0/10` CGNAT address or a VMware `192.168.160.x` adapter. Blanket-filtering those by IP or name would break legitimate CGNAT users and people who transfer over a VPN, so instead this adds an opt-in allowlist: `--iface Ethernet` restricts ICE gathering to interfaces whose name matches (case-insensitive, repeatable). Default behavior is unchanged. Implemented as a functional option (`peer.WithInterfaceAllowlist`) so `peer.New` stays backward compatible.

No wire-protocol change; connection setup only.

## Test plan
- New unit tests: `TestKeepICEIP` (link-local vs routable) and `TestMakeInterfaceAllowFilter` (allowlist matching, case-insensitive, empty-list default).
- `go build`, `go vet ./...`, `go test ./...` pass (including the real-ICE loopback suite).
- `--iface` appears in `floe --help`.
- Docs: `--iface` added to the flags reference plus a troubleshooting entry for slow connects behind a VPN/VM. No em dashes.
- Real-device verification on an affected machine confirmed the link-local candidates are eliminated.

Touches `cli/` and `docs/`, so full CI runs.