### PR TITLE
docs(cli): drop the v prefix from floe version sample output

### DIFF
--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -96,7 +96,7 @@ floe version
 Expected output:
 
 ```
-floe v1.x.x
+floe 1.x.x
 Docs: https://docs.floe.one
 ```
 

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -12,7 +12,7 @@ Prints the current version of the `floe` binary and a link to the documentation.
 ## Output
 
 ```
-floe v1.x.x
+floe 1.x.x
 Docs: https://docs.floe.one
 ```
 


### PR DESCRIPTION
## Summary

Release binaries print `floe 1.7.5`, not `floe v1.7.5`: GoReleaser injects `{{ .Version }}`, which strips the tag leading `v` before it reaches `main.version`. This aligns the two sample output blocks (`docs/cli/installation.mdx`, `docs/cli/version.mdx`) with what the shipped binary actually prints. The `Docs: https://docs.floe.one` line is genuinely printed by the `version` subcommand (`cli/cmd/floe/main.go`) and stays.

## Test plan

- [x] Confirmed against the real shipped binaries in a clean Linux container: both v1.7.4 and v1.7.5 print `floe 1.7.4` / `floe 1.7.5` with no `v`
- [x] Confirmed in source: `fmt.Printf("floe %s\n", version)` with GoReleaser default ldflags injecting the v-stripped version
- [x] Docs-only change, no code touched
