### PR TITLE
chore(deps): group only minor and patch npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,17 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     groups:
+      # Minor and patch only: a single incompatible major inside a 20-update
+      # group PR blocks every other update in it (day one: the TypeScript
+      # 5 -> 7 bump broke typescript-eslint and poisoned 22 good bumps).
+      # Majors fall out of the group and arrive as individual PRs instead,
+      # each judged on its own by the gated CI.
       npm-deps:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "gomod"
     directory: "/cli"


### PR DESCRIPTION
## Summary

Restricts the npm Dependabot group to minor and patch updates. Majors now arrive as individual PRs instead of riding inside the group, so a single incompatible major (day one: the TypeScript 5 to 7 bump that breaks typescript-eslint, blocking 22 good updates in #180) can never poison the routine bumps again. npm only: Go majors change import paths and rarely flow through version updates, and the grouped Actions majors already passed the full suite in #177.

## Test plan

- [x] dependabot.yml re-validated against the official schema: ok
- [ ] CI green on this PR
- [ ] Post-merge: close #180, re-trigger the npm check, confirm the next PRs split into grouped minors/patches plus individual majors