### PR TITLE
fix(client): clarify direct/relay badge tooltip and relay fallback copy

### DIFF
--- a/client/components/ConnectionStatusBadge.tsx
+++ b/client/components/ConnectionStatusBadge.tsx
@@ -6,6 +6,7 @@ interface ConnectionStatusBadgeProps {
     isConnected: boolean;
     ping: number;
     connectionType: 'direct' | 'relay' | null;
+    directScope: 'same-network' | 'internet' | null;
     progress: number;
 }
 
@@ -20,6 +21,7 @@ export function ConnectionStatusBadge({
     isConnected,
     ping,
     connectionType,
+    directScope,
     progress,
 }: ConnectionStatusBadgeProps) {
     const [showInfoTooltip, setShowInfoTooltip] = useState(false);
@@ -67,7 +69,11 @@ export function ConnectionStatusBadge({
                 </span>
                 <span>
                     {connectionType === 'direct'
-                        ? 'Direct'
+                        ? directScope === 'same-network'
+                            ? 'Direct (same network)'
+                            : directScope === 'internet'
+                                ? 'Direct (internet)'
+                                : 'Direct'
                         : connectionType === 'relay'
                             ? 'Relay'
                             : isConnected
@@ -90,7 +96,11 @@ export function ConnectionStatusBadge({
                                     <>
                                         <p className="text-[10px] font-bold text-green-400 uppercase tracking-wider mb-1">Direct Connection</p>
                                         <p className="text-[10px] font-normal normal-case tracking-normal text-zinc-400 leading-relaxed">
-                                            Your files go directly to the other device. No servers involved. Unlimited speed and size.{' '}
+                                            {directScope === 'same-network'
+                                                ? 'Your devices are on the same network. Files travel over it directly. No servers involved. Unlimited speed and size.'
+                                                : directScope === 'internet'
+                                                    ? "Your files travel peer-to-peer across the internet, even between different networks like mobile data and home Wi-Fi. No servers carry your data. Speed depends on both devices' connections."
+                                                    : 'Your files go directly to the other device. No servers involved. Unlimited speed and size.'}{' '}
                                             <a href="/how-it-works" target="_blank" rel="noreferrer" className="text-zinc-500 hover:text-white underline underline-offset-2 transition-colors">
                                                 Learn more
                                             </a>

--- a/client/components/ConnectionStatusBadge.tsx
+++ b/client/components/ConnectionStatusBadge.tsx
@@ -6,7 +6,6 @@ interface ConnectionStatusBadgeProps {
     isConnected: boolean;
     ping: number;
     connectionType: 'direct' | 'relay' | null;
-    directScope: 'same-network' | 'internet' | null;
     progress: number;
 }
 
@@ -21,7 +20,6 @@ export function ConnectionStatusBadge({
     isConnected,
     ping,
     connectionType,
-    directScope,
     progress,
 }: ConnectionStatusBadgeProps) {
     const [showInfoTooltip, setShowInfoTooltip] = useState(false);
@@ -69,11 +67,7 @@ export function ConnectionStatusBadge({
                 </span>
                 <span>
                     {connectionType === 'direct'
-                        ? directScope === 'same-network'
-                            ? 'Direct (same network)'
-                            : directScope === 'internet'
-                                ? 'Direct (internet)'
-                                : 'Direct'
+                        ? 'Direct'
                         : connectionType === 'relay'
                             ? 'Relay'
                             : isConnected
@@ -96,11 +90,7 @@ export function ConnectionStatusBadge({
                                     <>
                                         <p className="text-[10px] font-bold text-green-400 uppercase tracking-wider mb-1">Direct Connection</p>
                                         <p className="text-[10px] font-normal normal-case tracking-normal text-zinc-400 leading-relaxed">
-                                            {directScope === 'same-network'
-                                                ? 'Your devices are on the same network. Files travel over it directly. No servers involved. Unlimited speed and size.'
-                                                : directScope === 'internet'
-                                                    ? "Your files travel peer-to-peer across the internet, even between different networks like mobile data and home Wi-Fi. No servers carry your data. Speed depends on both devices' connections."
-                                                    : 'Your files go directly to the other device. No servers involved. Unlimited speed and size.'}{' '}
+                                            Your files go directly to the other device, even across different networks like mobile data. No servers involved. Unlimited speed and size.{' '}
                                             <a href="/how-it-works" target="_blank" rel="noreferrer" className="text-zinc-500 hover:text-white underline underline-offset-2 transition-colors">
                                                 Learn more
                                             </a>

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -23,7 +23,7 @@ import { useSignaling } from '@/hooks/useSignaling';
 import { useConnectionType } from '@/hooks/useConnectionType';
 import { useTransferAnalytics } from '@/hooks/useTransferAnalytics';
 import { useRelayConfiguration } from '@/hooks/useRelayConfiguration';
-import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate, classifyCandidatePair } from '@/lib/relay';
+import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate, isRelayPair } from '@/lib/relay';
 import { classifyPeerError } from '@/lib/peerErrors';
 
 import {
@@ -108,7 +108,6 @@ export function P2PTransfer() {
 
     const {
         connectionType,
-        directScope,
         startPolling: startConnectionTypePolling,
         stopPolling: stopConnectionTypePolling,
         reset: resetConnectionType,
@@ -520,7 +519,7 @@ export function P2PTransfer() {
                                 if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
                                     const lc = stats.get(report.localCandidateId);
                                     const rc = stats.get(report.remoteCandidateId);
-                                    if (classifyCandidatePair(lc?.candidateType, rc?.candidateType).isRelay) {
+                                    if (isRelayPair(lc?.candidateType, rc?.candidateType)) {
                                         isRelay = true;
                                     }
                                 }
@@ -761,7 +760,6 @@ export function P2PTransfer() {
                                 isConnected={isConnected}
                                 ping={ping}
                                 connectionType={connectionType}
-                                directScope={directScope}
                                 progress={progress}
                             />
 

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -23,7 +23,7 @@ import { useSignaling } from '@/hooks/useSignaling';
 import { useConnectionType } from '@/hooks/useConnectionType';
 import { useTransferAnalytics } from '@/hooks/useTransferAnalytics';
 import { useRelayConfiguration } from '@/hooks/useRelayConfiguration';
-import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate } from '@/lib/relay';
+import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate, classifyCandidatePair } from '@/lib/relay';
 import { classifyPeerError } from '@/lib/peerErrors';
 
 import {
@@ -108,6 +108,7 @@ export function P2PTransfer() {
 
     const {
         connectionType,
+        directScope,
         startPolling: startConnectionTypePolling,
         stopPolling: stopConnectionTypePolling,
         reset: resetConnectionType,
@@ -519,7 +520,7 @@ export function P2PTransfer() {
                                 if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
                                     const lc = stats.get(report.localCandidateId);
                                     const rc = stats.get(report.remoteCandidateId);
-                                    if ((lc && lc.candidateType === 'relay') || (rc && rc.candidateType === 'relay')) {
+                                    if (classifyCandidatePair(lc?.candidateType, rc?.candidateType).isRelay) {
                                         isRelay = true;
                                     }
                                 }
@@ -760,6 +761,7 @@ export function P2PTransfer() {
                                 isConnected={isConnected}
                                 ping={ping}
                                 connectionType={connectionType}
+                                directScope={directScope}
                                 progress={progress}
                             />
 

--- a/client/components/RelayFallbackToggle.tsx
+++ b/client/components/RelayFallbackToggle.tsx
@@ -35,7 +35,7 @@ export function RelayFallbackToggle({ relayEnabled, onChange }: RelayFallbackTog
                 <div className="space-y-1.5">
                     <p className="text-sm font-medium text-zinc-200 leading-none">Network Relay Fallback</p>
                     <p className="text-xs text-zinc-500 leading-relaxed">
-                        Uses a relay server when a direct connection is unavailable. Recommended for mobile data and private networks. 2 GB limit per session.{' '}
+                        Only used when a direct connection can&apos;t be established. Most transfers stay direct, even on mobile data. 2 GB limit when relayed.{' '}
                         <a
                             href="/how-it-works"
                             target="_blank"

--- a/client/hooks/useConnectionType.ts
+++ b/client/hooks/useConnectionType.ts
@@ -1,14 +1,17 @@
 import { useState, useRef } from 'react';
 import type { Instance as PeerInstance } from 'simple-peer';
+import { classifyCandidatePair } from '@/lib/relay';
 
 /**
  * Detects and tracks whether the active WebRTC connection is direct or routed
  * through a TURN relay, by polling the peer's ICE candidate-pair stats every 5s.
- * Pure connection-quality detection: it only drives the "Direct/Relay" badge and
- * has no effect on the transfer itself.
+ * For direct connections it also reports the scope: same-network (host↔host)
+ * or internet (hole-punched). Pure connection-quality detection: it only drives
+ * the "Direct/Relay" badge and has no effect on the transfer itself.
  */
 export function useConnectionType() {
     const [connectionType, setConnectionType] = useState<'direct' | 'relay' | null>(null);
+    const [directScope, setDirectScope] = useState<'same-network' | 'internet' | null>(null);
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     const checkConnectionType = async (peer: PeerInstance) => {
@@ -21,10 +24,12 @@ export function useConnectionType() {
                 if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
                     const localCandidate = stats.get(report.localCandidateId);
                     const remoteCandidate = stats.get(report.remoteCandidateId);
-                    const isRelay =
-                        localCandidate?.candidateType === 'relay' ||
-                        remoteCandidate?.candidateType === 'relay';
+                    const { isRelay, scope } = classifyCandidatePair(
+                        localCandidate?.candidateType,
+                        remoteCandidate?.candidateType
+                    );
                     setConnectionType(isRelay ? 'relay' : 'direct');
+                    setDirectScope(isRelay ? null : scope);
                 }
             });
         } catch { }
@@ -41,7 +46,10 @@ export function useConnectionType() {
         if (intervalRef.current) clearInterval(intervalRef.current);
     };
 
-    const reset = () => setConnectionType(null);
+    const reset = () => {
+        setConnectionType(null);
+        setDirectScope(null);
+    };
 
-    return { connectionType, startPolling, stopPolling, reset };
+    return { connectionType, directScope, startPolling, stopPolling, reset };
 }

--- a/client/hooks/useConnectionType.ts
+++ b/client/hooks/useConnectionType.ts
@@ -1,17 +1,15 @@
 import { useState, useRef } from 'react';
 import type { Instance as PeerInstance } from 'simple-peer';
-import { classifyCandidatePair } from '@/lib/relay';
+import { isRelayPair } from '@/lib/relay';
 
 /**
  * Detects and tracks whether the active WebRTC connection is direct or routed
  * through a TURN relay, by polling the peer's ICE candidate-pair stats every 5s.
- * For direct connections it also reports the scope: same-network (host↔host)
- * or internet (hole-punched). Pure connection-quality detection: it only drives
- * the "Direct/Relay" badge and has no effect on the transfer itself.
+ * Pure connection-quality detection: it only drives the "Direct/Relay" badge and
+ * has no effect on the transfer itself.
  */
 export function useConnectionType() {
     const [connectionType, setConnectionType] = useState<'direct' | 'relay' | null>(null);
-    const [directScope, setDirectScope] = useState<'same-network' | 'internet' | null>(null);
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
     const checkConnectionType = async (peer: PeerInstance) => {
@@ -24,12 +22,11 @@ export function useConnectionType() {
                 if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
                     const localCandidate = stats.get(report.localCandidateId);
                     const remoteCandidate = stats.get(report.remoteCandidateId);
-                    const { isRelay, scope } = classifyCandidatePair(
+                    const isRelay = isRelayPair(
                         localCandidate?.candidateType,
                         remoteCandidate?.candidateType
                     );
                     setConnectionType(isRelay ? 'relay' : 'direct');
-                    setDirectScope(isRelay ? null : scope);
                 }
             });
         } catch { }
@@ -46,10 +43,7 @@ export function useConnectionType() {
         if (intervalRef.current) clearInterval(intervalRef.current);
     };
 
-    const reset = () => {
-        setConnectionType(null);
-        setDirectScope(null);
-    };
+    const reset = () => setConnectionType(null);
 
-    return { connectionType, directScope, startPolling, stopPolling, reset };
+    return { connectionType, startPolling, stopPolling, reset };
 }

--- a/client/lib/relay.test.ts
+++ b/client/lib/relay.test.ts
@@ -3,7 +3,7 @@ import {
     RELAY_SIZE_LIMIT,
     filterIceServers,
     evaluateRelayGate,
-    classifyCandidatePair,
+    isRelayPair,
 } from './relay';
 
 const STUN: RTCIceServer = { urls: 'stun:stun.l.google.com:19302' };
@@ -34,44 +34,23 @@ describe('filterIceServers', () => {
     });
 });
 
-describe('classifyCandidatePair', () => {
-    it('classifies host↔host as direct on the same network', () => {
-        expect(classifyCandidatePair('host', 'host')).toEqual({
-            isRelay: false,
-            scope: 'same-network',
-        });
-    });
-
-    it('classifies hole-punched pairs as direct over the internet', () => {
-        expect(classifyCandidatePair('srflx', 'srflx')).toEqual({
-            isRelay: false,
-            scope: 'internet',
-        });
-        expect(classifyCandidatePair('srflx', 'host')).toEqual({
-            isRelay: false,
-            scope: 'internet',
-        });
-        expect(classifyCandidatePair('host', 'prflx')).toEqual({
-            isRelay: false,
-            scope: 'internet',
-        });
+describe('isRelayPair', () => {
+    it('classifies host and reflexive pairs as direct', () => {
+        expect(isRelayPair('host', 'host')).toBe(false);
+        expect(isRelayPair('srflx', 'srflx')).toBe(false);
+        expect(isRelayPair('srflx', 'host')).toBe(false);
+        expect(isRelayPair('host', 'prflx')).toBe(false);
     });
 
     it('reports relay when either side connects through TURN', () => {
-        expect(classifyCandidatePair('relay', 'host').isRelay).toBe(true);
-        expect(classifyCandidatePair('srflx', 'relay').isRelay).toBe(true);
-        expect(classifyCandidatePair('relay', 'relay').isRelay).toBe(true);
+        expect(isRelayPair('relay', 'host')).toBe(true);
+        expect(isRelayPair('srflx', 'relay')).toBe(true);
+        expect(isRelayPair('relay', 'relay')).toBe(true);
     });
 
-    it('treats missing candidate types as direct over the internet', () => {
-        expect(classifyCandidatePair(undefined, undefined)).toEqual({
-            isRelay: false,
-            scope: 'internet',
-        });
-        expect(classifyCandidatePair('host', undefined)).toEqual({
-            isRelay: false,
-            scope: 'internet',
-        });
+    it('treats missing candidate types as not relay', () => {
+        expect(isRelayPair(undefined, undefined)).toBe(false);
+        expect(isRelayPair('host', undefined)).toBe(false);
     });
 });
 

--- a/client/lib/relay.test.ts
+++ b/client/lib/relay.test.ts
@@ -3,6 +3,7 @@ import {
     RELAY_SIZE_LIMIT,
     filterIceServers,
     evaluateRelayGate,
+    classifyCandidatePair,
 } from './relay';
 
 const STUN: RTCIceServer = { urls: 'stun:stun.l.google.com:19302' };
@@ -30,6 +31,47 @@ describe('filterIceServers', () => {
     it('keeps every stun server when relay is disabled', () => {
         const stunOnly = [STUN, { urls: 'stun:stun1.l.google.com:19302' }];
         expect(filterIceServers(stunOnly, false)).toEqual(stunOnly);
+    });
+});
+
+describe('classifyCandidatePair', () => {
+    it('classifies host↔host as direct on the same network', () => {
+        expect(classifyCandidatePair('host', 'host')).toEqual({
+            isRelay: false,
+            scope: 'same-network',
+        });
+    });
+
+    it('classifies hole-punched pairs as direct over the internet', () => {
+        expect(classifyCandidatePair('srflx', 'srflx')).toEqual({
+            isRelay: false,
+            scope: 'internet',
+        });
+        expect(classifyCandidatePair('srflx', 'host')).toEqual({
+            isRelay: false,
+            scope: 'internet',
+        });
+        expect(classifyCandidatePair('host', 'prflx')).toEqual({
+            isRelay: false,
+            scope: 'internet',
+        });
+    });
+
+    it('reports relay when either side connects through TURN', () => {
+        expect(classifyCandidatePair('relay', 'host').isRelay).toBe(true);
+        expect(classifyCandidatePair('srflx', 'relay').isRelay).toBe(true);
+        expect(classifyCandidatePair('relay', 'relay').isRelay).toBe(true);
+    });
+
+    it('treats missing candidate types as direct over the internet', () => {
+        expect(classifyCandidatePair(undefined, undefined)).toEqual({
+            isRelay: false,
+            scope: 'internet',
+        });
+        expect(classifyCandidatePair('host', undefined)).toEqual({
+            isRelay: false,
+            scope: 'internet',
+        });
     });
 });
 

--- a/client/lib/relay.ts
+++ b/client/lib/relay.ts
@@ -20,6 +20,28 @@ export function filterIceServers(
     });
 }
 
+export interface CandidatePairClass {
+    isRelay: boolean;
+    scope: 'same-network' | 'internet';
+}
+
+/**
+ * Classifies the selected ICE candidate pair from getStats(). Relay means
+ * either side connects through a TURN server. For non-relay pairs, host↔host
+ * means both devices reached each other without NAT traversal (same network);
+ * anything involving a reflexive candidate is a hole-punched path across the
+ * internet. Informational only — a VPN can make distinct networks look local.
+ */
+export function classifyCandidatePair(
+    localType?: string,
+    remoteType?: string
+): CandidatePairClass {
+    const isRelay = localType === 'relay' || remoteType === 'relay';
+    const scope =
+        localType === 'host' && remoteType === 'host' ? 'same-network' : 'internet';
+    return { isRelay, scope };
+}
+
 export type RelayGateVerdict =
     | { action: 'proceed' }
     | { action: 'block-relay-disabled' }

--- a/client/lib/relay.ts
+++ b/client/lib/relay.ts
@@ -20,26 +20,13 @@ export function filterIceServers(
     });
 }
 
-export interface CandidatePairClass {
-    isRelay: boolean;
-    scope: 'same-network' | 'internet';
-}
-
 /**
- * Classifies the selected ICE candidate pair from getStats(). Relay means
- * either side connects through a TURN server. For non-relay pairs, host↔host
- * means both devices reached each other without NAT traversal (same network);
- * anything involving a reflexive candidate is a hole-punched path across the
- * internet. Informational only — a VPN can make distinct networks look local.
+ * Reports whether the selected ICE candidate pair from getStats() runs through
+ * a TURN relay, i.e. either side's candidate is a relay candidate. Anything
+ * else (host or reflexive on both ends) is a direct peer-to-peer path.
  */
-export function classifyCandidatePair(
-    localType?: string,
-    remoteType?: string
-): CandidatePairClass {
-    const isRelay = localType === 'relay' || remoteType === 'relay';
-    const scope =
-        localType === 'host' && remoteType === 'host' ? 'same-network' : 'internet';
-    return { isRelay, scope };
+export function isRelayPair(localType?: string, remoteType?: string): boolean {
+    return localType === 'relay' || remoteType === 'relay';
 }
 
 export type RelayGateVerdict =

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -57,11 +57,28 @@ description: "Answers to the most common questions about Floe."
   <Accordion title="What does the connection indicator color mean?">
     The indicator in the corner of the page shows connection state:
 
-    - **Green (Direct):** Files transfer directly between devices. No server involved. No size limit.
+    - **Green (Direct):** Files transfer directly between devices. No server involved. No size limit. The label also shows the path: **Direct (same network)** means both devices reached each other on the same local network, and **Direct (internet)** means they connected peer-to-peer across the internet.
     - **Amber (Relay):** Files route through the encrypted TURN relay. The 2 GB cap applies.
     - **Connecting:** Negotiating the WebRTC connection. This usually takes a few seconds.
 
     If the connection stays in "Connecting" for more than 30 seconds, see [Troubleshooting](/troubleshooting).
+  </Accordion>
+
+  <Accordion title="Why does it say Direct when my phone is on mobile data?">
+    Because the connection really is direct. WebRTC uses a technique called NAT hole punching (with the help of a STUN server) to open a peer-to-peer path between two devices even when they sit on completely different networks, such as home Wi-Fi on one side and mobile data on the other. Once that path is open, file bytes flow straight from one device to the other and no server carries them.
+
+    The relay only enters the picture when hole punching fails, which mostly happens on strict corporate firewalls or unusual carrier NAT setups. Most transfers, including those involving mobile data, connect directly.
+
+    Transfer speed on a direct connection is set by the slower of the two internet connections involved (typically the sender's upload speed or the receiver's mobile signal), not by Floe. See [Direct Connection](/how-it-works/direct-connection) for the full story.
+  </Accordion>
+
+  <Accordion title="Does turning off Network Relay Fallback stop or cancel my transfer?">
+    No. The toggle only controls whether Floe may fall back to a relay server when a direct connection cannot be established. It is checked once, when the connection is being set up.
+
+    - If the connection is **direct**, the toggle has no effect. The transfer proceeds whether relay fallback is on or off, because no relay is involved.
+    - If the connection would need a **relay** and the toggle is off, Floe blocks the transfer before any file data moves.
+
+    The toggle cannot affect a connection that is already established, which is why it is only shown before the share link is created.
   </Accordion>
 
   <Accordion title="Can I enter a short code in the browser to receive?">

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -57,7 +57,7 @@ description: "Answers to the most common questions about Floe."
   <Accordion title="What does the connection indicator color mean?">
     The indicator in the corner of the page shows connection state:
 
-    - **Green (Direct):** Files transfer directly between devices. No server involved. No size limit. The label also shows the path: **Direct (same network)** means both devices reached each other on the same local network, and **Direct (internet)** means they connected peer-to-peer across the internet.
+    - **Green (Direct):** Files transfer directly between devices, whether they share a network or connect peer-to-peer across the internet. No server involved. No size limit.
     - **Amber (Relay):** Files route through the encrypted TURN relay. The 2 GB cap applies.
     - **Connecting:** Negotiating the WebRTC connection. This usually takes a few seconds.
 


### PR DESCRIPTION
## Summary

A user on floe.one transferred PC (home internet) to phone (mobile data), saw the badge read Direct, and assumed the indicator was broken because they expected Relay. Investigation confirmed the detection logic is correct: a hole-punched srflx pair is a genuine direct P2P path, relay is fallback-only (never preferred), and the relay gate correctly lets direct transfers proceed with the toggle off. The confusion came from UI copy implying mobile data means relay.

- Badge label stays plain **Direct**; its tooltip now explains that direct paths span different networks, including mobile data.
- Relay toggle description reworded: it is only used when a direct connection cannot be established; most transfers stay direct, even on mobile data.
- Candidate-pair relay detection extracted into a pure `isRelayPair` helper in `lib/relay.ts`, now shared by `useConnectionType` and the sender relay-gate check (removes duplicated getStats classification in `P2PTransfer.tsx`).
- `connectionType` union, relay gate, telemetry values, and the `floe-connection-status` event are unchanged.
- FAQ: expanded the indicator-color entry and added two entries (why Direct on mobile data; what turning off Network Relay Fallback actually does).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` 88 passed, including new `isRelayPair` unit tests (host/reflexive pairs, relay either side, undefined types)
- [x] `pnpm build` (TypeScript) clean
- [x] Playwright `e2e/transfer.spec.ts` 3 passed (50 MB integrity, 0-byte, 512-byte)
- [x] Manual two-tab transfer against local server: badge, tooltip, and new toggle copy verified in the rendered DOM