### PR TITLE
fix(cli): fail fast when a transfer stalls instead of hanging

### DIFF
--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -17,6 +17,19 @@ import (
 	"github.com/schollz/progressbar/v3"
 )
 
+// Receive-loop stall watchdog. Before the first metadata the sender needs no
+// human input and metadata is due about one RTT after the channel opens, so a
+// silent 30 s means the transfer path is dead (the captured CI failure mode:
+// both sides log Connected, then nothing). Mid-transfer the bar is higher:
+// pion/sctp's retransmission timeout backs off toward 60 s on a lossy path and
+// the sender's own backpressure abort uses a 60 s window, so anything shorter
+// would kill transfers that are still legitimately recovering. Vars, not
+// consts, so tests can shrink them.
+var (
+	receiveIdleTimeout  = 30 * time.Second
+	receiveStallTimeout = 60 * time.Second
+)
+
 // FileInfo describes an incoming file (parsed from metadata message).
 type FileInfo struct {
 	ID         string
@@ -92,6 +105,14 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 		}
 	}()
 
+	// Stall watchdog: armed only while the loop is actually blocked on an
+	// empty msgCh, so it measures exactly "no data for this long" and can
+	// never fire while messages are flowing. The interactive accept prompt
+	// runs synchronously inside the metadata case below, outside any select,
+	// so a slow human can never trip it either.
+	stallTimer := time.NewTimer(receiveIdleTimeout)
+	defer stallTimer.Stop()
+
 	for {
 		// Prefer draining buffered messages over reacting to a close: a normal
 		// transfer ends with the final "end" marker already queued in msgCh,
@@ -100,6 +121,15 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 		select {
 		case msg = <-msgCh:
 		default:
+			// Bare Reset without a Stop/drain is correct under the Go 1.23+
+			// timer semantics this module's go directive activates; lowering
+			// the directive (or GODEBUG=asynctimerchan=1) would let a stale
+			// expiry misfire the very next select.
+			if waitingForFirst {
+				stallTimer.Reset(receiveIdleTimeout)
+			} else {
+				stallTimer.Reset(receiveStallTimeout)
+			}
 			select {
 			case msg = <-msgCh:
 			case <-done:
@@ -109,6 +139,32 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 						currentInfo.FileName, bytesReceived, currentInfo.FileSize)
 				}
 				return nil
+			case <-stallTimer.C:
+				// If the close raced the timer, report the close: it is the
+				// more precise diagnosis, and it keeps behavior identical to
+				// the done case above.
+				select {
+				case <-done:
+					if currentFile != nil {
+						return fmt.Errorf("connection closed mid-transfer: %s (%d of %d bytes)",
+							currentInfo.FileName, bytesReceived, currentInfo.FileSize)
+					}
+					return nil
+				default:
+				}
+				// Phase-aware stall errors. Deliberately no protocol or
+				// version phrasing: the "floe update" hint belongs to the
+				// incompatible path only.
+				switch {
+				case waitingForFirst:
+					return fmt.Errorf("connected, but no data arrived from the sender within %s", receiveIdleTimeout)
+				case currentFile != nil:
+					return fmt.Errorf("transfer stalled: no data for %s (%d of %d bytes of %q)",
+						receiveStallTimeout, bytesReceived, currentInfo.FileSize, currentInfo.FileName)
+				default:
+					return fmt.Errorf("transfer stalled: no data for %s (%d of %d files received)",
+						receiveStallTimeout, filesReceived, currentInfo.Total)
+				}
 			}
 		}
 

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -134,6 +135,19 @@ func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
 		}
 	})
 
+	// done is closed when the data channel closes, letting every wait below
+	// fail fast instead of burning its full deadline. pion fires OnClose on
+	// GRACEFUL closes only (remote dc.Close/pc.Close/browser tab close send a
+	// close notification): a kill -9 or dead network never errors the read
+	// chain (sctp retransmits forever by design and an ICE failure does not
+	// unblock reads), so the 120 s ack and 60 s backpressure deadlines remain
+	// the backstop for ungraceful death.
+	done := make(chan struct{})
+	var closeOnce sync.Once
+	dc.OnClose(func() {
+		closeOnce.Do(func() { close(done) })
+	})
+
 	// Backpressure: pion calls OnBufferedAmountLow once the send buffer drains
 	// to bufferedAmountLowWater. The send loop blocks on sendMore whenever the
 	// buffer is full so we never enqueue faster than the peer can drain.
@@ -156,7 +170,7 @@ func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
 	chunk := chunkSizeFor(sctpMax)
 
 	for i, entry := range files {
-		if err := sendFile(dc, ackCh, sendMore, entry, i+1, len(files), totalBytes, localVer, chunk); err != nil {
+		if err := sendFile(dc, ackCh, sendMore, done, entry, i+1, len(files), totalBytes, localVer, chunk); err != nil {
 			return fmt.Errorf("error sending %s: %w", entry.displayName, err)
 		}
 	}
@@ -189,6 +203,31 @@ drainLoop:
 			if dc.BufferedAmount() == 0 {
 				break drainLoop
 			}
+		case <-done:
+			// Success must win this race. pion delivers OnMessage before
+			// OnClose from the same read goroutine, so a "received" the peer
+			// sent just before closing is already sitting in ackCh: consult it
+			// before judging the close. And BufferedAmount is untrustworthy
+			// here (the SACK race above), so a nonzero value only means
+			// delivery could not be confirmed, never that data was lost.
+		drainAcks:
+			for {
+				select {
+				case raw := <-ackCh:
+					var msg struct {
+						Type string `json:"type"`
+					}
+					if json.Unmarshal(raw, &msg) == nil && msg.Type == "received" {
+						break drainLoop
+					}
+				default:
+					break drainAcks
+				}
+			}
+			if dc.BufferedAmount() == 0 {
+				break drainLoop
+			}
+			return fmt.Errorf("connection closed before delivery was confirmed (%d bytes unacknowledged)", dc.BufferedAmount())
 		case <-drainDeadline:
 			return fmt.Errorf("timed out waiting for delivery confirmation from peer")
 		}
@@ -254,7 +293,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 }
 
 // sendFile handles the full send sequence for a single file.
-func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, entry fileEntry, index, total int, totalBytes int64, localVer string, chunk int) error {
+func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, done <-chan struct{}, entry fileEntry, index, total int, totalBytes int64, localVer string, chunk int) error {
 	f, err := os.Open(entry.absPath)
 	if err != nil {
 		return err
@@ -340,6 +379,11 @@ ackLoop:
 				}
 			}
 			// Not our ack — keep waiting.
+		case <-done:
+			// A decline (the receiver's [Y/n] prompt closes the channel) or a
+			// receiver error-exit lands here in about a second instead of
+			// burning the full ack deadline.
+			return fmt.Errorf("connection closed while waiting for the receiver (transfer declined or receiver exited)")
 		case <-ackDeadline:
 			return fmt.Errorf("timed out waiting for ack")
 		}
@@ -370,6 +414,8 @@ ackLoop:
 			for dc.BufferedAmount() >= bufferedAmountHighWater {
 				select {
 				case <-sendMore:
+				case <-done:
+					return fmt.Errorf("connection closed mid-transfer (%d bytes still buffered)", dc.BufferedAmount())
 				case <-time.After(60 * time.Second):
 					cur := dc.BufferedAmount()
 					if backpressureStalled(lastBuffered, cur) {

--- a/cli/internal/transfer/watchdog_test.go
+++ b/cli/internal/transfer/watchdog_test.go
@@ -1,0 +1,166 @@
+// Watchdog tests: the receiver's stall timeouts and the sender's fast-fail on
+// data channel close, over real in-process pion pairs (see loopback_test.go
+// for the harness). Timeout vars are shrunk per test and restored via
+// t.Cleanup; they must be set BEFORE the receiver goroutine starts.
+package transfer
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestReceiverStallBeforeMetadata reproduces the captured CI failure mode:
+// both sides connect, then no data ever arrives. The receiver must fail fast
+// with a clear pre-metadata stall error instead of hanging forever.
+func TestReceiverStallBeforeMetadata(t *testing.T) {
+	old := receiveIdleTimeout
+	receiveIdleTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { receiveIdleTimeout = old })
+
+	_, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	start := time.Now()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	select {
+	case err := <-recvErr:
+		if err == nil {
+			t.Fatal("expected a stall error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no data arrived") {
+			t.Fatalf("expected a no-data stall error, got: %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > 5*time.Second {
+			t.Fatalf("stall error took %v; want well under 5s", elapsed)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return; the pre-metadata watchdog is missing")
+	}
+}
+
+// TestReceiverStallMidFile drives the receiver with a raw sender that delivers
+// metadata plus a partial chunk and then goes silent without closing. The
+// receiver must fail with a mid-file stall error naming the file and progress.
+func TestReceiverStallMidFile(t *testing.T) {
+	oldIdle, oldStall := receiveIdleTimeout, receiveStallTimeout
+	receiveIdleTimeout = 5 * time.Second
+	receiveStallTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { receiveIdleTimeout = oldIdle; receiveStallTimeout = oldStall })
+
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	// Let the receiver register its OnMessage handler before sending: pion
+	// drops messages delivered while the handler is nil.
+	time.Sleep(300 * time.Millisecond)
+
+	meta := `{"type":"metadata","id":"stall-1","fileName":"stall.bin","fileSize":4096,"index":1,"total":1,"totalBytes":4096}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	// Zero bytes: the first byte 0x00 fails the JSON-object probe, so this is
+	// written as file data (1024 of the promised 4096). Then: silence.
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil {
+			t.Fatal("expected a stall error, got nil")
+		}
+		if !strings.Contains(err.Error(), "stall.bin") || !strings.Contains(err.Error(), "1024 of 4096") {
+			t.Fatalf("expected a mid-file stall naming stall.bin with 1024 of 4096, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return; the mid-transfer watchdog is missing")
+	}
+}
+
+// TestReceiverNoMisfireWhileFlowing guards the timer-arming semantics: the
+// watchdog measures only time blocked on an empty message queue, so a normal
+// transfer must succeed even with a stall timeout far below its total
+// duration. A misfire here means the timer is being armed or reset wrong.
+func TestReceiverNoMisfireWhileFlowing(t *testing.T) {
+	oldStall := receiveStallTimeout
+	receiveStallTimeout = 2 * time.Second
+	t.Cleanup(func() { receiveStallTimeout = oldStall })
+
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "flow.bin")
+	content := bytes.Repeat([]byte{0xAB}, 2*1024*1024)
+	if err := os.WriteFile(src, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := runTransfer(t, []string{src})
+
+	got, err := os.ReadFile(filepath.Join(outDir, "flow.bin"))
+	if err != nil {
+		t.Fatalf("received file missing: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("received %d bytes, want %d identical bytes", len(got), len(content))
+	}
+}
+
+// TestSenderAckWaitConnectionClosed: the receiver's data channel closes while
+// the sender is waiting for an ack (the decline path and any receiver
+// error-exit land here). The sender must fail in seconds via its done channel,
+// not burn the 120-second ack deadline.
+func TestSenderAckWaitConnectionClosed(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "closed.bin")
+	if err := os.WriteFile(src, make([]byte, 4096), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Take the receiver's channel but never run ReceiveFiles: no ack will come.
+	dc := <-recvCh
+
+	start := time.Now()
+	sendErr := make(chan error, 1)
+	go func() { sendErr <- SendFiles(sender, []string{src}, "") }()
+
+	// Let the sender send metadata and enter its ack wait, then close the
+	// receiving side gracefully (stream reset reaches the sender's OnClose).
+	time.Sleep(300 * time.Millisecond)
+	if err := dc.Close(); err != nil {
+		t.Fatalf("receiver dc close: %v", err)
+	}
+
+	select {
+	case err := <-sendErr:
+		if err == nil {
+			t.Fatal("expected an error after the receiver closed, got nil")
+		}
+		if !strings.Contains(err.Error(), "connection closed while waiting") {
+			t.Fatalf("expected a connection-closed ack-wait error, got: %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Fatalf("sender took %v to fail; want well under 10s, never the 120s ack deadline", elapsed)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("SendFiles did not return; the done channel is not wired into the ack wait")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a transfer-stall watchdog to the CLI, motivated by the instrumented Class B CI capture: both peers open their data channels ("Connected" on both sides), then total silence; the receiver hung forever and the sender burned its full 120 s ack deadline. Any future occurrence now fails in seconds with a phase-labeled error, which the e2e transcripts capture verbatim.
- Receiver (`cli/internal/transfer/receiver.go`): an inactivity watchdog on the message loop, armed only while blocked on an empty queue, so it cannot fire while data flows and cannot fire during the interactive accept prompt (which runs synchronously outside the select). 30 s before the first metadata (due ~1 RTT after the channel opens, no human involved); 60 s mid-transfer (matches the sender's backpressure window and sctp RTO backoff so lossy-but-recovering relays are not killed). Phase-aware messages: "connected, but no data arrived", mid-file with byte progress, between-files with file counts.
- Sender (`cli/internal/transfer/sender.go`): a `done` channel from `dc.OnClose` makes the ack wait, backpressure wait, and drain loop fail in ~1 s on graceful remote closes (decline, receiver error-exit, browser tab close) instead of burning 120/60/30 s deadlines. Verified from pion sources: OnClose fires on graceful closes only, so the existing deadlines remain the ungraceful-death backstop. Drain loop orders success first (a "received" queued before the close is consulted, then empty buffer) so the SACK race guarded by `TestLoopbackImmediateReceiverClose` cannot be misreported as failure.
- No wire-protocol change, no `PROTOCOL_VERSION` bump, no new flags. Released CLIs interop unchanged (back-compat suite proves it in CI).

## Test plan

- [x] 4 new loopback unit tests over real pion pairs: pre-metadata stall (the captured Class B shape), mid-file stall (progress bar freezes at 25%, watchdog names the file and "1024 of 4096"), no-misfire-while-flowing (2 s watchdog on a multi-second transfer must pass), sender fast-fail on receiver close (<10 s, not 120 s)
- [x] `go vet` clean; full `go test -count=1 ./...` green on Windows
- [x] Race detector: all 7 transfer-package tests green under `-race` (Linux container; Windows host lacks a C toolchain)
- [x] Local e2e: cli-cli and cli-interop specs 4/4 green (fast transfers, watchdog silent)
- [x] Live decline simulation with real `floe` binaries against a local server: receiver answers `n`, sender exits in ~1 s with "connection closed while waiting for the receiver (transfer declined or receiver exited)" (previously hung the full 120 s)
- [ ] CI green, 3 attempts