### PR TITLE
docs(readme): simplify the Anthropic sponsorship credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,14 @@ Floe is supported by open source sponsorship programs that donate the tools and 
 
 - **Error monitoring** is generously provided by [Sentry](https://sentry.io) through [Sentry for Good](https://sentry.io/for/good/).
 - **Documentation** is generously hosted by [Mintlify](https://mintlify.com) through the [Mintlify OSS Program](https://mintlify.com/oss-program).
-- **Development** is supported by [Anthropic](https://www.anthropic.com), whose open source program accepted Floe for six months of [Claude](https://claude.com/claude-code) Max (20x).
+- **Development** is supported by [Claude](https://claude.com/claude-code) through Anthropic's open source program.
 
 Thank you to these programs for helping keep Floe sustainable as an independent open source project.
 
 <p align="center">
   <a href="https://sentry.io"><img src="https://img.shields.io/badge/Monitored%20by-Sentry-362D59?logo=sentry&logoColor=white" alt="Monitored by Sentry" /></a>
   <a href="https://mintlify.com"><img src="https://img.shields.io/badge/Docs%20by-Mintlify-18E299?logo=mintlify&logoColor=white" alt="Documentation by Mintlify" /></a>
-  <a href="https://www.anthropic.com"><img src="https://img.shields.io/badge/Accepted%20into-Claude%20Max%20(20x)-D97757?logo=anthropic&logoColor=white" alt="Accepted into Claude Max (20x)" /></a>
+  <a href="https://www.anthropic.com"><img src="https://img.shields.io/badge/Sponsored%20by-Anthropic-D97757?logo=anthropic&logoColor=white" alt="Sponsored by Anthropic" /></a>
 </p>
 
 ## License


### PR DESCRIPTION
## Summary

Simplifies the Development acknowledgment added in #162 to match the lowkey, one-line style of the Sentry and Mintlify credits.

- Bullet: now "Development is supported by Claude through Anthropic's open source program."
- Badge: "Sponsored by Anthropic" (was "Accepted into Claude Max (20x)").
- Drops the plan tier and duration for a cleaner, professional tone.

No em dashes. No code changes.

## Test plan

- [x] `git diff` reviewed: 2 lines changed in the Acknowledgments section only.
