### PR TITLE
fix(client): drop browser-extension errors via Sentry denyUrls

### DIFF
--- a/client/lib/browserExtensions.pipeline.test.ts
+++ b/client/lib/browserExtensions.pipeline.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { eventFiltersIntegration, rewriteFramesIntegration } from '@sentry/nextjs';
+import type { ErrorEvent, Event, EventHint, Exception, StackFrame } from '@sentry/nextjs';
+import { BROWSER_EXTENSION_URL_PATTERNS } from './browserExtensions';
+
+// Proves the FLOE-E fix against the REAL @sentry/core filter rather than a
+// reimplementation of it. sentry.client.config.ts cannot be imported here: it
+// calls Sentry.replayIntegration() at module scope, and in a node test
+// '@sentry/nextjs' resolves to build/cjs/index.server.js where that export does
+// not exist. So we drive the same integration the SDK installs, with the same
+// denyUrls value the config passes it.
+
+// --- Types -----------------------------------------------------------------
+// '@sentry/nextjs' re-exports Event/EventHint/ErrorEvent/Exception/StackFrame
+// but NOT Client or Integration. Derive what we need from the factory's own
+// signature so it tracks any SDK change instead of drifting from it.
+type ProcessEventFn = NonNullable<ReturnType<typeof eventFiltersIntegration>['processEvent']>;
+type ProcessEventResult = ReturnType<ProcessEventFn>;
+type SentryClientArg = Parameters<ProcessEventFn>[2];
+
+// EventFilters only ever calls client.getOptions() (see _mergeOptions in
+// @sentry/core/integrations/eventFilters.js), and RewriteFrames ignores the
+// argument entirely, so a one-method stub is faithful. The double cast is
+// required rather than lazy: a single `as` is rejected with TS2352 because the
+// stub and Client do not sufficiently overlap. Keeping the annotation on the
+// stub means the object itself is still typechecked.
+type ClientStub = { getOptions: () => Record<string, unknown> };
+const CLIENT_STUB: ClientStub = { getOptions: () => ({}) };
+const CLIENT = CLIENT_STUB as unknown as SentryClientArg;
+
+// EventFilters names this parameter `_hint` and never reads it.
+const EMPTY_HINT: EventHint = {};
+
+// processEvent is optional on the Integration interface and may declare a
+// thenable return. Both integrations here are synchronous, so narrow once and
+// fail loudly - otherwise a vanished hook would return undefined, which a
+// `.not.toBeNull()` assertion would happily accept.
+function assertSync(result: ProcessEventResult | undefined): Event | null {
+    if (result === undefined) throw new Error('integration exposed no processEvent hook');
+    if (result !== null && 'then' in result) throw new Error('expected a synchronous integration');
+    return result;
+}
+
+// --- Fixtures --------------------------------------------------------------
+
+const METAMASK_INPAGE_URL = 'chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js';
+const FLOE_CHUNK_URL = 'https://www.floe.one/_next/static/chunks/page-abc.js';
+
+// Events are built by factories, never shared. rewriteFramesIntegration returns
+// a new event but reuses the SAME frame objects, and its iteratee assigns to
+// frame.filename in place, so a module-level fixture would be mutated by one
+// test and silently change the meaning of the next.
+function metaMaskFrames(): StackFrame[] {
+    return [{ filename: METAMASK_INPAGE_URL, function: 'Object.connect', in_app: true, lineno: 7, colno: 84179 }];
+}
+
+// FLOE-E as Sentry received it: an unhandled rejection raised inside MetaMask's
+// injected script, with a chained "MetaMask extension not found" cause linked
+// to it by LinkedErrors.
+//
+// The shape is load-bearing. _getEventFilterUrl reverse-scans exception.values
+// for the first value with no mechanism.parent_id AND a non-empty frame list;
+// _getLastValidUrl then walks THAT value's frames backward, skipping
+// <anonymous> and [native code]. values[0] carries parent_id so it is skipped;
+// values[1] is what decides the filtered URL.
+function makeFloeEEvent(frames: StackFrame[] = metaMaskFrames()): ErrorEvent {
+    const values: Exception[] = [
+        {
+            type: 'Error',
+            value: 'MetaMask extension not found',
+            mechanism: { type: 'chained', handled: false, source: 'cause', exception_id: 1, parent_id: 0 },
+        },
+        {
+            type: 'i',
+            value: 'Failed to connect to MetaMask',
+            mechanism: { type: 'onunhandledrejection', handled: false, exception_id: 0 },
+            stacktrace: { frames },
+        },
+    ];
+    return { type: undefined, level: 'error', platform: 'javascript', exception: { values } };
+}
+
+// A real Floe bug: the regression guard.
+function makeFloeApplicationEvent(): ErrorEvent {
+    const values: Exception[] = [
+        {
+            type: 'TypeError',
+            value: "Cannot read properties of undefined (reading 'send')",
+            mechanism: { type: 'onunhandledrejection', handled: false },
+            stacktrace: {
+                frames: [
+                    { filename: FLOE_CHUNK_URL, function: 'sendFiles', in_app: true, lineno: 1, colno: 5312 },
+                    { filename: FLOE_CHUNK_URL, function: 'onDataChannelOpen', in_app: true, lineno: 1, colno: 4210 },
+                ],
+            },
+        },
+    ];
+    return { type: undefined, level: 'error', platform: 'javascript', exception: { values } };
+}
+
+// --- Drivers ---------------------------------------------------------------
+
+// A FRESH integration instance per call, on purpose: EventFilters memoizes its
+// merged options on first use, so one shared instance would make the
+// "no denyUrls" case reuse the "with denyUrls" options and pass for free.
+function runEventFilters(event: Event, denyUrls?: RegExp[]): Event | null {
+    const integration = eventFiltersIntegration(denyUrls ? { denyUrls } : {});
+    return assertSync(integration.processEvent?.(event, EMPTY_HINT, CLIENT));
+}
+
+// Replica of NextjsClientStackFrameNormalization.
+//
+// This is NOT the real integration: nextjsClientStackFrameNormalizationIntegration
+// is exported from no @sentry/nextjs build entry, and the package `exports` map
+// blocks deep imports. What it actually is, though, is rewriteFramesIntegration
+// wrapped around one custom iteratee, so we use the REAL rewriteFramesIntegration
+// and hand-copy that iteratee from
+// node_modules/@sentry/nextjs/build/cjs/client/clientNormalizationIntegration.js.
+// We copy the non-experimental branch because that is the one that runs here:
+// experimentalThirdPartyOriginStackFrames is off and next.config.mjs sets neither
+// assetPrefix nor basePath, so rewriteFramesAssetPrefixPath is ''.
+//
+// Being a replica, this documents the ordering assumption; it cannot detect a
+// future SDK change to the iteratee itself.
+const ASSET_PREFIX_PATH = '';
+
+// The one deliberate deviation from the SDK source, and the reason a verbatim
+// copy would prove nothing. The SDK calls `new URL(frame.filename).origin`.
+// Chromium registers chrome-extension: and friends as STANDARD schemes and
+// returns "chrome-extension://<id>", but Node's WHATWG URL treats them as
+// non-special and returns the opaque origin - the literal string "null" -
+// against which the SDK's .replace(origin, ...) is a silent no-op. Reproduce
+// the browser's answer so this file tests production behaviour.
+function browserOrigin(filename: string): string {
+    const nodeOrigin = new URL(filename).origin;
+    if (nodeOrigin !== 'null') return nodeOrigin;
+    const match = /^([a-z][a-z0-9+.-]*:\/\/[^/?#]+)/i.exec(filename);
+    if (!match) throw new TypeError(`no origin for ${filename}`);
+    return match[1];
+}
+
+function runNormalization(event: Event): Event {
+    const integration = rewriteFramesIntegration({
+        iteratee: (frame: StackFrame): StackFrame => {
+            try {
+                const origin = browserOrigin(frame.filename ?? '');
+                frame.filename = frame.filename?.replace(origin, 'app://').replace(ASSET_PREFIX_PATH, '');
+            } catch {
+                // Filename was not a URL, so there is nothing to rewrite.
+            }
+            return frame;
+        },
+    });
+    const processed = assertSync(integration.processEvent?.(event, EMPTY_HINT, CLIENT));
+    if (processed === null) throw new Error('RewriteFrames never drops events');
+    return processed;
+}
+
+describe('browser-extension denyUrls in the Sentry event pipeline', () => {
+    it('drops the MetaMask unhandled rejection (FLOE-E)', () => {
+        expect(runEventFilters(makeFloeEEvent(), BROWSER_EXTENSION_URL_PATTERNS)).toBeNull();
+    });
+
+    it('keeps the same event when denyUrls is absent (guards a false pass)', () => {
+        // Without this, the test above could pass for a reason unrelated to the
+        // fix: a DEFAULT_IGNORE_ERRORS entry matching the message, or
+        // _isUselessError discarding it. It must be denyUrls that drops FLOE-E.
+        expect(runEventFilters(makeFloeEEvent())).not.toBeNull();
+    });
+
+    it('keeps a genuine Floe application error (reporting must not regress)', () => {
+        expect(runEventFilters(makeFloeApplicationEvent(), BROWSER_EXTENSION_URL_PATTERNS)).not.toBeNull();
+    });
+
+    it('drops when the extension frame sits behind one of ours', () => {
+        // The real-world shape. Sentry orders frames oldest-first, so the
+        // injected script is last even though our bundle is on the stack, and
+        // _getLastValidUrl steps back over a trailing <anonymous> frame to
+        // find it. Observed live: the browser produced exactly
+        // [<app chunk>, chrome-extension://...inpage.js] for this rejection.
+        const frames: StackFrame[] = [
+            { filename: FLOE_CHUNK_URL, function: 'sendFiles', in_app: true },
+            { filename: METAMASK_INPAGE_URL, function: 'Object.connect', in_app: true },
+            { filename: '<anonymous>', function: 'new Promise', in_app: false },
+        ];
+        expect(runEventFilters(makeFloeEEvent(frames), BROWSER_EXTENSION_URL_PATTERNS)).toBeNull();
+    });
+});
+
+describe('EventFilters must run before NextjsClientStackFrameNormalization', () => {
+    it('rewrites the MetaMask frame to app:///scripts/inpage.js', () => {
+        // Pins the replica to the value the real integration produces in a
+        // browser. Observed live on a production build: the same event carried
+        // chrome-extension://...inpage.js at preprocessEvent time and
+        // app:///scripts/inpage.js by the time it reached the transport.
+        const normalized = runNormalization(makeFloeEEvent());
+        expect(normalized.exception?.values?.[1]?.stacktrace?.frames?.[0]?.filename).toBe(
+            'app:///scripts/inpage.js'
+        );
+    });
+
+    it('would report FLOE-E if normalization ran first', () => {
+        // The executable statement of the assumption this fix rests on. Once
+        // the filename is app:///scripts/inpage.js it is indistinguishable from
+        // our own code and no denyUrls entry can - or should - match it.
+        // @sentry/browser lists the filter FIRST in getDefaultIntegrations()
+        // and @sentry/nextjs pushes the normalization LAST, and processEvent
+        // hooks run in registration order, so in production the filter wins.
+        // If that ever changes, this test still passes and FLOE-E simply
+        // reappears in Sentry; treat it as documentation, not a canary.
+        const reported = runEventFilters(runNormalization(makeFloeEEvent()), BROWSER_EXTENSION_URL_PATTERNS);
+        expect(reported).not.toBeNull();
+    });
+});

--- a/client/lib/browserExtensions.test.ts
+++ b/client/lib/browserExtensions.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { BROWSER_EXTENSION_URL_PATTERNS } from './browserExtensions';
+
+// Sentry applies `denyUrls` by testing every pattern against ONE frame filename
+// (`_isDeniedUrl` -> `stringMatchesSomePattern` in @sentry/core), so the unit
+// under test is "does any pattern match this string", not any single regex.
+const isExtensionUrl = (url: string): boolean =>
+    BROWSER_EXTENSION_URL_PATTERNS.some((pattern) => pattern.test(url));
+
+// The exact filename from FLOE-E. `nkbihfbeogaeaoehlefnkodbefgpgknn` is
+// MetaMask's extension id and `scripts/inpage.js` is the script it injects into
+// every page, including pages that never touch a wallet.
+const METAMASK_INPAGE_URL = 'chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js';
+
+describe('BROWSER_EXTENSION_URL_PATTERNS', () => {
+    it("matches MetaMask's injected content script (FLOE-E)", () => {
+        expect(isExtensionUrl(METAMASK_INPAGE_URL)).toBe(true);
+    });
+
+    it('matches Chromium extension and internal-page schemes', () => {
+        expect(isExtensionUrl('chrome-extension://gighmmpiobklfepjocnamgkkbiglidom/adblock.js')).toBe(true);
+        expect(isExtensionUrl('chrome://newtab/')).toBe(true);
+    });
+
+    it('matches Firefox moz-extension frames', () => {
+        expect(isExtensionUrl('moz-extension://d0a2b1c3-4e5f-6789-abcd-ef0123456789/content.js')).toBe(true);
+    });
+
+    it('matches both Safari forms the SDK re-prefixes frames with', () => {
+        // extractSafariExtensionDetails in @sentry/browser's stack parser
+        // prepends the scheme onto whatever path its regex captured, so the
+        // "//authority" part is not guaranteed to be present. That is why this
+        // pattern anchors on the colon rather than on "://".
+        expect(isExtensionUrl('safari-web-extension://ABC12345-1234-1234-1234-1234567890AB/content.js')).toBe(true);
+        expect(isExtensionUrl('safari-extension://com.apple.Safari.Extension-ABC123/js/inject.js')).toBe(true);
+        expect(isExtensionUrl('safari-extension:/js/inject.js')).toBe(true);
+    });
+
+    it('matches regardless of scheme casing', () => {
+        expect(isExtensionUrl('Chrome-Extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js')).toBe(true);
+        expect(isExtensionUrl('MOZ-EXTENSION://d0a2b1c3/content.js')).toBe(true);
+    });
+
+    it('never matches Floe production or Vercel preview bundles', () => {
+        expect(isExtensionUrl('https://www.floe.one/_next/static/chunks/page-abc.js')).toBe(false);
+        expect(isExtensionUrl('https://floe.one/_next/static/chunks/main-app-9f2c1b8e.js')).toBe(false);
+        expect(
+            isExtensionUrl('https://p2p-file-share-git-fix-abc123-floe.vercel.app/_next/static/chunks/layout.js')
+        ).toBe(false);
+        expect(isExtensionUrl('http://localhost:3000/_next/static/chunks/page.js')).toBe(false);
+    });
+
+    it('never matches normalized app:/// frames', () => {
+        // app:/// is what NextjsClientStackFrameNormalization rewrites our OWN
+        // frames to. If any pattern matched that prefix we would silently stop
+        // reporting every production error. `app:///scripts/inpage.js` is here
+        // on purpose: it is what the MetaMask frame becomes AFTER the rewrite,
+        // and it must not match - which is exactly why the filter has to run
+        // before the rewrite. See browserExtensions.pipeline.test.ts.
+        expect(isExtensionUrl('app:///_next/static/chunks/page-9f2c1b8e4d.js')).toBe(false);
+        expect(isExtensionUrl('app:///scripts/inpage.js')).toBe(false);
+    });
+
+    it('never matches blob: or data: frames', () => {
+        // fflate's `zip` (hooks/useDownloadManager.ts) boots a worker from a
+        // blob: URL, so genuine in-app errors really can carry blob frames.
+        expect(isExtensionUrl('blob:https://www.floe.one/2f8a5f6c-1b7d-4a3e-9c2f-8d1e5a6b7c90')).toBe(false);
+        expect(isExtensionUrl('data:text/javascript;base64,Y29uc29sZS5sb2coMSk=')).toBe(false);
+    });
+
+    it('never matches an extension scheme appearing later in the URL', () => {
+        // Proves the ^ anchor. /docs is reverse-proxied to Mintlify
+        // (next.config.mjs), so arbitrary paths do reach frame filenames.
+        expect(isExtensionUrl('https://www.floe.one/docs/chrome-extension://guide')).toBe(false);
+        expect(isExtensionUrl('https://www.floe.one/blog/moz-extension://x')).toBe(false);
+    });
+
+    it('carries no stateful regex flags (Sentry reuses these instances)', () => {
+        for (const pattern of BROWSER_EXTENSION_URL_PATTERNS) {
+            expect(pattern.global).toBe(false);
+            expect(pattern.sticky).toBe(false);
+        }
+        // Same instances, tested twice, must agree.
+        expect(isExtensionUrl(METAMASK_INPAGE_URL)).toBe(true);
+        expect(isExtensionUrl(METAMASK_INPAGE_URL)).toBe(true);
+    });
+});

--- a/client/lib/browserExtensions.ts
+++ b/client/lib/browserExtensions.ts
@@ -1,0 +1,49 @@
+/**
+ * Browser-extension stack frames.
+ *
+ * Extensions inject content scripts into every page they run on, so an
+ * unhandled rejection thrown inside one is captured by Sentry's global
+ * handlers and reported as if it came from Floe. MetaMask does exactly this
+ * (FLOE-E) on a site with no web3 code at all:
+ *
+ *   chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn/scripts/inpage.js
+ *
+ * The message wording is useless as a filter - every extension words its
+ * failures differently, and Sentry's `ignoreErrors` only ever tests the LAST
+ * exception value anyway. The frame's URL scheme is the one reliable signal
+ * that the code is not ours, so that is what we match on.
+ *
+ * These patterns feed `denyUrls`, which the EventFilters integration evaluates
+ * FIRST in the event pipeline. That ordering is the whole point, and it is why
+ * this check cannot live in `beforeSend`: @sentry/nextjs's
+ * NextjsClientStackFrameNormalization integration runs later and rewrites every
+ * frame's origin to "app://", so by the time `beforeSend` sees the event the
+ * scheme is gone and the extension frame reads `app:///scripts/inpage.js` -
+ * indistinguishable from our own code. Verified in a real browser: the same
+ * event carries the chrome-extension:// filename before the processors run and
+ * app:/// by the time it reaches the transport. See
+ * browserExtensions.pipeline.test.ts.
+ *
+ * That same rewrite is why Sentry's server-side "browser extensions" inbound
+ * filter cannot help here: Relay matches stack-frame abs_path against
+ * `^chrome(-extension)?://` and the SDK has already erased it client-side.
+ *
+ * The list mirrors Relay's own EXTENSION_EXC_SOURCES minus `webkit-masked-url`,
+ * which Safari also uses for blob and eval'd first-party scripts and so is not
+ * an unambiguous signal.
+ *
+ * Deliberately no `g` or `y` flags: Sentry calls `.test()` on these same
+ * instances for every event, and a sticky flag would advance `lastIndex` and
+ * make the filter fire on only every other event.
+ */
+export const BROWSER_EXTENSION_URL_PATTERNS: RegExp[] = [
+    // Chrome, Edge, Brave, Opera. The optional group also denies bare
+    // chrome:// internal pages, which are equally unfixable from app code.
+    /^chrome(-extension)?:\/\//i,
+    // Firefox
+    /^moz-extension:\/\//i,
+    // Safari. Deliberately no "//": extractSafariExtensionDetails in
+    // @sentry/browser's stack parser string-prepends `safari-extension:` onto
+    // whatever path its regex captured, so an authority is not guaranteed.
+    /^safari(-web)?-extension:/i,
+];

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
+import { BROWSER_EXTENSION_URL_PATTERNS } from './lib/browserExtensions';
 import { isStaleBundleError } from './lib/staleBundle';
 import { scrubUrl } from './lib/scrubUrl';
 
@@ -27,6 +28,15 @@ Sentry.init({
         // Safari/iOS ResizeObserver noise
         'ResizeObserver loop',
     ],
+
+    // Drop errors thrown by browser extensions' injected content scripts: not
+    // Floe code, never actionable. Matched on the frame's URL scheme rather
+    // than its message, so this covers every extension without needing a
+    // per-wording entry above. It has to be denyUrls and not beforeSend:
+    // EventFilters runs first, before @sentry/nextjs rewrites every frame
+    // origin to "app://" (see lib/browserExtensions.ts). Fixes FLOE-E,
+    // MetaMask's inpage.js rejecting with "Failed to connect to MetaMask".
+    denyUrls: BROWSER_EXTENSION_URL_PATTERNS,
 
     // Sample 10% of transactions. Tracing every page load (1.0) flooded the
     // performance detectors with low-signal "Degraded HTTP Operation" issues on


### PR DESCRIPTION
## Summary

Sentry issue **FLOE-E** ("i: Failed to connect to MetaMask") contains no Floe code. MetaMask's injected content script (`chrome-extension://nkbihf.../scripts/inpage.js`) rejects a promise on the homepage and Sentry's global handlers capture it as ours. Floe has no web3 code.

The instance is trivial (2 events, 0 users impacted). The reason it is worth fixing in code is what the investigation turned up underneath it:

`@sentry/nextjs`'s `NextjsClientStackFrameNormalization` integration rewrites every frame unconditionally (`new URL(frame.filename).origin` then `.replace(origin, "app://")`). Chromium treats `chrome-extension` as a standard scheme, so the frame becomes `app:///scripts/inpage.js`. Combined with the browser stack parser hardcoding `in_app: true`, **every third-party frame gets laundered into something indistinguishable from first-party code**. The event arrives with `in_app_frame_mix: "in-app-only"` and a failed source scrape of a URL that cannot exist.

That also disarms Sentry's own server-side browser-extension inbound filter, which matches frame `abs_path` against `^chrome(-extension)?://` and never sees the real scheme. Enabling it would not catch this.

`denyUrls` is the one layer that still sees the truth: `EventFilters` is default integration #1, the normalization is #13, and `processEvent` hooks run in registration order. `beforeSend` runs last, so a frame check there could never work. The new module documents this so it does not get "simplified" later.

## Changes

- `client/lib/browserExtensions.ts` (new): `BROWSER_EXTENSION_URL_PATTERNS`, three scheme-anchored regexes, mirroring Relay's `EXTENSION_EXC_SOURCES` minus the ambiguous `webkit-masked-url`.
- `client/sentry.client.config.ts`: `denyUrls: BROWSER_EXTENSION_URL_PATTERNS`.
- Two test files covering the patterns and the real `eventFiltersIntegration`.

Scheme-based rather than message-based, so it needs no per-extension upkeep. It fails open: when no URL can be extracted from the event, nothing is dropped.

## Test plan

**Static.** `pnpm lint` clean, `pnpm build` clean (this is what typechecks the test files), `pnpm test` 13 files / 108 cases (was 11 / 92). The pipeline test drives the real `eventFiltersIntegration` against a faithful FLOE-E fixture and asserts it is *not* dropped when `denyUrls` is absent, so it cannot pass for the wrong reason.

**Live browser simulation.** Production build (Turbopack, as Vercel runs it) served locally against a sink DSN pointing at a local 404 route, so nothing reached Sentry. A fake extension rejection was injected via a `//# sourceURL=chrome-extension://...` directive inside a `setTimeout` callback, so it escapes to `window.onunhandledrejection` with the extension frame innermost. Verified first that the page's own bundled stack parser resolves that frame to the real `chrome-extension://` filename.

| Run | Build | Injection | Envelope POST | Result |
|---|---|---|---|---|
| A | before | extension | yes | negative control, harness works |
| B | before | genuine app frame | yes | |
| C | after | extension | **none** (3 separate nonces) | |
| D | after | genuine app frame | yes | reporting not broken |

C and D use identical message wording, shape, timing and page session, and differ only in the injected `sourceURL`, so `denyUrls` is the only variable that can explain the divergence. In run C the pre-filter hook confirms the event was built and carried `chrome-extension://.../inpage.js` at filter time, so it was not dropped for some unrelated upstream reason.

The simulation also captured the laundering in flight: the same run-A event reads `chrome-extension://nkbihf.../scripts/inpage.js` at `preprocessEvent` and `app:///scripts/inpage.js` by the time it reaches the transport.

## Follow-ups (not in this PR)

- `next.config.mjs` has `reactComponentAnnotation` under the `webpack:` key, which is inert because production builds with Turbopack. Sentry issues are getting no React component names.
- `_experimental.thirdPartyOriginStackFrames` would fix the laundering at source and re-arm Relay's filter, at the cost of regrouping existing issues. Deserves its own PR.
- FLOE-9 (Hydration Error on `/how-it-works`, 53 events) is the actually-actionable issue in the project.
