### PR TITLE
chore(ci): dependabot version updates, SHA-pinned actions, and a workflow lint gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot version updates. Monthly and grouped on purpose: this repo is
+# solo-maintained, so one grouped PR per ecosystem per month bounds the
+# review load. Security updates are unaffected by this schedule: they open
+# as soon as an advisory lands and have their own separate internal PR
+# limit, so the monthly cadence only throttles routine version bumps.
+version: 2
+updates:
+  # client/ (pnpm, packageManager pnpm@11.1.2) and server/ (plain npm) share
+  # one npm entry via the multi-directory form. Grouping is per directory,
+  # so client and server still arrive as separate single grouped PRs.
+  - package-ecosystem: "npm"
+    directories:
+      - "/client"
+      - "/server"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      npm-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/cli"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+
+  # Weekly rather than monthly: this entry is what keeps the commit-SHA pins
+  # in .github/workflows/ fresh (Dependabot bumps the pinned SHA and
+  # maintains the trailing # vX.Y.Z comment), and grouped actions PRs are
+  # tiny to review.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           # The pull_request checkout is the PR merged into its base; depth 2
           # brings in both parents so HEAD^1 (the base tip) is diffable.
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Classify changed files
         id: filter
@@ -79,6 +80,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -93,7 +96,7 @@ jobs:
 
       - name: Get pnpm store directory
         id: pnpm-cache
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -132,6 +135,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -161,6 +166,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -196,6 +203,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -219,7 +228,7 @@ jobs:
         # $(...) and $GITHUB_OUTPUT appends are bash-isms; the Windows default
         # shell is pwsh, so pin bash for a portable step.
         shell: bash
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -235,9 +244,9 @@ jobs:
         # Default per-OS browser paths: https://playwright.dev/docs/browsers
         run: |
           case "$RUNNER_OS" in
-            Linux)   echo "PLAYWRIGHT_CACHE=$HOME/.cache/ms-playwright" >> $GITHUB_OUTPUT ;;
-            macOS)   echo "PLAYWRIGHT_CACHE=$HOME/Library/Caches/ms-playwright" >> $GITHUB_OUTPUT ;;
-            Windows) echo "PLAYWRIGHT_CACHE=$LOCALAPPDATA/ms-playwright" >> $GITHUB_OUTPUT ;;
+            Linux)   echo "PLAYWRIGHT_CACHE=$HOME/.cache/ms-playwright" >> "$GITHUB_OUTPUT" ;;
+            macOS)   echo "PLAYWRIGHT_CACHE=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_OUTPUT" ;;
+            Windows) echo "PLAYWRIGHT_CACHE=$LOCALAPPDATA/ms-playwright" >> "$GITHUB_OUTPUT" ;;
             *)       echo "Unknown RUNNER_OS: $RUNNER_OS" >&2; exit 1 ;;
           esac
 
@@ -300,6 +309,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
@@ -320,7 +331,7 @@ jobs:
 
       - name: Get pnpm store directory
         id: pnpm-cache
-        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -379,7 +390,7 @@ jobs:
           mkdir -p "$dest"
           gh release download "$tag" --repo "$GITHUB_REPOSITORY" --dir "$dest" \
             --pattern 'floe_*_linux_amd64.tar.gz' --pattern 'checksums.txt'
-          cd "$dest"
+          cd "$dest" || exit 1
           # checksums.txt covers every asset; verify just the one we fetched.
           sha256sum --check <(grep linux_amd64.tar.gz checksums.txt)
           tar -xzf floe_*_linux_amd64.tar.gz floe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           # The pull_request checkout is the PR merged into its base; depth 2
           # brings in both parents so HEAD^1 (the base tip) is diffable.
@@ -78,15 +78,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           # Version comes from packageManager in client/package.json
           package_json_file: client/package.json
@@ -96,7 +96,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -131,10 +131,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
 
@@ -160,10 +160,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
           cache-dependency-path: cli/go.sum
@@ -195,21 +195,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
           cache-dependency-path: cli/go.sum
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           # Version comes from packageManager in client/package.json
           package_json_file: client/package.json
@@ -222,7 +222,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -242,7 +242,7 @@ jobs:
           esac
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.playwright-cache.outputs.PLAYWRIGHT_CACHE }}
           key: ${{ runner.os }}-playwright-${{ hashFiles('client/pnpm-lock.yaml') }}
@@ -282,7 +282,7 @@ jobs:
 
       - name: Upload traces and test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-traces-${{ matrix.os }}
           path: client/test-results/
@@ -299,21 +299,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
           cache-dependency-path: cli/go.sum
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           # Version comes from packageManager in client/package.json
           package_json_file: client/package.json
@@ -323,7 +323,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -331,7 +331,7 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           # Linux-only job, so no per-OS path dance like the e2e matrix; same
           # cache key as the ubuntu e2e leg so this job rides its cache.
@@ -397,7 +397,7 @@ jobs:
 
       - name: Upload traces and test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: back-compat-traces
           path: client/test-results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       # purpose: anything not under docs/ counts as code, so a new top-level
       # file or directory can never silently skip CI.
       code: ${{ steps.filter.outputs.code }}
+      # 'true' when any changed file is under .github/workflows/. Gates the
+      # actionlint job; push events always report true, same as code.
+      workflows: ${{ steps.filter.outputs.workflows }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -47,6 +50,7 @@ jobs:
           # diff under-classify the push.
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
             echo "push event: full suite"
             exit 0
           fi
@@ -67,6 +71,50 @@ jobs:
             echo "code=false" >> "$GITHUB_OUTPUT"
             echo "docs-only change: heavy jobs will be skipped"
           fi
+          # Same diff, second classification: workflow edits gate actionlint.
+          workflow_files="$(printf '%s\n' "$changed" | grep '^\.github/workflows/' || true)"
+          if [ -n "$workflow_files" ]; then
+            echo "workflows=true" >> "$GITHUB_OUTPUT"
+            echo "workflow changes:"
+            echo "$workflow_files"
+          else
+            echo "workflows=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [changes]
+    # Runs only when workflow files changed; the gate counts the skip as a
+    # pass, same as the docs fast path.
+    if: needs.changes.outputs.workflows == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Download actionlint
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Pinned release verified against a hardcoded digest, extending the
+          # commit-SHA pin philosophy to this download (the checksums file
+          # shipped with a release would match a compromised release). Bump
+          # version and hash together, deliberately.
+          ACTIONLINT_VERSION: v1.7.12
+          ACTIONLINT_SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          gh release download "$ACTIONLINT_VERSION" --repo rhysd/actionlint \
+            --pattern 'actionlint_*_linux_amd64.tar.gz'
+          echo "$ACTIONLINT_SHA256  actionlint_${ACTIONLINT_VERSION#v}_linux_amd64.tar.gz" | sha256sum --check
+          tar -xzf actionlint_*_linux_amd64.tar.gz actionlint
+          chmod +x actionlint
+
+      - name: Lint workflows
+        # Zero ignore flags on purpose: the tree lints clean after the
+        # quoting fixes and must stay clean.
+        run: ./actionlint -color
 
   build-and-lint:
     name: Build & Lint
@@ -429,7 +477,7 @@ jobs:
     # never become !cancelled(): without always() a failed or cancelled
     # dependency would skip this job, and GitHub counts a skipped required
     # check as passing.
-    needs: [changes, build-and-lint, server, cli, e2e, back-compat]
+    needs: [changes, actionlint, build-and-lint, server, cli, e2e, back-compat]
     if: always()
     steps:
       - name: Report dependency results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,24 +11,36 @@ on:
     tags:
       - 'v*'
 
-permissions:
-  contents: write
+# No workflow-level grants: the goreleaser job declares the contents: write
+# it needs, and any job added later starts from zero permissions.
+permissions: {}
 
 jobs:
   goreleaser:
     name: GoReleaser
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Create the GitHub Release and upload its assets.
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # full history + tags needed for changelog and versioning
+          # GoReleaser talks to GitHub through GITHUB_TOKEN env, never
+          # git-over-HTTP, so the checkout credential must not outlive this step.
+          persist-credentials: false
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
-          cache-dependency-path: cli/go.sum
+          # No module cache in the release build: this workflow publishes
+          # binaries from a tag push, and a cache entry poisoned by any other
+          # workflow would flow straight into the shipped artifacts. Building
+          # from source costs a few minutes once per release.
+          cache: false
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # full history + tags needed for changelog and versioning
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
           cache-dependency-path: cli/go.sum
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: '~> v2'
           args: release --clean

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Automated doc-maintenance PRs (style, links, SEO) are managed in the Mintlify da
 
 ## CI
 
-`CI green` is the single required status check on `main`. It is a gate job in `.github/workflows/ci.yml` that needs every other job; any new CI job must be added to its `needs` list or its failures are invisible to branch protection. New or experimental jobs should start OUTSIDE the gate's needs (visible but non-blocking) and be promoted in once stable.
+`CI green` is the single required status check on `main`. It is a gate job in `.github/workflows/ci.yml` that needs every other job; any new CI job must be added to its `needs` list or its failures are invisible to branch protection. New or experimental jobs should start OUTSIDE the gate's needs (visible but non-blocking) and be promoted in once stable. Deterministic linters (for example actionlint) are the exception and may enter the gate's `needs` immediately: their failures are reproducible locally, and their whole purpose is to block broken workflow edits, which a soak period outside the gate would defeat.
 
 ## Writing Style
 


### PR DESCRIPTION
## Summary

Supply-chain hardening in four commits, all CI/config, zero product code:

- **Dependabot version updates** (`.github/dependabot.yml`): npm for `/client` + `/server` (monthly, grouped per directory), Go modules for `/cli` (monthly, grouped), GitHub Actions weekly (it maintains the SHA pins below, and grouped actions PRs are tiny). Security updates are unaffected by the schedules. Conventional `commit-message` prefixes keep the squash history uniform. The client entry is the watch item (pnpm 11 support is pending upstream; the checked-in lockfileVersion 9.0 parses today).
- **Every action pinned to a full commit SHA** (26 `uses:` sites) with `# vX.Y.Z` comments Dependabot maintains. Latest tag within each already-pinned major line, dereferenced through the commits API. One disclosed delta: pnpm/action-setup lands on v4.4.0 (Node 24 relanded) while floating v4 still serves the v4.3.0 revert; a runtime no-op here since the workflow already forces Node 24.
- **Hardening**: `persist-credentials: false` on all 7 checkouts (no job does authenticated git; gh and GoReleaser use env tokens); release workflow gets `permissions: {}` at workflow level with `contents: write` scoped to the job, `timeout-minutes: 30`, and `cache: false` on setup-go (no poisonable module cache inside a publish path); the 6 remaining SC2086 sites and 1 SC2164 fixed so linters run with zero suppressions.
- **actionlint as a gated CI job**: downloads v1.7.12 pinned by tag AND verified against a hardcoded sha256 (`8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8`), runs with no ignore flags. The `changes` job gains a `workflows` output so the lint only runs when workflow files change (skips satisfy the gate). It enters the CI green gate immediately as the documented deterministic-linter exception in CLAUDE.md.

## Test plan

- [x] dependabot.yml validated against the official schema (check-jsonschema, vendored SchemaStore dependabot-2.0): ok
- [x] Pin audit: 26 pinned `uses:` lines, 0 unpinned remaining; every SHA dereferenced from its tag via the commits API
- [x] actionlint (no ignore flags) clean after C3 and after C4; zizmor v1.27.0 default persona: "No findings to report" on both workflows
- [x] All 4 commits signed
- [x] 3 fully green CI attempts (run 29694293772): 12 jobs green every time; the Lint workflows job ran live in ~8 s each attempt (pinned download, digest verified, zero findings); final attempt zero flaky across every leg (17 passed 4 skipped x3, server 47, back-compat 4). Retry-passes recorded: back-compat.spec.ts:155 (attempt 1), cli-cli.spec.ts:38 (attempt 2), both absorbed by retries: 1 and consistent with the known ambient-load pattern already tracked as a follow-up
- [ ] Post-merge: Dependabot tab shows 4 healthy rows (npm/client is the pnpm-11 acceptance test); release.yml changes are runtime-validated at the next `v*` tag

Note: release.yml only executes on tag pushes, so its changes (pins, permissions move, cache off) are statically linted here and behavior-checked at the next release.