### PR TITLE
docs: point the image examples at latest, and refresh the digest

### DIFF
--- a/docs/self-hosting/images.mdx
+++ b/docs/self-hosting/images.mdx
@@ -37,13 +37,15 @@ FLOE_IMAGE_TAG=1.9.0
 A tag can be repointed. A digest cannot, so it is the strongest pin:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/jannskiee/floe-server:main
+docker buildx imagetools inspect ghcr.io/jannskiee/floe-server:latest
 ```
+
+Take the digest it prints and pin that instead of the tag:
 
 ```yaml
 services:
   server:
-    image: ghcr.io/jannskiee/floe-server@sha256:6f7818b8...
+    image: ghcr.io/jannskiee/floe-server@sha256:f7d9ff66...
 ```
 
 Every tag is verified to resolve to a digest that passed a smoke test before it was applied, so a tag and its digest always refer to an image that was actually started and exercised.
@@ -53,8 +55,10 @@ Every tag is verified to resolve to a digest that passed a smoke test before it 
 Both images are published for **`linux/amd64`** and **`linux/arm64`**. Docker picks the right one automatically, so Raspberry Pi, Oracle Ampere, AWS Graviton, and Apple silicon all work with the same commands as anywhere else.
 
 ```bash
-docker buildx imagetools inspect ghcr.io/jannskiee/floe-client:main
+docker buildx imagetools inspect ghcr.io/jannskiee/floe-client:latest
 ```
+
+It lists one entry per platform, so you can confirm your architecture is covered.
 
 <Note>
   Each architecture is built and smoke-tested on its own hardware before any tag points at it, and a tag is only published once every architecture of both images has passed. A partly-built release is never visible.


### PR DESCRIPTION
Two stale examples on the Container Images page, plus a nudge for what looks like a stuck Mintlify build.

## The stale examples

- The `imagetools inspect` examples still inspected `:main`. That stopped being the recommended tag when the compose default moved to `:latest` in #220.
- The digest example was `sha256:6f7818b8...`, the pre-arm64 amd64-only build. Refreshed to the real current `floe-server:latest` index digest, read from the registry.
- Both examples said to run a command without saying what to do with its output, which is half an instruction.

## The stuck build

The live page serves a **pre-#218** copy of itself. It still says `linux/amd64 only` and `there is no linux/arm64 image yet`, both false since #218 merged.

This is not ordinary propagation lag. On the same site, `/docs/changelog` already serves content from `fed7ebb`, a **newer** commit than the `98abd28` whose change to `images.mdx` is missing. A pending whole-repo sync cannot produce "newer file live, older file stale."

Ruled out along the way:

- **Not the source.** `main` has been correct since #218; verified directly against `origin/main`.
- **Not the Vercel proxy.** The Mintlify origin (`floe.mintlify.site`) serves the same stale bytes.
- **Not misconfiguration.** Git source is `jannskiee/floe`, deploy branch `main`, content directory `docs`.
- **Not browser cache.** Reproduced with cache-busting query strings and `Cache-Control: no-cache`.

The admin SDK exposes no rebuild trigger, only settings operations, and changing git sources to force a resync is a riskier write than it is worth. So a commit touching the file is the supported way to prompt a resync.

**If the page is still stale after this merges, it needs a manual redeploy from the Mintlify dashboard.** I will check and report.
