### PR TITLE
docs: changelog for v1.7.6

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -3,6 +3,16 @@ title: "Changelog"
 description: "Release history for Floe."
 ---
 
+<Update label="v1.7.6" description="2026-07-21">
+  **Stalled transfers now fail fast with clear errors**
+
+  - Fixed transfers freezing forever when the connection silently broke right after setup. The receiver now reports "connected, but no data arrived from the sender" within 30 seconds if the transfer never starts, and "transfer stalled" with exact byte progress if data stops flowing mid-file for a full minute, instead of sitting on a frozen progress bar until you press Ctrl+C. These stalls are rare, but when one happened there was no way to tell it apart from a slow transfer.
+  - Fixed `floe send` waiting up to two minutes after the receiver declined the transfer or exited. It now reports "connection closed while waiting for the receiver" in about a second.
+  - Web app: the share link now appears only once the server has confirmed your room. This closes a rare race where a receiver that followed the link extremely quickly could be mistaken for the sender and fail with a role error.
+  - Updated the CLI's WebRTC stack (Pion) to the current releases.
+  - No transfer-protocol change, so v1.7.6 interoperates with older CLI and browser peers in every direction.
+</Update>
+
 <Update label="v1.7.5" description="2026-07-10">
   **Accurate progress on slow connections, and a CLI relay fix**
 


### PR DESCRIPTION
## Summary

Changelog entry for v1.7.6, following the existing Update-block conventions (newest first, bold title, CLI and web in one block, protocol-compat closing line, no em dashes).

Covers: the CLI transfer-stall watchdog (transfers that stall now fail in seconds with phase-labeled errors instead of freezing until Ctrl+C), the sender exiting in about a second when a receiver declines or exits (was up to two minutes), the web app rendering the share link only after the server confirms the room (closes the receiver role race), and the Pion WebRTC dependency updates.

Merging this PR is the agreed go signal: the v1.7.6 tag gets pushed on the resulting main head immediately after, which fires the release pipeline (first live run of the hardened release.yml, watched end to end).

## Test plan

- [x] Zero em dashes in the file (Vale rule); 19 matched Update open/close tag pairs
- [x] Entry format matches v1.7.5/v1.7.4 exactly
- [ ] Docs fast path: CI green reports via skip in under a minute