### PR TITLE
fix(client): reject malformed room links instead of waiting forever

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -72,6 +72,17 @@ function getRoomFromUrl(): string | null {
     return new URLSearchParams(window.location.search).get('room');
 }
 
+// Mirrors the signaling server's UUID_REGEX (server.js) so the client rejects a
+// malformed room id up front instead of emitting a join the server would refuse
+// with an 'error' event the browser does not listen for. Keep in sync with the
+// server: a loose format check, not a version/variant-strict UUID validation.
+const ROOM_ID_REGEX =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isValidRoomId(roomId: string): boolean {
+    return ROOM_ID_REGEX.test(roomId);
+}
+
 export function P2PTransfer() {
     const [isSender, setIsSender] = useState<boolean | null>(null);
     const [status, setStatus] = useState('Idle');
@@ -406,6 +417,18 @@ export function P2PTransfer() {
         const roomFromUrl = getRoomFromUrl();
 
         if (roomFromUrl) {
+            if (!isValidRoomId(roomFromUrl)) {
+                // A hand-edited or truncated fragment can carry a non-UUID room id.
+                // The server would reject the join with an 'error' event we do not
+                // listen for, leaving the receiver waiting forever; surface the same
+                // "Link Invalid" card the room-full path uses instead of joining.
+                // Fragment-derived state is set post-mount (SSR has no fragment),
+                // the same one-shot sync as the setIsSender effect above.
+                // eslint-disable-next-line react-hooks/set-state-in-effect
+                setError('Link Expired or Busy');
+                setStatus('Access Denied');
+                return;
+            }
             fetchIceServers().then(() => joinRoomAsReceiver(roomFromUrl));
         } else {
             fetchIceServers();

--- a/client/e2e/invalid-room.spec.ts
+++ b/client/e2e/invalid-room.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Malformed room-link guard.
+//
+// A share link always carries a valid UUID room id (the sender generates it
+// with uuidv4). A hand-edited or truncated fragment can carry a malformed one.
+// The client mirrors the signaling server's UUID_REGEX and rejects a bad id up
+// front, showing the existing "Link Invalid" card, instead of emitting a join
+// the server refuses with an 'error' event the browser does not listen for
+// (which would otherwise leave the receiver waiting on the sender forever).
+// ---------------------------------------------------------------------------
+
+test('a malformed room id shows the Link Invalid card, not an endless wait', async ({
+    page,
+}) => {
+    await page.goto('/#room=not-a-valid-uuid');
+
+    await expect(page.getByRole('heading', { name: 'Link Invalid' })).toBeVisible();
+    // The receiver handshake pipeline must never appear for a rejected link.
+    await expect(page.getByText(/waiting for the sender/i)).toHaveCount(0);
+});
+
+test('a well-formed room id is not rejected and reaches the handshake pipeline', async ({
+    page,
+}) => {
+    // Guards against over-rejection: a syntactically valid id must still join and
+    // wait for a sender rather than tripping the client-side validity check.
+    await page.goto('/#room=6f207790-92a6-4662-bb68-4c4059f75139');
+
+    await expect(page.getByText('Secure room joined')).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByRole('heading', { name: 'Link Invalid' })).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

A share link always carries a valid UUID room id (the sender generates it with `uuidv4`), but a hand-edited or truncated `#room` fragment can carry a malformed one. The signaling server rejects such a join with an `error` event the browser has no listener for, so the receiver sat on "Waiting for the sender to start" indefinitely.

This mirrors the server's `UUID_REGEX` in the client and validates the room id from the URL before joining. A malformed id now shows the existing "Link Invalid" card (the same one the room-full path already uses) instead of an endless wait. Valid ids are unaffected, and the malformed id never reaches the server.

Follow-up to the observation raised during QA of #159; kept out of that PR so this connect-path change is reviewed on its own.

## Test plan

- `lint` clean; `next build` TypeScript clean, 11 static pages.
- New `client/e2e/invalid-room.spec.ts` (both pass): a malformed id shows "Link Invalid" and never the waiting pipeline; a well-formed id is not rejected and reaches the handshake pipeline (guards against over-rejection).
- Full e2e suite green: 13/13 (transfer 50 MB / 0 B / 512 B, responsive 15-viewport, CLI interop both directions).
- Live: `/#room=not-a-valid-uuid` renders the Link Invalid card immediately; a valid UUID room still shows "Secure room joined / Waiting for the sender".

Client-only change; no server, CLI, or docs edits.
