### PR TITLE
fix(client): match the scrub base with its path separator

### DIFF
--- a/client/lib/scrubUrl.test.ts
+++ b/client/lib/scrubUrl.test.ts
@@ -36,4 +36,15 @@ describe('scrubUrl', () => {
         expect(scrubUrl(undefined)).toBeUndefined();
         expect(scrubUrl(null)).toBeUndefined();
     });
+
+    it('never mistakes a host starting with the dummy base for the base itself', () => {
+        // The base-strip must match "http://scrub.invalid/", not the bare
+        // prefix: this host merely starts with the same characters and must
+        // come back intact (still room-scrubbed), not sliced into garbage.
+        expect(scrubUrl('http://scrub.invalid.evil.com/path?room=secret-uuid')).toBe(
+            'http://scrub.invalid.evil.com/path?room=redacted'
+        );
+        // The dummy-base strip itself still works for relative inputs.
+        expect(scrubUrl('/path?room=secret-uuid')).toBe('/path?room=redacted');
+    });
 });

--- a/client/lib/scrubUrl.ts
+++ b/client/lib/scrubUrl.ts
@@ -18,7 +18,12 @@ export function scrubUrl(url: string | undefined | null): string | undefined {
         if (u.searchParams.has('room')) u.searchParams.set('room', 'redacted');
         u.hash = '';
         const out = u.toString();
-        return out.startsWith(BASE) ? out.slice(BASE.length) || '/' : out;
+        // Match BASE plus the path separator, not BASE as a bare prefix: a
+        // serialized URL always has '/' after the host, so this is only true
+        // when the dummy base itself was used, never for an absolute URL on a
+        // host that merely starts with "scrub.invalid" (for example
+        // scrub.invalid.evil.com), which must pass through intact.
+        return out.startsWith(BASE + '/') ? out.slice(BASE.length) || '/' : out;
     } catch {
         // Parsing failed (unusual breadcrumb value); fall back to a plain strip.
         return url


### PR DESCRIPTION
## Summary

Closes CodeQL alert #2 (js/incomplete-url-substring-sanitization in `client/lib/scrubUrl.ts`) with the real one-line tighten rather than a dismissal: the dummy-base strip now matches `http://scrub.invalid/` (base plus path separator) instead of the bare prefix, so an absolute URL on a host that merely starts with `scrub.invalid` (like `scrub.invalid.evil.com`) passes through intact instead of being sliced into a mangled breadcrumb. No secret was ever exposed (room redaction happens before the strip); this corrects the cosmetic mangling and satisfies the scanner with strictly more-correct behavior. CodeQL will close the alert as fixed on its next scan of main.

## Test plan

- [x] New unit test: pathological `scrub.invalid.evil.com` host comes back intact and room-redacted; relative-URL stripping unchanged
- [x] 92/92 client unit tests, ESLint, `tsc --noEmit` all green
- [ ] Full CI green
- [ ] Post-merge: CodeQL alert #2 auto-closes as fixed