### PR TITLE
ci: assert the image cache is actually written

### DIFF
--- a/.github/scripts/smoke-image.sh
+++ b/.github/scripts/smoke-image.sh
@@ -70,16 +70,34 @@ floe-client)
         || fail "/api/config was $cfg, expected the SOCKET_URL value"
     echo "OK  /api/config reflects SOCKET_URL"
 
+    img_url='http://localhost:3000/_next/image?url=%2Fgithub-mark-white.png&w=32&q=75'
+
     # A broken sharp does NOT 500. Next silently falls back to serving the
     # original PNG, so status alone proves nothing: the content type is the only
     # signal. This is the guard for the recorded ERR_DLOPEN_FAILED failure mode
     # under pnpm + alpine + standalone.
     ct="$(curl --fail --silent -H 'Accept: image/webp' -o /dev/null \
-        -w '%{content_type}' \
-        'http://localhost:3000/_next/image?url=%2Fgithub-mark-white.png&w=32&q=75')"
+        -w '%{content_type}' "$img_url")"
     [ "$ct" = "image/webp" ] \
         || fail "/_next/image returned '$ct', expected image/webp (sharp is broken)"
     echo "OK  /_next/image -> image/webp (sharp works)"
+
+    # The check above passed for the entire time the cache was broken, which is
+    # exactly how v1.9.0 shipped with /app/.next owned by root while the server
+    # runs as `node`. Next could not create /app/.next/cache, so every request
+    # re-encoded the image and logged an unhandled rejection, while still
+    # returning a correct 200 WebP. Nothing in the response said so.
+    #
+    # The cache header is the only signal that separates the two. Measured on the
+    # published digests: the broken image reports MISS on every request forever,
+    # the fixed one reports MISS then HIT. Asserting only the second request is
+    # deliberate; whether the first is a MISS depends on request ordering, but a
+    # HIT is unambiguous proof the cache was actually written.
+    cache="$(curl --fail --silent -H 'Accept: image/webp' -o /dev/null -D - "$img_url" \
+        | tr -d '\r' | awk 'tolower($1) == "x-nextjs-cache:" { print $2 }')"
+    [ "$cache" = "HIT" ] \
+        || fail "repeat /_next/image reported cache '$cache', expected HIT (the image cache is not writable)"
+    echo "OK  /_next/image is cached (repeat request -> HIT)"
 
     # Second run, different address. If the URL were baked at build time this
     # would still report the first value.


### PR DESCRIPTION
Adds the assertion that would have caught #221 before it shipped.

## Why

The client smoke test already asserts `/_next/image` returns `image/webp`, which is the guard against a broken sharp. That check passed for the entire time the cache was broken, so v1.9.0 shipped with `/app/.next` owned by `root` while the standalone server runs as `node`. Next could not create `/app/.next/cache`, so every request re-encoded the image and logged an unhandled rejection, while still returning a correct 200 WebP.

Status and content type both looked perfectly healthy. That is the whole problem.

## What it asserts

A second request to the same URL, requiring `x-nextjs-cache: HIT`. Measured against the two published digests:

| Digest | What it is | Cache header | EACCES lines |
|---|---|---|---|
| `sha256:96a66a59` | v1.9.0, and still what `latest` points at | `MISS`, `MISS`, `MISS` | 18 |
| `sha256:ae1b0724` | `main`, with the #221 fix | `MISS`, **`HIT`**, **`HIT`** | 0 |

On the broken image `/app/.next` is `root root` with no `cache/` directory. On the fixed one both `/app/.next` and `/app/.next/cache` are `node node`.

## Proof it is not vacuous

An assertion that cannot fail against the known-bad artifact is worth nothing, and this repo has now produced three bugs that never turned CI red (dropped OCI labels, the inert empty-tag guard, and this one). So the same script was run against both digests:

```
# BROKEN v1.9.0 image  (expect: FAIL)
OK  / -> 200
OK  /api/config reflects SOCKET_URL
OK  /_next/image -> image/webp (sharp works)
SMOKE FAIL: repeat /_next/image reported cache 'MISS', expected HIT
exit code: 1

# FIXED main image  (expect: PASS)
OK  / -> 200
OK  /api/config reflects SOCKET_URL
OK  /_next/image -> image/webp (sharp works)
OK  /_next/image is cached (repeat request -> HIT)
OK  /api/config follows a changed SOCKET_URL with no rebuild
SMOKE PASS: floe-client
exit code: 0
```

The three pre-existing checks pass against the broken image and only the new one fails, which is a precise demonstration that the suite was blind here.

## Notes

Only the second request is asserted. Whether the first is a `MISS` depends on request ordering, but a `HIT` is unambiguous proof the cache was written. If a future Next release drops the header the assertion fails loudly rather than silently going quiet, which is the correct direction for a smoke test.

The long image URL is now a variable instead of being repeated.

## Test plan

- `shellcheck -x` on all four scripts, clean.
- `actionlint`, clean.
- Script run against both published digests as above.
- Merging this republishes `:main`, since `.github/scripts/*.sh` is in `images.yml`'s path filter, so CI confirms it a second time on real hardware for both architectures.
