### PR TITLE
fix(cli): trim fetched ICE list to one URL per connectivity class

### DIFF
--- a/cli/internal/ice/credentials.go
+++ b/cli/internal/ice/credentials.go
@@ -5,9 +5,101 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/pion/webrtc/v4"
 )
+
+// iceURLClass buckets an ICE URL into a connectivity class. pion gathers
+// candidates and opens TURN allocations per URL per network interface, so
+// redundant URLs of the same class multiply connection-setup work for zero
+// connectivity gain.
+func iceURLClass(u string) string {
+	switch {
+	case strings.HasPrefix(u, "stun:"):
+		return "stun"
+	case strings.HasPrefix(u, "turns:"):
+		return "tls"
+	case strings.HasPrefix(u, "turn:"):
+		if strings.Contains(u, "transport=tcp") {
+			return "tcp"
+		}
+		return "udp" // RFC 7065: a turn: URI without a transport param is UDP
+	}
+	return ""
+}
+
+// pick returns the first URL in urls that contains pref, else the first URL.
+func pick(urls []string, pref string) string {
+	for _, u := range urls {
+		if strings.Contains(u, pref) {
+			return u
+		}
+	}
+	if len(urls) > 0 {
+		return urls[0]
+	}
+	return ""
+}
+
+// trimICEServers caps a server-provided ICE list to one URL per connectivity
+// class: one STUN (prefer :3478), one TURN over UDP (the fast relay path), and
+// one TURN over TLS preferring :443 (the firewall fallback; plain turn-tcp is
+// used only when no turns: URL exists). Entry structure and credentials are
+// preserved so per-entry username/credential pairs stay attached. Defense in
+// depth for servers that forward a provider's full redundant list (Cloudflare
+// mints 8 URLs); a minimal list like self-hosted coturn's passes through
+// unchanged. Returns the input untouched if trimming would remove everything.
+func trimICEServers(servers []webrtc.ICEServer) []webrtc.ICEServer {
+	var stun, udp, tcp, tls []string
+	for _, s := range servers {
+		for _, u := range s.URLs {
+			switch iceURLClass(u) {
+			case "stun":
+				stun = append(stun, u)
+			case "udp":
+				udp = append(udp, u)
+			case "tcp":
+				tcp = append(tcp, u)
+			case "tls":
+				tls = append(tls, u)
+			}
+		}
+	}
+
+	keep := map[string]bool{}
+	if u := pick(stun, ":3478"); u != "" {
+		keep[u] = true
+	}
+	if u := pick(udp, "transport=udp"); u != "" {
+		keep[u] = true
+	}
+	if u := pick(tls, ":443"); u != "" {
+		keep[u] = true
+	} else if u := pick(tcp, ""); u != "" {
+		keep[u] = true
+	}
+
+	var out []webrtc.ICEServer
+	for _, s := range servers {
+		var urls []string
+		for _, u := range s.URLs {
+			if keep[u] {
+				urls = append(urls, u)
+				delete(keep, u) // a URL duplicated across entries is kept once
+			}
+		}
+		if len(urls) > 0 {
+			trimmed := s
+			trimmed.URLs = urls
+			out = append(out, trimmed)
+		}
+	}
+	if len(out) == 0 {
+		return servers // nothing classifiable: leave the list alone
+	}
+	return out
+}
 
 // iceServerJSON is the raw JSON shape returned by /api/turn-credentials.
 // The "urls" field can be either a single string or an array of strings.
@@ -59,7 +151,7 @@ func Fetch(serverURL string) ([]webrtc.ICEServer, error) {
 	if len(servers) == 0 {
 		return defaults(), nil
 	}
-	return servers, nil
+	return trimICEServers(servers), nil
 }
 
 func defaults() []webrtc.ICEServer {

--- a/cli/internal/ice/credentials_test.go
+++ b/cli/internal/ice/credentials_test.go
@@ -1,0 +1,117 @@
+package ice
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// TestTrimICEServers verifies the defense-in-depth ICE list trim: one URL per
+// connectivity class, entry structure and credentials preserved.
+func TestTrimICEServers(t *testing.T) {
+	t.Run("cloudflare 8-URL shape reduces to 3 URLs across 2 entries", func(t *testing.T) {
+		in := []webrtc.ICEServer{
+			{URLs: []string{
+				"stun:stun.cloudflare.com:3478",
+				"stun:stun.cloudflare.com:53",
+			}},
+			{
+				URLs: []string{
+					"turn:turn.cloudflare.com:3478?transport=udp",
+					"turn:turn.cloudflare.com:3478?transport=tcp",
+					"turns:turn.cloudflare.com:5349?transport=tcp",
+					"turn:turn.cloudflare.com:53?transport=udp",
+					"turn:turn.cloudflare.com:80?transport=tcp",
+					"turns:turn.cloudflare.com:443?transport=tcp",
+				},
+				Username:   "user",
+				Credential: "pass",
+			},
+		}
+		got := trimICEServers(in)
+		want := []webrtc.ICEServer{
+			{URLs: []string{"stun:stun.cloudflare.com:3478"}},
+			{
+				URLs: []string{
+					"turn:turn.cloudflare.com:3478?transport=udp",
+					"turns:turn.cloudflare.com:443?transport=tcp",
+				},
+				Username:   "user",
+				Credential: "pass",
+			},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("coturn 3-entry shape passes through unchanged", func(t *testing.T) {
+		in := []webrtc.ICEServer{
+			{URLs: []string{"stun:turn.example.com:3478"}},
+			{URLs: []string{"turn:turn.example.com:3478"}, Username: "u", Credential: "c"},
+			{URLs: []string{"turns:turn.example.com:5349"}, Username: "u", Credential: "c"},
+		}
+		got := trimICEServers(in)
+		if !reflect.DeepEqual(got, in) {
+			t.Fatalf("coturn list must pass through unchanged, got %+v", got)
+		}
+	})
+
+	t.Run("multiple STUN-only entries collapse to one", func(t *testing.T) {
+		in := []webrtc.ICEServer{
+			{URLs: []string{"stun:stun.l.google.com:19302"}},
+			{URLs: []string{"stun:stun1.l.google.com:19302"}},
+		}
+		got := trimICEServers(in)
+		if len(got) != 1 || len(got[0].URLs) != 1 {
+			t.Fatalf("expected a single STUN URL, got %+v", got)
+		}
+	})
+
+	t.Run("falls back to turn tcp when no turns URL exists", func(t *testing.T) {
+		in := []webrtc.ICEServer{
+			{URLs: []string{
+				"turn:host:3478?transport=udp",
+				"turn:host:80?transport=tcp",
+			}, Username: "u", Credential: "c"},
+		}
+		got := trimICEServers(in)
+		want := []webrtc.ICEServer{
+			{URLs: []string{
+				"turn:host:3478?transport=udp",
+				"turn:host:80?transport=tcp",
+			}, Username: "u", Credential: "c"},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("returns input unchanged when nothing is classifiable", func(t *testing.T) {
+		in := []webrtc.ICEServer{{URLs: []string{"wss:not-an-ice-url"}}}
+		got := trimICEServers(in)
+		if !reflect.DeepEqual(got, in) {
+			t.Fatalf("unclassifiable list must be left alone, got %+v", got)
+		}
+	})
+}
+
+// TestIceURLClass pins the classification rules, including the RFC 7065
+// default (turn without a transport param is UDP).
+func TestIceURLClass(t *testing.T) {
+	cases := map[string]string{
+		"stun:host:3478":               "stun",
+		"turn:host:3478":               "udp",
+		"turn:host:3478?transport=udp": "udp",
+		"turn:host:80?transport=tcp":   "tcp",
+		"turns:host:443?transport=tcp": "tls",
+		"turns:host:5349":              "tls",
+		"http://not-ice":               "",
+	}
+	for u, want := range cases {
+		if got := iceURLClass(u); got != want {
+			t.Errorf("iceURLClass(%q) = %q, want %q", u, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Defense-in-depth companion to #152 (server-side ICE trim). pion gathers ICE candidates and opens TURN allocations **per URL per network interface**, so a server forwarding Cloudflare's full 8-URL list multiplies connection-setup work; on multi-adapter machines (VPN, VMware, WSL) this pushed "Connecting..." from ~1s to 20-30s.

`trimICEServers` caps any fetched list to one URL per connectivity class:
- one STUN (prefer `:3478`)
- one TURN over UDP (fast relay)
- one TURN over TLS preferring `:443` (plain turn-tcp only when no `turns:` exists)

Entry structure and per-entry credentials are preserved. A minimal list like self-hosted coturn's (3 entries) passes through unchanged; an unclassifiable list is returned untouched. This makes the CLI fast against ANY server: self-hosted instances that forward full provider lists, or a not-yet-updated api.floe.one.

## Test plan

- New table-driven tests (`credentials_test.go`): Cloudflare 8-URL shape -> 3 URLs across 2 entries with credentials preserved; coturn shape unchanged; multiple STUN entries collapse to one; turn-tcp fallback; unclassifiable input left alone; URL classification rules incl. the RFC 7065 no-transport-param = UDP default.
- `go build`, `go vet ./...`, `go test ./...` all pass (includes the real-ICE loopback suite).
- End-to-end verification happens with #152's deploy: real-machine CLI-to-CLI test with a VPN active.