### PR TITLE
ci: publish the self-hosting images to ghcr.io

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,24 @@ updates:
         patterns:
           - "*"
 
+  # The two Dockerfile base images. Unmanaged until now because the images were
+  # only ever built locally by self-hosters; once they are published to ghcr.io
+  # they are an artifact this repo ships, so a stale base image becomes our CVE
+  # surface rather than the builder's.
+  - package-ecosystem: "docker"
+    directories:
+      - "/client"
+      - "/server"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      docker-deps:
+        patterns:
+          - "*"
+
   # Weekly rather than monthly: this entry is what keeps the commit-SHA pins
   # in .github/workflows/ fresh (Dependabot bumps the pinned SHA and
   # maintains the trailing # vX.Y.Z comment), and grouped actions PRs are

--- a/.github/scripts/smoke-image.sh
+++ b/.github/scripts/smoke-image.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Smoke-tests a built Floe image before any user-facing tag points at it.
+#
+# Lives in a script rather than inline YAML so the identical checks can be run
+# locally against a local build before anything is pushed:
+#
+#   docker build -t floe-client:smoke ./client
+#   .github/scripts/smoke-image.sh floe-client floe-client:smoke
+#
+# Usage: smoke-image.sh <floe-server|floe-client> <image-ref>
+set -euo pipefail
+
+NAME="${1:?usage: smoke-image.sh <floe-server|floe-client> <image-ref>}"
+REF="${2:?usage: smoke-image.sh <floe-server|floe-client> <image-ref>}"
+
+CONTAINERS=()
+cleanup() {
+    for c in "${CONTAINERS[@]:-}"; do
+        [ -n "$c" ] || continue
+        echo "--- logs: $c ---" >&2
+        docker logs --tail 50 "$c" >&2 2>&1 || true
+        docker rm -f "$c" >/dev/null 2>&1 || true
+    done
+}
+trap cleanup EXIT
+
+run() {
+    local cname="$1" port="$2"
+    shift 2
+    docker run -d --name "$cname" -p "${port}:${port}" "$@" "$REF" >/dev/null
+    CONTAINERS+=("$cname")
+}
+
+# Poll rather than sleep: the client's standalone server is usually up in under
+# a second, but a cold CI runner can take several.
+wait_for() {
+    local url="$1"
+    curl --fail --silent --show-error --retry 30 --retry-delay 1 \
+        --retry-all-errors --max-time 60 -o /dev/null "$url"
+}
+
+fail() {
+    echo "SMOKE FAIL: $*" >&2
+    exit 1
+}
+
+case "$NAME" in
+floe-server)
+    run smoke-server 3001
+    wait_for http://localhost:3001/health || fail "/health never came up"
+
+    body="$(curl --fail --silent http://localhost:3001/health)"
+    echo "$body" | grep -q '"status":"healthy"' \
+        || fail "/health did not report healthy: $body"
+    echo "OK  /health -> healthy"
+    ;;
+
+floe-client)
+    # The client's /api/config just echoes SOCKET_URL, so this leg needs no
+    # signaling server. Two runs with DIFFERENT values is the real proof that the
+    # address is resolved at runtime and not baked, which is the whole premise of
+    # shipping one image to everyone.
+    run smoke-client 3000 -e SOCKET_URL=http://localhost:3001
+    wait_for http://localhost:3000/ || fail "client never served /"
+    echo "OK  / -> 200"
+
+    cfg="$(curl --fail --silent http://localhost:3000/api/config)"
+    [ "$cfg" = '{"socketUrl":"http://localhost:3001"}' ] \
+        || fail "/api/config was $cfg, expected the SOCKET_URL value"
+    echo "OK  /api/config reflects SOCKET_URL"
+
+    # A broken sharp does NOT 500. Next silently falls back to serving the
+    # original PNG, so status alone proves nothing: the content type is the only
+    # signal. This is the guard for the recorded ERR_DLOPEN_FAILED failure mode
+    # under pnpm + alpine + standalone.
+    ct="$(curl --fail --silent -H 'Accept: image/webp' -o /dev/null \
+        -w '%{content_type}' \
+        'http://localhost:3000/_next/image?url=%2Fgithub-mark-white.png&w=32&q=75')"
+    [ "$ct" = "image/webp" ] \
+        || fail "/_next/image returned '$ct', expected image/webp (sharp is broken)"
+    echo "OK  /_next/image -> image/webp (sharp works)"
+
+    # Second run, different address. If the URL were baked at build time this
+    # would still report the first value.
+    docker rm -f smoke-client >/dev/null 2>&1 || true
+    CONTAINERS=()
+    run smoke-client2 3000 -e SOCKET_URL=https://signal.example.test
+    wait_for http://localhost:3000/ || fail "client never served / on the second run"
+
+    cfg2="$(curl --fail --silent http://localhost:3000/api/config)"
+    [ "$cfg2" = '{"socketUrl":"https://signal.example.test"}' ] \
+        || fail "/api/config was $cfg2 on the second run, so the URL is baked, not runtime"
+    echo "OK  /api/config follows a changed SOCKET_URL with no rebuild"
+    ;;
+
+*)
+    fail "unknown image name '$NAME'"
+    ;;
+esac
+
+echo "SMOKE PASS: $NAME"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,10 @@ jobs:
             echo "docs-only change: heavy jobs will be skipped"
           fi
           # Same diff, second classification: workflow edits gate actionlint.
-          workflow_files="$(printf '%s\n' "$changed" | grep '^\.github/workflows/' || true)"
+          # scripts/ counts too. images.yml calls .github/scripts/smoke-image.sh,
+          # and a change to only that script would otherwise skip the lint job
+          # entirely, leaving the shell CI actually runs completely unchecked.
+          workflow_files="$(printf '%s\n' "$changed" | grep -E '^\.github/(workflows|scripts)/' || true)"
           if [ -n "$workflow_files" ]; then
             echo "workflows=true" >> "$GITHUB_OUTPUT"
             echo "workflow changes:"
@@ -121,6 +124,13 @@ jobs:
         # Zero ignore flags on purpose: the tree lints clean after the
         # quoting fixes and must stay clean.
         run: ./actionlint -color
+
+      - name: Lint shell scripts
+        # actionlint shellchecks the shell embedded in workflow YAML, but not the
+        # scripts that YAML calls out to. images.yml runs
+        # .github/scripts/smoke-image.sh, so check it directly. shellcheck is
+        # preinstalled on ubuntu-latest.
+        run: shellcheck .github/scripts/*.sh
 
   build-and-lint:
     name: Build & Lint

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -16,6 +16,7 @@ on:
       - 'client/**'
       - 'server/**'
       - '.github/workflows/images.yml'
+      - '.github/scripts/smoke-image.sh'
   workflow_dispatch:
 
 # No workflow-level grants. The publish job escalates on its own.
@@ -25,34 +26,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+env:
+  SERVER: ghcr.io/jannskiee/floe-server
+  CLIENT: ghcr.io/jannskiee/floe-client
+
 jobs:
+  # ONE job, deliberately not a matrix. The two images are released as a pair:
+  # docker-compose.yml pins both to the same ${FLOE_VERSION:-latest}. A matrix
+  # with fail-fast:false would move floe-server:latest while floe-client:latest
+  # stayed behind if only one leg failed, leaving self-hosters on a mismatched
+  # pair. Release tags are therefore applied only after BOTH images pass.
   publish:
-    name: Publish ${{ matrix.name }}
+    name: Publish images
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       # Only this job needs to write packages, and GITHUB_TOKEN is enough for a
       # package owned by this repo. No PAT.
       packages: write
-    strategy:
-      # One image failing must not hide the other's result
-      fail-fast: false
-      matrix:
-        include:
-          - name: floe-server
-            context: ./server
-            title: Floe signaling server
-            description: WebRTC signaling and TURN credentials for Floe. Never touches file data.
-          - name: floe-client
-            context: ./client
-            title: Floe web client
-            description: Browser client for Floe peer-to-peer file transfer.
-
-    env:
-      # Hardcoded rather than derived from github.repository, which is still
-      # "p2p-file-share" and is not the published product name.
-      IMAGE: ghcr.io/jannskiee/${{ matrix.name }}
 
     steps:
       - name: Checkout
@@ -63,26 +55,6 @@ jobs:
       - name: Set up Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ${{ env.IMAGE }}
-          # flavor latest=auto (the default) already emits `latest` for semver
-          # tags, so there is deliberately no `type=raw,value=latest` line: it
-          # would double-emit. No {{major}} either, a bare `1` tag would silently
-          # carry users across a breaking change.
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=ref,event=branch
-            type=sha
-          labels: |
-            org.opencontainers.image.title=${{ matrix.title }}
-            org.opencontainers.image.description=${{ matrix.description }}
-
-      # Login happens before the build because the build pushes by digest. The
-      # digest is untagged, so nothing is user-visible until the smoke test passes.
       - name: Log in to ghcr.io
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
@@ -90,63 +62,164 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Built ONCE, pushed by digest with no tags attached.
+      - name: Staging tag
+        id: stage
+        run: echo "tag=sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+
+      # flavor latest=auto (the default) already emits `latest` for semver tags
+      # and never for a branch push, so there is deliberately no type=raw latest
+      # line: it would double-emit. No {{major}} either, a bare `1` tag would
+      # silently carry users across a breaking change.
+      - name: Metadata (server)
+        id: meta_server
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.SERVER }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=sha
+          labels: |
+            org.opencontainers.image.title=Floe signaling server
+            org.opencontainers.image.description=WebRTC signaling and TURN credentials for Floe. Never touches file data.
+
+      - name: Metadata (client)
+        id: meta_client
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.CLIENT }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=sha
+          labels: |
+            org.opencontainers.image.title=Floe web client
+            org.opencontainers.image.description=Browser client for Floe peer-to-peer file transfer.
+
+      # Each image is built EXACTLY ONCE and pushed under the per-commit staging
+      # tag only. No release tag can then point at bytes the smoke test has not
+      # seen.
       #
-      # The obvious alternative is build --load, smoke test, then rebuild --push
-      # and rely on a cache hit. That has a hole: `pnpm install` and `next build`
-      # are not bit-reproducible, so on a cache miss the second build publishes
-      # bytes the smoke test never saw. Pushing by digest and tagging afterwards
-      # guarantees the tested artifact IS the published artifact.
+      # Do not add `load: true` here. build-push-action disables the default
+      # provenance attestation when a docker exporter is present, so a load build
+      # and a push build produce different artifacts; a "build, test, rebuild and
+      # push" shape would publish something the test never ran against. Leave
+      # `provenance` unset for the same reason: the public-repo default (mode=max)
+      # makes the pushed artifact an OCI index, and imagetools only re-tags an
+      # index verbatim. Given a bare manifest it re-wraps and the digest changes.
       #
       # linux/amd64 only. A broken arm64 entry would be worse than none, because
       # Docker auto-selects it on Apple silicon and sharp fails at dlopen time,
       # at runtime, not at build time. amd64-only is also today's status quo.
       #
-      # Provenance is left at BuildKit's public-repo default (mode=max), which
-      # records build-arg VALUES publicly. No secret may ever become a build arg.
-      - name: Build and push by digest
-        id: build
+      # mode=max provenance records build-arg VALUES publicly. No secret may ever
+      # become a build arg in this workflow.
+      - name: Build and push server (staging tag)
+        id: build_server
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
-          context: ${{ matrix.context }}
+          context: ./server
           platforms: linux/amd64
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+          push: true
+          tags: ${{ env.SERVER }}:${{ steps.stage.outputs.tag }}
+          labels: ${{ steps.meta_server.outputs.labels }}
+          cache-from: type=gha,scope=floe-server
+          cache-to: type=gha,mode=max,scope=floe-server
 
-      - name: Smoke test the pushed digest
-        env:
-          NAME: ${{ matrix.name }}
-          REF: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
-        # Invoked via bash rather than executed directly: the repo is developed on
-        # Windows, where git does not reliably record mode 755, and a missing
-        # exec bit would fail here as a bare "Permission denied".
-        run: bash .github/scripts/smoke-image.sh "$NAME" "$REF"
+      - name: Build and push client (staging tag)
+        id: build_client
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./client
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.CLIENT }}:${{ steps.stage.outputs.tag }}
+          labels: ${{ steps.meta_client.outputs.labels }}
+          cache-from: type=gha,scope=floe-client
+          cache-to: type=gha,mode=max,scope=floe-client
 
-      # Only reached when the smoke test passed, so every tag a user can pull
-      # points at a digest that was actually started and exercised.
-      - name: Tag the verified digest
+      # Both legs must pass before anything is tagged. Invoked via bash rather
+      # than executed directly: the repo is developed on Windows, where git does
+      # not reliably record mode 755.
+      - name: Smoke test the server digest
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
+          REF: ${{ env.SERVER }}@${{ steps.build_server.outputs.digest }}
+        run: bash .github/scripts/smoke-image.sh floe-server "$REF"
+
+      - name: Smoke test the client digest
+        env:
+          REF: ${{ env.CLIENT }}@${{ steps.build_client.outputs.digest }}
+        run: bash .github/scripts/smoke-image.sh floe-client "$REF"
+
+      # Metadata-only copy, no rebuild. Reached only when both images passed, so
+      # the pair always moves together.
+      - name: Apply release tags to the verified digests
+        env:
+          TAGS_SERVER: ${{ steps.meta_server.outputs.tags }}
+          TAGS_CLIENT: ${{ steps.meta_client.outputs.tags }}
+          DIGEST_SERVER: ${{ steps.build_server.outputs.digest }}
+          DIGEST_CLIENT: ${{ steps.build_client.outputs.digest }}
         run: |
-          # Built as an array rather than interpolating a command substitution,
-          # so the tag list cannot word-split unexpectedly.
-          args=()
-          while IFS= read -r tag; do
-            args+=(-t "$tag")
-          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
-          docker buildx imagetools create "${args[@]}" "${IMAGE}@${DIGEST}"
+          retag() {
+            local image="$1" digest="$2" tags="$3"
+            local args=()
+            # Built as an array rather than interpolating a command substitution,
+            # so a tag can never word-split.
+            while IFS= read -r t; do
+              [ -n "$t" ] && args+=(-t "$t")
+            done <<< "$tags"
+            docker buildx imagetools create "${args[@]}" "${image}@${digest}"
+          }
+          retag "$SERVER" "$DIGEST_SERVER" "$TAGS_SERVER"
+          retag "$CLIENT" "$DIGEST_CLIENT" "$TAGS_CLIENT"
+
+      # Closes the loop: proves every tag a user can pull resolves to the exact
+      # digest that was smoke-tested, rather than assuming imagetools copied
+      # verbatim.
+      - name: Verify every tag resolves to the verified digest
+        env:
+          TAGS_SERVER: ${{ steps.meta_server.outputs.tags }}
+          TAGS_CLIENT: ${{ steps.meta_client.outputs.tags }}
+          DIGEST_SERVER: ${{ steps.build_server.outputs.digest }}
+          DIGEST_CLIENT: ${{ steps.build_client.outputs.digest }}
+        run: |
+          check() {
+            local want="$1" tags="$2" got
+            while IFS= read -r t; do
+              [ -z "$t" ] && continue
+              # '{{.Manifest.Digest}}' silently falls back to human output on
+              # some buildx versions; go through json instead.
+              got="$(docker buildx imagetools inspect "$t" \
+                       --format '{{json .Manifest}}' | jq -r .digest)"
+              if [ "$got" != "$want" ]; then
+                echo "::error::$t resolves to $got, expected $want"
+                exit 1
+              fi
+              echo "ok  $t -> $got"
+            done <<< "$tags"
+          }
+          check "$DIGEST_SERVER" "$TAGS_SERVER"
+          check "$DIGEST_CLIENT" "$TAGS_CLIENT"
 
       - name: Summary
         env:
-          DIGEST: ${{ steps.build.outputs.digest }}
+          DIGEST_SERVER: ${{ steps.build_server.outputs.digest }}
+          DIGEST_CLIENT: ${{ steps.build_client.outputs.digest }}
+          TAGS_SERVER: ${{ steps.meta_server.outputs.tags }}
+          TAGS_CLIENT: ${{ steps.meta_client.outputs.tags }}
         run: |
           {
-            echo "### ${IMAGE}"
+            echo "### ${SERVER}"
             echo
-            echo "Digest: \`${DIGEST}\`"
+            echo "Digest: \`${DIGEST_SERVER}\`"
             echo
-            echo "Tags:"
-            jq -r '.tags[] | "- `" + . + "`"' <<< "$DOCKER_METADATA_OUTPUT_JSON"
+            echo "$TAGS_SERVER" | sed 's/^/- `/;s/$/`/'
+            echo
+            echo "### ${CLIENT}"
+            echo
+            echo "Digest: \`${DIGEST_CLIENT}\`"
+            echo
+            echo "$TAGS_CLIENT" | sed 's/^/- `/;s/$/`/'
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -24,7 +24,11 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  # Never cancel a publish. ci.yml cancels superseded runs because a stale test
+  # result is merely useless, but this workflow mutates a registry: a run killed
+  # between the staging push and the retag leaves the release tags pointing at
+  # the previous digest with no indication anything went wrong.
+  cancel-in-progress: false
 
 env:
   SERVER: ghcr.io/jannskiee/floe-server
@@ -170,6 +174,13 @@ jobs:
             while IFS= read -r t; do
               [ -n "$t" ] && args+=(-t "$t")
             done <<< "$tags"
+            # Without this, an empty tag list would run imagetools with no -t,
+            # which succeeds having published nothing: a green run that shipped
+            # no release tags.
+            if [ "${#args[@]}" -eq 0 ]; then
+              echo "::error::no tags resolved for ${image}"
+              exit 1
+            fi
             docker buildx imagetools create "${args[@]}" "${image}@${digest}"
           }
           retag "$SERVER" "$DIGEST_SERVER" "$TAGS_SERVER"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,152 @@
+name: Images
+
+# Publishes the two self-hosting images to ghcr.io so nobody has to clone the
+# repo and build to run Floe. PR #206 made the signaling URL runtime-resolved
+# precisely so ONE image can serve every deployment; this is what consumes that.
+#
+# Separate from release.yml on purpose: that workflow runs GoReleaser for the CLI
+# and publishes to package managers. A failed image build must not sit inside it.
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    # Path filters are NOT evaluated for tag pushes, so a v* tag always publishes
+    # while a docs-only merge to main does not.
+    paths:
+      - 'client/**'
+      - 'server/**'
+      - '.github/workflows/images.yml'
+  workflow_dispatch:
+
+# No workflow-level grants. The publish job escalates on its own.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  publish:
+    name: Publish ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      # Only this job needs to write packages, and GITHUB_TOKEN is enough for a
+      # package owned by this repo. No PAT.
+      packages: write
+    strategy:
+      # One image failing must not hide the other's result
+      fail-fast: false
+      matrix:
+        include:
+          - name: floe-server
+            context: ./server
+            title: Floe signaling server
+            description: WebRTC signaling and TURN credentials for Floe. Never touches file data.
+          - name: floe-client
+            context: ./client
+            title: Floe web client
+            description: Browser client for Floe peer-to-peer file transfer.
+
+    env:
+      # Hardcoded rather than derived from github.repository, which is still
+      # "p2p-file-share" and is not the published product name.
+      IMAGE: ghcr.io/jannskiee/${{ matrix.name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ${{ env.IMAGE }}
+          # flavor latest=auto (the default) already emits `latest` for semver
+          # tags, so there is deliberately no `type=raw,value=latest` line: it
+          # would double-emit. No {{major}} either, a bare `1` tag would silently
+          # carry users across a breaking change.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+            type=sha
+          labels: |
+            org.opencontainers.image.title=${{ matrix.title }}
+            org.opencontainers.image.description=${{ matrix.description }}
+
+      # Login happens before the build because the build pushes by digest. The
+      # digest is untagged, so nothing is user-visible until the smoke test passes.
+      - name: Log in to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Built ONCE, pushed by digest with no tags attached.
+      #
+      # The obvious alternative is build --load, smoke test, then rebuild --push
+      # and rely on a cache hit. That has a hole: `pnpm install` and `next build`
+      # are not bit-reproducible, so on a cache miss the second build publishes
+      # bytes the smoke test never saw. Pushing by digest and tagging afterwards
+      # guarantees the tested artifact IS the published artifact.
+      #
+      # linux/amd64 only. A broken arm64 entry would be worse than none, because
+      # Docker auto-selects it on Apple silicon and sharp fails at dlopen time,
+      # at runtime, not at build time. amd64-only is also today's status quo.
+      #
+      # Provenance is left at BuildKit's public-repo default (mode=max), which
+      # records build-arg VALUES publicly. No secret may ever become a build arg.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ${{ matrix.context }}
+          platforms: linux/amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Smoke test the pushed digest
+        env:
+          NAME: ${{ matrix.name }}
+          REF: ${{ env.IMAGE }}@${{ steps.build.outputs.digest }}
+        # Invoked via bash rather than executed directly: the repo is developed on
+        # Windows, where git does not reliably record mode 755, and a missing
+        # exec bit would fail here as a bare "Permission denied".
+        run: bash .github/scripts/smoke-image.sh "$NAME" "$REF"
+
+      # Only reached when the smoke test passed, so every tag a user can pull
+      # points at a digest that was actually started and exercised.
+      - name: Tag the verified digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          # Built as an array rather than interpolating a command substitution,
+          # so the tag list cannot word-split unexpectedly.
+          args=()
+          while IFS= read -r tag; do
+            args+=(-t "$tag")
+          done < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          docker buildx imagetools create "${args[@]}" "${IMAGE}@${DIGEST}"
+
+      - name: Summary
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          {
+            echo "### ${IMAGE}"
+            echo
+            echo "Digest: \`${DIGEST}\`"
+            echo
+            echo "Tags:"
+            jq -r '.tags[] | "- `" + . + "`"' <<< "$DOCKER_METADATA_OUTPUT_JSON"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -210,16 +210,21 @@ jobs:
           TAGS_SERVER: ${{ steps.meta_server.outputs.tags }}
           TAGS_CLIENT: ${{ steps.meta_client.outputs.tags }}
         run: |
+          # A plain loop rather than sed: a `s/$/.../` replacement puts a $
+          # inside single quotes, which trips shellcheck SC2016 and CI lints
+          # workflows with zero ignore flags.
+          section() {
+            local image="$1" digest="$2" tags="$3"
+            echo "### ${image}"
+            echo
+            echo "Digest: \`${digest}\`"
+            echo
+            while IFS= read -r t; do
+              [ -n "$t" ] && echo "- \`${t}\`"
+            done <<< "$tags"
+            echo
+          }
           {
-            echo "### ${SERVER}"
-            echo
-            echo "Digest: \`${DIGEST_SERVER}\`"
-            echo
-            echo "$TAGS_SERVER" | sed 's/^/- `/;s/$/`/'
-            echo
-            echo "### ${CLIENT}"
-            echo
-            echo "Digest: \`${DIGEST_CLIENT}\`"
-            echo
-            echo "$TAGS_CLIENT" | sed 's/^/- `/;s/$/`/'
+            section "$SERVER" "$DIGEST_SERVER" "$TAGS_SERVER"
+            section "$CLIENT" "$DIGEST_CLIENT" "$TAGS_CLIENT"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Publishes the two self-hosting images to `ghcr.io` so nobody has to clone the repo and build to run Floe. This is the last piece of the self-hosting programme: #205 fixed the ports, #206 made the signaling URL runtime-resolved, and this consumes that capability.

This is **PR 1 of 3**, and it is deliberately inert on its own. Nothing in the repo points at the published images yet, so merging changes nothing for existing users. The sequence is:

| | What | Gate |
|---|---|---|
| **this PR** | publish workflow + Dependabot docker | none |
| manual | flip both packages Public, verify anonymous pull | this PR green |
| PR 2 | `docker-compose.yml` pulls instead of builds, plus docs | `:latest` exists and is public |
| PR 3 | promote `docker-smoke` into the `CI green` gate | PR 2 stable |

`docker-compose.yml` cannot be flipped to pulling before the images exist and are public, or `main` would ship a compose file that fails for everyone.

## How a release is made safe

**Each image is built exactly once**, pushed under a per-commit `sha-` tag, smoke-tested at that digest, and only then given its release tags via `docker buildx imagetools create`, which is a metadata-only copy.

The obvious alternative is build `--load`, test, then rebuild `--push` and rely on a cache hit. That is unsafe for two independent reasons: `build-push-action` drops the default provenance attestation whenever a docker exporter is present, so a load build and a push build are different artifacts; and `pnpm install` plus `next build` are not bit-reproducible, so a cache miss would publish bytes the test never saw. `provenance` is left unset for a related reason: the public-repo default makes the pushed artifact an OCI index, and `imagetools` re-tags an index verbatim but re-wraps a bare manifest, which would change the digest.

**One job, not a matrix.** The two images are released as a pair, since `docker-compose.yml` pins both to the same `${FLOE_VERSION:-latest}`. A matrix with `fail-fast: false` would move `floe-server:latest` while `floe-client:latest` stayed behind if only one leg failed, leaving self-hosters on a mismatched pair. Release tags are applied only after both images pass.

**A final step asserts the tags landed.** Every emitted tag is resolved through `imagetools inspect` and compared to the smoke-tested digest. It goes through `{{json .Manifest}}` rather than `{{.Manifest.Digest}}`, which silently falls back to human-readable output on some buildx versions and would make the check pass vacuously.

## The smoke test asserts more than a 200

The checks live in `.github/scripts/smoke-image.sh` rather than inline YAML, so the identical assertions run locally against a local build before anything is pushed.

A broken `sharp` does not fail loudly; Next silently serves the original PNG, so status alone proves nothing. The client leg checks that `/_next/image` returns `content-type: image/webp`, which is the only signal for the `ERR_DLOPEN_FAILED` failure mode this repo has hit before under pnpm + alpine + standalone. It then starts the client a second time with a different `SOCKET_URL` and asserts `/api/config` follows, which is what actually proves the address is resolved at runtime rather than baked. That property is the whole reason one image can serve everyone.

## Other notes

`linux/amd64` only. Free native `ubuntu-24.04-arm` runners exist now, so arm64 is cheap to add later, but a broken arm64 entry is worse than none: Docker auto-selects it on Apple silicon, and `sharp` fails at dlopen time rather than build time, so a green build would prove nothing. amd64 is also the status quo today, so this is not a regression.

Least privilege: workflow-level `permissions: {}`, and only the publish job takes `packages: write`, using `GITHUB_TOKEN` with no PAT. `mode=max` provenance records build-arg values publicly, so no secret may ever become a build arg; there is a comment on the build step saying so.

Actions are SHA-pinned with `# vX.Y.Z` comments. All five were resolved against the GitHub API today. GitHub's own "Publishing Docker images" doc still pins v3/v5-era SHAs that resolve to no current tag, so those were not copied.

Dependabot now tracks the two Dockerfile base images. They were unmanaged while the images were only ever built locally by self-hosters; once published they are an artifact this repo ships, so a stale base becomes our CVE surface.

## Test plan

Verified locally against real images built in WSL Ubuntu 22.04, before anything was pushed anywhere:

- `docker build ./server` then the smoke script: `/health` reports healthy. **Pass.**
- `docker build ./client` then the smoke script:
  - `/` returns 200
  - `/api/config` reflects `SOCKET_URL`
  - `/_next/image` returns `image/webp`, so sharp resolves correctly in the alpine standalone image
  - a second run with a different `SOCKET_URL` changes `/api/config` with no rebuild

  **Pass, all four.**
- `actionlint` v1.7.12 (the version CI pins) clean, **with shellcheck present**, which is how CI runs it. Verified the integration actually engages by linting a deliberately bad probe file and confirming it is rejected; actionlint silently skips shellcheck when the binary is absent, which is how an SC2016 slipped through on the first push.
- The script is invoked via `bash` rather than executed, because the repo is developed on Windows where git does not reliably record mode 755. The commit confirms it landed as `100644`.

The publish workflow itself does not run on this PR (it triggers on pushes to `main` and on tags), so it is exercised by merging or by `workflow_dispatch`.

## Note for the maintainer

GHCR creates a new package **private** by default even in a public repo. After this merges and the workflow runs green, both `floe-server` and `floe-client` need flipping to Public under Package settings, Danger Zone. That is a one-way change and it is UI only. PR 2 must not merge until an anonymous `docker pull` succeeds.
