### PR TITLE
chore(ci): add back-compat job pairing HEAD with the latest released CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,3 +221,107 @@ jobs:
           path: client/test-results/
           if-no-files-found: ignore
           retention-days: 7
+
+  back-compat:
+    name: Back-compat (HEAD vs latest release)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Same toolchain needs as e2e; ubuntu-only because the wire protocol under
+    # test is OS-independent and one leg keeps the release download cheap.
+    needs: [cli, build-and-lint, server]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: cli/go.sum
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          # Version comes from packageManager in client/package.json
+          package_json_file: client/package.json
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          # Linux-only job, so no per-OS path dance like the e2e matrix; same
+          # cache key as the ubuntu e2e leg so this job rides its cache.
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('client/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install client dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: client
+
+      - name: Install server dependencies
+        run: npm install
+        working-directory: server
+
+      - name: Install Playwright Chromium
+        # Always run: on a browser-cache hit the download is skipped anyway,
+        # but the Linux system dependencies (--with-deps) still need installing.
+        run: pnpm exec playwright install --with-deps chromium
+        working-directory: client
+
+      - name: Download latest released CLI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Resolve the tag FIRST, then download BY TAG: if a release published
+          # mid-job, "latest" could otherwise change between the two gh calls.
+          tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          echo "Released tag: $tag"
+          dest="$RUNNER_TEMP/floe-released"
+          mkdir -p "$dest"
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" --dir "$dest" \
+            --pattern 'floe_*_linux_amd64.tar.gz' --pattern 'checksums.txt'
+          cd "$dest"
+          # checksums.txt covers every asset; verify just the one we fetched.
+          sha256sum --check <(grep linux_amd64.tar.gz checksums.txt)
+          tar -xzf floe_*_linux_amd64.tar.gz floe
+          chmod +x floe
+          echo "FLOE_RELEASED_CLI=$dest/floe" >> "$GITHUB_ENV"
+          echo "FLOE_RELEASED_VERSION=$tag" >> "$GITHUB_ENV"
+
+      - name: Run back-compat E2E tests
+        working-directory: client
+        env:
+          NEXT_PUBLIC_SOCKET_URL: http://localhost:3001
+        run: |
+          # Fail loud if the export above ever regresses; otherwise the spec
+          # would skip itself and this job would go green testing nothing.
+          test -x "$FLOE_RELEASED_CLI"
+          pnpm exec playwright test e2e/back-compat.spec.ts
+
+      - name: Upload traces and test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: back-compat-traces
+          path: client/test-results/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/client/e2e/back-compat.spec.ts
+++ b/client/e2e/back-compat.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Released-CLI ↔ HEAD back-compat tests.
+ *
+ * floe.one ships the browser client the moment a PR merges, but installed
+ * CLIs only change when a user runs brew/scoop/winget or `floe update`, so
+ * the latest RELEASED binary keeps talking to freshly deployed code for
+ * weeks. The e2e matrix proves HEAD against HEAD; this spec proves the
+ * released binary against HEAD in all four pairings, so a PR that breaks
+ * the wire protocol for already-installed CLIs goes red before merge
+ * instead of after deploy.
+ *
+ * Gating: the released binary's path arrives via FLOE_RELEASED_CLI, set by
+ * the back-compat CI job (which downloads the latest GitHub Release and
+ * verifies it against checksums.txt) or by a local opt-in. Everywhere else
+ * this whole file reports as skipped, leaving the 3-OS e2e matrix legs
+ * untouched.
+ *
+ * The HEAD CLI still comes from e2e/global-setup.ts via helpers.cliBinary().
+ * --no-relay keeps every pairing on host/loopback candidates (hermetic).
+ */
+
+import { test, expect } from '@playwright/test';
+import { mkdirSync, rmSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+import { tmpdir } from 'os';
+import {
+    CLI_TIMEOUT_MS,
+    createFixture,
+    sha256OfFile,
+    sha256OfBlobUrl,
+    browserSenderSetup,
+    spawnSend,
+    spawnReceive,
+    waitForExit,
+} from './helpers';
+
+// Spawned CLIs inherit this process's env. v1.7.5 only phones GitHub from
+// `floe version`, but a future released binary under test might check on
+// send/receive startup too; suppress up front so no pairing ever leaves
+// localhost. (Stats need no gate: the CLI reports them to --server, which
+// is the local test server here.)
+process.env.FLOE_NO_UPDATE_CHECK = '1';
+
+// Runs only where the back-compat CI job (or a local opt-in) provides a
+// released binary; everywhere else the file reports as skipped.
+test.skip(!process.env.FLOE_RELEASED_CLI, 'FLOE_RELEASED_CLI is not set (back-compat CI job only)');
+
+const FIXTURE_DIR = join(tmpdir(), 'floe-back-compat');
+// Same 12 MB as cli-interop: large enough to exercise the 8 MB backpressure loop.
+const FIXTURE_SIZE = 12 * 1024 * 1024;
+
+/**
+ * Path of the released CLI downloaded by the back-compat CI job. Throws so
+ * a half-configured environment names the fix instead of failing on ENOENT.
+ */
+function releasedCli(): string {
+    const bin = process.env.FLOE_RELEASED_CLI;
+    if (!bin) {
+        throw new Error(
+            'FLOE_RELEASED_CLI is not set. The back-compat CI job exports it ' +
+            'after downloading the latest GitHub Release; without it this ' +
+            'spec should have been skipped.',
+        );
+    }
+    return bin;
+}
+
+test.beforeAll(() => {
+    // Pin down which release this run actually exercised.
+    console.log(`Released tag: ${process.env.FLOE_RELEASED_VERSION ?? 'unknown'}`);
+});
+
+test.afterAll(() => {
+    try { rmSync(FIXTURE_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+test('released CLI send → HEAD CLI receive (SHA-256 integrity)', async () => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_DIR, FIXTURE_SIZE);
+    // HEAD floe receive creates the output directory itself.
+    const outputDir = join(FIXTURE_DIR, 'received-released-to-head');
+
+    const { linkPromise, proc: sender } = spawnSend(fixturePath, releasedCli());
+    try {
+        const roomLink = await linkPromise;
+        expect(roomLink).toContain('#room=');
+
+        await spawnReceive(roomLink, outputDir);
+
+        const receivedPath = join(outputDir, basename(fixturePath));
+        expect(existsSync(receivedPath)).toBe(true);
+        expect(sha256OfFile(receivedPath)).toBe(expectedHash);
+
+        // The released sender's drain loop waits for the receiver's
+        // {"type":"received"} confirmation; a HEAD receiver that stops
+        // sending it strands every deployed sender, so assert exit 0.
+        expect(await waitForExit(sender, CLI_TIMEOUT_MS)).toBe(0);
+    } finally {
+        sender.kill();
+    }
+});
+
+test('HEAD CLI send → released CLI receive (SHA-256 integrity)', async () => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_DIR, FIXTURE_SIZE);
+    // Pre-create: only HEAD's receive is known to create --output itself.
+    const outputDir = join(FIXTURE_DIR, 'received-head-to-released');
+    mkdirSync(outputDir, { recursive: true });
+
+    const { linkPromise, proc: sender } = spawnSend(fixturePath);
+    try {
+        const roomLink = await linkPromise;
+        expect(roomLink).toContain('#room=');
+
+        await spawnReceive(roomLink, outputDir, releasedCli());
+
+        const receivedPath = join(outputDir, basename(fixturePath));
+        expect(existsSync(receivedPath)).toBe(true);
+        expect(sha256OfFile(receivedPath)).toBe(expectedHash);
+
+        // Mirror image of the previous test: the HEAD sender must still
+        // drain and exit 0 on the released receiver's confirmation.
+        expect(await waitForExit(sender, CLI_TIMEOUT_MS)).toBe(0);
+    } finally {
+        sender.kill();
+    }
+});
+
+test('released CLI send → HEAD browser receive (SHA-256 integrity)', async ({ browser }) => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_DIR, FIXTURE_SIZE);
+
+    // Start the released sender first so the room exists before the browser joins.
+    const { linkPromise, proc } = spawnSend(fixturePath, releasedCli());
+    const roomLink = await linkPromise;
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    try {
+        // v1.7.5 prints a #room= fragment link and the current client reads
+        // the fragment first, so the link is handed over exactly as printed.
+        await page.goto(roomLink);
+
+        // Wait for the download button, meaning the file fully arrived.
+        const downloadLink = page.locator('a[download]').first();
+        await expect(downloadLink).toBeVisible({ timeout: 90_000 });
+
+        const blobUrl = (await downloadLink.getAttribute('href'))!;
+        const receivedHash = await sha256OfBlobUrl(page, blobUrl);
+        expect(receivedHash).toBe(expectedHash);
+    } finally {
+        await ctx.close();
+        proc.kill();
+    }
+});
+
+test('HEAD browser send → released CLI receive (SHA-256 integrity)', async ({ browser }) => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_DIR, FIXTURE_SIZE);
+    // Pre-create: only HEAD's receive is known to create --output itself.
+    const outputDir = join(FIXTURE_DIR, 'received-browser-to-released');
+    mkdirSync(outputDir, { recursive: true });
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    try {
+        // The client renders a #room= fragment link; v1.7.5's resolver
+        // parses both ?room= and #room=, so it is handed over as-is.
+        const roomLink = await browserSenderSetup(page, fixturePath);
+
+        await spawnReceive(roomLink, outputDir, releasedCli());
+
+        const receivedPath = join(outputDir, basename(fixturePath));
+        expect(existsSync(receivedPath)).toBe(true);
+        expect(sha256OfFile(receivedPath)).toBe(expectedHash);
+    } finally {
+        await ctx.close();
+    }
+});

--- a/client/e2e/helpers.ts
+++ b/client/e2e/helpers.ts
@@ -7,6 +7,10 @@
  * publishes its path via the FLOE_E2E_CLI_BINARY environment variable;
  * cliBinary() reads it back here.
  *
+ * spawnSend/spawnReceive default to that HEAD build but accept an explicit
+ * binary path, so back-compat.spec.ts can drive a downloaded released CLI
+ * through the same process plumbing.
+ *
  * --no-relay keeps both peers on host/loopback candidates so CLI tests run
  * hermetically without a TURN server or real network.
  */
@@ -107,12 +111,16 @@ export async function browserSenderSetup(page: Page, fixturePath: string): Promi
  * Spawn `floe send` and return a promise that resolves to the room link once
  * it appears in stdout, plus the process so the caller can await/kill it.
  * The caller owns the process and must kill it in a finally block.
+ *
+ * `binary` defaults to the HEAD build. The default is evaluated per call and
+ * only when the argument is omitted, so existing call sites keep cliBinary()'s
+ * fail-loud contract and back-compat callers can pass a released binary.
  */
-export function spawnSend(path: string): {
+export function spawnSend(path: string, binary: string = cliBinary()): {
     linkPromise: Promise<string>;
     proc: ChildProcess;
 } {
-    const proc = spawn(cliBinary(), [
+    const proc = spawn(binary, [
         'send', path,
         '--server', SERVER_URL,
         '--web', WEB_URL,
@@ -152,10 +160,12 @@ export function spawnSend(path: string): {
  * Spawn `floe receive` and return a promise that resolves once the process
  * exits successfully (its integrity guard ties exit 0 to every byte of every
  * file being on disk), and rejects on nonzero exit or after CLI_TIMEOUT_MS.
+ *
+ * `binary` defaults to the HEAD build, same contract as spawnSend.
  */
-export function spawnReceive(link: string, outputDir: string): Promise<void> {
+export function spawnReceive(link: string, outputDir: string, binary: string = cliBinary()): Promise<void> {
     return new Promise((resolve, reject) => {
-        const proc = spawn(cliBinary(), [
+        const proc = spawn(binary, [
             'receive', link,
             '--server', SERVER_URL,
             '--output', outputDir,

--- a/client/e2e/helpers.ts
+++ b/client/e2e/helpers.ts
@@ -129,8 +129,11 @@ export function spawnSend(path: string, binary: string = cliBinary()): {
 
     const linkPromise = new Promise<string>((resolve, reject) => {
         let stdout = '';
+        let stderr = '';
         const timer = setTimeout(
-            () => reject(new Error(`CLI send did not emit a room link within ${CLI_TIMEOUT_MS} ms`)),
+            () => reject(new Error(
+                `CLI send did not emit a room link within ${CLI_TIMEOUT_MS} ms${tail(stdout, stderr)}`,
+            )),
             CLI_TIMEOUT_MS,
         );
 
@@ -143,12 +146,13 @@ export function spawnSend(path: string, binary: string = cliBinary()): {
                 resolve(match[0].trim());
             }
         });
+        proc.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
 
         proc.on('error', (err) => { clearTimeout(timer); reject(err); });
         proc.on('close', (code) => {
             if (code !== 0 && code !== null) {
                 clearTimeout(timer);
-                reject(new Error(`floe send exited with code ${code}`));
+                reject(new Error(`floe send exited with code ${code}${tail(stdout, stderr)}`));
             }
         });
     });
@@ -173,8 +177,16 @@ export function spawnReceive(link: string, outputDir: string, binary: string = c
             '--no-relay',
         ]);
 
+        let stdout = '';
+        let stderr = '';
+        proc.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+        proc.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
         const timer = setTimeout(
-            () => { proc.kill(); reject(new Error(`floe receive timed out after ${CLI_TIMEOUT_MS} ms`)); },
+            () => {
+                proc.kill();
+                reject(new Error(`floe receive timed out after ${CLI_TIMEOUT_MS} ms${tail(stdout, stderr)}`));
+            },
             CLI_TIMEOUT_MS,
         );
 
@@ -182,9 +194,23 @@ export function spawnReceive(link: string, outputDir: string, binary: string = c
         proc.on('close', (code) => {
             clearTimeout(timer);
             if (code === 0) resolve();
-            else reject(new Error(`floe receive exited with code ${code}`));
+            else reject(new Error(`floe receive exited with code ${code}${tail(stdout, stderr)}`));
         });
     });
+}
+
+/**
+ * Format the tail of a CLI process's output for an error message, so a
+ * failed or timed-out spawn carries the binary's own words instead of just
+ * an exit code. Vital for back-compat runs, where the failing binary may be
+ * a released version whose failure cannot be reproduced from HEAD sources.
+ */
+function tail(stdout: string, stderr: string): string {
+    const clip = (s: string) => s.trim().slice(-500);
+    let out = '';
+    if (stderr.trim()) out += `\nstderr: ${clip(stderr)}`;
+    if (stdout.trim()) out += `\nstdout: ${clip(stdout)}`;
+    return out;
 }
 
 /**


### PR DESCRIPTION
## Summary

- e2e helpers accept an explicit CLI binary path; the HEAD build from global-setup stays the default and existing call sites are unchanged. Spawn failures now carry the CLI's own stdout/stderr tails, so a failing released binary names its complaint instead of just an exit code (this also removed a latent risk: spawnReceive previously never read its pipes, so a chatty child could in principle block on a full pipe buffer).
- new `client/e2e/back-compat.spec.ts` runs four SHA-256-verified WebRTC transfers pairing the latest released CLI with HEAD (CLI to CLI in both directions, released CLI vs HEAD browser in both directions), gated on `FLOE_RELEASED_CLI` and skipped everywhere else
- new ubuntu-only `Back-compat (HEAD vs latest release)` job resolves the latest release tag, downloads the linux/amd64 tarball by that same tag (immune to a release publishing mid-job), verifies it against `checksums.txt`, and runs only the back-compat spec; a `test -x` guard fails loudly if the env export ever regresses so the gated spec can never silently skip in its own job

## Why

floe.one deploys the browser client on every merge, but installed CLIs upgrade on the user's schedule, so the latest released binary keeps talking to freshly deployed code for weeks. Until now no PR check proved that pairing; a wire-protocol break for existing users would only surface after deploy. This job turns that break into a red X before merge. All existing tests are new-code-vs-new-code and structurally cannot catch this class.

## Test plan

- [x] `pnpm lint` and actionlint clean
- [x] Simulated locally on Windows against the real `floe_1.7.5_windows_amd64.zip` (SHA-256 verified against `checksums.txt`; the guard caught a genuinely truncated first download and passed on re-fetch): 4 passed
- [x] Full local suite without the env var proves the spec skips cleanly: 15 passed, 4 skipped
- [x] back-compat job green in all 7 CI executions across both SHAs, each logging `Released tag: v1.7.5` and a checksum OK; 6 executions were a clean `4 passed`, one early execution (before the stderr-diagnostics commit) was `1 flaky, 3 passed` - a released receiver exited 1 once and passed on retry, which motivated commit e812881 and did not recur afterward
- [x] all three e2e matrix legs report `15 passed, 4 skipped`
- [x] 3 fully green CI attempts on the final head commit (one additional attempt excluded as an unrelated macOS runner webServer startup timeout; no tests ran, back-compat was green in it)

## Known follow-up (pre-existing, not introduced here)

The one flaky most plausibly traces to a join-order race that is a real product robustness gap independent of this PR: the browser sender emits `join-room` fire-and-forget and never re-joins after a Socket.IO reconnect, while the server deletes the room when a peer disconnects - so a transient socket blip can leave a sender's displayed link pointing at a room the next joiner enters first (the CLI then correctly refuses the unexpected sender role). Worth its own issue/fix; the new stderr tails will name it directly if it ever recurs.
