### PR TITLE
fix(client): point docs rewrite at the base-path host (mintlify.site)

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -21,8 +21,8 @@ const nextConfig = {
     // /docs/:path* rule also covers Mintlify's re-rooted assets.
     async rewrites() {
         return [
-            { source: '/docs', destination: 'https://floe.mintlify.app/docs' },
-            { source: '/docs/:path*', destination: 'https://floe.mintlify.app/docs/:path*' },
+            { source: '/docs', destination: 'https://floe.mintlify.site/docs' },
+            { source: '/docs/:path*', destination: 'https://floe.mintlify.site/docs/:path*' },
         ];
     },
 


### PR DESCRIPTION
## Summary

Follow-up to #195. The `/docs` rewrite proxied to `floe.mintlify.app`, but that host serves the docs at the root regardless of the deployment base path. Only `floe.mintlify.site` (Mintlify's documented reverse-proxy origin) serves the `/docs` base path. So with the base path set to `/docs`, `floe.mintlify.app/docs` returned 404 and `www.floe.one/docs` 404'd. This switches the rewrite destination to `floe.mintlify.site/docs`.

## Test plan

- Verified empirically under base path `/docs`: `floe.mintlify.site/docs/introduction` and `floe.mintlify.dev/docs/introduction` return 200; `floe.mintlify.app/docs/introduction` returns 404.
- `Build & Lint` validates `next.config.mjs`.
- After this deploys and the base path is flipped to `/docs`, `www.floe.one/docs/introduction` serves 200 (verified during cutover).
