### PR TITLE
feat(client): serve docs at /docs via Mintlify reverse proxy

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -13,6 +13,34 @@ const nextConfig = {
     // Strict Mode is therefore kept off. All socket/peer logic uses refs +
     // cleanup functions to avoid the double-mount problem if re-enabled later.
     reactStrictMode: false,
+
+    // Documentation lives on Mintlify and is served at floe.one/docs (a subpath
+    // of the primary domain, for SEO) via a reverse proxy: every /docs request
+    // is rewritten to the Mintlify deployment, which is configured with base
+    // path /docs so its own links and assets resolve under /docs too. The single
+    // /docs/:path* rule also covers Mintlify's re-rooted assets.
+    async rewrites() {
+        return [
+            { source: '/docs', destination: 'https://floe.mintlify.app/docs' },
+            { source: '/docs/:path*', destination: 'https://floe.mintlify.app/docs/:path*' },
+        ];
+    },
+
+    // The docs used to live at docs.floe.one; they permanently moved onto the
+    // subpath. Once docs.floe.one points at this Vercel project, a request on
+    // that host is 301'd to the matching www.floe.one/docs URL with the full
+    // path preserved. Scoped by host so it never touches the main site. This is
+    // inert until docs.floe.one's DNS is repointed here during cutover.
+    async redirects() {
+        return [
+            {
+                source: '/:path*',
+                has: [{ type: 'host', value: 'docs.floe.one' }],
+                destination: 'https://www.floe.one/docs/:path*',
+                statusCode: 301,
+            },
+        ];
+    },
 };
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
## Summary

Moves the documentation from the `docs.floe.one` subdomain onto a subpath, `www.floe.one/docs`, to consolidate SEO/domain authority onto the primary domain (the modern developer-first convention).

`client/next.config.mjs` gains two functions:
- `rewrites()`: `/docs` and `/docs/:path*` reverse-proxy to the Mintlify deployment at `floe.mintlify.app/docs/*`. Mintlify runs with base path `/docs`, so its internal links and assets resolve under `/docs`; the single `/docs/:path*` rule also covers those re-rooted assets.
- `redirects()`: a host-scoped `301` from `docs.floe.one/:path*` to `https://www.floe.one/docs/:path*`, preserving the full path.

## Safe to merge on its own (nothing user-facing changes yet)

- The `/docs/*` rewrite returns 404 until Mintlify's base path is flipped to `/docs` (a later cutover step). No links point at `www.floe.one/docs` yet.
- The redirect only fires on the `docs.floe.one` host, which still points at Mintlify (not this project) until the DNS cutover, so it is inert.
- `docs.floe.one` keeps serving normally throughout.

The Mintlify base-path flip, the `docs.floe.one` DNS repoint, and the internal link updates ship as separate coordinated steps after this deploys.

## Test plan

- `node --check` passes on `next.config.mjs`.
- Vercel preview build succeeds (validates the config).
- Post-deploy: `curl -sSI https://www.floe.one/docs/` returns 404 (expected pre-cutover); `docs.floe.one` unaffected.
