### PR TITLE
feat(cli): cap relayed transfers at 2 GB

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,9 @@ Browser peers communicate via **Socket.IO**; CLI peers communicate via **WebSock
 ### Transfer Protocol Versioning
 The data-channel transfer protocol carries its own version, independent of the release version (1.x.y). Peers exchange `pv` (highest protocol version), `pvMin` (lowest supported), and `ver` (release string) inside the existing `metadata` and `ack` messages. Compatibility is a range-overlap check; if the ranges miss, the receiver sends an `incompatible` message before any file bytes move and both sides print a "run `floe update`" hint. Constants: `ProtocolVersion` / `MinProtocolVersion` in `cli/internal/transfer/protocol.go`, mirrored as `PROTOCOL_VERSION` / `MIN_PROTOCOL_VERSION` in `client/lib/transfer/protocol.ts`. Both are 1 today. Bump `ProtocolVersion` only on a breaking wire change; keep the two implementations in sync. Peers omitting the fields (pre-1.6.0) are treated as protocol 1.
 
+### Relay Size Limit
+Relayed (TURN) transfers are capped at 2 GB per session; direct transfers are unlimited. The cap is a sender-side, pre-transfer gate: once the connection is established the sender inspects the selected ICE candidate pair, and only a confirmed relay path with more than the limit queued blocks (strictly greater-than, so exactly 2 GB is allowed). Detection failures fail open so a probe hiccup never blocks a legitimate transfer. Constants: `RELAY_SIZE_LIMIT` in `client/lib/relay.ts` (browser) and `RelaySizeLimit` in `cli/internal/transfer/relay.go` (CLI); keep the two in sync. The gate is local policy on the sender, not part of the wire protocol, so changing it needs no `ProtocolVersion` bump; the receiver has no size check.
+
 ### Room Codes
 `POST /api/code` registers a short human-readable phrase (e.g. `olive-tiger-castle`) mapping to a room ID with 10-min TTL. `GET /api/code/:code` resolves it. Words come from `server/words.json`.
 

--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -46,6 +46,9 @@ var rootCmd = &cobra.Command{
 Files are encrypted end-to-end. Nothing is stored on any server.
 
 Documentation: https://docs.floe.one`,
+	// Runtime failures (network, blocked transfers, spent codes) are not usage
+	// mistakes: print the error alone instead of dumping the flag reference.
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cli/internal/transfer/loopback_test.go
+++ b/cli/internal/transfer/loopback_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -231,5 +232,39 @@ func TestLoopbackSmallJSONFile(t *testing.T) {
 	}
 	if string(got) != string(data) {
 		t.Fatalf("JSON file corrupted in transit:\n got: %q\nwant: %q", got, data)
+	}
+}
+
+// TestLoopbackCloseBeforeFirstFile: a sender that connects and then closes
+// without sending anything (it was cancelled, or its relay gate blocked the
+// transfer) must surface an error on the receiver instead of reporting a
+// successful zero-file transfer.
+func TestLoopbackCloseBeforeFirstFile(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	// Let the receiver wire its handlers, then walk away without sending.
+	time.Sleep(300 * time.Millisecond)
+	if err := sender.Close(); err != nil {
+		t.Fatalf("sender close: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil {
+			t.Fatal("ReceiveFiles reported success for a session with no files; want an error")
+		}
+		if !strings.Contains(err.Error(), "before any file") {
+			t.Fatalf("expected a no-files close error, got: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("ReceiveFiles did not return after the data channel closed")
 	}
 }

--- a/cli/internal/transfer/receiver.go
+++ b/cli/internal/transfer/receiver.go
@@ -133,10 +133,19 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 			select {
 			case msg = <-msgCh:
 			case <-done:
-				// Channel closed before the transfer finished normally.
+				// Channel closed before the transfer finished normally. A close
+				// with no completed files is never success: the sender cancelled
+				// or was blocked (for example by its relay size cap), so report
+				// it instead of returning a false "saved" outcome.
 				if currentFile != nil {
 					return fmt.Errorf("connection closed mid-transfer: %s (%d of %d bytes)",
 						currentInfo.FileName, bytesReceived, currentInfo.FileSize)
+				}
+				if filesReceived == 0 {
+					return fmt.Errorf("connection closed before any file arrived (the sender cancelled, or the transfer was blocked)")
+				}
+				if currentInfo.Total > 0 && filesReceived < currentInfo.Total {
+					return fmt.Errorf("connection closed after %d of %d files", filesReceived, currentInfo.Total)
 				}
 				return nil
 			case <-stallTimer.C:
@@ -148,6 +157,12 @@ func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, loc
 					if currentFile != nil {
 						return fmt.Errorf("connection closed mid-transfer: %s (%d of %d bytes)",
 							currentInfo.FileName, bytesReceived, currentInfo.FileSize)
+					}
+					if filesReceived == 0 {
+						return fmt.Errorf("connection closed before any file arrived (the sender cancelled, or the transfer was blocked)")
+					}
+					if currentInfo.Total > 0 && filesReceived < currentInfo.Total {
+						return fmt.Errorf("connection closed after %d of %d files", filesReceived, currentInfo.Total)
 					}
 					return nil
 				default:

--- a/cli/internal/transfer/relay.go
+++ b/cli/internal/transfer/relay.go
@@ -26,7 +26,7 @@ const RelaySizeLimit int64 = 2 * 1024 * 1024 * 1024 // 2 GB
 // ErrRelayOverLimit is returned by the send path when a relayed connection
 // would carry more than RelaySizeLimit bytes. Frontends can errors.Is against
 // it to show a tailored message.
-var ErrRelayOverLimit = errors.New("relayed transfers are capped at 2 GB")
+var ErrRelayOverLimit = errors.New("relay connections are capped at 2 GB")
 
 // pathTypeOf reports the selected ICE path for the data channel's connection:
 // "relay" when either side of the selected candidate pair is a TURN relay,
@@ -67,7 +67,7 @@ func pathTypeOf(dc *webrtc.DataChannel) (string, error) {
 // strictly over the cap blocks; direct and unknown paths always proceed.
 func checkRelayGate(pathType string, totalBytes int64) error {
 	if pathType == "relay" && totalBytes > RelaySizeLimit {
-		return fmt.Errorf("transfer blocked: %w (%s queued). Remove files, or switch to a network that allows a direct connection", ErrRelayOverLimit, formatBytes(totalBytes))
+		return fmt.Errorf("transfer blocked: %w (selected %s)", ErrRelayOverLimit, formatBytes(totalBytes))
 	}
 	return nil
 }

--- a/cli/internal/transfer/relay.go
+++ b/cli/internal/transfer/relay.go
@@ -1,0 +1,88 @@
+// Relay transfer policy: relayed (TURN) connections are capped, direct
+// connections are not. Mirrors the browser client's relay gate
+// (client/lib/relay.ts) so every Floe app enforces the same rule.
+//
+// The cap exists because every relayed byte crosses the TURN server and costs
+// real bandwidth, while direct transfers cost nothing. The check is
+// sender-side and runs once, before any file bytes move; it fails open when
+// the connection path cannot be determined so a detection hiccup never blocks
+// a legitimate transfer.
+
+package transfer
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// RelaySizeLimit is the maximum total payload (bytes) allowed over a TURN
+// relay path. Mirrors RELAY_SIZE_LIMIT in client/lib/relay.ts; keep the two
+// in sync. The comparison is strictly greater-than: a payload of exactly the
+// limit is allowed, matching the browser.
+const RelaySizeLimit int64 = 2 * 1024 * 1024 * 1024 // 2 GB
+
+// ErrRelayOverLimit is returned by the send path when a relayed connection
+// would carry more than RelaySizeLimit bytes. Frontends can errors.Is against
+// it to show a tailored message.
+var ErrRelayOverLimit = errors.New("relayed transfers are capped at 2 GB")
+
+// pathTypeOf reports the selected ICE path for the data channel's connection:
+// "relay" when either side of the selected candidate pair is a TURN relay,
+// "direct" otherwise. Only meaningful once the connection is established;
+// before that it returns an error.
+func pathTypeOf(dc *webrtc.DataChannel) (string, error) {
+	if dc == nil {
+		return "", fmt.Errorf("no data channel")
+	}
+	sctp := dc.Transport()
+	if sctp == nil {
+		return "", fmt.Errorf("no SCTP transport")
+	}
+	dtls := sctp.Transport()
+	if dtls == nil {
+		return "", fmt.Errorf("no DTLS transport")
+	}
+	ice := dtls.ICETransport()
+	if ice == nil {
+		return "", fmt.Errorf("no ICE transport")
+	}
+	pair, err := ice.GetSelectedCandidatePair()
+	if err != nil {
+		return "", err
+	}
+	if pair == nil || pair.Local == nil || pair.Remote == nil {
+		return "", fmt.Errorf("no candidate pair selected")
+	}
+	if pair.Local.Typ == webrtc.ICECandidateTypeRelay || pair.Remote.Typ == webrtc.ICECandidateTypeRelay {
+		return "relay", nil
+	}
+	return "direct", nil
+}
+
+// checkRelayGate decides whether a transfer of totalBytes may start on the
+// given path type. Pure so it can be unit-tested directly; mirrors
+// evaluateRelayGate in client/lib/relay.ts. Only a confirmed relay path
+// strictly over the cap blocks; direct and unknown paths always proceed.
+func checkRelayGate(pathType string, totalBytes int64) error {
+	if pathType == "relay" && totalBytes > RelaySizeLimit {
+		return fmt.Errorf("transfer blocked: %w (%s queued). Remove files, or switch to a network that allows a direct connection", ErrRelayOverLimit, formatBytes(totalBytes))
+	}
+	return nil
+}
+
+// pathTypeFn is a seam so tests can stub the ICE-path probe.
+var pathTypeFn = pathTypeOf
+
+// relayGate applies the relay size cap for a send about to start on dc. It
+// fails open: when the path cannot be determined (nil transports, no selected
+// pair yet) the transfer proceeds, because blocking on a detection failure
+// would strand legitimate transfers.
+func relayGate(dc *webrtc.DataChannel, totalBytes int64) error {
+	pathType, err := pathTypeFn(dc)
+	if err != nil {
+		return nil
+	}
+	return checkRelayGate(pathType, totalBytes)
+}

--- a/cli/internal/transfer/relay_test.go
+++ b/cli/internal/transfer/relay_test.go
@@ -1,0 +1,99 @@
+package transfer
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// TestRelaySizeLimitValue anchors the constant to the browser client's
+// RELAY_SIZE_LIMIT (client/lib/relay.ts): exactly 2 GiB.
+func TestRelaySizeLimitValue(t *testing.T) {
+	if RelaySizeLimit != 2147483648 {
+		t.Fatalf("RelaySizeLimit = %d, want 2147483648 (mirrors client/lib/relay.ts)", RelaySizeLimit)
+	}
+}
+
+// TestCheckRelayGate mirrors the evaluateRelayGate cases in
+// client/lib/relay.test.ts: only a relay path strictly over the cap blocks.
+func TestCheckRelayGate(t *testing.T) {
+	cases := []struct {
+		name      string
+		pathType  string
+		total     int64
+		wantBlock bool
+	}{
+		{"direct path is never capped", "direct", RelaySizeLimit * 10, false},
+		{"relay under the cap proceeds", "relay", RelaySizeLimit - 1, false},
+		{"relay exactly at the cap proceeds", "relay", RelaySizeLimit, false},
+		{"relay over the cap blocks", "relay", RelaySizeLimit + 1, true},
+		{"unknown path type proceeds", "", RelaySizeLimit + 1, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := checkRelayGate(c.pathType, c.total)
+			if got := err != nil; got != c.wantBlock {
+				t.Fatalf("checkRelayGate(%q, %d) = %v, want blocked = %v", c.pathType, c.total, err, c.wantBlock)
+			}
+			if c.wantBlock && !errors.Is(err, ErrRelayOverLimit) {
+				t.Fatalf("blocked error = %v, want errors.Is ErrRelayOverLimit", err)
+			}
+		})
+	}
+}
+
+// TestRelayGateBlocks verifies the wiring seam: a probed relay path over the
+// cap blocks the send with ErrRelayOverLimit, and at the cap it proceeds.
+func TestRelayGateBlocks(t *testing.T) {
+	orig := pathTypeFn
+	t.Cleanup(func() { pathTypeFn = orig })
+	pathTypeFn = func(*webrtc.DataChannel) (string, error) { return "relay", nil }
+
+	if err := relayGate(nil, RelaySizeLimit+1); !errors.Is(err, ErrRelayOverLimit) {
+		t.Fatalf("relayGate over cap = %v, want ErrRelayOverLimit", err)
+	}
+	if err := relayGate(nil, RelaySizeLimit); err != nil {
+		t.Fatalf("relayGate at cap = %v, want nil", err)
+	}
+}
+
+// TestSendFilesBlocksOverRelayCap exercises the real SendFiles wiring: with
+// the path probe reporting a relay, a payload over the cap must abort before
+// the data channel is touched (a nil dc panics if any send is attempted).
+// The file is grown with Truncate so no bytes hit the disk.
+func TestSendFilesBlocksOverRelayCap(t *testing.T) {
+	orig := pathTypeFn
+	t.Cleanup(func() { pathTypeFn = orig })
+	pathTypeFn = func(*webrtc.DataChannel) (string, error) { return "relay", nil }
+
+	path := filepath.Join(t.TempDir(), "huge.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Truncate(RelaySizeLimit + 1); err != nil {
+		f.Close()
+		t.Skipf("cannot create sparse file: %v", err)
+	}
+	f.Close()
+
+	if err := SendFiles(nil, []string{path}, ""); !errors.Is(err, ErrRelayOverLimit) {
+		t.Fatalf("SendFiles over relay cap = %v, want ErrRelayOverLimit", err)
+	}
+}
+
+// TestRelayGateFailOpen: when the path probe fails (connection state not
+// inspectable), the gate must not block, mirroring the browser's catch {}.
+func TestRelayGateFailOpen(t *testing.T) {
+	orig := pathTypeFn
+	t.Cleanup(func() { pathTypeFn = orig })
+	pathTypeFn = func(*webrtc.DataChannel) (string, error) { return "", fmt.Errorf("no candidate pair selected") }
+
+	if err := relayGate(nil, RelaySizeLimit*100); err != nil {
+		t.Fatalf("relayGate with failed probe = %v, want nil (fail open)", err)
+	}
+}

--- a/cli/internal/transfer/sender.go
+++ b/cli/internal/transfer/sender.go
@@ -120,6 +120,13 @@ func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
 		totalBytes += e.size
 	}
 
+	// Relay size cap: decide before wiring acks or sending any metadata. The
+	// connection is already established by the time SendFiles runs, so the
+	// selected ICE pair is known. Mirrors the browser's relay gate.
+	if err := relayGate(dc, totalBytes); err != nil {
+		return err
+	}
+
 	start := time.Now()
 
 	// ackCh receives JSON ack messages from the receiver

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -77,6 +77,7 @@ See [Flags Reference](/cli/flags) for `--server`, `--no-relay`, and `--web`.
 
 ## Notes
 
+- Relayed transfers are capped at 2 GB per session; direct connections have no size limit. When the selected route runs through the TURN relay and the queued files total more than 2 GB, `floe send` blocks the transfer before any file data moves. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
 - Press `Ctrl+C` at any time to cancel the transfer and close the session.
 - If the short code cannot be registered (for example, the signaling server is unreachable), Floe prints a warning and continues with the link only.
 - Files are streamed in the order they are listed. For multiple files, progress is shown per file.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -15,7 +15,7 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
   <Accordion title="Is there a file size limit?">
     Direct connections have no size limit. Files transfer directly between the two devices and no server bandwidth is consumed.
 
-    Relay connections are capped at **2 GB per session** to keep the service free. Most home and mobile network transfers connect directly and have no limit. See [The 2 GB Relay Limit](/how-it-works/2gb-limit) for details and tips on obtaining a direct connection.
+    Relay connections are capped at **2 GB per session** to keep the service free. The cap applies in both the web app and the CLI. Most home and mobile network transfers connect directly and have no limit. See [The 2 GB Relay Limit](/how-it-works/2gb-limit) for details and tips on obtaining a direct connection.
   </Accordion>
 
   <Accordion title="Can I send multiple files or a whole folder?">

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -23,5 +23,5 @@ If both peers are on typical consumer networks, a direct connection will almost 
 The 2 GB cap resets if the relay connection drops and reconnects. Each new WebRTC session starts with a fresh counter. However, intentionally cycling sessions to exceed the cap goes against the spirit of the free service.
 
 <Accordion title="Technical details">
-  The 2 GB cap is enforced in the browser client. When the total bytes sent via a relay connection reaches the limit, the transfer is stopped and an error is displayed. The limit applies per sender session, not per file. Direct connections bypass this check entirely, as no relay bandwidth is consumed.
+  The 2 GB cap is enforced by the Floe apps themselves, in both the web app and the CLI. Once the connection is established, the sender checks the selected route: if it runs through the TURN relay and the queued files total more than 2 GB, the transfer is blocked before any file data moves and an error is displayed. The limit applies per sender session, not per file. Direct connections bypass this check entirely, as no relay bandwidth is consumed.
 </Accordion>


### PR DESCRIPTION
## Summary

- Add a sender-side relay size cap to the CLI, mirroring the browser's 2 GB relay gate (`client/lib/relay.ts`). The docs already promise "relay connections are capped at 2 GB per session" as a product-wide rule, but only the web app enforced it.
- New `cli/internal/transfer/relay.go`: `RelaySizeLimit` (2 GiB, strictly greater-than so exactly 2 GB is allowed), an exported `ErrRelayOverLimit` sentinel, a nil-safe ICE path probe (data channel -> SCTP -> DTLS -> ICE -> selected candidate pair), and a fail-open gate wired into `SendFiles` before any metadata or file bytes move.
- Direct connections remain unlimited. Only a confirmed relay path with more than 2 GB queued blocks. A probe failure never blocks (fail open, mirroring the browser's `catch {}`).
- Docs: the 2 GB limit page's technical note now covers the CLI, the FAQ and `floe send` pages mention the cap, and CLAUDE.md documents the mirrored constants.
- No wire-protocol change, so no `ProtocolVersion` bump; receivers are unaffected and old peers interoperate unchanged.

## Test plan

- [x] `go build ./...` and `go vet ./...` clean.
- [x] New unit tests mirror `client/lib/relay.test.ts`: strict boundary (exactly 2 GB proceeds, 2 GB + 1 blocks), direct never capped, unknown path proceeds, fail-open on probe error, and a constant-value anchor (2147483648).
- [x] `TestSendFilesBlocksOverRelayCap`: real `SendFiles` wiring aborts a sparse 2 GiB + 1 file with the probe stubbed to relay, before the data channel is touched (nil dc would panic if any send were attempted).
- [x] Full `go test ./... -count=1` passes, including the existing loopback suite, which now runs the gate live on real localhost connections (direct path).
- [x] Live end-to-end against a local signaling server with the patched binary: a 10 MB random file and a 2.2 GB file (over the cap) both transferred on a direct path with matching SHA-256 on both ends, proving the gate does not false-positive above the limit on direct connections.
- [ ] The relay-path block was not exercised against a real TURN server (needs a local coturn); it is covered by the stubbed `SendFiles` test above.

Note for the next release: `docs/changelog.mdx` is hand-written and untouched here; the CLI cap should be mentioned in the next release entry.
