### PR TITLE
fix(transfer): report delivered bytes so sender and receiver progress stay in sync

### DIFF
--- a/cli/internal/transfer/backpressure_test.go
+++ b/cli/internal/transfer/backpressure_test.go
@@ -1,0 +1,28 @@
+package transfer
+
+import "testing"
+
+// TestBackpressureStalled verifies the abort rule for a timed-out backpressure
+// wait: abort only when the buffer made no progress over the window. A relay
+// slower than ~70 KB/s legitimately needs more than 60 s to drain the 4 MB
+// between the watermarks, and must not have its transfer killed.
+func TestBackpressureStalled(t *testing.T) {
+	cases := []struct {
+		name string
+		prev uint64
+		cur  uint64
+		want bool
+	}{
+		{"frozen buffer aborts", 8 << 20, 8 << 20, true},
+		{"growing buffer aborts", 8 << 20, 9 << 20, true},
+		{"slow drain keeps waiting", 8 << 20, (8 << 20) - 1, false},
+		{"steady drain keeps waiting", 8 << 20, 5 << 20, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := backpressureStalled(c.prev, c.cur); got != c.want {
+				t.Fatalf("backpressureStalled(%d, %d) = %v, want %v", c.prev, c.cur, got, c.want)
+			}
+		})
+	}
+}

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -63,6 +63,14 @@ const (
 	bufferedAmountLowWater  = 4 * 1024 * 1024 // resume sending below 4 MB buffered
 )
 
+// backpressureStalled reports whether a backpressure wait that just hit its
+// timeout should abort the transfer: only when the buffer failed to shrink at
+// all over the window. Any drain, however slow, means the peer is alive and
+// the wait should continue.
+func backpressureStalled(prev, cur uint64) bool {
+	return cur >= prev
+}
+
 // metadataMsg is sent before each file to describe it.
 type metadataMsg struct {
 	Type       string `json:"type"`
@@ -354,12 +362,20 @@ ackLoop:
 		if n > 0 {
 			// Backpressure: block until pion's buffer drains below the low-water
 			// mark before queuing more. The loop re-checks after each wakeup so a
-			// stale signal can't let us run away from the receiver.
+			// stale signal can't let us run away from the receiver. Abort only
+			// when the buffer makes no progress across a full 60 s window: a
+			// slow-but-draining relay (below ~70 KB/s the 4 MB drain takes over
+			// a minute) must not kill the transfer.
+			lastBuffered := dc.BufferedAmount()
 			for dc.BufferedAmount() >= bufferedAmountHighWater {
 				select {
 				case <-sendMore:
 				case <-time.After(60 * time.Second):
-					return fmt.Errorf("backpressure stall: peer not draining (%d bytes buffered)", dc.BufferedAmount())
+					cur := dc.BufferedAmount()
+					if backpressureStalled(lastBuffered, cur) {
+						return fmt.Errorf("backpressure stall: peer not draining (%d bytes buffered)", cur)
+					}
+					lastBuffered = cur
 				}
 			}
 			if sendErr := dc.Send(buf[:n]); sendErr != nil {

--- a/client/e2e/transfer.spec.ts
+++ b/client/e2e/transfer.spec.ts
@@ -86,7 +86,9 @@ test('transfers a 50 MB binary file with SHA-256 integrity check', async ({ brow
 
         // Measure once the receiver reports it is actively receiving, so the
         // throughput figure reflects the data path rather than connection setup.
-        await expect(receiverPage.getByText(/Receiving file/i)).toBeVisible({ timeout: 30_000 });
+        // .first(): the status line and the in-progress file row can both show
+        // "Receiving file 1 of 1" at the same time.
+        await expect(receiverPage.getByText(/Receiving file/i).first()).toBeVisible({ timeout: 30_000 });
         const transferStart = Date.now();
 
         // Wait for the download button to appear — file is fully in memory as a blob

--- a/client/lib/transfer/progressSync.test.ts
+++ b/client/lib/transfer/progressSync.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { sendFiles, type SenderDeps } from './sender';
+import { createReceiver } from './receiver';
+import { ackMessage, metadataMessage, endMessage } from './protocol';
+
+const enc = new TextEncoder();
+
+// Regression tests for progress truthfulness: the sender must report DELIVERED
+// bytes (queued minus what still sits in the channel buffer), keep the bar
+// moving while blocked on a slow drain, and switch the displayed file only
+// when the receiver has acked it. The receiver must report progress on a byte
+// threshold that works for any chunk size (the old exact-modulo check never
+// fired with 256 KB chunks on files under 6.25 MB).
+
+function makeFile(sizeBytes: number, name = 'test.bin'): File {
+    const buf = new Uint8Array(sizeBytes);
+    for (let i = 0; i < sizeBytes; i++) buf[i] = (i * 31 + 7) % 256;
+    return new File([buf], name, { type: 'application/octet-stream' });
+}
+
+// A buffer channel whose fill level the test controls: sent chunks pile up in
+// bufferedAmount and only "reach the peer" when the test drains them.
+function makeDrainableDeps() {
+    const listeners = new Set<() => void>();
+    const channel = {
+        bufferedAmount: 0,
+        bufferedAmountLowThreshold: 0,
+        addEventListener: (_: 'bufferedamountlow', h: () => void) => { listeners.add(h); },
+        removeEventListener: (_: 'bufferedamountlow', h: () => void) => { listeners.delete(h); },
+    };
+    let handler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+    const controls: string[] = [];
+    const deps: SenderDeps = {
+        send: (d) => {
+            if (typeof d === 'string') controls.push(d);
+            else channel.bufferedAmount += d.byteLength;
+        },
+        onData: (h) => {
+            handler = h;
+            return () => { handler = null; };
+        },
+        channel,
+        sctpMaxMessageSize: 64 * 1024,
+    };
+    return {
+        deps,
+        controls,
+        deliverAck: (id: string) => handler?.(enc.encode(ackMessage(id, 0))),
+        drainTo: (amount: number) => {
+            channel.bufferedAmount = amount;
+            listeners.forEach((h) => h());
+        },
+    };
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('sender: delivered-bytes progress', () => {
+    it('reports delivered bytes, keeps the bar moving during a slow drain, and completes only after the buffer empties', async () => {
+        vi.useFakeTimers();
+        const { deps, deliverAck, drainTo } = makeDrainableDeps();
+        const progress: number[] = [];
+        const onAllSent = vi.fn();
+        const onFileStart = vi.fn();
+
+        const SIZE = 1024 * 1024;
+        const p = sendFiles(deps, [{ id: 'f1', file: makeFile(SIZE) }], {
+            onProgress: (pct) => progress.push(pct),
+            onFileStart,
+            onAllSent,
+        });
+
+        // Metadata is out; no ack yet, so the displayed file must not switch.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(onFileStart).not.toHaveBeenCalled();
+
+        deliverAck('f1');
+        await vi.advanceTimersByTimeAsync(0);
+        expect(onFileStart).toHaveBeenCalledTimes(1);
+
+        // The whole 1 MB is queued (below the 8 MB high-water mark) but nothing
+        // has been delivered — the old queued-bytes accounting reported 100%
+        // here; delivered-bytes accounting must report 0%.
+        await vi.advanceTimersByTimeAsync(600);
+        expect(progress[progress.length - 1]).toBe(0);
+        expect(onAllSent).not.toHaveBeenCalled();
+
+        // Half the buffer drains: the ticker must move the bar to 50% even
+        // though the send loop is idle (this was the frozen-for-a-minute UI).
+        drainTo(SIZE / 2);
+        await vi.advanceTimersByTimeAsync(600);
+        expect(progress[progress.length - 1]).toBe(50);
+        expect(onAllSent).not.toHaveBeenCalled();
+
+        // Full drain: 100% and only now "all sent".
+        drainTo(0);
+        await vi.advanceTimersByTimeAsync(600);
+        await p;
+        expect(progress[progress.length - 1]).toBe(100);
+        expect(onAllSent).toHaveBeenCalledTimes(1);
+    });
+
+    it('switches the displayed file only after the receiver acks it', async () => {
+        vi.useFakeTimers();
+        const { deps, controls, deliverAck, drainTo } = makeDrainableDeps();
+        const fileStarts: number[] = [];
+
+        const p = sendFiles(
+            deps,
+            [
+                { id: 'a', file: makeFile(256 * 1024, 'a.bin') },
+                { id: 'b', file: makeFile(1024, 'b.bin') },
+            ],
+            { onFileStart: (i) => fileStarts.push(i) }
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+        deliverAck('a');
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fileStarts).toEqual([0]);
+
+        // File a is fully queued but undelivered; b's metadata must wait for
+        // the tail to drain, and b's onFileStart must wait for b's ack.
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(controls.some((c) => c.includes('"b.bin"'))).toBe(false);
+        expect(fileStarts).toEqual([0]);
+
+        drainTo(0);
+        await vi.advanceTimersByTimeAsync(300);
+        expect(controls.some((c) => c.includes('"b.bin"'))).toBe(true);
+        expect(fileStarts).toEqual([0]);
+
+        deliverAck('b');
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fileStarts).toEqual([0, 1]);
+
+        drainTo(0);
+        await vi.advanceTimersByTimeAsync(300);
+        await p;
+    });
+});
+
+describe('receiver: progress cadence', () => {
+    it('reports progress at least every 1 MB with 256 KB chunks', () => {
+        const reported: number[] = [];
+        const rx = createReceiver({
+            send: () => { },
+            onProgress: (_pct, received) => reported.push(received),
+        });
+
+        const SIZE = 5 * 1024 * 1024;
+        rx.handleMessage(enc.encode(metadataMessage('big', 'big.bin', SIZE, 1, 1, SIZE)));
+        const chunk = new Uint8Array(256 * 1024); // > 1000 bytes, treated as file data
+        for (let i = 0; i < 20; i++) rx.handleMessage(chunk);
+        rx.handleMessage(enc.encode(endMessage()));
+
+        // 1 MB steps plus completion, then the (0,0,0) reset on 'end'. The old
+        // exact-modulo condition emitted nothing at all for this sequence.
+        expect(reported).toEqual([
+            1024 * 1024,
+            2 * 1024 * 1024,
+            3 * 1024 * 1024,
+            4 * 1024 * 1024,
+            5 * 1024 * 1024,
+            0,
+        ]);
+    });
+});

--- a/client/lib/transfer/receiver.ts
+++ b/client/lib/transfer/receiver.ts
@@ -36,9 +36,14 @@ export interface ReceiverCallbacks {
     onError?: (msg: string) => void;
 }
 
+// Report receive progress at least once per this many bytes. A byte-count
+// threshold (rather than an exact modulo) works for any negotiated chunk size.
+const PROGRESS_STEP = 1024 * 1024; // 1 MB
+
 interface PartialDownload {
     chunks: ArrayBuffer[];
     received: number;
+    lastReported: number; // `received` value at the last onProgress emission
 }
 
 /**
@@ -118,7 +123,7 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
                 if (existing) {
                     offset = existing.received;
                 } else {
-                    partialDownloads.set(msg.id, { chunks: [], received: 0 });
+                    partialDownloads.set(msg.id, { chunks: [], received: 0, lastReported: 0 });
                 }
 
                 // Send ack with protocol version fields so the sender can verify
@@ -185,9 +190,10 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
 
         if (
             currentMetadata.fileSize &&
-            (fileData.received % (160 * 1024 * 10) === 0 ||
+            (fileData.received - fileData.lastReported >= PROGRESS_STEP ||
                 fileData.received === currentMetadata.fileSize)
         ) {
+            fileData.lastReported = fileData.received;
             cb.onProgress?.(
                 Math.round((fileData.received / currentMetadata.fileSize) * 100),
                 fileData.received,

--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -50,6 +50,31 @@ export interface SenderDeps {
     sctpMaxMessageSize?: number | null;
 }
 
+// How often the progress ticker re-derives delivered bytes for the UI. It runs
+// through backpressure and ack waits, so the bar keeps moving while the send
+// loop itself is blocked on a slow link.
+const PROGRESS_TICK_MS = 500;
+
+// Buffer level to drain to before starting the next file's metadata/ack
+// handshake. The ack can only arrive after the receiver consumes the previous
+// file's tail (the channel is ordered), so draining first keeps the 120 s ack
+// deadline from having to absorb a multi-MB drain on a slow relay.
+const METADATA_DRAIN_THRESHOLD = 64 * 1024;
+
+// Tracks the file currently shown in the UI. Progress is derived from
+// DELIVERED bytes (queued offset minus what still sits in the channel buffer),
+// not queued bytes: with an 8 MB high-water mark the two can differ by a
+// minute's worth of data on a slow relay. The per-file ack guarantees the
+// buffer only ever holds the displayed file's unsent tail (plus <1 KB of
+// control messages), so the subtraction is sound.
+interface ProgressView {
+    active: boolean;
+    size: number;
+    offset: number; // bytes of this file queued into the channel so far
+    lastSpeedTime: number;
+    lastSpeedDelivered: number;
+}
+
 /**
  * Sends all files over the data channel in order.
  *
@@ -71,16 +96,90 @@ export async function sendFiles(
     const destroyed = cb.isDestroyed ?? (() => false);
     const totalBytes = files.reduce((s, e) => s + e.file.size, 0);
 
-    for (let i = 0; i < files.length; i++) {
-        if (destroyed()) break;
-        const entry = files[i];
-        cb.onFileStart?.(i, files.length, entry.file.name);
-        await sendSingleFile(deps, entry, i + 1, files.length, totalBytes, cb);
-    }
+    const view: ProgressView = {
+        active: false,
+        size: 0,
+        offset: 0,
+        lastSpeedTime: performance.now(),
+        lastSpeedDelivered: 0,
+    };
 
-    if (!destroyed()) {
+    const emitView = () => {
+        if (!view.active || destroyed()) return;
+        const delivered = Math.min(
+            view.size,
+            Math.max(0, view.offset - deps.channel.bufferedAmount)
+        );
+        cb.onProgress?.(
+            view.size > 0 ? Math.round((delivered / view.size) * 100) : 100
+        );
+        const now = performance.now();
+        const dt = (now - view.lastSpeedTime) / 1000;
+        if (dt >= 1 && delivered > view.lastSpeedDelivered) {
+            const bytesPerSec = (delivered - view.lastSpeedDelivered) / dt;
+            cb.onSpeed?.(bytesPerSec, (view.size - delivered) / bytesPerSec);
+            view.lastSpeedTime = now;
+            view.lastSpeedDelivered = delivered;
+        }
+    };
+
+    const ticker = setInterval(emitView, PROGRESS_TICK_MS);
+
+    try {
+        for (let i = 0; i < files.length; i++) {
+            if (destroyed()) return;
+            const entry = files[i];
+            const ok = await sendSingleFile(
+                deps, entry, i + 1, files.length, totalBytes, cb, view, emitView
+            );
+            if (!ok) return;
+        }
+
+        if (destroyed()) return;
+
+        // "All Files Sent!" must mean delivered, not queued: the last file's
+        // tail (up to HIGH_WATER bytes) can still be in the buffer here.
+        await drainBelow(deps.channel, 0, destroyed);
+        if (destroyed()) return;
+
+        emitView();
+        cb.onSpeedReset?.();
         cb.onAllSent?.();
+    } finally {
+        clearInterval(ticker);
     }
+}
+
+// Resolves once the channel buffer has drained to at most `threshold` bytes
+// (or the peer is destroyed). Uses the bufferedamountlow event plus a poll
+// fallback, since the event is unreliable when the threshold changes while a
+// drain is already in flight.
+function drainBelow(
+    channel: BufferChannel,
+    threshold: number,
+    destroyed: () => boolean
+): Promise<void> {
+    if (channel.bufferedAmount <= threshold || destroyed()) {
+        return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+        const prevThreshold = channel.bufferedAmountLowThreshold;
+        channel.bufferedAmountLowThreshold = threshold;
+        let poll: ReturnType<typeof setInterval> | null = null;
+        const finish = () => {
+            channel.removeEventListener('bufferedamountlow', onLow);
+            if (poll) clearInterval(poll);
+            channel.bufferedAmountLowThreshold = prevThreshold;
+            resolve();
+        };
+        const onLow = () => {
+            if (channel.bufferedAmount <= threshold) finish();
+        };
+        channel.addEventListener('bufferedamountlow', onLow);
+        poll = setInterval(() => {
+            if (destroyed() || channel.bufferedAmount <= threshold) finish();
+        }, 200);
+    });
 }
 
 // Result of waiting for the receiver's ack.
@@ -89,21 +188,30 @@ type AckResult =
     | { type: 'incompatible'; reason: string }
     | { type: 'timeout' };
 
+// Returns false when the transfer must stop (error already reported via cb).
 async function sendSingleFile(
     deps: SenderDeps,
     entry: FileEntry,
     index: number,
     total: number,
     totalBytes: number,
-    cb: SenderCallbacks
-): Promise<void> {
+    cb: SenderCallbacks,
+    view: ProgressView,
+    emitView: () => void
+): Promise<boolean> {
     const { file, id } = entry;
     const { send, onData, channel } = deps;
     const destroyed = cb.isDestroyed ?? (() => false);
 
-    if (destroyed()) return;
+    if (destroyed()) return true;
 
     const CHUNK_SIZE = chunkSize(deps.sctpMaxMessageSize);
+
+    // Let the previous file's tail drain before the handshake; the progress
+    // ticker keeps updating the previous file's bar during this wait. No-op on
+    // the first file (buffer is empty).
+    await drainBelow(channel, METADATA_DRAIN_THRESHOLD, destroyed);
+    if (destroyed()) return true;
 
     channel.bufferedAmountLowThreshold = LOW_WATER;
 
@@ -111,18 +219,18 @@ async function sendSingleFile(
     try {
         send(metadataMessage(id, file.name, file.size, index, total, totalBytes));
     } catch {
-        return;
+        return false;
     }
 
-    // 2. Wait for ack (15 s timeout), handling incompatible responses
+    // 2. Wait for ack (120 s timeout), handling incompatible responses
     const ackResult = await waitForAck(onData, id);
     if (ackResult.type === 'timeout') {
         cb.onError?.('Transfer timed out waiting for receiver. Please try again.');
-        return;
+        return false;
     }
     if (ackResult.type === 'incompatible') {
         cb.onError?.(ackResult.reason);
-        return;
+        return false;
     }
 
     // Defense in depth: verify protocol compat from the receiver's pv fields on
@@ -140,15 +248,22 @@ async function sendSingleFile(
                 MIN_PROTOCOL_VERSION, PROTOCOL_VERSION,
                 ackResult.pvMin ?? 1, ackResult.pv ?? 1
             ));
-            return;
+            return false;
         }
     }
 
+    // The ack means the receiver has consumed everything before this file and
+    // opened it — only now switch the displayed file, so the sender's label
+    // and bar stay in step with what the receiver is actually working on.
+    cb.onFileStart?.(index - 1, total, file.name);
+    view.active = true;
+    view.size = file.size;
+    view.offset = ackResult.offset;
+    view.lastSpeedTime = performance.now();
+    view.lastSpeedDelivered = ackResult.offset;
+    emitView();
+
     let offset = ackResult.offset;
-    let speedMeasureStart = performance.now();
-    let speedMeasureBytes = 0;
-    let lastSpeedUpdate = 0;
-    let chunkCount = 0;
 
     const waitForBuffer = () =>
         new Promise<void>((r) => {
@@ -163,7 +278,9 @@ async function sendSingleFile(
             }
         });
 
-    // 3. Send chunks
+    // 3. Send chunks. Progress/speed emission is owned by the ticker in
+    // sendFiles, which derives delivered bytes from view.offset minus the
+    // channel's bufferedAmount — this loop only advances view.offset.
     while (offset < file.size) {
         if (destroyed()) break;
 
@@ -197,34 +314,16 @@ async function sendSingleFile(
 
             slabOffset += chunkLen;
             offset += chunkLen;
-            speedMeasureBytes += chunkLen;
-            chunkCount++;
-
-            const now = performance.now();
-            if (now - lastSpeedUpdate > 1000) {
-                const elapsed = (now - speedMeasureStart) / 1000;
-                if (elapsed > 0) {
-                    const bytesPerSec = speedMeasureBytes / elapsed;
-                    const remaining = file.size - offset;
-                    cb.onSpeed?.(bytesPerSec, remaining / bytesPerSec);
-                }
-                speedMeasureStart = now;
-                speedMeasureBytes = 0;
-                lastSpeedUpdate = now;
-            }
-
-            if (chunkCount % 10 === 0 || offset >= file.size) {
-                cb.onProgress?.(Math.round((offset / file.size) * 100));
-            }
+            view.offset = offset;
         }
     }
-
-    cb.onSpeedReset?.();
 
     // 4. Send end marker
     try {
         send(endMessage());
     } catch { }
+
+    return true;
 }
 
 function waitForAck(


### PR DESCRIPTION
## Summary

Users saw relay transfers "freeze for ~1 minute then resume" and sender/receiver progress drift badly out of sync (sender at 50% with the receiver's bar unmoved; sender on file 9 while the receiver is on file 8). Investigation showed the transport never pauses - three display/flow defects created the illusion:

- **Sender counted queued bytes as sent.** Since the 8 MB / 4 MB watermark change (`572b5b3`), the sender ran up to 8 MB ahead of delivery, and during the 8 MB to 4 MB drain (40-60 s at ~100 KB/s) no progress or speed callbacks fired at all, freezing the UI. Progress and speed are now derived from delivered bytes (queued minus `bufferedAmount`) by a 500 ms ticker that keeps running through backpressure and ack waits. "All Files Sent!" now fires only after the buffer fully drains.
- **Receiver progress condition was an exact modulo** (`received % 1,638,400 === 0`), written for fixed 16 KB chunks and silently broken by v1.7.3 adaptive 256 KB chunks - it aligned only every 6.25 MB and never for smaller files (one bar update per ~65 s at relay speed). Replaced with a 1 MB threshold that works for any chunk size.
- **File label ran a file ahead.** The sender now switches the displayed file only after the receiver acks it, and the next file's metadata waits for the previous tail to drain below 64 KB - which also keeps the 120 s ack deadline from having to absorb a multi-MB drain on slow links.
- **CLI: flat 60 s backpressure timeout killed slow-but-healthy relays** (below ~70 KB/s the 4 MB drain legitimately takes over a minute). The CLI sender now aborts only when the buffer makes no progress across a full 60 s window.

No wire changes; `ProtocolVersion` is untouched. The e2e locator for "Receiving file" needed `.first()` because the status line and the in-progress file row can now legitimately show the text at the same time.

## Test plan

- [x] `pnpm lint`, `pnpm build` (TypeScript) clean
- [x] `pnpm test` 91 passed, including new `progressSync.test.ts`: delivered-bytes accounting under a simulated slow drain, bar movement while the send loop is blocked, file label switching only after ack, `onAllSent` only after full drain, receiver 1 MB cadence with 256 KB chunks
- [x] `go test ./...` passes, including the real CLI loopback transfer suite and a new `backpressureStalled` table test
- [x] Playwright `e2e/transfer.spec.ts` 3 passed (50 MB SHA-256 integrity, 0-byte, 512-byte)
- [x] Throughput A/B on the same dev server: 10.12 MB/s before vs 10.13 MB/s after (no regression)