### PR TITLE
fix: signaling room survives disconnects and clients rejoin on reconnect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,9 @@ jobs:
         run: pnpm exec playwright test
         working-directory: client
         env:
-          NEXT_PUBLIC_SOCKET_URL: http://localhost:3001
+          # 127.0.0.1, not localhost: see the webServer env note in
+          # client/playwright.config.ts (its env overrides this line anyway).
+          NEXT_PUBLIC_SOCKET_URL: http://127.0.0.1:3001
 
       - name: Upload traces and test results on failure
         if: failure()
@@ -310,7 +312,9 @@ jobs:
       - name: Run back-compat E2E tests
         working-directory: client
         env:
-          NEXT_PUBLIC_SOCKET_URL: http://localhost:3001
+          # 127.0.0.1, not localhost: see the webServer env note in
+          # client/playwright.config.ts (its env overrides this line anyway).
+          NEXT_PUBLIC_SOCKET_URL: http://127.0.0.1:3001
         run: |
           # Fail loud if the export above ever regresses; otherwise the spec
           # would skip itself and this job would go green testing nothing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ NEXT_PUBLIC_SENTRY_DSN=    # optional
 3. Peers exchange WebRTC `signal` messages (offer → answer → ICE candidates) via the server.
 4. Once WebRTC connects, the data channel is used directly (server is out of the loop).
 
+A disconnect removes only that peer from the room (the room is deleted once empty), and browser peers re-send `join-room` automatically after a Socket.IO reconnect until the WebRTC connection is up.
+
 Browser peers communicate via **Socket.IO**; CLI peers communicate via **WebSocket at `/ws`**. Both share the same `rooms` registry on the server (`Map<roomId, [peer, peer]>`), so browser-to-CLI transfers work transparently.
 
 ### Transfer Protocol Versioning

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -133,6 +133,10 @@ export function P2PTransfer() {
     // The room this page instance is handling as a receiver. Used to detect a
     // fragment-only navigation (scanning a second QR code into the same tab).
     const joinedRoomRef = useRef<string | null>(null);
+    // The room this page instance created as a sender (handleCreateLink). The
+    // displayed link keeps pointing at this id, so a socket reconnect must
+    // re-join it or the link goes dead.
+    const createdRoomRef = useRef<string | null>(null);
     const receivedFilesRef = useRef<ReceivedFile[]>([]);
     const transferCompleteRef = useRef(false);
     const progressRef = useRef(0);
@@ -201,7 +205,31 @@ export function P2PTransfer() {
                 setError('Too many refreshes. Reconnecting');
             }
         },
-        onReconnect: () => setError(''),
+        onReconnect: () => {
+            setError('');
+            // A Socket.IO auto-reconnect comes back under a fresh socket.id,
+            // and the server room only ever contained the old id, so this
+            // client is no longer in its room. Re-join while the WebRTC data
+            // channel is not yet up and the transfer has not finished; once
+            // either is true, signaling is done and re-joining would only
+            // churn the room.
+            if (transferCompleteRef.current || receivedFilesRef.current.length > 0) return;
+            if (peerRef.current?.connected) return;
+            if (joinedRoomRef.current) {
+                // Receiver: a bare re-join is not enough. The sender reacts to
+                // the rejoin's user-connected with a brand-new initiator peer
+                // and a fresh offer, which the old half-negotiated peer cannot
+                // answer, so recreate the peer by re-running the join flow.
+                peerRef.current?.destroy();
+                hasJoinedRef.current = false;
+                joinRoomAsReceiver(joinedRoomRef.current);
+            } else if (createdRoomRef.current) {
+                // Sender: re-enter the room only. Peer creation stays driven by
+                // user-connected, whose handler (handleCreateLink) replaces any
+                // stale peer when a receiver joins or re-joins.
+                joinRoom(createdRoomRef.current);
+            }
+        },
     });
 
     const fetchIceServers = async () => {
@@ -495,6 +523,7 @@ export function P2PTransfer() {
         const nonce = uuidv4().slice(0, 8);
         const link = `${window.location.protocol}//${window.location.host}/?s=${nonce}#room=${newRoomId}`;
         setGeneratedLink(link);
+        createdRoomRef.current = newRoomId;
         joinRoom(newRoomId);
         setStatus('Waiting for peer');
 

--- a/client/e2e/reconnect.spec.ts
+++ b/client/e2e/reconnect.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Signaling resilience tests.
+ *
+ * The room registry must survive one peer's socket dropping: the sender's
+ * displayed link has to stay valid across a Socket.IO blip (the client
+ * re-joins its room on reconnect) and across a receiver closing its tab
+ * (the server removes only that peer instead of deleting the room).
+ *
+ * Offline emulation notes (context.setOffline):
+ *   - It reliably fails NEW connections and in-flight HTTP, but does NOT tear
+ *     down an already-established WebSocket. The client instead detects the
+ *     drop via the window 'offline' event: engine.io-client closes its
+ *     transport on that event, but skips registering the listener when the
+ *     signaling host is literally "localhost". That is why the e2e
+ *     environment points NEXT_PUBLIC_SOCKET_URL at http://127.0.0.1:3001
+ *     (see playwright.config.ts), which is also the production code path.
+ *   - setOffline is per browser context; receiver contexts stay online.
+ */
+
+import { test, expect } from '@playwright/test';
+import { rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { createFixture, sha256OfBlobUrl, browserSenderSetup } from './helpers';
+
+const FIXTURE_DIR = join(tmpdir(), 'floe-e2e-reconnect');
+// Small on purpose: these tests exercise room lifecycle, not throughput.
+const FIXTURE_SIZE = 1024 * 1024;
+
+test.afterAll(() => {
+    try { rmSync(FIXTURE_DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+test('sender link survives a signaling blip (client re-joins on reconnect)', async ({ browser }) => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_DIR, FIXTURE_SIZE);
+
+    const senderCtx = await browser.newContext();
+    const receiverCtx = await browser.newContext();
+    const senderPage = await senderCtx.newPage();
+    const receiverPage = await receiverCtx.newPage();
+
+    try {
+        const link = await browserSenderSetup(senderPage, fixturePath);
+
+        // 'Ready'/'Offline' is the ConnectionStatusBadge's socket indicator,
+        // and the only place either word appears on the page.
+        await expect(senderPage.getByText('Ready', { exact: true })).toBeVisible({ timeout: 10_000 });
+
+        await senderCtx.setOffline(true);
+        // The client must OBSERVE the drop before we go back online, otherwise
+        // there is no disconnect/reconnect cycle to test (see header note).
+        await expect(
+            senderPage.getByText('Offline', { exact: true }),
+            'sender never noticed the socket drop; is the client running with NEXT_PUBLIC_SOCKET_URL=http://127.0.0.1:3001?',
+        ).toBeVisible({ timeout: 15_000 });
+
+        await senderCtx.setOffline(false);
+        // Reconnect is attempt-driven (delay 500 ms, capped at 3000 ms), so
+        // the badge recovers within a few seconds. The re-join emit is buffered
+        // and flushed BEFORE the client's own 'connect' handler runs, so once
+        // the badge shows Ready the join-room packet is already on the wire;
+        // the short settle only covers the server processing it.
+        await expect(senderPage.getByText('Ready', { exact: true })).toBeVisible({ timeout: 15_000 });
+        await senderPage.waitForTimeout(500);
+
+        // The ORIGINAL link must still work for a fresh receiver.
+        await receiverPage.goto(link);
+        const downloadLink = receiverPage.locator('a[download]').first();
+        await expect(downloadLink).toBeVisible({ timeout: 30_000 });
+
+        const blobUrl = (await downloadLink.getAttribute('href'))!;
+        expect(await sha256OfBlobUrl(receiverPage, blobUrl)).toBe(expectedHash);
+        await expect(senderPage.getByText('All Files Sent!').first()).toBeVisible({ timeout: 10_000 });
+    } finally {
+        await senderCtx.close();
+        await receiverCtx.close();
+    }
+});
+
+test('sender link survives a receiver closing its tab before the transfer finishes', async ({ browser }) => {
+    const { path: fixturePath, sha256: expectedHash } = createFixture(FIXTURE_DIR, FIXTURE_SIZE);
+
+    const senderCtx = await browser.newContext();
+    const senderPage = await senderCtx.newPage();
+    const firstReceiverCtx = await browser.newContext();
+    const secondReceiverCtx = await browser.newContext();
+
+    try {
+        const link = await browserSenderSetup(senderPage, fixturePath);
+
+        // First receiver joins, then leaves before the transfer completes.
+        // 'Peer joined' appears on the plain socket join, and the sender only
+        // sends the first byte a fixed 2 s AFTER the WebRTC connect (the
+        // relay-detection window in handleCreateLink), so closing now is
+        // guaranteed to interrupt even with a small fixture.
+        const firstReceiverPage = await firstReceiverCtx.newPage();
+        await firstReceiverPage.goto(link);
+        await expect(senderPage.getByText(/Peer joined/).first()).toBeVisible({ timeout: 30_000 });
+        await firstReceiverCtx.close();
+
+        // The context close reaches the server as a clean disconnect; the
+        // sender is told and goes back to waiting. Pre-fix, the server also
+        // deleted the whole room here, which the second join disproves.
+        await expect(senderPage.getByText(/Peer disconnected/).first()).toBeVisible({ timeout: 15_000 });
+
+        // A second receiver joins the SAME link and completes the transfer.
+        const secondReceiverPage = await secondReceiverCtx.newPage();
+        await secondReceiverPage.goto(link);
+        const downloadLink = secondReceiverPage.locator('a[download]').first();
+        await expect(downloadLink).toBeVisible({ timeout: 30_000 });
+
+        const blobUrl = (await downloadLink.getAttribute('href'))!;
+        expect(await sha256OfBlobUrl(secondReceiverPage, blobUrl)).toBe(expectedHash);
+        await expect(senderPage.getByText('All Files Sent!').first()).toBeVisible({ timeout: 10_000 });
+    } finally {
+        await senderCtx.close();
+        try { await firstReceiverCtx.close(); } catch { /* already closed mid-test */ }
+        await secondReceiverCtx.close();
+    }
+});

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -80,7 +80,13 @@ export default defineConfig({
             reuseExistingServer: true,
             timeout: 120_000,
             env: {
-                NEXT_PUBLIC_SOCKET_URL: 'http://localhost:3001',
+                // 127.0.0.1 (not localhost) so engine.io-client registers its
+                // window 'offline' listener, which reconnect.spec.ts relies on:
+                // the client hardcodes a skip of that listener for the literal
+                // host "localhost", and setOffline alone never tears down an
+                // established WebSocket. Also the production code path, since
+                // real deployments never use "localhost".
+                NEXT_PUBLIC_SOCKET_URL: 'http://127.0.0.1:3001',
             },
         },
     ],

--- a/server/server.js
+++ b/server/server.js
@@ -499,15 +499,16 @@ function handleDisconnect(peer) {
     const room = rooms.get(peer.roomId);
     if (!room) return;
 
-    // Notify the other peer in the room
-    room.forEach(p => {
-        if (p.id !== peer.id) {
-            p.send('peer-disconnected', {});
-            p.roomId = null;
-        }
-    });
-
-    rooms.delete(peer.roomId);
+    // Remove only the disconnecting peer (same shape as the leave-old-room
+    // block in handleJoinRoom). The remaining peer keeps its seat and roomId,
+    // so the room survives a one-sided drop: the departed side can rejoin the
+    // same room id after a Socket.IO auto-reconnect, and a stale socket's late
+    // ping-timeout disconnect removes just its own ghost entry instead of
+    // tearing down a room the same user has already rejoined.
+    const remaining = room.filter(p => p.id !== peer.id);
+    remaining.forEach(p => p.send('peer-disconnected', {}));
+    if (remaining.length === 0) rooms.delete(peer.roomId);
+    else rooms.set(peer.roomId, remaining);
     peer.roomId = null;
 }
 

--- a/server/server.test.js
+++ b/server/server.test.js
@@ -250,7 +250,7 @@ describe('handleSignal', () => {
 describe('handleDisconnect', () => {
     beforeEach(() => { rooms.clear(); });
 
-    it('notifies the remaining peer and removes the room', () => {
+    it('removes only the disconnecting peer; the room survives with the remaining peer', () => {
         const pA = makePeer('peer-A');
         const pB = makePeer('peer-B');
         handleJoinRoom(pA, ROOM_ID);
@@ -261,8 +261,8 @@ describe('handleDisconnect', () => {
         handleDisconnect(pA);
 
         assert.ok(pB.msgs.some(m => m.type === 'peer-disconnected'));
-        assert.equal(pB.roomId, null);
-        assert.equal(rooms.has(ROOM_ID), false);
+        assert.equal(pB.roomId, ROOM_ID, 'remaining peer must keep its roomId');
+        assert.deepEqual(rooms.get(ROOM_ID).map(p => p.id), ['peer-B']);
     });
 
     it('clears roomId on the disconnecting peer', () => {
@@ -279,6 +279,47 @@ describe('handleDisconnect', () => {
         const p = makePeer('lone');
         handleDisconnect(p); // should not throw
         assert.equal(p.msgs.length, 0);
+    });
+
+    it('an out-of-order stale disconnect removes only the ghost entry, not the rejoined peer', () => {
+        // A dirty network drop is only noticed via ping timeout, so the old
+        // socket's disconnect can arrive AFTER the same user already rejoined
+        // the room under a fresh socket id. It must evict only itself.
+        const pOld = makePeer('peer-A-old');
+        const pNew = makePeer('peer-A-new');
+        handleJoinRoom(pOld, ROOM_ID);
+        handleJoinRoom(pNew, ROOM_ID); // rejoin lands while the ghost still holds a seat
+        pNew.msgs.length = 0;
+
+        handleDisconnect(pOld);
+
+        assert.deepEqual(rooms.get(ROOM_ID).map(p => p.id), ['peer-A-new']);
+        assert.equal(pNew.roomId, ROOM_ID, 'rejoined peer must keep its seat');
+    });
+
+    it('deletes the room when the last peer disconnects', () => {
+        const pA = makePeer('peer-A');
+        const pB = makePeer('peer-B');
+        handleJoinRoom(pA, ROOM_ID);
+        handleJoinRoom(pB, ROOM_ID);
+
+        handleDisconnect(pA);
+        handleDisconnect(pB);
+
+        assert.equal(rooms.has(ROOM_ID), false);
+    });
+
+    it('a fresh join after a full disconnect recreates the room with sender role', () => {
+        const pA = makePeer('peer-A');
+        handleJoinRoom(pA, ROOM_ID);
+        handleDisconnect(pA); // sole peer leaving deletes the room
+
+        const pA2 = makePeer('peer-A2'); // same user, new socket id after reconnect
+        handleJoinRoom(pA2, ROOM_ID);
+
+        assert.equal(pA2.msgs[0].type, 'room-joined');
+        assert.equal(pA2.msgs[0].data.role, 'sender');
+        assert.deepEqual(rooms.get(ROOM_ID).map(p => p.id), ['peer-A2']);
     });
 });
 


### PR DESCRIPTION
## Summary

- `handleDisconnect` now removes only the disconnecting peer; the room survives until empty (remaining peers keep their `roomId`, still receive `peer-disconnected`). A stale socket's late ping-timeout disconnect evicts only its own ghost entry.
- The browser re-sends `join-room` after a Socket.IO reconnect while the WebRTC channel is not yet up: the sender re-enters its room (new `createdRoomRef`), the receiver re-runs the full join flow (the old half-negotiated peer cannot answer the fresh offer a rejoin triggers).
- Two e2e regression tests (`reconnect.spec.ts`): a sender network blip via `context.setOffline` with the ORIGINAL link completing afterward, and a receiver closing its tab with a second receiver completing the same link. Both fail pre-fix.
- The e2e environment now points the browser at `http://127.0.0.1:3001` instead of `localhost`: engine.io-client skips its window-offline listener for the literal host "localhost", so setOffline would never produce a client-visible disconnect. 127.0.0.1 is also the production code path.

## Why

One Socket.IO blip killed a Floe room three ways: the sender's displayed link silently died after any network hiccup (the client never re-joined, and the next joiner became first-in-room with the wrong role), a receiver closing their tab permanently expired the link even though the sender kept waiting, and on a dirty drop the old socket's late ping-timeout disconnect would have torn down a room its own user had already rejoined. This is the root cause of the one flaky seen in the back-compat CI (PR #169) and affects real users on flaky networks.

## Test plan

- [x] Server unit tests: 47 passing (was 44; new coverage for room survival, the out-of-order ghost disconnect, last-peer deletion, and rejoin-after-drop)
- [x] `pnpm lint`, `pnpm test` (91 vitest), actionlint all clean
- [x] Local Windows run: reconnect spec 2 passed in 16 s on the first try; full suite 17 passed, 4 skipped
- [x] 3 green CI attempts (1, 3, 4): each e2e leg 17 passed 4 skipped, server job 47 passing, back-compat 4 passed, zero flaky on the final attempt. Attempt 2 excluded: the macOS runner's next dev never became ready (webServer 120 s timeout, zero tests ran) - third occurrence of this known runner-pool issue, unrelated to this change.

## Known follow-ups (documented, out of scope)

Squatted-room race window shrinks from forever to the reconnect delay (0.5-4.5 s); receiver-present-during-sender-blip still stalls (receiver has no `user-connected` handler); CLI signaling has no auto-reconnect; the recurring macOS webServer startup timeouts justify switching the CI client to `next build && next start` in a follow-up hardening PR.
