### PR TITLE
docs(readme): acknowledge Claude Max (20x) OSS sponsorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,14 +134,18 @@ Floe is free and open source. Contributions help cover the ongoing costs of back
 
 ## Acknowledgments
 
-Floe is supported by open source sponsorship programs that donate the infrastructure behind it:
+Floe is supported by open source sponsorship programs that donate the tools and infrastructure behind it:
 
 - **Error monitoring** is generously provided by [Sentry](https://sentry.io) through [Sentry for Good](https://sentry.io/for/good/).
 - **Documentation** is generously hosted by [Mintlify](https://mintlify.com) through the [Mintlify OSS Program](https://mintlify.com/oss-program).
+- **Development** is supported by [Anthropic](https://www.anthropic.com), whose open source program accepted Floe for six months of [Claude](https://claude.com/claude-code) Max (20x).
+
+Thank you to these programs for helping keep Floe sustainable as an independent open source project.
 
 <p align="center">
   <a href="https://sentry.io"><img src="https://img.shields.io/badge/Monitored%20by-Sentry-362D59?logo=sentry&logoColor=white" alt="Monitored by Sentry" /></a>
   <a href="https://mintlify.com"><img src="https://img.shields.io/badge/Docs%20by-Mintlify-18E299?logo=mintlify&logoColor=white" alt="Documentation by Mintlify" /></a>
+  <a href="https://www.anthropic.com"><img src="https://img.shields.io/badge/Accepted%20into-Claude%20Max%20(20x)-D97757?logo=anthropic&logoColor=white" alt="Accepted into Claude Max (20x)" /></a>
 </p>
 
 ## License


### PR DESCRIPTION
## Summary

Credits Anthropic in the README Acknowledgments section for accepting Floe into its open source program (six months of Claude Max, 20x), matching the existing Sentry and Mintlify credits. Changes:

- New **Development** bullet crediting Anthropic / Claude, framed as an acceptance into the OSS program.
- Matching shields.io badge: "Accepted into Claude Max (20x)".
- Reworded intro line to "tools and infrastructure" so the section covers development tooling as well as runtime infrastructure, plus a short thank-you line.

No em dashes (writing-style rule). No code changes.

## Test plan

- [x] `git diff` reviewed: only the Acknowledgments section changed (5 insertions, 1 deletion).
- [ ] GitHub renders the three badges in one row; new bullet and links resolve.
