### PR TITLE
ci: judge Dockerfile changes at PR time, not after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,23 @@ jobs:
       - name: Build images
         run: docker compose -f docker-compose.yml -f docker-compose.build.yml build
 
+      - name: Smoke the built images
+        # The same assertions images.yml gates publishing on, run here so a
+        # Dockerfile change is judged at PR time rather than after merge.
+        #
+        # Starting the stack and curling / is not enough on its own. A broken
+        # image optimiser does not fail: Next quietly serves the original PNG, so
+        # / still returns 200 while every visitor silently loses optimisation.
+        # Measured: a working optimiser answers image/webp, the fallback answers
+        # image/png, and the content type is the only thing that separates them.
+        #
+        # Runs BEFORE the stack starts, not after: the script publishes 3000 and
+        # 3001 itself, the same ports the compose stack uses. It removes its own
+        # containers on exit.
+        run: |
+          bash .github/scripts/smoke-image.sh floe-server floe-server:dev
+          bash .github/scripts/smoke-image.sh floe-client floe-client:dev
+
       - name: Start the stack
         # No .env file, exactly what a first-time self-hoster gets. The stack
         # must come up with zero configuration.


### PR DESCRIPTION
## Summary

`docker-smoke` built the images and then only checked that `/health` and `/` return 200. Every stronger assertion lived in `.github/scripts/smoke-image.sh`, which runs from `images.yml`, and `images.yml` has **no `pull_request` trigger**. So a Dockerfile change could go fully green on a PR, and the first job capable of catching a regression would run *after* merge, on `main`, at publish time.

| Assertion | `docker-smoke` before | `smoke-image.sh` | `docker-smoke` after |
|---|---|---|---|
| `/health` healthy | yes | yes | yes |
| `/` returns 200 | yes | yes | yes |
| `/api/config` reflects `SOCKET_URL` | **no** | yes | yes |
| `/_next/image` returns `image/webp` | **no** | yes | yes |
| A changed `SOCKET_URL` takes effect | **no** | yes | yes |

This is not theoretical. **#209 bumps the client from Node 22 to 26 and the server from Node 20 to 26**, and it is green today having proven only that the containers answer.

## Why the image optimiser is the assertion that matters

It is the one that fails *silently*. A broken optimiser does not 500; Next serves the original PNG instead, so `/` still returns 200 and nothing looks wrong until someone notices every visitor is downloading unoptimised images.

Measured against the current client image:

```
optimiser working                  -> content-type: image/webp
raw file, i.e. the broken fallback -> content-type: image/png
```

The content type is the only thing separating them, which is why a status check cannot substitute.

## Implementation notes

**Reuses the script rather than duplicating it.** The build overlay already tags its output `floe-server:dev` and `floe-client:dev`, which is exactly what `smoke-image.sh` takes, so this is two lines of invocation and no new assertions to keep in sync.

**Runs before the stack starts, not after.** The script publishes 3000 and 3001 itself, the same ports the compose stack uses, so the ordering is load-bearing. It removes its own containers on exit.

**The compose assertions stay.** They cover different ground: `depends_on` with `service_healthy`, the container healthcheck, and the published port mapping, none of which the per-image script exercises.

The job stays **outside** the `ci-green` gate. Promoting it is a separate decision, since it changes CI behaviour for every future PR.

## Test plan

- Proved the new assertion **discriminates** rather than merely passing, which was the point of adding it. Against a running client image: `/_next/image?...` returned `image/webp`, while the same request for the raw `/github-mark-white.png` returned `image/png`. A broken optimiser produces the second, so the check catches exactly the failure mode it exists for.
- `actionlint` clean **with shellcheck present**, which is how CI runs it. Worth noting that actionlint silently skips its shellcheck integration when the binary is absent, so a local run without it reports clean on shell CI would reject.
- Step ordering verified: `Build images` → `Smoke the built images` → `Start the stack`.
- `smoke-image.sh` itself is unchanged, so its existing use in `images.yml` is unaffected.

One environment note for anyone running the script locally: it uses `curl -o /dev/null`, which Git Bash on Windows rejects with exit 23. It is Linux-only by design, which is where CI runs it. Use WSL locally.
