### PR TITLE
docs: put the desktop releases in the changelog, and tag every entry

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Changelog"
-description: "Release history for Floe."
+description: "Release history for Floe: every user-visible change to the web app at floe.one, the Floe Desktop app for Windows, and the floe command-line tool."
 ---
 
-<Update label="Unreleased">
+<Update label="Unreleased" tags={["CLI"]}>
   **Received files are never overwritten, and Windows marks them as downloads**
 
   - `floe receive` no longer overwrites an existing file that has the same name as an incoming one. The new file is saved with a numbered suffix before the extension (`report.pdf`, then `report (1).pdf`), the same way browsers de-duplicate downloads. The progress line shows the name actually written.
@@ -11,7 +11,31 @@ description: "Release history for Floe."
   - No transfer-protocol change, so this release interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.9.1" description="2026-07-30">
+<Update label="desktop-v0.2.0" description="2026-08-02" tags={["Desktop"]}>
+  **Floe Desktop arrives on the Microsoft Store**
+
+  - Floe Desktop is now on the [Microsoft Store](https://apps.microsoft.com/detail/9NBQ8ZQ1065L). Microsoft re-signs the package, so it installs with no "unknown publisher" warning and updates itself in the background. This is the recommended way to install it.
+  - The installer and portable zip on GitHub continue in parallel and are not going away. They serve machines without Store access, and they are the fallback if a Store update ever goes wrong. Those builds are unsigned, so Windows still warns on first run.
+  - The **Show in right-click menu** setting is hidden on a Store install, along with the Windows section of Settings that contains it. A packaged app's registry writes land in a private view that File Explorer never reads, so the entry could be written but would never appear. The GitHub build still offers it.
+  - Both builds keep their settings in the same place, so switching between them, or between the desktop app and the `floe` CLI, keeps your server address and preferences.
+  - Desktop releases carry their own `desktop-vX.Y.Z` numbers, separate from the `vX.Y.Z` tags that release the CLI and the server. The two lines never need to match.
+  - No transfer-protocol change, so Floe Desktop 0.2.0 transfers with browser and CLI peers in every direction.
+</Update>
+
+<Update label="desktop-v0.1.0" description="2026-08-01" tags={["Desktop"]}>
+  **Floe Desktop, the first beta**
+
+  - A native Windows app, and the third way to use Floe alongside the web app and the CLI. It runs the same transfer engine as the CLI, so it sends to and receives from browser peers and CLI peers with no extra setup. See [Floe Desktop](/desktop/installation).
+  - Send files, whole folders without zipping, or a typed note. Add them with the picker, by dropping them anywhere on the window, or with `Ctrl` `V` for files copied in File Explorer and for screenshots straight off the clipboard.
+  - Receive with a room code or a share link, choose where files land, then open the file or reveal it in File Explorer. Nothing is ever overwritten, and received files are tagged as downloads so Windows applies its usual caution.
+  - A local history of the last 50 transfers, a Windows notification when one finishes, and the machine is kept awake while a transfer is connected.
+  - Settings cover the save folder, a **Hide my IP** mode that routes everything through the relay, the global-stats opt-out, the File Explorer **Send with Floe** entry, and a self-hosted server address with a **Test** button that checks the three endpoints a transfer actually needs.
+  - The installer is per user, so there is no administrator prompt, and uninstalling leaves your settings and history in place.
+  - Relayed transfers are capped at 2 GB per session, the same rule the web app and the CLI already apply. Direct transfers have no limit.
+  - No transfer-protocol change, so Floe Desktop 0.1.0 transfers with browser and CLI peers in every direction.
+</Update>
+
+<Update label="v1.9.1" description="2026-07-30" tags={["Self-hosting"]}>
   **A self-hosting image fix. The CLI is unchanged.**
 
   - Fixed the self-hosted web client re-encoding every image on every request instead of caching it. `/app/.next` was owned by `root` while the server runs as `node`, so the image cache could never be written. Pages rendered correctly throughout, which is why it went unnoticed: the only symptoms were wasted CPU on every request and an `EACCES` unhandled rejection in the container logs each time. This affects `1.9.0`, and `latest` as it stood before this release.
@@ -22,7 +46,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.9.1 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.9.0" description="2026-07-30">
+<Update label="v1.9.0" description="2026-07-30" tags={["Self-hosting", "CLI"]}>
   **Self-hosting without a clone, on any common hardware**
 
   - Prebuilt images are published to `ghcr.io/jannskiee/floe-server` and `ghcr.io/jannskiee/floe-client`, and `docker-compose.yml` pulls them. A working instance is two commands: download the compose file, then `docker compose up -d`. No repository, no Node, no Go, nothing compiled locally. See [Container Images](/self-hosting/images).
@@ -38,7 +62,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.9.0 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.8.0" description="2026-07-23">
+<Update label="v1.8.0" description="2026-07-23" tags={["CLI"]}>
   **The 2 GB relay cap now applies to the CLI, plus honest receiver errors**
 
   - `floe send` now enforces the same 2 GB relay session cap as the web app. Once the connection is established, the sender checks the selected route: if it runs through the TURN relay and the queued files total more than 2 GB, the transfer is blocked before any data moves, with a clear error. Direct connections keep no size limit, and a connection whose path cannot be determined is never blocked. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
@@ -47,7 +71,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.8.0 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.7.6" description="2026-07-21">
+<Update label="v1.7.6" description="2026-07-21" tags={["CLI", "Web"]}>
   **Stalled transfers now fail fast with clear errors**
 
   - Fixed transfers freezing forever when the connection silently broke right after setup. The receiver now reports "connected, but no data arrived from the sender" within 30 seconds if the transfer never starts, and "transfer stalled" with exact byte progress if data stops flowing mid-file for a full minute, instead of sitting on a frozen progress bar until you press Ctrl+C. These stalls are rare, but when one happened there was no way to tell it apart from a slow transfer.
@@ -57,7 +81,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.7.6 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.7.5" description="2026-07-10">
+<Update label="v1.7.5" description="2026-07-10" tags={["CLI", "Web"]}>
   **Accurate progress on slow connections, and a CLI relay fix**
 
   - Fixed the sender's progress running far ahead of the receiver. The sender counted bytes handed to the connection's send buffer rather than bytes that actually reached the other side, so on slower or relayed connections its bar raced ahead by up to 8 MB, froze for up to a minute while the buffer drained, moved to the next file before the receiver finished the previous one, and showed "All Files Sent!" while the receiver was still downloading. The sender now reports delivered bytes: both sides move together at the real network speed, the file counter stays in step, and completion means the receiver has everything.
@@ -67,7 +91,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.7.5 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.7.4" description="2026-07-10">
+<Update label="v1.7.4" description="2026-07-10" tags={["CLI", "Web"]}>
   **Faster connection setup**
 
   - Fixed connections taking 20 to 30 seconds to establish on machines running VPN or virtual machine software (Tailscale, VMware, WSL, Hyper-V). Two causes were addressed: the signaling server handed every client a redundant list of eight relay endpoints where three suffice, and the CLI probed dead auto-configuration network interfaces during setup. The server-side fix is already live and speeds up all existing versions, browser included; this release adds the CLI-side hardening so connections stay fast against any server, including self-hosted ones.
@@ -76,7 +100,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.7.4 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.7.3" description="2026-07-09">
+<Update label="v1.7.3" description="2026-07-09" tags={["CLI", "Web"]}>
   **Faster CLI transfers, and a browser-to-CLI reliability fix**
 
   - `floe send` now sends file data in larger blocks, sized to what the connection negotiates (up to 256 KB) rather than a fixed 16 KB. On fast paths such as a local network or a direct connection, this removes most of the per-block overhead and noticeably increases throughput. Relayed or slower connections are unaffected, since their speed is set by the link rather than the block size.
@@ -84,7 +108,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.7.3 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.7.2" description="2026-06-30">
+<Update label="v1.7.2" description="2026-06-30" tags={["CLI"]}>
   **CLI: share links keep the room secret in the URL fragment**
 
   - `floe send` now prints a `https://floe.one/#room=<id>` link. The room id sits in the URL fragment (after the `#`), which a browser never sends to the web server, never puts in the `Referer` header, and never exposes to pageview analytics. Previously it was a `?room=` query parameter that could reach those places when a recipient opened the link in a browser. This brings the CLI in line with the web app.
@@ -92,7 +116,7 @@ description: "Release history for Floe."
   - No transfer-protocol change, so v1.7.2 interoperates with older CLI and browser peers in every direction.
 </Update>
 
-<Update label="v1.7.1" description="2026-06-22">
+<Update label="v1.7.1" description="2026-06-22" tags={["CLI"]}>
   **Reliable global-counter reporting for the CLI**
 
   - Fixed CLI transfers not always being counted in the global homepage counter. The receiver's byte-count report was sent in the background and could be cut short when the sender closed the connection and the process exited, so larger transfers (several GB and up) were frequently missed and smaller ones counted only intermittently.
@@ -100,7 +124,7 @@ description: "Release history for Floe."
   - Browser transfers were never affected by this issue.
 </Update>
 
-<Update label="v1.7.0" description="2026-06-22">
+<Update label="v1.7.0" description="2026-06-22" tags={["Web", "CLI", "Self-hosting"]}>
   **Global transfer counter with opt-out**
 
   - Added a public, all-time counter of total bytes transferred across every Floe user, shown on the homepage with a rolling-number animation. The number rolls up from zero on each visit and ticks higher as transfers complete worldwide.
@@ -110,7 +134,7 @@ description: "Release history for Floe."
   - Self-hosters can opt in by pointing the server at a free [Upstash Redis](https://upstash.com) database (`UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`). Without it, the counter still works but resets on restart. See [Configuration](/self-hosting/configuration).
 </Update>
 
-<Update label="v1.6.0" description="2026-06-22">
+<Update label="v1.6.0" description="2026-06-22" tags={["CLI", "Web"]}>
   **Protocol version negotiation**
 
   - Added a wire protocol version that the sender and receiver exchange when a transfer starts. It is separate from the release version (1.6.x), so peers on different releases still transfer normally. A patch or minor difference such as v1.5.4 and v1.5.5 is never a conflict and is never blocked.
@@ -118,49 +142,49 @@ description: "Release history for Floe."
   - Works in every direction: CLI-to-CLI, browser-to-CLI, and CLI-to-browser. Older peers that predate this change are treated as the baseline protocol and stay fully compatible.
 </Update>
 
-<Update label="v1.5.5" description="2026-06-21">
+<Update label="v1.5.5" description="2026-06-21" tags={["CLI"]}>
   **`floe update` permission fix**
 
   - Fixed `floe update` failing with "permission denied" when floe is installed in a root-owned directory such as `/usr/local/bin` on Linux and macOS. The updater now downloads and extracts as the current user, installs directly when the location is user-writable (for example `~/.local/bin`), and automatically requests sudo only for the final atomic swap when it is not. To upgrade from an older version one time, run `sudo floe update`; after that plain `floe update` works.
 </Update>
 
-<Update label="v1.5.4" description="2026-06-21">
+<Update label="v1.5.4" description="2026-06-21" tags={["CLI"]}>
   **CLI progress bar fix**
 
   - Fixed the transfer progress bar printing a new line for every percentage on narrow or Windows terminals. The bar now sizes itself to the terminal width so the line never wraps, and it updates in place on a single line per file.
 </Update>
 
-<Update label="v1.5.3" description="2026-06-21">
+<Update label="v1.5.3" description="2026-06-21" tags={["CLI"]}>
   **Installer and self-update download fix**
 
   - Fixed a 404 when installing or updating floe. The install scripts (`install.sh`, `install.ps1`) and the built-in `floe update` requested the release archive with a leading "v" in the version (for example `floe_v1.5.2_linux_arm64.tar.gz`), but the published asset name omits it (`floe_1.5.2_linux_arm64.tar.gz`). All download paths now use the correct filename. This affected every platform and architecture, including Raspberry Pi (linux/arm64).
 </Update>
 
-<Update label="v1.5.2" description="2026-06-17">
+<Update label="v1.5.2" description="2026-06-17" tags={["CLI"]}>
   **CLI stability fix**
 
   - Fixed a rare concurrent-write panic in the CLI signaling client. Rapid ICE candidate negotiation could trigger simultaneous WebSocket writes from separate goroutines; all writes are now serialized.
 </Update>
 
-<Update label="v1.5.1" description="2026-06-17">
+<Update label="v1.5.1" description="2026-06-17" tags={["CLI"]}>
   **CLI output improvement**
 
   - The `Sending` summary line (file name and total size) now appears above the sharing box, so you can see what is being sent before the peer connects.
 </Update>
 
-<Update label="v1.5.0" description="2026-06-17">
+<Update label="v1.5.0" description="2026-06-17" tags={["CLI"]}>
   **File summary on both sides**
 
   - Both the sender and the receiver now see a file count and total size before and after the transfer. Example: `Sending   3 files · 11.8 MB` on the sender side and `Incoming   3 files · 11.8 MB` on the receiver side.
 </Update>
 
-<Update label="v1.4.0" description="2026-06-17">
+<Update label="v1.4.0" description="2026-06-17" tags={["CLI"]}>
   **CLI-to-CLI transfer fix**
 
   - Fixed an error reported by the CLI sender after a successful CLI-to-CLI transfer. The transfer completed correctly but the sender exited with an error code. It now exits cleanly.
 </Update>
 
-<Update label="v1.3.0" description="2026-06-17">
+<Update label="v1.3.0" description="2026-06-17" tags={["CLI"]}>
   **One-command install and self-update**
 
   - `floe update` now works on all platforms (script installs, manual installs). It downloads, verifies, and replaces the running binary in one step.
@@ -169,7 +193,7 @@ description: "Release history for Floe."
   - Security: updated `ws`, `esbuild`, and `postcss` transitive dependencies to address published advisories.
 </Update>
 
-<Update label="v1.2.0" description="2026-06-16">
+<Update label="v1.2.0" description="2026-06-16" tags={["CLI"]}>
   **Rich transfer summary**
 
   - At the end of each transfer, the CLI now prints a boxed summary with the total data transferred, elapsed time, and average speed. Example:
@@ -184,7 +208,7 @@ description: "Release history for Floe."
   - The receiver summary also includes the `Saved to` path.
 </Update>
 
-<Update label="v1.1.0" description="2026-06-16">
+<Update label="v1.1.0" description="2026-06-16" tags={["CLI", "Web"]}>
   **Transfer reliability and browser fixes**
 
   - Fixed several CLI transfer sync bugs that could cause stalled or incomplete transfers, especially in CLI-to-CLI sessions. Added cross-implementation loopback tests to prevent regressions.
@@ -196,7 +220,7 @@ description: "Release history for Floe."
   - Performance: improved browser-to-browser transfer throughput with better backpressure tuning.
 </Update>
 
-<Update label="v1.0.0" description="2026-06-14">
+<Update label="v1.0.0" description="2026-06-14" tags={["Web", "CLI", "Self-hosting"]}>
   **Initial public release**
 
   - Browser-based peer-to-peer file transfer at [floe.one](https://floe.one). No account, no installation, no file storage.


### PR DESCRIPTION
## Summary

The desktop app has shipped twice and the changelog has never mentioned it. That is worse than an omission, because two links already promise otherwise: the global footer carries a **Changelog** link on every page including `/download`, and `/download` itself renders a link labelled **Release notes** pointing at the GitHub release, whose body is workflow boilerplate with no changelog content in it at all. Both are dead ends for a desktop user today.

Two hand-written entries, interleaved by date rather than split onto their own page, plus tags on all 25 entries.

## Why one page and not two

Floe Desktop is one product on a third surface, not a separate product: it imports `cli/engine` and speaks the same wire protocol. Obsidian, Tailscale and LocalSend all keep one timeline for that reason. Docker and 1Password split theirs because those really are separate products with separate teams. A second page would also mean a second RSS feed and a footer link that has to pick one.

The two version lines are handled by naming, not by structure. The label is the git tag (`desktop-v0.2.0`), which is simultaneously the GitHub release tag, the asset-name stem, and `DESKTOP_TAG` in `client/lib/desktopRelease.ts`, so a reader can never mistake it for `v1.9.1` when both are on screen. The interop closer is reworded for those entries, because "interoperates with older peers" is meaningless across two independent version lines.

`desktop-v0.2.1` gets no entry. Its only two commits were a Store tile colour and a CI gate change, and the hand-written policy exists precisely so a release with nothing user-visible gets nothing.

## Tags

Mintlify renders `tags` on `<Update>` as filters in the side panel, so this gives per-surface filtering without a second page or a tabbed restructure. Four and only four: `Desktop` (2), `CLI` (22), `Web` (8), `Self-hosting` (4).

Tagging the two new entries alone would have left a single-chip filter implying everything untagged was desktop-irrelevant, so the existing 23 are backfilled. That adds one attribute per block and changes no order, no label and no prose, so it is not a restructure under the rule in `CLAUDE.md`.

## Test plan

- [x] Diff verified to touch only `<Update>` opener lines plus the frontmatter, so no prose moved
- [x] All 25 entries carry tags; exactly four tags in the vocabulary; newest-first order preserved
- [x] `tags` confirmed a real `<Update>` prop against Mintlify's own component docs
- [x] 0 broken links and 0 broken anchors across all 36 pages
- [x] Frontmatter description brought into the house 131 to 167 range

Docs-only, so the `changes` job skips the heavy suite.

## Merge order

Second of four. Based on `docs/desktop-app` rather than `main`, because the `desktop-v0.1.0` entry links to `/desktop/installation`. My link checker flags it as broken when this branch sits on `main` alone, which is the mechanical proof that the two belong in one deploy.

Because the repo squash-merges, after #1 lands this branch needs a rebase onto the new `main` before merging, or its diff will re-show #1's changes. Ping me and I will do it.
