### PR TITLE
chore(deps): bump socket.io-parser, brace-expansion and postcss pins

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -7,15 +7,15 @@ settings:
 overrides:
   esbuild: ^0.28.1
   ws: ^8.21.0
-  postcss: ^8.5.15
+  postcss: ^8.5.23
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   minimatch@3: ^3.1.3
   minimatch@9: ^9.0.7
-  socket.io-parser: ^4.2.6
+  socket.io-parser: ^4.2.7
   flatted: ^3.4.2
-  brace-expansion@1: ^1.1.16
-  brace-expansion@5: ^5.0.8
+  brace-expansion@1: ^1.1.18
+  brace-expansion@5: ^5.0.9
   js-yaml: ^4.3.0
 
 importers:
@@ -1714,11 +1714,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.17:
-    resolution: {integrity: sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2773,10 +2773,6 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.24:
     resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2954,8 +2950,8 @@ packages:
     resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
     engines: {node: '>=10.0.0'}
 
-  socket.io-parser@4.2.6:
-    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
     engines: {node: '>=10.0.0'}
 
   source-map-js@1.2.1:
@@ -4386,7 +4382,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.19
+      postcss: 8.5.25
       tailwindcss: 4.3.3
 
   '@tybys/wasm-util@0.10.3':
@@ -4843,12 +4839,12 @@ snapshots:
 
   baseline-browser-mapping@2.11.6: {}
 
-  brace-expansion@1.1.17:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5865,11 +5861,11 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.17
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -6030,12 +6026,6 @@ snapshots:
       fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.5.19:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.24:
     dependencies:
@@ -6310,13 +6300,13 @@ snapshots:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3
       engine.io-client: 6.6.5
-      socket.io-parser: 4.2.6
+      socket.io-parser: 4.2.7
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.6:
+  socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
       debug: 4.4.3

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -9,22 +9,25 @@ allowBuilds:
 overrides:
   esbuild: ^0.28.1
   ws: ^8.21.0
-  postcss: ^8.5.15
+  postcss: ^8.5.23
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   minimatch@3: ^3.1.3
   minimatch@9: ^9.0.7
-  socket.io-parser: ^4.2.6
+  socket.io-parser: ^4.2.7
   flatted: ^3.4.2
-  # GHSA advisories 2026-07: DoS via pathological inputs in dev tooling.
-  # brace-expansion needs a pin per major line. GHSA-mh99-v99m-4gvg
-  # (CVE-2026-14257) declares a single affected range, <= 5.0.7, with no
-  # per-major carve-out, so the 1.x line is nominally in scope as well. It
-  # cannot be moved: minimatch@3 (via eslint's config-array and eslintrc)
-  # CommonJS-requires brace-expansion's default export, and 5.x changed that
-  # shape, so forcing 5.0.8 there fails with "expand is not a function" and
-  # breaks eslint outright. 1.x has no patched release. The 5.x instance does
-  # move to the fixed 5.0.8. Both lines are dev tooling that never ships.
-  brace-expansion@1: ^1.1.16
-  brace-expansion@5: ^5.0.8
+  # GHSA advisories 2026-07 and GHSA-rgw5-rvv9-x895: DoS via pathological inputs
+  # in dev tooling. brace-expansion needs a pin per major line, because the two
+  # lines reach us through different minimatch majors.
+  #
+  # The 1.x line used to be stuck. The previous note here said it "cannot be
+  # moved" because minimatch@3 (via eslint's config-array and eslintrc)
+  # CommonJS-requires brace-expansion's default export, 5.x changed that shape,
+  # and forcing 5.0.8 there failed with "expand is not a function". That is
+  # still true of 5.x on minimatch@3, but the conclusion is now stale: 1.1.18
+  # exists and is the same CommonJS shape as 1.1.17, same dependency set, so the
+  # 1.x line moves to its own patched release rather than across majors.
+  # Both lines are dev tooling that never ships.
+  brace-expansion@1: ^1.1.18
+  brace-expansion@5: ^5.0.9
   js-yaml: ^4.3.0


### PR DESCRIPTION
## Summary

Closes the three Dependabot alerts against `client/pnpm-lock.yaml` that had no fix PR. All three were already pinned in `client/pnpm-workspace.yaml`, so each is a range bump plus a lockfile re-resolve.

| Alert | Package | From | To |
| --- | --- | --- | --- |
| #106 | `socket.io-parser` | `^4.2.6` | `^4.2.7` |
| #104 | `brace-expansion@5` | `^5.0.8` | `^5.0.9` |
| #104 | `brace-expansion@1` | `^1.1.16` | `^1.1.18` |
| #108 | `postcss` | `^8.5.15` | `^8.5.23` |

## Exposure, stated honestly

**#106 does ship in the browser bundle** (the decoder's own error strings are in the client chunk), but it is hygiene rather than urgent, and the difference from the server-side fix in #237 is worth being precise about.

On the server, any anonymous peer could open a socket and feed the decoder directly. In the browser, the only party who can is whoever operates the signaling endpoint that browser was configured to use:

- `lib/socketUrl.ts` resolves the endpoint from a build-time constant or a same-origin `/api/config`. There is no `?server=` escape hatch, and no URL-derived value reaches it.
- A hostile *peer* cannot reach the vulnerable reconstructor, because the server re-encodes every relayed signal as a plain EVENT packet. A peer controls the payload, never the frame type or attachment header.
- The desktop app is unaffected entirely: it speaks the protocol through the Go engine, not socket.io.

**#104 and #108 are build-only**, despite Dependabot labelling brace-expansion "runtime". That label is a manifest-scope artifact: the path is `@sentry/nextjs` to its bundler plugins to `glob` to `minimatch`, all Next build plugins. Neither package reaches the shipped bundle.

## The brace-expansion 1.x line was stuck, and no longer is

The comment in `pnpm-workspace.yaml` said the 1.x line "cannot be moved". That reasoning was about forcing **5.x** onto `minimatch@3`, which does still break eslint with `expand is not a function`. But it is no longer the only option: **1.1.18 exists**, with the same CommonJS shape as 1.1.17 and the same dependency set, so the 1.x line moves to its own patched release instead of across majors.

The comment is rewritten rather than left to mislead the next reader, following what #191 and #201 did before it.

## Result

`pnpm audit` goes from **6 findings to 2**, and `pnpm audit --prod` agrees:

- `sharp` (#80) stays open on purpose, since 0.35.x breaks with `ERR_DLOPEN_FAILED` under pnpm + alpine in the standalone image
- `fast-uri` (#109) is covered by Dependabot #238

## Test plan

- **`pnpm lint` clean.** This is the real gate for this change: it is exactly where the previous brace-expansion attempt failed, and the reason the 1.x pin was abandoned last time.
- 151 unit tests pass.
- Production build succeeds.
- Full Playwright suite against that build: **27 passed, 4 skipped**, including the 50 MB browser-to-browser transfer with a SHA-256 integrity check and both CLI interop directions. The e2e run is the meaningful check here, since `socket.io-parser` is the browser's signaling decoder.
- Resolved versions confirmed: `socket.io-parser@4.2.7` under `socket.io-client@4.8.3`; `brace-expansion@1.1.18` under `minimatch@3.1.5` and `@5.0.9` under `minimatch@10.2.6`; the vulnerable `postcss@8.5.19` is gone.

Both files are committed together, since a `pnpm-workspace.yaml` change without the matching lockfile fails `--frozen-lockfile` in four separate CI steps.
