### PR TITLE
fix(client): join the new room when a fresh QR link opens in an existing tab

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -121,6 +121,9 @@ export function P2PTransfer() {
 
     const peerRef = useRef<PeerInstance | null>(null);
     const hasJoinedRef = useRef(false);
+    // The room this page instance is handling as a receiver. Used to detect a
+    // fragment-only navigation (scanning a second QR code into the same tab).
+    const joinedRoomRef = useRef<string | null>(null);
     const receivedFilesRef = useRef<ReceivedFile[]>([]);
     const transferCompleteRef = useRef(false);
     const progressRef = useRef(0);
@@ -266,6 +269,7 @@ export function P2PTransfer() {
     const joinRoomAsReceiver = (roomId: string) => {
         if (hasJoinedRef.current) return;
         hasJoinedRef.current = true;
+        joinedRoomRef.current = roomId;
 
         setStatus('Connecting');
 
@@ -419,6 +423,23 @@ export function P2PTransfer() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // The room id lives in the URL fragment (#room=<id>). Swapping only the
+    // fragment is a same-document navigation, so opening a new room link in an
+    // existing tab (e.g. scanning a second QR code on a phone that already has
+    // Floe open) changes the hash without reloading, so the mount effect above
+    // never re-runs and the tab stays stuck on the previous transfer. Detect
+    // that here and reload so the receiver joins the new room from a clean slate.
+    useEffect(() => {
+        const onHashChange = () => {
+            const room = getRoomFromUrl();
+            if (room && room !== joinedRoomRef.current) {
+                window.location.reload();
+            }
+        };
+        window.addEventListener('hashchange', onHashChange);
+        return () => window.removeEventListener('hashchange', onHashChange);
+    }, []);
+
     useEffect(() => {
         const handleVisibilityChange = () => {
             if (document.visibilityState === 'visible' && isConnected) {
@@ -444,7 +465,14 @@ export function P2PTransfer() {
 
     const handleCreateLink = () => {
         const newRoomId = uuidv4();
-        const link = `${window.location.protocol}//${window.location.host}/#room=${newRoomId}`;
+        // A unique per-link nonce in the query string (not the fragment) makes
+        // every transfer link a distinct document. Without it, two links differ
+        // only in the fragment, which browsers treat as the same page, so a phone
+        // that already has Floe open can reuse a stale tab when a new QR is
+        // scanned instead of joining the new room. The secret room id stays in
+        // the fragment (never sent to the server); the nonce carries no info.
+        const nonce = uuidv4().slice(0, 8);
+        const link = `${window.location.protocol}//${window.location.host}/?s=${nonce}#room=${newRoomId}`;
         setGeneratedLink(link);
         joinRoom(newRoomId);
         setStatus('Waiting for peer');


### PR DESCRIPTION
## Summary

Browser-to-browser transfers put the room id **only in the URL fragment** (`#room=<id>`), so any two transfer links differ only by their fragment. Browsers treat a fragment-only change as the *same document*: when a phone that already has Floe open scans a second QR code, it reuses the stale tab and swaps the hash **without reloading**. The mount effect that reads the room and joins never re-runs (and `hasJoinedRef` is already set), so the receiver stays stuck on the previous transfer and the new one never starts.

The room id must stay in the fragment (it is the transfer's only secret and must never reach the server), so instead of moving the secret, this makes each link a genuinely distinct document.

## Changes

- **Primary fix:** `handleCreateLink` now adds a unique, non-secret nonce to the query string (`/?s=<nonce>#room=<id>`). A differing query makes every link a distinct document, so a reused tab is always forced into a full reload and joins the new room, regardless of whether the browser opens a new tab or reuses an existing one. The secret room id stays in the fragment; the nonce carries no information about the transfer.
- **Safety net:** a `hashchange` listener reloads the page when the room id changes, covering any browser that still performs a fragment-only navigation into the same tab.

No protocol, server, or routing changes. Old `?room=` / `#room=` links still resolve.

## Test plan

- `pnpm lint` — clean
- `pnpm test` — 85/85 unit tests pass
- `pnpm build` — production build + TypeScript pass
- Manual browser verification against the dev app:
  - Generated link has the intended shape `/?s=<nonce>#room=<uuid>`; the secret is in the fragment and **not** leaked to the query.
  - Loading a second QR link (different nonce/room) into the same tab performs a **full document reload** and the page joins the **new** room.
  - A fragment-only room change triggers the `hashchange` reload safety net.