### PR TITLE
fix(installer): correct FLOE_VERSION usage in pinned-install examples

### DIFF
--- a/client/public/install.sh
+++ b/client/public/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # Floe CLI installer for macOS and Linux
 # Usage: curl -fsSL https://floe.one/install.sh | sh
-#        FLOE_VERSION=v1.2.0 curl -fsSL https://floe.one/install.sh | sh
+#        curl -fsSL https://floe.one/install.sh | FLOE_VERSION=v1.2.0 sh
 # Re-running upgrades an existing install in place.
 
 set -e
@@ -44,7 +44,7 @@ fi
 if [ -z "${FLOE_VERSION}" ]; then
   echo "Could not determine latest version." >&2
   echo "Set FLOE_VERSION=vX.Y.Z to install a specific version, e.g.:" >&2
-  echo "  FLOE_VERSION=v1.0.0 curl -fsSL https://floe.one/install.sh | sh" >&2
+  echo "  curl -fsSL https://floe.one/install.sh | FLOE_VERSION=v1.0.0 sh" >&2
   exit 1
 fi
 

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -56,7 +56,7 @@ upgrades an existing install in place.
 
     To install a specific version:
     ```bash
-    FLOE_VERSION=v1.2.0 curl -fsSL https://floe.one/install.sh | sh
+    curl -fsSL https://floe.one/install.sh | FLOE_VERSION=v1.2.0 sh
     ```
 
     The script detects your OS and architecture, downloads the correct archive, verifies the


### PR DESCRIPTION
## Summary

`FLOE_VERSION=vX.Y.Z curl -fsSL https://floe.one/install.sh | sh` sets the variable only for `curl`; the `sh` process running the installer never sees it, so the requested version is silently ignored and the latest release is installed instead.

This moves the assignment to the `sh` side of the pipe in the three places the broken form appeared:

- `docs/cli/installation.mdx` (pinned-version example)
- `client/public/install.sh` usage comment
- `client/public/install.sh` could-not-determine-version error hint

No behavioral change to the installer itself: its `FLOE_VERSION` handling was always correct once the variable actually reaches `sh`. The PowerShell examples (`$env:FLOE_VERSION = vX.Y.Z; irm ... | iex`) already work as documented and are unchanged.

## Test plan

All runs in a clean `alpine:3.20` container (busybox ash), latest release being v1.7.5:

- [x] Reproduced the bug with the old documented form: `FLOE_VERSION=v1.7.4 cat install.sh | sh` printed `Fetching latest version... v1.7.5` and installed 1.7.5, ignoring the pin
- [x] Corrected form with the patched script: `cat install.sh | FLOE_VERSION=v1.7.4 sh` skipped latest-version resolution and installed 1.7.4, checksum verified
- [x] Exact documented command against production: `curl -fsSL https://floe.one/install.sh | FLOE_VERSION=v1.7.4 sh` installed 1.7.4
- [x] Regression: unpinned `cat install.sh | sh` still resolves and installs latest (1.7.5)
- [x] Pipeline env-prefix form (valid POSIX grammar) verified to reach `sh` under busybox ash, bash in sh mode, and dash (Ubuntu `/bin/sh`)
- [x] `sh -n` syntax check on the edited script

Fixes #164