### PR TITLE
docs: point all docs.floe.one links at floe.one/docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ All under `cli/internal/`:
 
 ## Documentation Site
 
-The docs live in `docs/` (Mintlify), git-synced to `main`, and deploy to docs.floe.one.
+The docs live in `docs/` (Mintlify), git-synced to `main`, and are served at `floe.one/docs` (Mintlify deployment `floe` at base path `/docs`, reverse-proxied through the Vercel app's `next.config.mjs` rewrite to `floe.mintlify.site`; the old `docs.floe.one` 301-redirects there).
 
 - `docs/changelog.mdx` is written by hand; do not auto-generate or restructure it.
 - Docs-only PRs stay fast without dodging branch protection: the `changes` job in `.github/workflows/ci.yml` diffs the PR and, when every changed file is under `docs/`, the heavy jobs skip and the `CI green` check reports success in under a minute, so docs and Mintlify PRs merge quickly without running the client/server/CLI/e2e suite.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 <p align="center">
   <a href="https://floe.one">Try Floe</a> ·
   <a href="https://floe.one/how-it-works">How It Works</a> ·
-  <a href="https://docs.floe.one">Documentation</a> ·
+  <a href="https://www.floe.one/docs">Documentation</a> ·
   <a href="#cli">CLI</a> ·
   <a href="#self-hosting">Self-Hosting</a> ·
   <a href="#contributing">Contributing</a>
@@ -36,13 +36,13 @@ A signaling server (`api.floe.one`) handles WebRTC negotiation and issues short-
 
 [floe.one](https://floe.one) runs entirely in your browser. Open it, pick a file, and share the code or link. No account or installation required.
 
-New to Floe? The [Quick Start guide](https://docs.floe.one/quickstart) walks through sending and receiving your first file.
+New to Floe? The [Quick Start guide](https://www.floe.one/docs/quickstart) walks through sending and receiving your first file.
 
 ## How It Works
 
 Files transfer directly between devices using WebRTC. A signaling server handles connection setup, then steps aside once both peers are connected. When a direct path cannot be established, an optional TURN relay bridges the connection with encrypted data that is never stored.
 
-For a plain-language overview, visit [floe.one/how-it-works](https://floe.one/how-it-works). For the full technical reference covering signaling, ICE and NAT traversal, encryption, and relay fallback, see the [documentation](https://docs.floe.one/how-it-works/signaling).
+For a plain-language overview, visit [floe.one/how-it-works](https://floe.one/how-it-works). For the full technical reference covering signaling, ICE and NAT traversal, encryption, and relay fallback, see the [documentation](https://www.floe.one/docs/how-it-works/signaling).
 
 ## CLI
 
@@ -67,7 +67,7 @@ curl -fsSL https://floe.one/install.sh | sh
 # Windows PowerShell: irm https://floe.one/install.ps1 | iex
 ```
 
-No runtime or dependencies required. For Go devs: `go install github.com/jannskiee/floe/cli/cmd/floe@latest`. For all install options, checksum verification, and PATH setup, see the [installation guide](https://docs.floe.one/cli/installation).
+No runtime or dependencies required. For Go devs: `go install github.com/jannskiee/floe/cli/cmd/floe@latest`. For all install options, checksum verification, and PATH setup, see the [installation guide](https://www.floe.one/docs/cli/installation).
 
 ### Update
 
@@ -106,7 +106,7 @@ FLOE_NO_STATS=1 floe receive ...              # permanent (add to shell profile)
 
 The global total is visible only in the browser. The CLI contributes to it but never displays it.
 
-For all commands, flags, and advanced usage, see the [documentation](https://docs.floe.one).
+For all commands, flags, and advanced usage, see the [documentation](https://www.floe.one/docs).
 
 ## Self-Hosting
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -4,7 +4,7 @@ Run your own Floe instance (the web client and the signaling server) on your own
 infrastructure, independent of `floe.one`. File data still flows peer-to-peer; the
 server you run only brokers the WebRTC handshake.
 
-Full documentation is at **[docs.floe.one/self-hosting](https://docs.floe.one/self-hosting)**,
+Full documentation is at **[floe.one/docs/self-hosting](https://www.floe.one/docs/self-hosting)**,
 including production deployment, reverse-proxy and TLS setup, and the complete
 configuration reference.
 

--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -45,7 +45,7 @@ var rootCmd = &cobra.Command{
 	Long: `Floe transfers files directly between devices using WebRTC.
 Files are encrypted end-to-end. Nothing is stored on any server.
 
-Documentation: https://docs.floe.one`,
+Documentation: https://www.floe.one/docs`,
 	// Runtime failures (network, blocked transfers, spent codes) are not usage
 	// mistakes: print the error alone instead of dumping the flag reference.
 	SilenceUsage: true,
@@ -329,7 +329,7 @@ var versionCmd = &cobra.Command{
 	Short: "Print the floe version",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("floe %s\n", version)
-		fmt.Println("Docs: https://docs.floe.one")
+		fmt.Println("Docs: https://www.floe.one/docs")
 		if latest := selfupdate.CheckAvailable(version); latest != "" {
 			fmt.Printf("Update available: %s  run `floe update` to upgrade\n", latest)
 		}

--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -101,7 +101,7 @@ export default function HowItWorks() {
                         and the binary transfer protocol in depth.
                     </p>
                     <a
-                        href="https://docs.floe.one/how-it-works/signaling"
+                        href="https://www.floe.one/docs/how-it-works/signaling"
                         target="_blank"
                         rel="noreferrer"
                         className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-bold text-black transition hover:bg-zinc-200"
@@ -111,11 +111,11 @@ export default function HowItWorks() {
                     </a>
                     <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
                         {[
-                            { label: 'Signaling', href: 'https://docs.floe.one/how-it-works/signaling' },
-                            { label: 'Direct Connection', href: 'https://docs.floe.one/how-it-works/direct-connection' },
-                            { label: 'Relay Connection', href: 'https://docs.floe.one/how-it-works/relay-connection' },
-                            { label: '2 GB Limit', href: 'https://docs.floe.one/how-it-works/2gb-limit' },
-                            { label: 'Encryption', href: 'https://docs.floe.one/how-it-works/encryption' },
+                            { label: 'Signaling', href: 'https://www.floe.one/docs/how-it-works/signaling' },
+                            { label: 'Direct Connection', href: 'https://www.floe.one/docs/how-it-works/direct-connection' },
+                            { label: 'Relay Connection', href: 'https://www.floe.one/docs/how-it-works/relay-connection' },
+                            { label: '2 GB Limit', href: 'https://www.floe.one/docs/how-it-works/2gb-limit' },
+                            { label: 'Encryption', href: 'https://www.floe.one/docs/how-it-works/encryption' },
                         ].map(({ label, href }) => (
                             <a
                                 key={label}
@@ -132,7 +132,7 @@ export default function HowItWorks() {
 
                 {/* Footer nav */}
                 <div className="pt-4 border-t border-white/5 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[10px] text-zinc-500 uppercase tracking-wide">
-                    <a href="https://docs.floe.one" target="_blank" rel="noreferrer" className="whitespace-nowrap hover:text-white transition-colors">Docs</a>
+                    <a href="https://www.floe.one/docs" target="_blank" rel="noreferrer" className="whitespace-nowrap hover:text-white transition-colors">Docs</a>
                     <span>•</span>
                     <Link href="/privacy" className="whitespace-nowrap hover:text-white transition-colors">Privacy Policy</Link>
                     <span>•</span>

--- a/client/components/landing/CapabilitiesSection.tsx
+++ b/client/components/landing/CapabilitiesSection.tsx
@@ -41,7 +41,7 @@ const items: {
         icon: Server,
         title: 'Self-hostable',
         body: 'Run your own signaling server and relay with Docker. The docs cover production setup.',
-        href: 'https://docs.floe.one/self-hosting/overview',
+        href: 'https://www.floe.one/docs/self-hosting/overview',
     },
     {
         icon: Scale,

--- a/client/components/landing/CliSection.tsx
+++ b/client/components/landing/CliSection.tsx
@@ -98,7 +98,7 @@ export function CliSection() {
                         Also available via Scoop, a PowerShell one-liner, and{' '}
                         <code className="font-mono text-[12px]">go install</code>.{' '}
                         <a
-                            href="https://docs.floe.one/cli/installation"
+                            href="https://www.floe.one/docs/cli/installation"
                             target="_blank"
                             rel="noreferrer"
                             className="group inline-flex items-center gap-1 text-zinc-300 transition hover:text-ice"

--- a/client/components/landing/PrivacySection.tsx
+++ b/client/components/landing/PrivacySection.tsx
@@ -75,7 +75,7 @@ export function PrivacySection() {
             </div>
             <div className="mt-10">
                 <a
-                    href="https://docs.floe.one/security-privacy"
+                    href="https://www.floe.one/docs/security-privacy"
                     target="_blank"
                     rel="noreferrer"
                     className="group inline-flex items-center gap-1.5 text-sm text-zinc-300 transition hover:text-ice"

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -12,24 +12,24 @@ const columns: {
         links: [
             { name: 'How it works', href: '/how-it-works' },
             { name: 'FAQ', href: '#faq' },
-            { name: 'Docs', href: 'https://docs.floe.one', external: true },
-            { name: 'Changelog', href: 'https://docs.floe.one/changelog', external: true },
+            { name: 'Docs', href: 'https://www.floe.one/docs', external: true },
+            { name: 'Changelog', href: 'https://www.floe.one/docs/changelog', external: true },
         ],
     },
     {
         label: 'CLI',
         links: [
-            { name: 'Installation', href: 'https://docs.floe.one/cli/installation', external: true },
-            { name: 'Commands & flags', href: 'https://docs.floe.one/cli/flags', external: true },
-            { name: 'Self-hosted server', href: 'https://docs.floe.one/cli/self-hosted-server', external: true },
+            { name: 'Installation', href: 'https://www.floe.one/docs/cli/installation', external: true },
+            { name: 'Commands & flags', href: 'https://www.floe.one/docs/cli/flags', external: true },
+            { name: 'Self-hosted server', href: 'https://www.floe.one/docs/cli/self-hosted-server', external: true },
         ],
     },
     {
         label: 'Project',
         links: [
             { name: 'GitHub', href: 'https://github.com/jannskiee/floe', external: true },
-            { name: 'Self-hosting', href: 'https://docs.floe.one/self-hosting/overview', external: true },
-            { name: 'Security & privacy', href: 'https://docs.floe.one/security-privacy', external: true },
+            { name: 'Self-hosting', href: 'https://www.floe.one/docs/self-hosting/overview', external: true },
+            { name: 'Security & privacy', href: 'https://www.floe.one/docs/security-privacy', external: true },
         ],
     },
 ];

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -93,7 +93,7 @@ export const Navbar = () => {
                         </button>
                     ))}
                     <a
-                        href="https://docs.floe.one"
+                        href="https://www.floe.one/docs"
                         target="_blank"
                         rel="noreferrer"
                         className="rounded-full px-2.5 max-[359px]:px-1.5 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice"

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -97,7 +97,7 @@ Expected output:
 
 ```
 floe 1.x.x
-Docs: https://docs.floe.one
+Docs: https://www.floe.one/docs
 ```
 
 ## Verify the checksum (manual download)

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -13,7 +13,7 @@ Prints the current version of the `floe` binary and a link to the documentation.
 
 ```
 floe 1.x.x
-Docs: https://docs.floe.one
+Docs: https://www.floe.one/docs
 ```
 
 ## Alternatives


### PR DESCRIPTION
## Summary

The documentation moved from the `docs.floe.one` subdomain to the `floe.one/docs` subpath (see #195 / #196). This updates every in-repo reference to the new URL:
- Web app footer, navbar, and landing-section links (`client/`)
- The CLI's printed Documentation URL (`cli/cmd/floe/main.go`)
- `README.md`, `SELF_HOSTING.md`, and the docs CLI example output (`docs/cli/{installation,version}.mdx`)
- `CLAUDE.md` (reworded the docs deploy-target line)

Old `docs.floe.one/*` links keep working via the 301 redirect, so this is cosmetic cleanup that just removes the extra redirect hop.

Intentionally left unchanged: the `next.config.mjs` redirect rule keeps `docs.floe.one` as its host matcher, and the `docs/changelog.mdx` historical entry stays as-is (hand-written).

## Test plan

- `Build & Lint` validates the client changes.
- `www.floe.one/docs/*` verified serving 200 and `docs.floe.one/*` verified 301-redirecting to it (migration is live).
