### PR TITLE
chore(ci): serve e2e from a production build, npm ci server installs, read-only token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           node-version: 20
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: server
 
       - name: Test
@@ -198,7 +198,7 @@ jobs:
         working-directory: client
 
       - name: Install server dependencies
-        run: npm install
+        run: npm ci
         working-directory: server
 
       - name: Install Playwright Chromium
@@ -289,7 +289,7 @@ jobs:
         working-directory: client
 
       - name: Install server dependencies
-        run: npm install
+        run: npm ci
         working-directory: server
 
       - name: Install Playwright Chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
     paths-ignore:
       - 'docs/**'
 
+# Least-privilege default for the GITHUB_TOKEN in every job. The only token
+# use is back-compat's gh release view/download against this repo's public
+# releases, which contents: read covers.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Cancel superseded runs on PRs; never cancel runs on main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,13 +207,22 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
         working-directory: client
 
-      - name: Run E2E tests (browser + CLI interop)
-        run: pnpm exec playwright test
+      - name: Build client (production)
+        # NEXT_PUBLIC_* is inlined into the bundle at BUILD time by Next.js,
+        # so the socket URL must be set here, not on the test step (next start
+        # never reads it). Each leg builds its own client: build-and-lint
+        # bakes the production https://api.floe.one URL, and a .next built on
+        # one OS is not reused on another.
+        run: pnpm build
         working-directory: client
         env:
           # 127.0.0.1, not localhost: see the webServer env note in
-          # client/playwright.config.ts (its env overrides this line anyway).
+          # client/playwright.config.ts.
           NEXT_PUBLIC_SOCKET_URL: http://127.0.0.1:3001
+
+      - name: Run E2E tests (browser + CLI interop)
+        run: pnpm exec playwright test
+        working-directory: client
 
       - name: Upload traces and test results on failure
         if: failure()
@@ -289,6 +298,19 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
         working-directory: client
 
+      - name: Build client (production)
+        # NEXT_PUBLIC_* is inlined into the bundle at BUILD time by Next.js,
+        # so the socket URL must be set here, not on the test step (next start
+        # never reads it). Each leg builds its own client: build-and-lint
+        # bakes the production https://api.floe.one URL, and a .next built on
+        # one OS is not reused on another.
+        run: pnpm build
+        working-directory: client
+        env:
+          # 127.0.0.1, not localhost: see the webServer env note in
+          # client/playwright.config.ts.
+          NEXT_PUBLIC_SOCKET_URL: http://127.0.0.1:3001
+
       - name: Download latest released CLI
         env:
           GH_TOKEN: ${{ github.token }}
@@ -311,10 +333,6 @@ jobs:
 
       - name: Run back-compat E2E tests
         working-directory: client
-        env:
-          # 127.0.0.1, not localhost: see the webServer env note in
-          # client/playwright.config.ts (its env overrides this line anyway).
-          NEXT_PUBLIC_SOCKET_URL: http://127.0.0.1:3001
         run: |
           # Fail loud if the export above ever regresses; otherwise the spec
           # would skip itself and this job would go green testing nothing.

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -71,11 +71,17 @@ export default defineConfig({
             },
         },
         {
-            command: 'pnpm dev',
+            // CI serves the production build (created by the "Build client
+            // (production)" workflow step): next dev compiles routes on
+            // demand, and on macOS runners that first compile repeatedly
+            // blew the 120s startup budget below. Local runs keep next dev
+            // so the edit-refresh flow is untouched.
+            command: process.env.CI ? 'pnpm start' : 'pnpm dev',
             cwd: __dirname,
             // URL readiness makes Playwright issue a real GET / before tests
-            // start, forcing next dev to compile the home page up front; on the
-            // slow Windows runner that first compile must not eat test timeouts.
+            // start. Under next dev that forces the home page to compile up
+            // front so the first test's timeout never pays for it; under
+            // next start it just confirms the server is routing.
             url: 'http://localhost:3000',
             reuseExistingServer: true,
             timeout: 120_000,
@@ -86,6 +92,11 @@ export default defineConfig({
                 // host "localhost", and setOffline alone never tears down an
                 // established WebSocket. Also the production code path, since
                 // real deployments never use "localhost".
+                // NEXT_PUBLIC_* is inlined at BUILD time, so this value only
+                // takes effect through next dev (local runs). On CI the same
+                // value is baked in by the "Build client (production)" step
+                // and next start ignores this block. reconnect.spec.ts
+                // asserts the effective value at runtime either way.
                 NEXT_PUBLIC_SOCKET_URL: 'http://127.0.0.1:3001',
             },
         },


### PR DESCRIPTION
## Summary

CI-only reliability changes, no product code:

- Both Playwright jobs (the 3-OS e2e matrix and back-compat) now run the web client as a production build (`next build` + `next start`) instead of `next dev`. macOS runners failed 3-4 times on next dev's on-demand compile blowing the 120 s webServer startup timeout; `next start` boots in well under a second. Local runs keep `pnpm dev` via a CI conditional in playwright.config.ts. `NEXT_PUBLIC_SOCKET_URL` moves onto the new build steps (NEXT_PUBLIC_* is inlined at build time); the now-inert copies on the run steps are removed. Each leg builds its own client: build-and-lint bakes https://api.floe.one and a .next does not move across OSes.
- `npm ci` replaces `npm install` at all three server install sites (server, e2e, back-compat) so installs are lockfile-exact and any manifest/lockfile drift fails loudly.
- Workflow-level `permissions: contents: read`. The only token use is back-compat's `gh release` download of a public release.

## Test plan

- [x] Local simulation of the new CI path (Windows): built the client with the baked 127.0.0.1 socket URL, served it with `next start` (ready in 358 ms, standalone warning is cosmetic on pinned Next 16.2.6), ran the full suite with CI=1: 17 passed, 4 skipped in 1.0 m (reconnect spec proves the baked URL end to end)
- [x] `pnpm lint` clean; actionlint: zero new findings (the 6 pre-existing info-level SC2086 notes on untouched lines are identical on origin/main and left for the supply-chain PR)
- [x] 3 fully green CI attempts (run 29687164951, attempts 1-3): all 9 jobs green every time; final attempt zero flaky (each e2e leg 17 passed 4 skipped, server 47 passing, back-compat 4 passed). Build step 12-23 s per leg; every leg's Playwright time now under 2 minutes (the windows leg was previously the 5m50s long pole); no webServer startup timeouts in any of the 12 Playwright job executions. Attempts 1-2 had retry-passes absorbed by retries: 1, recorded for transparency: cli-interop.spec.ts:66 (browser send to CLI receive) in attempts 1 (macOS) and 2 (ubuntu), back-compat.spec.ts:77 in attempt 1; all are the pre-existing WebRTC handshake-jitter class (the back-compat one is CLI-to-CLI with no browser involved), not the startup class this PR fixes.