### PR TITLE
fix(desktop): pin the Store tile background to the brand dark

### DIFF
--- a/desktop/build/msix/AppxManifest.xml
+++ b/desktop/build/msix/AppxManifest.xml
@@ -54,7 +54,7 @@
       <uap:VisualElements
         DisplayName="Floe Desktop"
         Description="Secure, encrypted peer-to-peer file transfer"
-        BackgroundColor="transparent"
+        BackgroundColor="#18181B"
         Square150x150Logo="Assets\Square150x150Logo.png"
         Square44x44Logo="Assets\Square44x44Logo.png">
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" ShortName="Floe" />


### PR DESCRIPTION
## Summary
- `BackgroundColor="transparent"` in the MSIX manifest makes Windows paint the tile plate with the user's accent color (blue by default). The icon art is an inset rounded square with a transparent margin, so the Store app and Start menu show a blue ring around the dark icon.
- Pin the plate to `#18181B`, the midpoint of the icon's own gradient, so tiles read as one seamless dark square.

## Test plan
- Manifest-only change; `desktop` CI job builds the frontend and vets the Go module as usual.
- Ships as `desktop-v0.2.1`; the packed MSIX replaces 1.2.0.0 in the open Store submission, and the tile renders on the updated Store install after certification.
