### PR TITLE
feat(client): send security headers, starting with frame-ancestors

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -28,6 +28,51 @@ const nextConfig = {
         formats: ['image/webp'],
     },
 
+    // Security response headers. floe.one previously sent none at all: the only
+    // one on the wire was Vercel's own HSTS, while api.floe.one has had the full
+    // helmet set all along.
+    //
+    // frame-ancestors is the one that actually matters here, and it is not a
+    // checkbox. A receiver page joins its room on mount and creates an
+    // ICE-gathering peer with no user interaction (P2PTransfer.tsx), so a hidden
+    // iframe pointed at an attacker's room made every visitor silently relay
+    // their host and server-reflexive candidates, which is their LAN and public
+    // IP, with zero clicks. X-Frame-Options repeats it for user agents that
+    // predate frame-ancestors.
+    //
+    // Deliberately no script-src or connect-src. Next inlines the RSC payload as
+    // ~17 bootstrap <script> blocks and only emits a nonce when it can parse one
+    // out of an inbound request header, which a static headers() cannot provide,
+    // so a script-src here would need 'unsafe-inline' and buy nothing. The
+    // directives below are enforced regardless of inline script, which is
+    // precisely why they are the ones worth having. connect-src and worker-src
+    // are also quietly load-bearing: both would need blob:, or the fflate zip
+    // worker and the ZIP download stop working.
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: [
+                    {
+                        key: 'Content-Security-Policy',
+                        value: "frame-ancestors 'none'; object-src 'none'; base-uri 'none'; form-action 'self'",
+                    },
+                    { key: 'X-Frame-Options', value: 'DENY' },
+                    { key: 'X-Content-Type-Options', value: 'nosniff' },
+                    // Room links carry their secret in the fragment, which is never
+                    // sent as a referrer. Older links used ?room= in the query
+                    // string (see lib/scrubUrl.ts), which is, so this closes a real
+                    // if legacy leak to every outbound link on the page.
+                    { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+                    {
+                        key: 'Permissions-Policy',
+                        value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()',
+                    },
+                ],
+            },
+        ];
+    },
+
     // Documentation lives on Mintlify and is served at floe.one/docs (a subpath
     // of the primary domain, for SEO) via a reverse proxy: every /docs request
     // is rewritten to the Mintlify deployment, which is configured with base

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,4 +1,9 @@
-const CACHE_NAME = 'floe-cache-v3';
+// Bump on any change to what is cached OR to the response headers, because the
+// Cache API stores whole responses, headers included, and everything except a
+// navigation is served cache-first. Without a bump, returning visitors keep
+// pre-change headers on those assets indefinitely. v4 carries the first
+// security-header set the site has ever sent.
+const CACHE_NAME = 'floe-cache-v4';
 const STATIC_ASSETS = [
     '/',
     '/download',


### PR DESCRIPTION
## Summary

floe.one sends no security headers. Measured on the live site, the only one on the wire is Vercel's own HSTS:

```
$ curl -sSI https://www.floe.one/
HTTP/1.1 200 OK
Strict-Transport-Security: max-age=63072000
Server: Vercel
...
```

No `X-Content-Type-Options`, no `X-Frame-Options`, no `Content-Security-Policy`, no `Referrer-Policy`. Meanwhile `api.floe.one` has had the full helmet set since it was written, so the gap between the two halves of the product is total.

## The actual risk, which is not clickjacking

A receiver page joins its room on mount and creates an ICE-gathering peer with **no user interaction**:

- `P2PTransfer.tsx:465` calls `joinRoomAsReceiver` inside a mount effect, gated only on the room id being a valid UUID
- `:329` constructs the peer immediately after

So a hidden iframe on any page:

```html
<iframe src="https://www.floe.one/?s=x#room=<attacker-uuid>" style="display:none"></iframe>
```

makes every visitor's browser silently join the attacker's room and relay its host and server-reflexive candidates through the signaling server to the attacker's waiting sender. That is the visitor's **LAN and public IP**, with zero clicks and nothing visible.

`frame-ancestors 'none'` closes it. `X-Frame-Options: DENY` repeats it for user agents that predate `frame-ancestors`.

## What ships

```
Content-Security-Policy: frame-ancestors 'none'; object-src 'none'; base-uri 'none'; form-action 'self'
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()
```

`Referrer-Policy` is not decoration here either. Room links carry their secret in the fragment, which is never sent as a referrer, but older links used `?room=` in the query string (`lib/scrubUrl.ts:4-7`) and that **is** sent. Every outbound link on the page was a potential leak of a legacy room id to GitHub, Ko-fi, or Microsoft.

## Why no script-src or connect-src

Next inlines the RSC payload as roughly 17 bootstrap `<script>` blocks, and it only emits a nonce when it can parse one out of an **inbound request header**, which a static `headers()` cannot provide. Nonces would need `middleware.ts`, which would also opt pages out of static prerendering. So `script-src` here would require `'unsafe-inline'` and buy essentially nothing.

The directives that did ship are enforced regardless of inline script, which is precisely why they are the ones worth having.

Leaving `connect-src` and `worker-src` out is also deliberate, and load-bearing. Both would need `blob:`:

- `useDownloadManager.ts:77` does `fetch()` on a `blob:` URL, so a `connect-src` without `blob:` breaks the ZIP download
- the fflate zip worker and Sentry's compression worker are both `new Worker(URL.createObjectURL(...))`, so a `worker-src` without `blob:` breaks them

Omitting those directives makes that class of breakage impossible rather than merely untested.

## Service worker

`sw.js` goes `floe-cache-v3` to `v4` in the same commit. The Cache API stores whole responses, headers included, and everything except a navigation is served cache-first, so without the bump returning visitors would keep pre-change headers on those assets indefinitely.

## Test plan

**The framing block, verified in a real browser with a same-origin A/B** rather than assumed:

| Frame target | `contentDocument` | `contentWindow.location` |
| --- | --- | --- |
| `about:blank` (control, allowed) | `accessible` | `about:blank` |
| the receiver page | **`null`** | **throws `SecurityError`** |

A same-origin iframe always exposes `contentDocument` unless the load was refused, and the control proves the probe itself works.

**Headers on the wire**, confirmed present on `/`, `/download`, and a `/_next/static/chunks/*.js` asset, and compiled into `routes-manifest.json` as a single rule.

**Nothing regressed:** lint clean, 151 unit tests, and the full Playwright suite green against a real production build (not a dev server): **27 passed, 4 skipped**, including the 50 MB browser-to-browser transfer with a SHA-256 integrity check, both CLI interop directions, and the responsive sweep across every route.

## Not in this PR

The Sentry Session Replay room-secret leak was scoped alongside this and is **not fixed here**. It needs a different approach and is tracked separately, so it is not held up behind this change.
