### PR TITLE
feat(images): publish linux/arm64, and move both images to Node 24 LTS

### DIFF
--- a/.github/scripts/manifest-lib.sh
+++ b/.github/scripts/manifest-lib.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for assembling and checking the multi-arch image indexes.
+# Sourced by publish-indexes.sh and verify-indexes.sh.
+#
+# Terminology, because the digests are easy to confuse:
+#   leg digest   what one build job pushed. Already an OCI index (provenance is
+#                left on), containing one linux manifest plus attestations.
+#   child digest the actual platform image inside a leg index. This is what
+#                `docker run` resolves to, so it is what the smoke test exercised.
+#   tag digest   what a released tag points at after imagetools merges the legs.
+#                It equals NEITHER leg digest, which is why the old
+#                "tag digest == build digest" assertion had to be replaced
+#                rather than adjusted.
+
+set -euo pipefail
+
+# Reads the digest a build leg recorded. Errors go to stderr so they survive
+# command substitution; an "::error::" swallowed into a variable becomes part of
+# an image reference and produces a baffling failure much later.
+leg_digest() {
+    local image="$1" platform="$2" file="digests/${1}-${2}"
+    if [ ! -s "$file" ]; then
+        echo "::error::no verified digest recorded for ${image} linux/${platform}" >&2
+        return 1
+    fi
+    tr -d '[:space:]' < "$file"
+}
+
+# The platform image inside a leg index, which is the artifact the smoke test ran.
+#
+# Asserts the leg holds exactly ONE linux manifest and that its architecture is
+# the expected one. Checking only "one manifest of the arch I asked for" would
+# let a leg carrying two architectures through: the native smoke would exercise
+# only the host-arch child and the other would be merged into a released tag
+# having never been run. That is a one-token edit away for anyone adding a third
+# platform, so it is guarded here rather than left to the post-publish check.
+child_digest() {
+    local ref="$1" want="$2" json linux_count arch child
+    json="$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest}}')"
+
+    linux_count="$(jq '[.manifests[]? | select(.platform.os == "linux")] | length' <<< "$json")"
+    if [ "$linux_count" != "1" ]; then
+        echo "::error::${ref} contains ${linux_count} linux manifests, expected exactly 1" >&2
+        return 1
+    fi
+
+    arch="$(jq -r '[.manifests[]? | select(.platform.os == "linux")][0].platform.architecture' <<< "$json")"
+    if [ "$arch" != "$want" ]; then
+        echo "::error::${ref} is linux/${arch}, expected linux/${want}" >&2
+        return 1
+    fi
+
+    child="$(jq -r '[.manifests[]? | select(.platform.os == "linux")][0].digest' <<< "$json")"
+    if [ -z "$child" ] || [ "$child" = "null" ]; then
+        echo "::error::could not read the platform digest from ${ref}" >&2
+        return 1
+    fi
+    echo "$child"
+}
+
+# Every linux platform a released tag actually offers, one "os/arch" per line.
+tag_platforms() {
+    docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' \
+        | jq -r '.manifests[]? | select(.platform.os == "linux")
+                 | "\(.platform.os)/\(.platform.architecture)"' \
+        | sort
+}
+
+# Every linux child digest a released tag offers, one per line.
+tag_child_digests() {
+    docker buildx imagetools inspect "$1" --format '{{json .Manifest}}' \
+        | jq -r '.manifests[]? | select(.platform.os == "linux") | .digest' \
+        | sort
+}
+
+# Turns a newline-separated tag list into repeated -t arguments.
+tag_args() {
+    local tags="$1" out=()
+    while IFS= read -r t; do
+        [ -n "$t" ] && out+=(-t "$t")
+    done <<< "$tags"
+    if [ "${#out[@]}" -eq 0 ]; then
+        echo "::error::empty tag list" >&2
+        return 1
+    fi
+    printf '%s\n' "${out[@]}"
+}

--- a/.github/scripts/publish-indexes.sh
+++ b/.github/scripts/publish-indexes.sh
@@ -36,8 +36,20 @@ for pair in "server:$SERVER" "client:$CLIENT"; do
     done
 done
 
-mapfile -t SERVER_ARGS < <(tag_args "$TAGS_SERVER")
-mapfile -t CLIENT_ARGS < <(tag_args "$TAGS_CLIENT")
+# Captured into a variable first, deliberately. `mapfile -t X < <(f)` runs f in a
+# process substitution whose exit status set -e never observes, so a failing
+# tag_args would be silently discarded and imagetools would run with zero -t
+# arguments: a green run that published nothing. Verified: that form survives
+# with count=0.
+server_tag_args="$(tag_args "$TAGS_SERVER")"
+client_tag_args="$(tag_args "$TAGS_CLIENT")"
+mapfile -t SERVER_ARGS <<< "$server_tag_args"
+mapfile -t CLIENT_ARGS <<< "$client_tag_args"
+
+if [ "${#SERVER_ARGS[@]}" -eq 0 ] || [ "${#CLIENT_ARGS[@]}" -eq 0 ]; then
+    echo "::error::refusing to publish with an empty tag list" >&2
+    exit 1
+fi
 
 # ---- publish, with nothing between the two creates ---------------------------
 

--- a/.github/scripts/publish-indexes.sh
+++ b/.github/scripts/publish-indexes.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Merges the per-platform build legs into one multi-arch index per image and
+# applies the release tags.
+#
+# Structured deliberately as validate-everything-then-publish-everything. The
+# obvious shape, "validate server, publish server, validate client, publish
+# client", puts two network round-trips between the two tag moves, so a transient
+# registry error in the middle leaves the server released and the client behind.
+# docker-compose.yml pins both images to the same tag, so a mismatched pair is a
+# broken stack for every self-hoster who pulls during that window.
+set -euo pipefail
+
+# shellcheck source=.github/scripts/manifest-lib.sh
+. "$(dirname "$0")/manifest-lib.sh"
+
+: "${SERVER:?SERVER must be set}"
+: "${CLIENT:?CLIENT must be set}"
+: "${TAGS_SERVER:?TAGS_SERVER must be set}"
+: "${TAGS_CLIENT:?TAGS_CLIENT must be set}"
+
+# ---- validate every leg of both images, before anything is published ---------
+
+declare -A LEG=()
+for pair in "server:$SERVER" "client:$CLIENT"; do
+    name="${pair%%:*}"
+    image="${pair#*:}"
+    for platform in amd64 arm64; do
+        digest="$(leg_digest "$name" "$platform")"
+        # Asserts the leg is a single linux manifest of the expected architecture
+        # and returns the child the smoke test actually ran.
+        child="$(child_digest "${image}@${digest}" "$platform")"
+        LEG["${name}-${platform}-leg"]="$digest"
+        LEG["${name}-${platform}-child"]="$child"
+        echo "ok  ${name} linux/${platform}  leg=${digest}  smoke-tested child=${child}"
+    done
+done
+
+mapfile -t SERVER_ARGS < <(tag_args "$TAGS_SERVER")
+mapfile -t CLIENT_ARGS < <(tag_args "$TAGS_CLIENT")
+
+# ---- publish, with nothing between the two creates ---------------------------
+
+docker buildx imagetools create "${SERVER_ARGS[@]}" \
+    "${SERVER}@${LEG[server-amd64-leg]}" \
+    "${SERVER}@${LEG[server-arm64-leg]}"
+
+docker buildx imagetools create "${CLIENT_ARGS[@]}" \
+    "${CLIENT}@${LEG[client-amd64-leg]}" \
+    "${CLIENT}@${LEG[client-arm64-leg]}"
+
+echo "published both indexes"

--- a/.github/scripts/verify-indexes.sh
+++ b/.github/scripts/verify-indexes.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Closes the loop after publishing: proves every released tag is genuinely
+# multi-arch and that each platform entry is a digest that was smoke-tested on
+# its own architecture.
+#
+# This replaces, rather than adjusts, the single-arch assertion it grew out of.
+# That one compared a tag's digest to the build step's digest. Under a merge,
+# imagetools mints a NEW index, so the tag digest equals neither leg digest and
+# the old comparison would fail on every run. The meaningful comparison is one
+# level down: the CHILD digests a tag offers must be exactly the children the
+# smoke tests exercised.
+#
+# Detection, not prevention. It necessarily runs after the tags moved, so its job
+# is to make a bad publish loud instead of silent.
+set -euo pipefail
+
+# shellcheck source=.github/scripts/manifest-lib.sh
+. "$(dirname "$0")/manifest-lib.sh"
+
+: "${SERVER:?SERVER must be set}"
+: "${CLIENT:?CLIENT must be set}"
+: "${TAGS_SERVER:?TAGS_SERVER must be set}"
+: "${TAGS_CLIENT:?TAGS_CLIENT must be set}"
+
+WANT_PLATFORMS="$(printf 'linux/amd64\nlinux/arm64\n')"
+
+check_image() {
+    local name="$1" image="$2" tags="$3" want_children tag got_platforms got_children
+
+    # The children the smoke tests actually ran, rebuilt from the recorded legs.
+    want_children="$(
+        for platform in amd64 arm64; do
+            child_digest "${image}@$(leg_digest "$name" "$platform")" "$platform"
+        done | sort
+    )"
+
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+
+        got_platforms="$(tag_platforms "$tag")"
+        if [ "$got_platforms" != "$WANT_PLATFORMS" ]; then
+            echo "::error::${tag} offers [$(tr '\n' ' ' <<< "$got_platforms")], expected linux/amd64 and linux/arm64"
+            exit 1
+        fi
+
+        got_children="$(tag_child_digests "$tag")"
+        if [ "$got_children" != "$want_children" ]; then
+            echo "::error::${tag} points at digests that were not the ones smoke-tested"
+            echo "  offered:      $(tr '\n' ' ' <<< "$got_children")"
+            echo "  smoke-tested: $(tr '\n' ' ' <<< "$want_children")"
+            exit 1
+        fi
+
+        echo "ok  ${tag}  multi-arch, both platforms smoke-tested"
+    done <<< "$tags"
+}
+
+check_image server "$SERVER" "$TAGS_SERVER"
+check_image client "$CLIENT" "$TAGS_CLIENT"
+echo "all tags verified"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -19,15 +19,13 @@ on:
       - '.github/scripts/smoke-image.sh'
   workflow_dispatch:
 
-# No workflow-level grants. The publish job escalates on its own.
+# No workflow-level grants. Each job escalates on its own.
 permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Never cancel a publish. ci.yml cancels superseded runs because a stale test
-  # result is merely useless, but this workflow mutates a registry: a run killed
-  # between the staging push and the retag leaves the release tags pointing at
-  # the previous digest with no indication anything went wrong.
+  # result is merely useless, but this workflow mutates a registry.
   cancel-in-progress: false
 
 env:
@@ -35,19 +33,116 @@ env:
   CLIENT: ghcr.io/jannskiee/floe-client
 
 jobs:
-  # ONE job, deliberately not a matrix. The two images are released as a pair:
-  # docker-compose.yml pins both to the same ${FLOE_IMAGE_TAG:-main}. A matrix
-  # with fail-fast:false would move floe-server:main while floe-client:main
-  # stayed behind if only one leg failed, leaving self-hosters on a mismatched
-  # pair. Release tags are therefore applied only after BOTH images pass.
-  publish:
-    name: Publish images
-    runs-on: ubuntu-latest
+  # Four legs: two images across two architectures. Each pushes BY DIGEST with no
+  # tag attached, so nothing a user can pull by name exists until every leg has
+  # passed its own smoke test.
+  #
+  # arm64 builds on a native runner rather than under QEMU. Emulation does work,
+  # measured end to end on both images, so this is not a correctness argument. It
+  # is cost (the CPU-bound build step measured 9.5x slower emulated) and honesty:
+  # a QEMU pass is a statement about instruction translation, not about how the
+  # image behaves on a Raspberry Pi. Native runners are free for public repos.
+  build:
+    name: Build ${{ matrix.image }} (${{ matrix.platform }})
+    runs-on: ${{ matrix.platform == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     timeout-minutes: 45
     permissions:
       contents: read
-      # Only this job needs to write packages, and GITHUB_TOKEN is enough for a
-      # package owned by this repo. No PAT.
+      packages: write
+    strategy:
+      # No fail-fast: one architecture failing should still show the others, and
+      # the publish job below refuses to run unless all four succeed anyway.
+      fail-fast: false
+      matrix:
+        image: [server, client]
+        platform: [amd64, arm64]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # The whole point of native runners is that the smoke test exercises real
+      # hardware. Assert it rather than trusting the runs-on expression: if a
+      # future edit points an arm64 leg at an x64 runner, the image would run
+      # under emulation and report a pass that means much less than it appears to.
+      - name: Assert the runner architecture matches the target
+        env:
+          WANT: ${{ matrix.platform }}
+        run: |
+          got="$(docker version --format '{{.Server.Arch}}')"
+          if [ "$got" != "$WANT" ]; then
+            echo "::error::runner arch is $got but this leg targets $WANT"
+            exit 1
+          fi
+          echo "runner arch $got matches target $WANT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Built EXACTLY ONCE per image per platform. pnpm install and next build are
+      # not bit-reproducible, so any rebuild risks publishing bytes no smoke test
+      # ever saw.
+      #
+      # Do not add `load: true`: build-push-action drops the default provenance
+      # attestation whenever a docker exporter is present, which changes the
+      # artifact. Leave `provenance` unset for the same reason; the public-repo
+      # default makes each leg an OCI index, which is what imagetools can flatten.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: ./${{ matrix.image }}
+          platforms: linux/${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/jannskiee/floe-${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.platform }}
+
+      # Runs on this leg's own architecture, against the digest just pushed. The
+      # /_next/image assertion inside is the one that matters: a broken image
+      # optimiser does not fail, Next quietly serves the original PNG, so only the
+      # content type distinguishes it. Verified as a real tripwire by hiding
+      # libvips in an arm64 image and watching the response flip to image/png.
+      - name: Smoke test the pushed digest
+        env:
+          NAME: floe-${{ matrix.image }}
+          REF: ghcr.io/jannskiee/floe-${{ matrix.image }}@${{ steps.build.outputs.digest }}
+        run: bash .github/scripts/smoke-image.sh "$NAME" "$REF"
+
+      - name: Record the verified digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p digests
+          echo "$DIGEST" > "digests/${{ matrix.image }}-${{ matrix.platform }}"
+
+      - name: Upload the digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digest-${{ matrix.image }}-${{ matrix.platform }}
+          path: digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  # Needs the WHOLE build matrix, so a single failed leg means no tag moves for
+  # either image on either architecture. That preserves the original invariant
+  # (both images release as a pair, since docker-compose.yml pins them to the same
+  # tag) and extends it across architectures.
+  publish:
+    name: Publish multi-arch tags
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [build]
+    permissions:
+      contents: read
       packages: write
 
     steps:
@@ -66,19 +161,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Staging tag
-        id: stage
-        run: echo "tag=sha-${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+      - name: Download the verified digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          # Scoped to this run by default, so a previous run's digests can never
+          # be picked up.
+          pattern: digest-*
+          path: digests
+          merge-multiple: true
 
       # flavor latest=auto (the default) emits `latest` for semver tags and never
-      # for a branch push, which is what we want: `latest` means newest RELEASE.
-      # A type=raw,value=latest,enable={{is_default_branch}} line is deliberately
-      # absent, and not because it would conflict: is_default_branch is false on a
-      # tag push, so the two would not overlap. It is absent because it would make
-      # `latest` mean "newest main" or "newest release" depending on which
-      # happened more recently, which is the worst possible behaviour for the tag
-      # self-hosters pull by default. No {{major}} either: a bare `1` would
-      # silently carry users across a breaking change.
+      # for a branch push, so `latest` means the newest RELEASE. A
+      # type=raw,value=latest,enable={{is_default_branch}} line is deliberately
+      # absent: not because it would conflict, but because it would make `latest`
+      # mean "newest main" or "newest release" depending on which happened last,
+      # the worst possible behaviour for the tag self-hosters pull by default.
       - name: Metadata (server)
         id: meta_server
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -107,133 +204,34 @@ jobs:
             org.opencontainers.image.title=Floe web client
             org.opencontainers.image.description=Browser client for Floe peer-to-peer file transfer.
 
-      # Each image is built EXACTLY ONCE and pushed under the per-commit staging
-      # tag only. No release tag can then point at bytes the smoke test has not
-      # seen.
-      #
-      # Do not add `load: true` here. build-push-action disables the default
-      # provenance attestation when a docker exporter is present, so a load build
-      # and a push build produce different artifacts; a "build, test, rebuild and
-      # push" shape would publish something the test never ran against. Leave
-      # `provenance` unset for the same reason: the public-repo default (mode=max)
-      # makes the pushed artifact an OCI index, and imagetools only re-tags an
-      # index verbatim. Given a bare manifest it re-wraps and the digest changes.
-      #
-      # linux/amd64 only. A broken arm64 entry would be worse than none, because
-      # Docker auto-selects it on Apple silicon and sharp fails at dlopen time,
-      # at runtime, not at build time. amd64-only is also today's status quo.
-      #
-      # mode=max provenance records build-arg VALUES publicly. No secret may ever
-      # become a build arg in this workflow.
-      - name: Build and push server (staging tag)
-        id: build_server
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ./server
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.SERVER }}:${{ steps.stage.outputs.tag }}
-          labels: ${{ steps.meta_server.outputs.labels }}
-          cache-from: type=gha,scope=floe-server
-          cache-to: type=gha,mode=max,scope=floe-server
-
-      - name: Build and push client (staging tag)
-        id: build_client
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: ./client
-          platforms: linux/amd64
-          push: true
-          tags: ${{ env.CLIENT }}:${{ steps.stage.outputs.tag }}
-          labels: ${{ steps.meta_client.outputs.labels }}
-          cache-from: type=gha,scope=floe-client
-          cache-to: type=gha,mode=max,scope=floe-client
-
-      # Both legs must pass before anything is tagged. Invoked via bash rather
-      # than executed directly: the repo is developed on Windows, where git does
-      # not reliably record mode 755.
-      - name: Smoke test the server digest
-        env:
-          REF: ${{ env.SERVER }}@${{ steps.build_server.outputs.digest }}
-        run: bash .github/scripts/smoke-image.sh floe-server "$REF"
-
-      - name: Smoke test the client digest
-        env:
-          REF: ${{ env.CLIENT }}@${{ steps.build_client.outputs.digest }}
-        run: bash .github/scripts/smoke-image.sh floe-client "$REF"
-
-      # Metadata-only copy, no rebuild. Reached only when both images passed, so
-      # the pair always moves together.
-      - name: Apply release tags to the verified digests
+      # Every check for BOTH images runs before either tag moves. Validating one
+      # image and publishing it before validating the other would put two network
+      # round-trips between the two tag moves, so a transient ghcr error could
+      # leave the server released and the client behind.
+      - name: Publish the multi-arch indexes
         env:
           TAGS_SERVER: ${{ steps.meta_server.outputs.tags }}
           TAGS_CLIENT: ${{ steps.meta_client.outputs.tags }}
-          DIGEST_SERVER: ${{ steps.build_server.outputs.digest }}
-          DIGEST_CLIENT: ${{ steps.build_client.outputs.digest }}
-        run: |
-          retag() {
-            local image="$1" digest="$2" tags="$3"
-            local args=()
-            # Built as an array rather than interpolating a command substitution,
-            # so a tag can never word-split.
-            while IFS= read -r t; do
-              [ -n "$t" ] && args+=(-t "$t")
-            done <<< "$tags"
-            # Without this, an empty tag list would run imagetools with no -t,
-            # which succeeds having published nothing: a green run that shipped
-            # no release tags.
-            if [ "${#args[@]}" -eq 0 ]; then
-              echo "::error::no tags resolved for ${image}"
-              exit 1
-            fi
-            docker buildx imagetools create "${args[@]}" "${image}@${digest}"
-          }
-          retag "$SERVER" "$DIGEST_SERVER" "$TAGS_SERVER"
-          retag "$CLIENT" "$DIGEST_CLIENT" "$TAGS_CLIENT"
+        run: bash .github/scripts/publish-indexes.sh
 
-      # Closes the loop: proves every tag a user can pull resolves to the exact
-      # digest that was smoke-tested, rather than assuming imagetools copied
-      # verbatim.
-      - name: Verify every tag resolves to the verified digest
+      # Detection, not prevention: this necessarily runs after the tags moved. It
+      # exists so a bad publish is loud rather than silent.
+      - name: Verify every tag is multi-arch and points at verified bytes
         env:
           TAGS_SERVER: ${{ steps.meta_server.outputs.tags }}
           TAGS_CLIENT: ${{ steps.meta_client.outputs.tags }}
-          DIGEST_SERVER: ${{ steps.build_server.outputs.digest }}
-          DIGEST_CLIENT: ${{ steps.build_client.outputs.digest }}
-        run: |
-          check() {
-            local want="$1" tags="$2" got
-            while IFS= read -r t; do
-              [ -z "$t" ] && continue
-              # '{{.Manifest.Digest}}' silently falls back to human output on
-              # some buildx versions; go through json instead.
-              got="$(docker buildx imagetools inspect "$t" \
-                       --format '{{json .Manifest}}' | jq -r .digest)"
-              if [ "$got" != "$want" ]; then
-                echo "::error::$t resolves to $got, expected $want"
-                exit 1
-              fi
-              echo "ok  $t -> $got"
-            done <<< "$tags"
-          }
-          check "$DIGEST_SERVER" "$TAGS_SERVER"
-          check "$DIGEST_CLIENT" "$TAGS_CLIENT"
+        run: bash .github/scripts/verify-indexes.sh
 
       - name: Summary
         env:
-          DIGEST_SERVER: ${{ steps.build_server.outputs.digest }}
-          DIGEST_CLIENT: ${{ steps.build_client.outputs.digest }}
           TAGS_SERVER: ${{ steps.meta_server.outputs.tags }}
           TAGS_CLIENT: ${{ steps.meta_client.outputs.tags }}
         run: |
-          # A plain loop rather than sed: a `s/$/.../` replacement puts a $
-          # inside single quotes, which trips shellcheck SC2016 and CI lints
-          # workflows with zero ignore flags.
           section() {
-            local image="$1" digest="$2" tags="$3"
+            local image="$1" tags="$2"
             echo "### ${image}"
             echo
-            echo "Digest: \`${digest}\`"
+            echo "Platforms: \`linux/amd64\`, \`linux/arm64\`"
             echo
             while IFS= read -r t; do
               [ -n "$t" ] && echo "- \`${t}\`"
@@ -241,6 +239,6 @@ jobs:
             echo
           }
           {
-            section "$SERVER" "$DIGEST_SERVER" "$TAGS_SERVER"
-            section "$CLIENT" "$DIGEST_CLIENT" "$TAGS_CLIENT"
+            section "$SERVER" "$TAGS_SERVER"
+            section "$CLIENT" "$TAGS_CLIENT"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -16,7 +16,10 @@ on:
       - 'client/**'
       - 'server/**'
       - '.github/workflows/images.yml'
-      - '.github/scripts/smoke-image.sh'
+      # All of them, not just smoke-image.sh: the publish and verify scripts are
+      # part of this pipeline too, and a change to only those would otherwise
+      # never exercise the path it just modified.
+      - '.github/scripts/*.sh'
   workflow_dispatch:
 
 # No workflow-level grants. Each job escalates on its own.
@@ -56,6 +59,14 @@ jobs:
       matrix:
         image: [server, client]
         platform: [amd64, arm64]
+        # Decorates the existing four combinations; adds no legs.
+        include:
+          - image: server
+            title: Floe signaling server
+            description: WebRTC signaling and TURN credentials for Floe. Never touches file data.
+          - image: client
+            title: Floe web client
+            description: Browser client for Floe peer-to-peer file transfer.
 
     steps:
       - name: Checkout
@@ -88,6 +99,20 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Labels have to be applied HERE, at build time. They live in each
+      # platform's image config, and imagetools copies children byte for byte
+      # when it merges, so a label missing from a leg can never be added later.
+      # org.opencontainers.image.source is the one that matters: it is what links
+      # the GHCR package back to this repository.
+      - name: Metadata
+        id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/jannskiee/floe-${{ matrix.image }}
+          labels: |
+            org.opencontainers.image.title=${{ matrix.title }}
+            org.opencontainers.image.description=${{ matrix.description }}
+
       # Built EXACTLY ONCE per image per platform. pnpm install and next build are
       # not bit-reproducible, so any rebuild risks publishing bytes no smoke test
       # ever saw.
@@ -102,6 +127,7 @@ jobs:
         with:
           context: ./${{ matrix.image }}
           platforms: linux/${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/jannskiee/floe-${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.platform }}
@@ -125,7 +151,7 @@ jobs:
           echo "$DIGEST" > "digests/${{ matrix.image }}-${{ matrix.platform }}"
 
       - name: Upload the digest
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digest-${{ matrix.image }}-${{ matrix.platform }}
           path: digests/*
@@ -162,7 +188,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download the verified digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # Scoped to this run by default, so a previous run's digests can never
           # be picked up.
@@ -186,9 +212,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
             type=sha
-          labels: |
-            org.opencontainers.image.title=Floe signaling server
-            org.opencontainers.image.description=WebRTC signaling and TURN credentials for Floe. Never touches file data.
 
       - name: Metadata (client)
         id: meta_client
@@ -200,9 +223,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
             type=sha
-          labels: |
-            org.opencontainers.image.title=Floe web client
-            org.opencontainers.image.description=Browser client for Floe peer-to-peer file transfer.
 
       # Every check for BOTH images runs before either tag moves. Validating one
       # image and publishing it before validating the other would put two network

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,11 +11,13 @@
 # without rebuilding. It defaults to empty for exactly that reason.
 
 # ---- Builder ---------------------------------------------------------------
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 
 # Pin pnpm to package.json's `packageManager` version so `--frozen-lockfile`
-# matches the lockfile exactly. pnpm 11.x requires Node 22+ (it uses the
-# node:sqlite builtin), which is why the base image is node:22, not node:20.
+# matches the lockfile exactly. pnpm 11.x needs Node 22+ (it uses the node:sqlite
+# builtin), which the Active LTS satisfies. Track LTS rather than Current here:
+# this image is run unattended by self-hosters, so a runtime with a long support
+# window matters more than a new one.
 RUN npm install -g pnpm@11.1.2
 WORKDIR /app
 
@@ -52,7 +54,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
 # ---- Runner ----------------------------------------------------------------
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -14,6 +14,15 @@ description: "Release history for Floe."
   - `linux/amd64` only for now. ARM hosts build from source.
 </Update>
 
+<Update label="ARM support" description="2026-07-30">
+  **Images now run on ARM, and both images move to Node 24 LTS**
+
+  - `linux/arm64` is published alongside `linux/amd64`, so Raspberry Pi, Oracle Ampere, AWS Graviton, and Apple silicon run the same two commands as everyone else. Docker selects the right architecture automatically.
+  - Each architecture is built and smoke-tested on its own hardware, and a tag is published only after every architecture of both images passes. A partly-built release is never visible. This matters because the image optimiser fails silently: when it cannot load, it serves the original file rather than erroring, so a broken ARM image would look healthy to anything that only checks whether the page loads.
+  - Both images move from Node 22 and Node 20 to **Node 24**, the Active LTS. The server was on a Maintenance release, which is the more meaningful half of that change.
+  - 32-bit ARM (`linux/arm/v7`) is not published: Node dropped support for it and no prebuilt image-processing binaries exist.
+</Update>
+
 <Update label="v1.8.0" description="2026-07-23">
   **The 2 GB relay cap now applies to the CLI, plus honest receiver errors**
 

--- a/docs/self-hosting/images.mdx
+++ b/docs/self-hosting/images.mdx
@@ -49,21 +49,19 @@ Every tag is verified to resolve to a digest that passed a smoke test before it 
 
 ## Architectures
 
-`linux/amd64` only, which covers ordinary VPS and desktop hosts.
-
-There is no `linux/arm64` image yet, so Raspberry Pi and ARM cloud instances need to build from source:
+Both images are published for **`linux/amd64`** and **`linux/arm64`**. Docker picks the right one automatically, so Raspberry Pi, Oracle Ampere, AWS Graviton, and Apple silicon all work with the same commands as anywhere else.
 
 ```bash
-git clone https://github.com/jannskiee/floe.git
-cd floe
-docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+docker buildx imagetools inspect ghcr.io/jannskiee/floe-client:main
 ```
 
-Building from source needs the repository, since the overlay compiles the working tree.
-
 <Note>
-  ARM is not published rather than published-and-broken on purpose. Docker selects the ARM entry automatically on Apple silicon, and the image optimiser fails at load time rather than at build time, so a broken ARM image would look healthy in CI and fail on a user's machine.
+  Each architecture is built and smoke-tested on its own hardware before any tag points at it, and a tag is only published once every architecture of both images has passed. A partly-built release is never visible.
+
+  That matters more than it sounds. The image optimiser fails at load time rather than at build time, and when it fails it does not error: it quietly serves the original file. So a broken ARM image would look perfectly healthy to anything that only checks whether the page loads. The smoke test asserts the optimiser actually returns WebP, on real ARM.
 </Note>
+
+32-bit ARM (`linux/arm/v7`, older Raspberry Pi models) is not published. Node dropped support for it and no prebuilt image-processing binaries exist.
 
 ## Building from source
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@
 # touches file data. It binds 0.0.0.0:$PORT (default 3001) and reads its config
 # from environment variables (see server/.env.example).
 
-FROM node:20-alpine
+FROM node:24-alpine
 
 # dumb-init reaps zombies and forwards SIGTERM/SIGINT so the server's graceful
 # shutdown handlers fire cleanly on `docker stop`.


### PR DESCRIPTION
## Summary

Raspberry Pi, Oracle Ampere, AWS Graviton and Apple silicon users had to build Floe from source. This publishes `linux/arm64` alongside `linux/amd64`, so every common host runs the same two commands. It also moves both images to **Node 24**, the Active LTS, which closes #209.

This is the last gap in self-hosting.

## The reason arm64 was deferred was wrong

I blocked this on sharp's native module. That reasoning does not hold: sharp 0.34.5 uses **Node-API v9**, which is ABI-stable across Node majors by explicit guarantee, and `@img/sharp-linuxmusl-arm64` was already in the lockfile.

Measured on a real arm64 image rather than argued: the correct musl-arm64 binaries land, libvips dlopens, and `/_next/image` returns `image/webp`.

## How a release is kept safe

Four build legs, two images across two architectures. Each **pushes by digest with no tag attached** and is **smoke-tested on its own hardware**. A publish job needing the whole matrix then merges the legs into one index per image and applies the tags.

Nothing a user can pull by name exists until every leg has passed, which extends the existing both-images-or-neither invariant across architectures as well.

**Native ARM runners, not QEMU.** Emulation does work, so this is not a correctness argument. It is cost (the CPU-bound build step measured **9.5x** slower emulated) and honesty: a QEMU pass is a statement about instruction translation, not about how the image behaves on a Pi.

## The tag assertion had to be replaced, not adjusted

The old check compared a tag's digest to the build digest. When `imagetools` merges legs it mints a **new** index, so the tag digest now equals neither leg and that comparison would fail on **every** run.

The meaningful check is one level down: the child digests a tag offers must be exactly the children the smoke tests ran, and every tag must list both platforms.

## Four guards against silently publishing a bad tag

Adversarial review of the first design found these. Each can publish something broken while reporting green:

1. **`set -euo pipefail` in both scripts.** `run: bash script.sh` starts a *new* shell that does not inherit the step's `-e`. Without it, a failed first image exits 0 with the pair half published. This was reproduced, not theorised.
2. **Every check for both images runs before either tag moves.** Validating and publishing one image at a time puts two network round-trips between the tag moves, so a transient registry error could leave the server released and the client behind.
3. **A leg must hold exactly one linux manifest of the expected architecture.** Asserting only "one manifest of the arch I asked for" would let a second platform ride into a released tag having never been run, which is one token away for anyone adding a third platform.
4. **The runner architecture is asserted against the matrix target.** Otherwise "tested natively" is a comment, and an arm64 image pointed at an x64 runner would run under emulation and report a pass that means much less than it appears to.

## Test plan

Verified locally across all four combinations before pushing:

| Build | Result |
|---|---|
| client, **arm64**, Node 24 | `arch=arm64`, `uname=aarch64`, `node v24.18.0`, `/_next/image` → **`image/webp`** |
| client, amd64, Node 24 | `node v24.18.0`, `image/webp`, `/api/config` correct. No regression. |
| server, **arm64**, Node 24 | `node v24.18.0`, `/health` healthy |
| server, amd64, Node 24 | healthy |

The arm64 client carries exactly `@img/sharp-linuxmusl-arm64@0.34.5` and `@img/sharp-libvips-linuxmusl-arm64@1.2.4`, with no x64 or glibc variant present.

The `image/webp` assertion is a proven tripwire, not a tautology: in earlier work, hiding libvips inside a running arm64 container flipped the response to `image/png` while still returning HTTP 200. That is exactly the silent failure this guards, and it is why a status check cannot substitute.

Also: `shellcheck` clean on all four scripts using the same invocation CI runs, and `actionlint` clean with shellcheck present.

## Follow-ups, deliberately not here

- Cutting `v1.9.0`, which mints `latest`, `1.9.0` and `1.9`. Deliberately after this merges so those tags are multi-arch rather than amd64-only.
- Flipping the compose default from `:main` to `:latest`, which cannot happen before that tag exists.
- Promoting `docker-smoke` into the required gate, once this has soaked.

Closes #209.
