### PR TITLE
chore(ci): manual dispatch trigger and flaky-test evidence capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,6 +358,11 @@ jobs:
             client/test-results/
           if-no-files-found: ignore
           retention-days: 7
+          # Artifact names are immutable within a run since upload-artifact
+          # v4, so without this a full re-run fails at upload. A re-run
+          # replaces the previous attempt's artifact: harvest evidence
+          # before re-running.
+          overwrite: true
 
   back-compat:
     name: Back-compat (HEAD vs latest release)
@@ -479,6 +484,8 @@ jobs:
             client/test-results/
           if-no-files-found: ignore
           retention-days: 7
+          # Same re-run rationale as the e2e leg.
+          overwrite: true
 
   ci-green:
     # The one required status check on main (see the main-protection

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Manual full-suite run. Recovery for dropped push events (GitHub's event
+  # pipeline lost two main pushes on 2026-07-19; lost runs never fire
+  # retroactively) and a cheap way to re-roll the suite when investigating
+  # flaky tests. The changes job treats every non-pull_request event as a
+  # full-suite run, so no path skips apply here.
+  workflow_dispatch:
 
 # Least-privilege default for the GITHUB_TOKEN in every job. The only token
 # use is back-compat's gh release view/download against this repo's public
@@ -337,12 +343,19 @@ jobs:
         run: pnpm exec playwright test
         working-directory: client
 
-      - name: Upload traces and test results on failure
-        if: failure()
+      - name: Upload Playwright evidence
+        # Not failure()-gated: a test that fails once and passes on the CI
+        # retry leaves a green job, and its first-attempt trace plus the CLI
+        # transcripts attached by e2e/helpers.ts live in these directories.
+        # Uploading them on every non-cancelled run is what makes flaky
+        # attempts investigable at all.
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-traces-${{ matrix.os }}
-          path: client/test-results/
+          name: e2e-evidence-${{ matrix.os }}
+          path: |
+            client/playwright-report/
+            client/test-results/
           if-no-files-found: ignore
           retention-days: 7
 
@@ -454,12 +467,16 @@ jobs:
           test -x "$FLOE_RELEASED_CLI"
           pnpm exec playwright test e2e/back-compat.spec.ts
 
-      - name: Upload traces and test results on failure
-        if: failure()
+      - name: Upload Playwright evidence
+        # Same reasoning as the e2e leg: keep first-attempt traces and CLI
+        # transcripts from retry-passed (green) runs.
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: back-compat-traces
-          path: client/test-results/
+          name: back-compat-evidence
+          path: |
+            client/playwright-report/
+            client/test-results/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,8 @@ Automated doc-maintenance PRs (style, links, SEO) are managed in the Mintlify da
 
 `CI green` is the single required status check on `main`. It is a gate job in `.github/workflows/ci.yml` that needs every other job; any new CI job must be added to its `needs` list or its failures are invisible to branch protection. New or experimental jobs should start OUTSIDE the gate's needs (visible but non-blocking) and be promoted in once stable. Deterministic linters (for example actionlint) are the exception and may enter the gate's `needs` immediately: their failures are reproducible locally, and their whole purpose is to block broken workflow edits, which a soak period outside the gate would defeat.
 
+ci.yml also has a `workflow_dispatch` trigger: a dispatched run behaves exactly like a push (full suite, no path skips). Use it to recover from a lost push event or to re-roll the suite when investigating flaky tests. The e2e and back-compat jobs upload a Playwright evidence artifact (HTML report, traces, and stamped CLI transcripts) on every non-cancelled run, so a test that fails once and passes on the CI retry still leaves its first attempt inspectable.
+
 ## Writing Style
 
 Do not use em dashes (--) in any markdown files or documentation. Use periods, commas, hyphens, or parentheses instead. In `docs/`, this is enforced deterministically by Vale (`docs/.vale.ini` plus the `docs/styles/Floe/EmDash.yml` rule, surfaced as the Mintlify Grammar linter CI check) and reinforced by the weekly Apply style guide automation.

--- a/client/e2e/helpers.ts
+++ b/client/e2e/helpers.ts
@@ -15,7 +15,7 @@
  * hermetically without a TURN server or real network.
  */
 
-import { expect, type Page } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { createHash, randomBytes } from 'crypto';
 import { writeFileSync, mkdirSync, readFileSync } from 'fs';
 import { join, dirname } from 'path';
@@ -108,6 +108,39 @@ export async function browserSenderSetup(page: Page, fixturePath: string): Promi
 // ---------------------------------------------------------------------------
 
 /**
+ * Mirror a spawned CLI's stdout/stderr into a transcript, each data event
+ * prefixed with the milliseconds since spawn, and attach it to the current
+ * test's report when the process ends. Runs alongside the callers' own
+ * stream handlers (Node supports multiple 'data' listeners) so the existing
+ * link-matching and error-tail logic stays untouched.
+ *
+ * The attachment survives retry-passes: a flaky first attempt leaves the
+ * CLI's own timeline in the report artifact, alignable against the browser
+ * trace, instead of vanishing behind the green retry. Best-effort on
+ * purpose: attaching evidence must never fail a test, and a process that
+ * outlives its test (test.info() then throws) just drops the transcript.
+ */
+function captureTranscript(proc: ChildProcess, name: string): void {
+    const t0 = Date.now();
+    let transcript = '';
+    let attached = false;
+    const record = (stream: 'out' | 'err') => (chunk: Buffer) => {
+        transcript += `[+${Date.now() - t0}ms ${stream}] ${chunk.toString()}`;
+    };
+    const attach = () => {
+        if (attached) return;
+        attached = true;
+        try {
+            test.info().attach(name, { body: transcript, contentType: 'text/plain' }).catch(() => { });
+        } catch { }
+    };
+    proc.stdout?.on('data', record('out'));
+    proc.stderr?.on('data', record('err'));
+    proc.on('close', attach);
+    proc.on('error', attach);
+}
+
+/**
  * Spawn `floe send` and return a promise that resolves to the room link once
  * it appears in stdout, plus the process so the caller can await/kill it.
  * The caller owns the process and must kill it in a finally block.
@@ -126,6 +159,7 @@ export function spawnSend(path: string, binary: string = cliBinary()): {
         '--web', WEB_URL,
         '--no-relay',
     ]);
+    captureTranscript(proc, 'floe send transcript');
 
     const linkPromise = new Promise<string>((resolve, reject) => {
         let stdout = '';
@@ -176,6 +210,7 @@ export function spawnReceive(link: string, outputDir: string, binary: string = c
             '--yes',       // auto-accept
             '--no-relay',
         ]);
+        captureTranscript(proc, 'floe receive transcript');
 
         let stdout = '';
         let stderr = '';

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -18,6 +18,12 @@ export default defineConfig({
     // protocol break fails every attempt; the unit tests are the real correctness
     // guard, this just stops infra jitter from reddening the build.
     retries: process.env.CI ? 1 : 0,
+    // Terminal output stays list; the HTML report additionally persists every
+    // attempt's attachments (the stamped CLI transcripts from e2e/helpers.ts)
+    // and retried-test traces, so a flaky first attempt inside a green run
+    // leaves evidence in the uploaded CI artifact instead of vanishing.
+    // open: 'never' keeps local runs from popping a browser after failures.
+    reporter: [['list'], ['html', { open: 'never' }]],
     use: {
         baseURL: 'http://localhost:3000',
         headless: true,


### PR DESCRIPTION
## Summary

- Adds a `workflow_dispatch` trigger to ci.yml: a dispatched run behaves exactly like a push (the `changes` job already treats every non-pull_request event as full-suite, so no filter changes). Recovery button for dropped push events (GitHub's event pipeline lost the runs for two main pushes on 2026-07-19; lost runs never fire retroactively) and a cheap way to re-roll the suite when investigating flaky tests.
- Keeps e2e evidence from green runs: the e2e and back-compat artifact uploads were `failure()`-gated, which discarded exactly what flaky tests produce (a first attempt that fails, then retry-passes, leaves a green job and its trace vanished). Uploads now run on every non-cancelled run and include the Playwright HTML report (new `list` + `html` reporter) alongside `test-results/`.
- Instruments the CLI e2e helpers: every spawned `floe` process mirrors stdout/stderr into a transcript, each data event stamped with milliseconds since spawn, attached to the test report on process close. Best-effort by design (can never fail a test). The flaky ledger spans browser-to-CLI and pure CLI-to-CLI transfers, and until now a retry-passed first attempt left zero CLI-side evidence.
- Documents the dispatch trigger and evidence artifact in the CLAUDE.md CI section.

No product code changes; test infrastructure and workflow config only.

## Test plan

- [x] actionlint (Docker, no ignore flags): zero findings
- [x] `pnpm lint` and `tsc --noEmit` in client: clean
- [x] Local run of `e2e/cli-cli.spec.ts`: green, and the JSON report shows `floe send transcript` / `floe receive transcript` (text/plain) attached to every test; decoded transcript shows stamped milestones (`[+38ms] Connecting to sender...`, `[+378ms] Connected`)
- [x] Failure-path validation: an intentionally over-parallel local stress run produced failing tests whose reports all carry the stamped transcripts
- [ ] CI green on this PR (workflows and code paths both exercise: actionlint runs live, full suite runs, evidence artifacts upload on green legs)
- [ ] `gh workflow run` dispatch experiment on this branch: run appears as workflow_dispatch, changes outputs true/true, all jobs run, gate green