### PR TITLE
chore(deps): bump socket.io-parser to 4.2.7 (GHSA-2m8v-j782-fhvr)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1288,9 +1288,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",


### PR DESCRIPTION
## Summary

Closes Dependabot alert #105. `socket.io-parser` 4.2.6 carries GHSA-2m8v-j782-fhvr, "Zero-attachment Memory Exhaustion": high severity, CVSS 7.5 `AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`. A remote, unauthenticated peer sends a binary packet declaring zero attachments, the decoder is left holding a reconstructor it never completes and never frees, and repeated packets exhaust the process. Affected range is `>= 4.0.0 < 4.2.7`.

That decoder sits in front of every browser peer on the signaling server, which is a single host, so this is worth taking on its own rather than waiting for a grouped dependency bump.

## Why this is lockfile-only

`socket.io` 4.8.3 already requires `"socket.io-parser": "~4.2.4"`, which resolves to `>=4.2.4 <4.3.0`. 4.2.7 is inside that range, so no `package.json` edit is needed and no `overrides` entry is added.

Leaving the override out is deliberate rather than an oversight. A pinned override that later disagrees with a bumped dependency is exactly what produced the unresolvable lockfile in #179, and the `"ws": "$ws"` reference form exists so that cannot happen again. Adding `socket.io-parser` here would reintroduce the failure shape, since there is no matching direct dependency for the `"$name"` form to track.

4.2.7 declares the same dependencies as 4.2.6 (`debug ~4.4.1`, `@socket.io/component-emitter ~3.1.0`), both already at their newest in-range version in the lock, and the same `engines`. So the whole change is three fields.

## The diff

```diff
     "node_modules/socket.io-parser": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
-      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.7.tgz",
+      "integrity": "sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==",
```

## Test plan

| Check | Result |
| --- | --- |
| `npm ci` in `server/` | clean install, integrity verified |
| `npm ls socket.io-parser` | single entry, `socket.io-parser@4.2.7` under `socket.io@4.8.3` |
| one copy in the tree | confirmed, no nested duplicate |
| `npm audit --omit=dev` | `found 0 vulnerabilities` |
| `npm test` | 47 pass, 0 fail |
| `playwright test transfer reconnect invalid-room cli-interop` | 9 passed, including a 50 MB browser-to-browser transfer with a SHA-256 integrity check |

The 47 unit tests drive pure functions against a fake peer object and never load `socket.io-parser`, so they are a regression guard rather than evidence for this change. The Playwright specs are the real coverage: they boot `node server.js` against this lockfile and exercise the full `join-room` / offer / answer / ICE handshake through the new parser. `cli-cli` and `back-compat` are not evidence here, since the Go CLI speaks the raw `/ws` endpoint and never touches `socket.io-parser`.

Worth noting as a strength rather than a gap: `client/node_modules` still carries 4.2.6, so the suite proves a 4.2.7 server interoperates with a 4.2.6 client. That is precisely the production configuration between deploying the server and shipping the client fix.

Floe's Socket.IO traffic is JSON only, so the binary reconstructor path this release hardens is never taken by legitimate traffic. There is no behavioural surface to regress.

## Note for reviewers

Plain `npm audit` in `server/` still reports one high, for `brace-expansion`. That arrives through `nodemon`, is a devDependency that never ships, and has no open alert against `server/package-lock.json`. It is out of scope here, which is why the acceptance criterion above is `npm audit --omit=dev`.

## Deployment

This needs `npm ci` on the host. A lockfile-only change moves no source file, so `git pull` followed by a process restart would re-execute against the existing `node_modules` and leave 4.2.6 running while looking like a successful deploy.

## Follow-up

Alert #106 is the same advisory against `client/pnpm-lock.yaml`, where `socket.io-parser` is pinned in `client/pnpm-workspace.yaml`. It ships to Vercel rather than the signaling host and its exposure is different (only the server you are already connected to can feed that decoder), so it is tracked separately.
