### PR TITLE
docs: add v1.7.4 changelog; align relay endpoints and chunk-size claims

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,15 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.7.4" description="2026-07-10">
+  **Faster connection setup**
+
+  - Fixed connections taking 20 to 30 seconds to establish on machines running VPN or virtual machine software (Tailscale, VMware, WSL, Hyper-V). Two causes were addressed: the signaling server handed every client a redundant list of eight relay endpoints where three suffice, and the CLI probed dead auto-configuration network interfaces during setup. The server-side fix is already live and speeds up all existing versions, browser included; this release adds the CLI-side hardening so connections stay fast against any server, including self-hosted ones.
+  - Added an advanced `--iface` flag to restrict the CLI to specific network interfaces by name (for example `--iface Ethernet`), useful for pinning a transfer to a chosen network. Most users never need it. See the [flags reference](/cli/flags).
+  - Web app: opening a fresh share link in a tab that already had Floe open now joins the new room correctly instead of reusing the old session.
+  - No transfer-protocol change, so v1.7.4 interoperates with older CLI and browser peers in every direction.
+</Update>
+
 <Update label="v1.7.3" description="2026-07-09">
   **Faster CLI transfers, and a browser-to-CLI reliability fix**
 

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -45,7 +45,7 @@ With relay disabled, the transfer fails if a direct path cannot be established.
 
   **Credentials:** The signaling server mints short-lived credentials from Cloudflare's Realtime TURN service and hands them to peers via `/api/turn-credentials`. Credentials are valid for up to 24 hours. (Self-hosted deployments can instead use coturn with time-limited HMAC-SHA1 credentials; see the self-hosting guide.)
 
-  **Endpoints:** `turn:turn.cloudflare.com:3478` (STUN/TURN over UDP and TCP) and `turns:turn.cloudflare.com:5349` (TURN over TLS), plus TCP fallbacks on ports 80 and 443.
+  **Endpoints:** the signaling server hands peers a minimal set of three: `stun:stun.cloudflare.com:3478` for address discovery, `turn:turn.cloudflare.com:3478` over UDP as the primary relay path, and `turns:turn.cloudflare.com:443` over TLS as the fallback on networks that block UDP (TLS on port 443 looks like ordinary HTTPS traffic). Cloudflare mints more endpoint variants, but every extra URL multiplies the connection checks each client runs during setup, so the redundant ones are trimmed before serving.
 
   **Relay detection:** The browser polls `RTCStatsReport` every 5 seconds and examines the nominated candidate pair. If either candidate is of type `relay`, the connection indicator shows amber.
 </Accordion>

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -53,7 +53,7 @@ The signaling server never touches file data, never stores your files or any rec
   **Data-channel transfer protocol:** Once the WebRTC data channel opens, the sender runs this sequence for each file:
   1. Sends a JSON `metadata` message with the filename, size in bytes, and the file's index and total count in the batch.
   2. Waits for the receiver to reply with a JSON `ack` message. The ack carries a byte offset, so a transfer can resume mid-file.
-  3. Streams the file as binary chunks until the whole file is sent. The CLI uses 16 KB chunks. The browser sender uses larger adaptive chunks and adds backpressure-based flow control, pausing when the data channel's send buffer fills.
+  3. Streams the file as binary chunks until the whole file is sent. Both senders size chunks adaptively to what the connection negotiates, up to 256 KB, and apply backpressure-based flow control, pausing when the data channel's send buffer fills.
   4. Sends a JSON `end` message to signal completion.
 
   For multi-file transfers, this four-step sequence repeats for each file in order.

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -170,7 +170,7 @@ Once the WebRTC data channel is open, the sender runs the following sequence for
 
 **Binary chunks (raw bytes)**
 
-The CLI sends 16 KB chunks. The browser sender sends larger adaptive chunks.
+Both the CLI and the browser size chunks adaptively to the connection's negotiated maximum message size, capped at 256 KB. Chunk size is a local sender choice, not part of the wire protocol; receivers handle any size.
 
 **End marker (JSON, sender to receiver)**
 


### PR DESCRIPTION
## Summary

Release prep for v1.7.4 plus a docs-accuracy pass after the recent changes:

- **Changelog:** adds the `v1.7.4` entry (faster connection setup: server-side ICE trim already live, CLI-side hardening in this release, `--iface`, and the web QR-link fix from #151).
- **`how-it-works/relay-connection.mdx`:** the endpoints paragraph still described the full Cloudflare list (`:5349` TLS plus TCP fallbacks on 80/443). Updated to the minimal three-URL set the server now serves, with the reason (each extra URL multiplies per-client connection checks).
- **`how-it-works/signaling.mdx`** and **`reference/architecture.mdx`:** both still claimed "the CLI uses 16 KB chunks"; both senders have sized chunks adaptively up to 256 KB since v1.7.3.

Docs-only change; no em dashes introduced.