### PR TITLE
fix(client): enable Sentry component annotation on Turbopack builds

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -52,21 +52,31 @@ export default withSentryConfig(nextConfig, {
     // Suppress non-error logs during build
     silent: !process.env.CI,
 
-    // Annotate React components with their names for clearer error reports
-    webpack: {
-        reactComponentAnnotation: {
+    // Annotate React components with their names, so Sentry breadcrumbs, UI
+    // click spans and Session Replay show component names instead of raw DOM
+    // nodes. The Babel transform writes data-sentry-component /
+    // data-sentry-element / data-sentry-source-file attributes into the JSX, so
+    // it still pays off with `sourcemaps.disable` set below: it annotates the
+    // DOM rather than symbolicating stack traces.
+    //
+    // This MUST be the _experimental key. Production builds use Turbopack (Next
+    // 16 defaults to it, and Next sets TURBOPACK=auto before this config is even
+    // loaded), and the `webpack.reactComponentAnnotation` equivalent is inert
+    // there: the webpack config is never constructed, and getBuildPluginOptions
+    // separately forces the option to undefined. It was configured under
+    // `webpack` here until 2026-07 and silently annotated nothing.
+    //
+    // Turbopack has no equivalent for `webpack.treeshake.removeDebugLogging`,
+    // so Sentry's debug logging stays in the production bundle. That was already
+    // true; the old comment claiming otherwise was wrong.
+    //
+    // _experimental options may be renamed without notice, so re-check on any
+    // @sentry/nextjs upgrade. Requires Next 16+.
+    _experimental: {
+        turbopackReactComponentAnnotation: {
             enabled: true,
         },
-        // Strip Sentry debug logging from the production bundle. Replaces the
-        // deprecated top-level `disableLogger`. This is webpack-only; Turbopack
-        // builds ignore it, which is fine as debug logging is already disabled.
-        treeshake: {
-            removeDebugLogging: true,
-        },
     },
-
-    // Hide Sentry source maps from the browser bundle
-    hideSourceMaps: true,
 
     // Source map uploads require SENTRY_AUTH_TOKEN env var.
     // Add it to Vercel project settings to enable detailed stack traces.


### PR DESCRIPTION
## Summary

Three options in the `withSentryConfig` block were doing nothing. Found while investigating FLOE-E (#202).

Production builds use **Turbopack**: Next 16 defaults to it and sets `TURBOPACK=auto` before `next.config.mjs` is even loaded, which is exactly what Sentry's `detectActiveBundler` reads. Under that path:

| Option | Status | Why |
|---|---|---|
| `webpack.reactComponentAnnotation` | inert | Severed twice over: the webpack config is never constructed, and `getBuildPluginOptions` separately forces the option to `undefined` |
| `webpack.treeshake.removeDebugLogging` | inert, no Turbopack equivalent | Only read inside that same never-built webpack config |
| `hideSourceMaps` | does not exist in @sentry/nextjs 10.66.0 | Absent from `SentryBuildOptions`; nothing reads it |

None of the three warn at build time, which is why this went unnoticed. The comment claiming debug logging was "already disabled" was wrong: it ships in the production bundle and always did. (Confirmed empirically during the #202 work, where the Sentry debug logger was enabled at runtime on a production build and emitted, which it could not do had `__SENTRY_DEBUG__` been tree-shaken.)

## Change

Switch annotation to `_experimental.turbopackReactComponentAnnotation`, the key the Turbopack loader actually reads, and drop the two dead options rather than leave config that lies about what the build does.

Annotation does **not** need source maps. It is a Babel transform that writes `data-sentry-component` / `data-sentry-element` / `data-sentry-source-file` attributes into the JSX, read from the DOM at runtime, so it keeps delivering value with `sourcemaps.disable` set.

## Test plan

**Annotation actually lands.** Prerendered HTML, before to after:

| Page | `data-sentry-component` before | after |
|---|---|---|
| `/` | 0 | 38 |
| `/privacy` | 0 | 32 |
| `/terms` | 0 | 16 |
| `/how-it-works` | 0 | 3 |
| `/_not-found` | 0 | 2 |

This is the check that matters, because the loader swallows transform failures and `silent: !CI` can hide the log. A silent no-op would show as zeros.

**Live browser, production build.** 22 component names resolve from the DOM (`RootLayout`, `Home`, `Navbar`, `P2PTransfer`, `GlobalStats`, `FAQItem`, `Footer`, …) across 16 source files. A clicked element resolves to its owning component (`Navbar`), which is precisely what Sentry uses to name breadcrumbs and UI-click spans.

**Cost, measured on clean builds** (`.next` deleted, warm-up build discarded):

| Metric | Before | After | Delta |
|---|---|---|---|
| Build time | 17.7s | 18.2s | +0.5s (+2.8%) |
| Prerendered HTML, raw | 193,657 B | 204,974 B | +11,317 B (+5.8%) |
| Prerendered HTML, gzipped | 40,063 B | 41,294 B | **+1,231 B (+3.1%)** |

The loader calls `this.cacheable(false)`, so every `.tsx`/`.jsx` gets an uncached Babel pass on each build. At this codebase's size that costs half a second. The raw HTML delta overstates the wire cost, since the added attributes are highly repetitive and compress well; the gzipped number is the one that ships.

**Static.** eslint clean, 13 test files / 108 cases green, `next build` clean.

## Caveat

`_experimental` options may be renamed without notice, and the neighbouring `turbopackApplicationKey` has already been deprecated in favour of a top-level key, so this one will likely be promoted too. Flagged in a code comment to re-check on any `@sentry/nextjs` upgrade.
