### PR TITLE
chore(ci): matrix cli job across 3 OSes, add timeouts and concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
     paths-ignore:
       - 'docs/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Cancel superseded runs on PRs; never cancel runs on main
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -17,6 +22,7 @@ jobs:
   build-and-lint:
     name: Build & Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
@@ -66,6 +72,7 @@ jobs:
   server:
     name: Server (Node.js)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout
@@ -85,8 +92,14 @@ jobs:
         working-directory: server
 
   cli:
-    name: CLI (Go)
-    runs-on: ubuntu-latest
+    name: CLI (Go, ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      # One OS failing must not hide results from the others
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - name: Checkout
@@ -113,6 +126,7 @@ jobs:
   e2e:
     name: E2E (browser + CLI interop)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Requires both Go (CLI binary) and Node (server + client + Playwright)
     needs: [cli, build-and-lint, server]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.1.2
+          # Version comes from packageManager in client/package.json
+          package_json_file: client/package.json
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -148,7 +149,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.1.2
+          # Version comes from packageManager in client/package.json
+          package_json_file: client/package.json
 
       - name: Get pnpm store directory
         id: pnpm-cache


### PR DESCRIPTION
## Summary

- Run the Go cli job on ubuntu-latest, windows-latest, and macos-latest (fail-fast disabled, per-OS setup-go caches). The in-process WebRTC loopback suite now executes on all three OSes on every PR.
- Add workflow-level concurrency: superseded runs on the same ref are cancelled, never on main.
- Add timeout-minutes to every job (build-and-lint 15, server 10, cli 15, e2e 30).
- Single-source the pnpm version from client/package.json packageManager (separate commit, revertable on its own).

No test or step logic changes; the e2e job still gates on all cli legs.

## Test plan

- [x] actionlint clean locally (only pre-existing SC2086 info notes on unchanged lines)
- [x] go vet / go test / go build pass locally on Windows against main's cli/ layout (loopback suite 13.6s)
- [x] Attempt 1 green: cold windows and macos legs executed the cli/internal/transfer loopback tests fresh (11.6s / 11.2s, go1.25.12 windows/amd64 and darwin/arm64)
- [x] Attempt 2 green (rerun): per-OS setup-go caches restored on all three legs
- [x] Attempt 3 green after deleting setup-go caches: fresh loopback execution on all three OSes (11.4s / 11.8s / 11.2s), caches re-saved
- [x] Job durations recorded per leg as the Phase 1 baseline: cli cold ubuntu 50s, windows 84s, macos 41s; warm 11s / 43s / 20s; e2e ~2m; total run 2m49s warm to 3m36s cold

9 of 9 matrix-leg executions green across 3 attempts, zero flakes.