### PR TITLE
ci: promote the Desktop job into the CI green gate; tick Store-plan b and c

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,10 +256,6 @@ jobs:
     name: Desktop (Wails, windows-latest)
     # Windows-only on purpose: the desktop app ships Windows-only for the beta,
     # and the Go code is thick with windows build tags that other runners skip.
-    #
-    # NOT in the ci-green gate yet: per the repo convention, new jobs start
-    # outside the gate's needs (visible but non-blocking) and get promoted in
-    # once stable. Promote by adding "desktop" to ci-green's needs list.
     runs-on: windows-latest
     timeout-minutes: 15
     needs: [changes]
@@ -640,7 +636,7 @@ jobs:
     # never become !cancelled(): without always() a failed or cancelled
     # dependency would skip this job, and GitHub counts a skipped required
     # check as passing.
-    needs: [changes, actionlint, build-and-lint, server, cli, e2e, back-compat]
+    needs: [changes, actionlint, build-and-lint, server, cli, desktop, e2e, back-compat]
     if: always()
     steps:
       - name: Report dependency results

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -210,13 +210,17 @@ binary.
       assets, and `desktop/build/msix/pack.ps1`; workflow packs an UNSIGNED
       .msix into a CI artifact (its only consumer is Partner Center; end users
       cannot install unsigned exe-activation packages)
-- [ ] b. Tag `desktop-v0.2.0`: GitHub release + MSIX artifact from one tag
-- [ ] c. Partner Center submission, PRIVATE audience first (public->private is
+- [x] b. Tag `desktop-v0.2.0`: GitHub release + MSIX artifact from one tag
+      (released 2026-08-01; all three assets verified live, and the
+      FloeDesktop_1.2.0.0_x64.msix artifact validated in Partner Center)
+- [x] c. Partner Center submission, PRIVATE audience first (public->private is
       permanently forbidden): upload the .msix, category Utilities & tools >
       File managers, age ratings, privacy URL https://www.floe.one/privacy,
       support URL = GitHub issues, screenshots at 1366x768 or larger, and
       certification notes that explain testing with floe.one in a browser as
       the second peer (the desktop receive field accepts share links)
+      (submitted 2026-08-02 to the private audience, in certification; every
+      section re-verified against the saved state before submit)
 - [ ] d. Private beta: install from the Store, verify transfers against web and
       CLI, verify no SmartScreen, settings survive an update, context-menu row
       hidden; then promote to PUBLIC


### PR DESCRIPTION
## Summary

- Promotes the `desktop` CI job into the `CI green` gate's `needs` list. It has run green on every invocation since landing (#230, #231, and both main pushes), which satisfies the soak convention; `docker-smoke` is again the single outside-the-gate exception the gate comment describes.
- Ticks DESKTOP.md Store-plan items b and c: `desktop-v0.2.0` released 2026-08-01 (three assets verified live, MSIX artifact validated in Partner Center) and the Store submission made 2026-08-02 (private audience, in certification).

## Test plan

- `actionlint` clean locally
- This PR's own CI run is the promotion simulation: the Desktop job must pass and the `CI green` gate must pass with `desktop` in its needs
- Rollback if the job ever flakes on main: a one-line revert removing `desktop` from the needs list
