### PR TITLE
chore(client): drop @types/uuid, which uuid has made redundant

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,6 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/simple-peer": "^9.11.9",
-    "@types/uuid": "^10.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.12",
     "tailwindcss": "^4",

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -92,9 +92,6 @@ importers:
       '@types/simple-peer':
         specifier: ^9.11.9
         version: 9.11.9
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       eslint:
         specifier: ^9
         version: 9.39.5(jiti@2.7.0)
@@ -1330,9 +1327,6 @@ packages:
 
   '@types/simple-peer@9.11.9':
     resolution: {integrity: sha512-6Gdl7TSS5oh9nuwKD4Pl8cSmaxWycYeZz9HLnJBNvIwWjZuGVsmHe9RwW3+9RxfhC1aIR9Z83DvaJoMw6rhkbg==}
-
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
@@ -4446,8 +4440,6 @@ snapshots:
   '@types/simple-peer@9.11.9':
     dependencies:
       '@types/node': 26.1.2
-
-  '@types/uuid@10.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION
chore(client): drop @types/uuid, which uuid has made redundant

Dependabot opened #213 to bump @types/uuid from 10 to 11. Version 11.0.0 is not
a release, it is a DefinitelyTyped tombstone. The npm registry marks it
deprecated with "This is a stub types definition. uuid provides its own type
definitions, so you do not need this installed", and its only content is a
dependency edge on uuid itself.

The package was already inert here. uuid is a direct dependency at 14.0.1 and
ships ./dist/index.d.ts, so TypeScript resolves types from the package and never
consults @types/uuid; @types/* is only a fallback for packages without their
own. Taking the bump would have installed a deprecated package, added a
pointless uuid: "*" edge, and changed nothing.

Verified after removal: tsc --noEmit exits 0, eslint clean, 134 tests across 15
files pass, and the production build succeeds. The lockfile diff is nine
deletions, all @types/uuid.

Closes #213.
