### PR TITLE
fix(client): let the image cache actually be written

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -71,9 +71,16 @@ ENV PORT=3000
 WORKDIR /app
 
 # Copy only the self-contained output produced by `output: 'standalone'`.
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/.next/standalone ./
-COPY --from=builder /app/.next/static ./.next/static
+#
+# --chown matters, it is not tidiness. COPY writes as root by default, so
+# /app/.next ends up root-owned while the server runs as `node` below. Next then
+# cannot create /app/.next/cache, and every /_next/image request fails to write
+# its cache entry: the response is still a correct WebP, so nothing looks broken,
+# but the image is re-encoded on every single request and an unhandled rejection
+# is logged each time. Silent CPU burn plus log noise for every self-hoster.
+COPY --from=builder --chown=node:node /app/public ./public
+COPY --from=builder --chown=node:node /app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/.next/static ./.next/static
 
 USER node
 EXPOSE 3000


### PR DESCRIPTION
Found by verifying the published v1.9.0 artifact rather than by CI. It ships in v1.9.0 today.

## What happens

`COPY` writes as root by default, so `/app/.next` ends up root-owned while the standalone server runs as `node`. Next cannot create `/app/.next/cache`.

Measured against `ghcr.io/jannskiee/floe-client:1.9.0`:

```
/app/.next  drwxr-xr-x  root root      <- but we run as uid=1000(node)
X-Nextjs-Cache: MISS                   <- on every request, forever
Error: EACCES: permission denied, mkdir '/app/.next/cache'
unhandledRejection                     <- once per request
```

## Why it survived review and CI

**Nothing looks broken.** The response is a correct WebP and the status is 200. The smoke suite asserts `/_next/image` returns `image/webp`, and it did, throughout.

The real cost is invisible from outside: every self-hoster re-encodes every image on every request, and collects an unhandled rejection in their logs each time. Silent CPU burn plus log noise.

## The fix

`--chown=node:node` on the three runner-stage `COPY` lines.

## Test plan

Rebuilt and measured, before and after:

| | before | after |
|---|---|---|
| 1st `/_next/image` | MISS | MISS |
| 2nd `/_next/image` | **MISS** | **HIT** |
| EACCES / unhandledRejection | present | **0** |
| `/app/.next` owner | `root:root` | `node:node` |
| `/app/.next/cache` | does not exist | exists, `node:node` |
| content type | `image/webp` | `image/webp` |

The last row is the point: the assertion CI does have never moved, which is exactly why this got through.

## Worth a follow-up

The smoke suite could assert `X-Nextjs-Cache: HIT` on a second request. That would have caught this. Deliberately not bundled here so this fix stays minimal and easy to reason about.

Note this only reaches `:latest` users on a v1.9.1. Merging fixes `:main` immediately.