### PR TITLE
chore(ci): in-workflow docs filter and a CI green gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,3 +403,32 @@ jobs:
           path: client/test-results/
           if-no-files-found: ignore
           retention-days: 7
+
+  ci-green:
+    # The one required status check on main (see the main-protection
+    # ruleset). DO NOT rename this job or its name without updating the
+    # ruleset first: the ruleset matches the check by the name string
+    # "CI green", and after a rename every PR would block on a check that
+    # never reports again.
+    name: CI green
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Every job in this workflow must be listed here, or its failure is
+    # invisible to branch protection. if: always() is load-bearing and must
+    # never become !cancelled(): without always() a failed or cancelled
+    # dependency would skip this job, and GitHub counts a skipped required
+    # check as passing.
+    needs: [changes, build-and-lint, server, cli, e2e, back-compat]
+    if: always()
+    steps:
+      - name: Report dependency results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: echo "$NEEDS_JSON"
+
+      - name: Fail if any dependency failed or was cancelled
+        # Skipped is a pass on purpose: docs-only PRs skip the heavy jobs.
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required job failed or was cancelled; see the results above."
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
 
 # Least-privilege default for the GITHUB_TOKEN in every job. The only token
 # use is back-compat's gh release view/download against this repo's public
@@ -25,10 +21,60 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      # 'true' unless every changed file is under docs/. Negation-based on
+      # purpose: anything not under docs/ counts as code, so a new top-level
+      # file or directory can never silently skip CI.
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # The pull_request checkout is the PR merged into its base; depth 2
+          # brings in both parents so HEAD^1 (the base tip) is diffable.
+          fetch-depth: 2
+
+      - name: Classify changed files
+        id: filter
+        run: |
+          # Push events (main) always run the full suite: main only advances
+          # by PR merge, and a multi-commit (rebase) merge would make a HEAD^1
+          # diff under-classify the push.
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "push event: full suite"
+            exit 0
+          fi
+          # First-parent diff of the merge commit = the PR's effective changes
+          # against the base tip. A bare assignment on purpose: under the
+          # default bash -e shell a failing git diff fails this job, every
+          # heavy job then skips, and the CI green gate goes red (fail
+          # closed). --no-renames lists a rename as delete plus add, so a
+          # file moved between docs/ and code paths always surfaces its code
+          # side.
+          changed="$(git diff --name-only --no-renames HEAD^1 HEAD)"
+          non_docs="$(printf '%s\n' "$changed" | grep -v '^docs/' || true)"
+          if [ -n "$non_docs" ]; then
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "non-docs changes:"
+            echo "$non_docs"
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "docs-only change: heavy jobs will be skipped"
+          fi
+
   build-and-lint:
     name: Build & Lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: [changes]
+    # changes must be listed in needs above, or this expression reads an
+    # empty context, evaluates false, and the job silently never runs again.
+    if: needs.changes.outputs.code == 'true'
 
     steps:
       - name: Checkout
@@ -80,6 +126,8 @@ jobs:
     name: Server (Node.js)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
 
     steps:
       - name: Checkout
@@ -102,6 +150,8 @@ jobs:
     name: CLI (Go, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
     strategy:
       # One OS failing must not hide results from the others
       fail-fast: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,9 +119,13 @@ All under `cli/internal/`:
 The docs live in `docs/` (Mintlify), git-synced to `main`, and deploy to docs.floe.one.
 
 - `docs/changelog.mdx` is written by hand; do not auto-generate or restructure it.
-- CI on docs-only changes is skipped via `paths-ignore: docs/**` in `.github/workflows/ci.yml`, so doc-only PRs do not run the client/server/CLI/e2e suite.
+- Docs-only PRs stay fast without dodging branch protection: the `changes` job in `.github/workflows/ci.yml` diffs the PR and, when every changed file is under `docs/`, the heavy jobs skip and the `CI green` check reports success in under a minute, so docs and Mintlify PRs merge quickly without running the client/server/CLI/e2e suite.
 
 Automated doc-maintenance PRs (style, links, SEO) are managed in the Mintlify dashboard. They open PRs against `main`, only edit `docs/**`, and never auto-merge.
+
+## CI
+
+`CI green` is the single required status check on `main`. It is a gate job in `.github/workflows/ci.yml` that needs every other job; any new CI job must be added to its `needs` list or its failures are invisible to branch protection. New or experimental jobs should start OUTSIDE the gate's needs (visible but non-blocking) and be promoted in once stable.
 
 ## Writing Style
 


### PR DESCRIPTION
## Summary

Makes the workflow gateable so "CI green" can become the single required status check on main (the ruleset change itself is a settings step after this merges):

- The docs-only skip moves from workflow-level `paths-ignore` into a first `changes` job. A required check plus `paths-ignore` would deadlock docs-only PRs forever (the check never reports and GitHub waits on "Expected"); a job-level skip officially satisfies required checks. The job classifies the PR with plain git (`fetch-depth: 2`, first-parent diff of the merge commit, `--no-renames` so a file moved into `docs/` still surfaces its code side) and is negation-based: anything not under `docs/` counts as code, so new top-level files can never silently skip CI. The diff is a bare assignment on purpose: a failing `git diff` fails the job and CI fails closed instead of green-skipping everything. Push events always run the full suite.
- `build-and-lint`, `server`, and `cli` gain `needs: [changes]` with `if: needs.changes.outputs.code == 'true'`. The `needs` entry is load-bearing: without it the expression reads an empty context, is silently false, and the job would never run again. `e2e` and `back-compat` are untouched (skipped needs already cascade-skip them).
- New `ci-green` gate job ("CI green"): `needs` every job, `if: always()` (never `!cancelled()`: a skipped required check counts as passing, so a failed dependency must not skip the gate), fails on any `failure` or `cancelled` result, and treats `skipped` as a pass (that is the docs fast path).
- CLAUDE.md: the stale `paths-ignore` note is replaced with the new mechanism, plus a CI section recording the convention that every new job must join the gate's `needs` list.

## Test plan

- [x] Filter logic simulated against real history: docs-only squash `cd13d60` classifies code=false (empty pipeline output), code commit `85e07e9` classifies code=true; anchor test proves `docsfoo/x` and a file literally named `docs` count as code
- [x] actionlint after each edit pass: zero new findings (the 6 pre-existing info-level SC2086 notes are unchanged); both commits signed
- [x] 3 fully green CI attempts (run 29689727924): all 11 jobs green every time; attempt 1 had zero flaky anywhere; the changes job classifies in ~5 s and the gate reports in ~4 s. Retry-passes absorbed by retries: 1 and recorded for transparency: cli-interop.spec.ts:66 (browser send to CLI receive) in attempts 2 and 3 (ubuntu) and back-compat.spec.ts:155 (same direction, released receiver) in attempt 2. This spec direction is a pre-existing timing sensitivity now tracked as a follow-up; it never failed a run and this PR changes no test or serving code (attempt 1 was fully clean).
- [ ] Post-merge, after the ruleset flip: scratch docs-only PR proves BLOCKED while the gate is pending, heavy jobs all skipped, CI green in under a minute, then mergeable; a mixed commit proves the full suite classification; probe PR closed unmerged