### PR TITLE
fix(client): remove Session Replay, which transmitted the room secret

### DIFF
--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -22,7 +22,7 @@ const toc = [
     { id: 'collect', label: 'Information we collect' },
     { id: 'third-parties', label: 'Third-party services' },
     { id: 'relay', label: 'Relay server' },
-    { id: 'errors', label: 'Error monitoring & session replay' },
+    { id: 'errors', label: 'Error monitoring' },
     { id: 'analytics', label: 'Usage analytics' },
     { id: 'desktop', label: 'The desktop app' },
     { id: 'contact', label: 'Contact & abuse reports' },
@@ -138,7 +138,7 @@ export default function PrivacyPolicy() {
                 </p>
             </LegalSection>
 
-            <LegalSection id="errors" index="05" title="Error monitoring & session replay">
+            <LegalSection id="errors" index="05" title="Error monitoring">
                 <p>
                     The <strong className="font-semibold text-zinc-200">web app</strong> uses Sentry
                     to monitor application errors and performance. This applies to floe.one in the
@@ -149,18 +149,19 @@ export default function PrivacyPolicy() {
                     items={[
                         'Error stack traces and browser metadata (browser version, OS, device type)',
                         'Connection type (direct or relay), transfer progress, file count, and total size at the time of an error',
-                        <>
-                            <strong className="font-semibold text-zinc-200">Session replay.</strong> An
-                            anonymized, video-like recording of a small sample of browser sessions,
-                            plus any session where an error occurs. All on-screen text and media are
-                            masked, so file names and file contents are never captured.
-                        </>,
                     ]}
                 />
                 <p>
+                    Session replay is{' '}
+                    <strong className="font-semibold text-zinc-200">not</strong> enabled. Floe used to
+                    record a sample of browser sessions. A recording reported the page address, and on
+                    a receiver page that address contains the room link, so replay was removed rather
+                    than kept: the room link is the only thing protecting a transfer.
+                </p>
+                <p>
                     Sentry does <strong className="font-semibold text-zinc-200">not</strong> capture
-                    file names, file contents, or any personally identifiable information. Session
-                    recordings are used solely for debugging technical issues.{' '}
+                    file names, file contents, or any personally identifiable information. The room
+                    link is stripped from every error report and breadcrumb before it is sent.{' '}
                     <a
                         href="https://sentry.io/privacy/"
                         target="_blank"

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -79,19 +79,30 @@ Sentry.init({
         return breadcrumb;
     },
 
-    // Session replay: capture 10% of sessions, 100% of sessions with errors
-    replaysSessionSampleRate: 0.1,
-    replaysOnErrorSampleRate: 1.0,
-
-    integrations: [
-        Sentry.replayIntegration({
-            // Mask all text and block media so replays never capture file names,
-            // on-screen content, or previews. This upholds the Privacy Policy
-            // (Section 5): file names and file contents are never captured.
-            maskAllText: true,
-            blockAllMedia: true,
-        }),
-    ],
+    // Session Replay is deliberately absent, and must not be added back.
+    //
+    // A replay envelope reports the page URL in `request.url`, and on a receiver
+    // page that is the whole /?s=<nonce>#room=<id> link. The room id is the only
+    // thing protecting a transfer: anyone holding it can join as the receiver.
+    // Captured envelopes confirmed it, so this was a live leak, not a theory.
+    //
+    // It cannot be scrubbed. Replay does not send through the client, so none of
+    // the hooks reach it: beforeSend is bypassed (replay uses prepareEvent and
+    // never enters _processEvent), an event processor had no effect, and
+    // beforeEnvelope is only emitted inside Client.sendEnvelope while
+    // @sentry/replay calls transport.send(envelope) directly. maskAllText does
+    // not help either, because the URL is envelope metadata rather than DOM.
+    //
+    // Omitting both `replays*SampleRate` options and the integration is
+    // sufficient and complete. Replay is NOT one of @sentry/nextjs's default
+    // client integrations (those are the browser set plus browserTracing and
+    // nextjsClientStackFrameNormalization), and nothing auto-enables it from the
+    // sample rates. Independently, the integration hard-gates itself: with both
+    // rates at 0 or absent, initializeSampling() returns before attaching any
+    // listener.
+    //
+    // Error and performance monitoring are unaffected and keep their scrubbing
+    // through beforeSend and beforeBreadcrumb above.
 
     debug: false,
 });


### PR DESCRIPTION
## Summary

Session Replay was transmitting the room secret to Sentry. A replay envelope reports the page URL in `request.url`, and on a receiver page that is the whole `/?s=<nonce>#room=<id>` link. The room id is the only thing protecting a transfer: anyone holding it can join as the receiver.

Confirmed against **captured envelopes**, not inferred:

```json
"request":{"url":"https://.../?s=<nonce>#room=<uuid>"}
```

Live for 10% of sessions (`replaysSessionSampleRate`) plus every session with an error (`replaysOnErrorSampleRate: 1.0`). It contradicted both the privacy policy and the entire purpose of `lib/scrubUrl.ts`.

## Why it is removed rather than scrubbed

**Replay does not send through the client**, so none of the scrubbing hooks reach it. All three were tried against real envelopes:

| Hook | Why it fails |
| --- | --- |
| `beforeSend` | replay builds its event with `prepareEvent` and never enters `_processEvent`, where `beforeSend` lives |
| `addEventProcessor` | registers on the isolation scope; the captured envelope still carried the fragment with it in place |
| `beforeEnvelope` | only emitted inside `Client.sendEnvelope`, and `@sentry/replay` calls `transport.send(envelope)` **directly** |

`maskAllText` does not help either, because the URL is envelope metadata rather than DOM. So the choice was replay or the room secret.

## Why removing the integration and the two sample rates is sufficient

Replay is **not** one of `@sentry/nextjs`'s default client integrations (those are the `@sentry/browser` set plus `browserTracing` and `nextjsClientStackFrameNormalization`), and nothing auto-enables it from the sample rates. Independently, the integration hard-gates itself: with both rates absent, `initializeSampling()` returns before attaching any listener.

Error and performance monitoring are untouched and keep their existing scrubbing through `beforeSend` and `beforeBreadcrumb`.

## Verification

Three independent checks, all of which had to hold.

**1. The bundle.** The recording machinery is not merely disabled, it is no longer shipped.

| Marker | Before | After |
| --- | --- | --- |
| `replaysSessionSampleRate:` | 1 | **0** |
| `rrweb` | present | **0 chunks** |
| `sentryReplaySession` | present | **0 chunks** |

**2. Runtime**, against a build with a working DSN so Sentry was genuinely enabled (`enabled: true`, `dsnSet: true`):

```
integrations: InboundFilters, FunctionToString, ConversationId, BrowserApiErrors,
              Breadcrumbs, GlobalHandlers, LinkedErrors, Dedupe, HttpContext,
              CultureContext, BrowserSession, BrowserTracing,
              NextjsClientStackFrameNormalization, WebVitals
hasReplayIntegration: false
replaysSessionSampleRate: undefined
replaysOnErrorSampleRate: undefined
```

14 integrations resolved, none of them Replay.

**3. Captured envelopes**, via a local sink DSN so nothing left the machine:

| | |
| --- | --- |
| error events transmitted | **2** (this is what makes the result meaningful rather than vacuous) |
| `replay_event` | **0** |
| `replay_recording` | **0** |
| room id anywhere in transmitted bytes | **0** |
| `#room=` anywhere in transmitted bytes | **0** |
| `request.url` as sent | `http://localhost:3000/?s=<nonce>` |

That last row is the proof that nothing else regressed: `beforeSend` still strips the fragment and still leaves the non-secret nonce alone (the nonce is documented at `P2PTransfer.tsx:527` as carrying no information).

**A note on an earlier false negative**, since it would otherwise be repeated: a first attempt appeared to fail because a stale tab keeps flushing replay for up to 15 minutes on a 5 second debounce, so it was still posting from the previous bundle. The verification above clears the service worker and the `sentryReplaySession` key first, and cross-checks envelope timestamps against the build time.

Also: lint clean, 151 unit tests, and the full Playwright suite green against a production build (27 passed, 4 skipped).

## Privacy policy

The policy said replay was active and described what it masked. That section now says it is not enabled and why, and the heading drops "session replay".
