### PR TITLE
docs: bring the existing pages in line with the product

### DIFF
--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Floe CLI Flags Reference"
-description: "Complete reference for every floe CLI flag, covering send, receive, self-hosted server URLs, output paths, timeouts, and verbose logging options."
+description: "Complete reference for every floe CLI flag, covering the global server, relay and interface options, the receive and update flags, and the environment variables."
 ---
 
 ## Global flags
@@ -11,18 +11,21 @@ Available on all commands (`send`, `receive`, `update`, `version`).
 |------|---------|-------------|
 | `--server <url>` | `https://api.floe.one` | Signaling server URL. Use `http://localhost:3001` for local testing or your self-hosted server URL. |
 | `--no-relay` | `false` | Disable the TURN relay. Only direct (STUN) connections are attempted. The transfer fails if a direct path cannot be established. Useful for ensuring files never pass through a relay. |
-| `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: the production server defaults to `https://floe.one`, and `localhost:3001` defaults to `http://localhost:3000`. |
+| `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: `https://api.floe.one` maps to `https://floe.one`, `http://localhost:3001` maps to `http://localhost:3000`, and any other server maps to itself, on the assumption that one origin serves both the API and the web app. Set `--web` only when your web app has its own hostname. |
 | `--iface <name>` | _(all interfaces)_ | Restrict WebRTC to network interfaces whose name contains this value (case-insensitive). Repeatable. Use when a VPN or virtual-machine adapter (Tailscale, VMware, WSL, Hyper-V) slows connection setup, for example `--iface Ethernet`. See [Troubleshooting](/troubleshooting). |
+
+The desktop app has equivalents for two of these. `--server` and `--web` are **Server address** and **Share link address**, under Advanced in **Settings**. `--no-relay` has no desktop equivalent: the **Hide my IP address** toggle does the opposite, forcing every transfer through the relay rather than refusing it. See [Desktop Settings](/desktop/settings).
 
 ## Environment variables
 
-If you run your own signaling server, set it once in your environment instead of passing `--server` on every command.
+Floe reads four environment variables. If you run your own signaling server, set it once in your environment instead of passing `--server` on every command.
 
 | Variable | Equivalent flag | Description |
 |----------|-----------------|-------------|
 | `FLOE_SERVER` | `--server` | Signaling server URL, used by every command. |
 | `FLOE_WEB` | `--web` | Web app URL used for the browser link printed by `floe send`. |
 | `FLOE_NO_STATS` | `--no-report` | Set to `1` to never report byte counts. Applies to `floe receive`. See [Opting out of the global counter](#opting-out-of-the-global-counter). |
+| `FLOE_NO_UPDATE_CHECK` | _(no flag)_ | Set to `1` to suppress the "Update available" hint that `floe version` prints. It does not affect transfers or `floe update` itself. |
 
 A flag always beats its variable, so you can override the setting for a single command without unsetting anything:
 
@@ -41,7 +44,7 @@ floe send photo.jpg
 
 Trailing slashes are trimmed, so `https://floe.example.com/` and `https://floe.example.com` behave the same.
 
-Set `FLOE_WEB` only when your web app runs on a different host than your signaling server. Leave it unset and share links point at the same host, which is what you want when one domain serves both.
+Set `FLOE_WEB` only when your web app runs on a different host than your signaling server. Leave it unset and share links point at the same host as your server, which is what you want when one domain serves both. The only exceptions are Floe's own deployment and the local dev pair, which are special-cased to their web hosts as described under `--web` above.
 
 ## `floe receive` flags
 
@@ -53,9 +56,19 @@ Specific to the `receive` command.
 | `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
 | `--no-report` | | `false` | Do not report the transferred byte count to Floe's public global counter. See [Opting out of the global counter](#opting-out-of-the-global-counter) below. |
 
+## `floe update` flags
+
+Specific to the `update` command.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (v1.9.1)` and stops either way. On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
+
 ## Opting out of the global counter
 
-After a successful transfer, the **receiver** sends only the total byte count to Floe's signaling server to power the public "transferred globally" counter on the homepage. No file names, contents, or identity are included, and reporting is always fire-and-forget (it never blocks or slows a transfer). The **sender** never reports.
+After a successful transfer, the **receiver** sends only the total byte count to the signaling server it is connected to (`api.floe.one` by default, or your own server when you set `--server` or `FLOE_SERVER`) to power the public "transferred globally" counter. No file names, contents, or identity are included. The **sender** never reports.
+
+Errors are ignored, so a failed report never changes the outcome of a transfer. The request goes out after every file is written and the summary has printed, and it carries a 5 second timeout, so an unreachable server can delay `floe receive` from exiting by a few seconds but never affects the files.
 
 To opt out for a single transfer, pass `--no-report`:
 
@@ -71,6 +84,8 @@ floe receive olive-tiger-castle
 ```
 
 When opted out, no request is sent to the server and the global counter is not incremented for that transfer. The transfer itself is unaffected.
+
+In the desktop app the same choice is the **Contribute to global stats** toggle in **Settings**, and turning it off is the equivalent of `--no-report`.
 
 ## Examples
 

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -5,6 +5,13 @@ description: "Install the floe CLI in one command on macOS, Windows, or Linux to
 
 The `floe` CLI is a single self-contained binary with no runtime dependencies.
 
+<Note>
+  Want a desktop app instead of a terminal tool? Floe Desktop for Windows runs on the same
+  transfer engine as the CLI, so the two interoperate. See
+  [Install Floe Desktop](/desktop/installation). Floe Desktop is Windows only; on macOS and
+  Linux, use this CLI or the [web app](/web-app/sending).
+</Note>
+
 ## Package managers
 
 The fastest way to install floe. Package manager installs also get updates via the
@@ -54,9 +61,10 @@ upgrades an existing install in place.
     curl -fsSL https://floe.one/install.sh | sh
     ```
 
-    To install a specific version:
+    To install a specific version, using any tag from the
+    [releases page](https://github.com/jannskiee/floe/releases):
     ```bash
-    curl -fsSL https://floe.one/install.sh | FLOE_VERSION=v1.2.0 sh
+    curl -fsSL https://floe.one/install.sh | FLOE_VERSION=vX.Y.Z sh
     ```
 
     The script detects your OS and architecture, downloads the correct archive, verifies the
@@ -68,9 +76,10 @@ upgrades an existing install in place.
     irm https://floe.one/install.ps1 | iex
     ```
 
-    To install a specific version:
+    To install a specific version, using any tag from the
+    [releases page](https://github.com/jannskiee/floe/releases):
     ```powershell
-    $env:FLOE_VERSION = "v1.2.0"; irm https://floe.one/install.ps1 | iex
+    $env:FLOE_VERSION = "vX.Y.Z"; irm https://floe.one/install.ps1 | iex
     ```
 
     The script downloads the correct `.zip` for your architecture, verifies the SHA-256 checksum,
@@ -87,6 +96,19 @@ If you have Go 1.25 or later installed:
 go install github.com/jannskiee/floe/cli/cmd/floe@latest
 ```
 
+Go writes the binary to `$(go env GOPATH)/bin` (or `$(go env GOBIN)`), which is not on your
+`PATH` on a default Go setup. Add that directory to your `PATH` before running `floe`. The
+package managers and the install script above handle this for you.
+
+<Warning>
+  `go install` does not give you a release build. `cli` is a nested Go module and the
+  repository carries no `cli/vX.Y.Z` tags, so `@latest` resolves to the current tip of `main`
+  as a pseudo-version rather than to the newest release. The version string is stamped in at
+  release time, so a binary built this way reports `floe dev`, and `floe update` refuses to run
+  with "Cannot update a dev build." Use a package manager or the install script if you want a
+  released build with working self-update.
+</Warning>
+
 ## Verify the install
 
 ```bash
@@ -99,6 +121,16 @@ Expected output:
 floe 1.x.x
 Docs: https://www.floe.one/docs
 ```
+
+If you pinned an older version, a third line appears once the update check completes:
+
+```
+Update available: v1.x.x  run `floe update` to upgrade
+```
+
+Set `FLOE_NO_UPDATE_CHECK=1` to silence it. See [floe version](/cli/version) for what that
+check does. A binary from `go install` or built from source prints `floe dev` instead of a
+version number.
 
 ## Verify the checksum (manual download)
 
@@ -139,5 +171,10 @@ cd floe/cli
 go build ./cmd/floe
 ```
 
-Move the resulting `floe` binary to a directory on your `PATH` (e.g. `/usr/local/bin` on
-macOS and Linux).
+Move the resulting `floe` binary to a directory on your `PATH`. On macOS and Linux,
+`/usr/local/bin` is the usual choice, but it is root-owned on a stock system, so the move
+needs elevation: `sudo mv floe /usr/local/bin/`. A user-owned directory such as
+`~/.local/bin` works without `sudo`, as long as it is on your `PATH`.
+
+Like a `go install` build, a binary compiled this way reports `floe dev` and cannot update
+itself.

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -42,14 +42,14 @@ Running `floe receive olive-tiger-castle -o ~/Downloads`:
 ```
   Connecting to sender...
   Connected
+
   ─────────────────────────────────────────────────
   Incoming   2 files · 2.3 MB
   ─────────────────────────────────────────────────
 
   Accept? [Y/n] y
-
-  [1/2] photo.jpg  [████████████████] 2.3 MB/2.3 MB
-  [2/2] notes.txt  [████████████████] 14 KB/14 KB
+  [1/2] photo.jpg 100% [███████████████] (480 kB/s)
+  [2/2] notes.txt 100% [███████████████] (14 kB/s)
 
   ─────────────────────────────────────────────────
   Received   2 files (2.3 MB)
@@ -72,8 +72,8 @@ When the first file's metadata arrives, Floe shows a summary of what is incoming
   Accept? [Y/n]
 ```
 
-- Press **Enter**, `y`, or `Y` to accept and begin receiving.
-- Type `n` or `no` to decline. The transfer is cancelled and the connection closes.
+- Type `n` or `no`, in any capitalization, to decline. The transfer is cancelled and the connection closes.
+- Press **Enter** or type anything else to accept and begin receiving. The prompt only looks for a decline, so a typo counts as yes.
 
 Pass `-y` to skip this prompt and accept automatically.
 
@@ -85,7 +85,7 @@ Pass `-y` to skip this prompt and accept automatically.
 | `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
 | `--no-report` | | `false` | Do not report the transferred byte count to Floe's public global counter. Set `FLOE_NO_STATS=1` to opt out permanently. |
 
-See [Flags Reference](/cli/flags) for global flags (`--server`, `--no-relay`) and full opt-out documentation.
+See [Flags Reference](/cli/flags) for the global flags that matter here (`--server`, `--no-relay`, `--iface`) and full opt-out documentation.
 
 ## Notes
 

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -19,6 +19,18 @@ Point `--server` at the origin that serves `/api` and `/ws`. On a
 users open in a browser, so this is all you need: the share link that `floe send`
 prints resolves to the same origin and opens the web client correctly.
 
+If you always use the same server, set it once in your environment instead of
+repeating the flag on every command:
+
+```bash
+export FLOE_SERVER=https://floe.example.com
+floe send photo.jpg
+```
+
+A flag always beats the variable, so you can still override it for a single
+command. Use `FLOE_WEB` the same way when your web app has its own hostname. See
+[Flags Reference](/cli/flags#environment-variables).
+
 ## When the web client is on a different host
 
 The browser link printed by `floe send` defaults to the same origin as `--server`.
@@ -45,5 +57,16 @@ floe receive olive-tiger-castle --server http://localhost:3001
 ```
 
 The browser link will point to `http://localhost:3000` automatically when using `localhost:3001`.
+
+## Desktop app
+
+The Floe desktop app can target a self-hosted server too. Open **Settings**, expand
+**Advanced**, and put your origin in **Server address**, then press **Test** to confirm
+the app can reach it. Leave **Share link address** blank on a one-domain deployment:
+the app derives the share link from the server address using the same rule the CLI
+uses. Fill it in only when your web app has its own hostname. **Use default server**
+appears once a custom address is set and clears both fields back to `api.floe.one`.
+See [Desktop Settings](/desktop/settings#advanced) for what Test checks and what each
+result means.
 
 See [Self-Hosting](/self-hosting/overview) for instructions on running your own Floe instance.

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -49,15 +49,17 @@ Once the recipient connects, Floe negotiates the WebRTC connection and streams e
   Connecting...
   Connected
 
-  [1/3] report.pdf              [████████░░░░░░░] 8.1 MB/9.5 MB
-  [2/3] photo.jpg               [████████████████] 2.3 MB/2.3 MB
-  [3/3] notes.txt               [████████████████] 14 KB/14 KB
+  [1/3] report.pdf 100% [███████████████] (1.4 MB/s)
+  [2/3] photo.jpg 100% [███████████████] (2.1 MB/s)
+  [3/3] notes.txt 100% [███████████████] (900 kB/s)
 
   ─────────────────────────────────────────────────
   Sent   3 files (11.8 MB)
   Time   8s · avg 1.4 MB/s
   ─────────────────────────────────────────────────
 ```
+
+While a file is still in flight its line also carries elapsed and remaining time, for example `  [1/3] report.pdf  85% [██████████░░░░░] (1.4 MB/s) [6s:1s]`. Those brackets disappear once the line reaches 100%. The bar stretches to the width of your terminal, so the number of blocks varies with your window, and names longer than 30 characters are truncated. The rate in parentheses uses base-1000 units (`kB`, `MB`), while the summary rows below it use base-1024 units, so the two do not always agree to the decimal.
 
 Share the **code** with CLI recipients or the **link** with browser recipients. The short code is valid for 10 minutes. The room link stays active until the session ends or you press `Ctrl+C`.
 
@@ -71,9 +73,18 @@ floe send ./documents
 # Receiver gets: ./documents/report.pdf, ./documents/images/photo.jpg
 ```
 
+A trailing slash changes this. Floe names each file relative to the folder's parent, and a trailing slash makes the folder itself the parent, so the folder name drops out and its contents land directly in the receiver's output directory:
+
+```bash
+floe send ./documents/
+# Receiver gets: ./report.pdf, ./images/photo.jpg
+```
+
+The same applies to a trailing backslash on Windows. Shell tab-completion often adds one, so drop it if you want the folder name preserved.
+
 ## Flags
 
-See [Flags Reference](/cli/flags) for `--server`, `--no-relay`, and `--web`.
+See [Flags Reference](/cli/flags) for `--server`, `--no-relay`, `--web`, and `--iface`.
 
 ## Notes
 

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -6,12 +6,28 @@ description: "Keep the floe CLI up to date on macOS, Windows, and Linux using th
 ## Package manager installs
 
 If you installed floe via a package manager, use the standard upgrade command for that tool.
+`floe update` detects a package-managed install from the binary's path and stops with a message
+pointing you at the right command, rather than replacing the binary behind your package
+manager's back. The same guard applies to `floe update --check`.
 
 | Install method | Upgrade command |
 | -------------- | --------------- |
 | Homebrew (macOS) | `brew upgrade floe` |
 | Winget (Windows) | `winget upgrade jannskiee.floe` |
 | Scoop (Windows) | `scoop update floe` |
+
+Detection is a substring match for `homebrew`, `cellar`, `linuxbrew`, `scoop`, or `winget`
+anywhere in the binary's path, so a script install that happens to live under a directory
+containing one of those words is treated as package-managed too.
+
+<Note>
+  This page covers the `floe` command-line tool. Floe Desktop updates on its own track: the
+  Microsoft Store build updates itself, while the GitHub `.exe` and `.zip` builds have no
+  in-app updater, so you download and run the current build again. `floe update` never touches
+  the desktop app, and desktop builds ship on their own `desktop-v*` tags as GitHub
+  pre-releases, so they are never picked up by `floe update` or the install scripts. See
+  [Update Floe Desktop](/desktop/installation#update).
+</Note>
 
 ## Script and manual installs
 
@@ -24,13 +40,18 @@ floe update
 This checks the latest release on GitHub, downloads the correct archive for your OS and
 architecture, verifies the SHA-256 checksum, and replaces the running binary in place.
 
+On macOS and Linux, if floe lives in a root-owned directory such as `/usr/local/bin` (the
+install script's default), the final swap needs elevation, so floe asks for your sudo password
+once. Everything before that step (download, checksum, extraction) runs as your normal user. If
+sudo is not installed, the update stops and tells you to re-run as root or reinstall with the
+install script. On Windows no elevation is involved: floe renames the running executable aside
+and moves the new one into place.
+
 To check for an update without installing:
 
 ```bash
 floe update --check
 ```
-
-To suppress the update hint shown by `floe version`, set `FLOE_NO_UPDATE_CHECK=1`.
 
 You can also re-run the original install script at any time to upgrade:
 
@@ -41,6 +62,23 @@ curl -fsSL https://floe.one/install.sh | sh
 # Windows
 irm https://floe.one/install.ps1 | iex
 ```
+
+## The update hint
+
+When a newer release exists, `floe version` prints an extra line:
+
+```
+Update available: v1.x.x  run `floe update` to upgrade
+```
+
+Only `floe version` runs this check automatically, never `send` or `receive`. The result is
+cached for 24 hours in `floe/update-check.json` inside your user config directory (`~/.config`
+on Linux, `~/Library/Application Support` on macOS, `%AppData%` on Windows), so deleting that
+file forces a fresh check. `floe update --check` is a separate, deliberate check: it asks GitHub
+directly and ignores the cache.
+
+Set `FLOE_NO_UPDATE_CHECK=1` to suppress the hint entirely. Binaries compiled from source never
+check.
 
 ## Version compatibility
 

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -1,13 +1,14 @@
 ---
 title: "floe version command"
-description: "Print the installed floe CLI version, build metadata, and platform to verify your install and share diagnostic details when reporting an issue."
+description: "Print the installed floe CLI version and the docs link, plus a one-line update hint when a newer release exists, so you can confirm which build you are running."
 ---
 
 ```bash
 floe version
 ```
 
-Prints the current version of the `floe` binary and a link to the documentation.
+Prints the current version of the `floe` binary, a link to the documentation, and an update
+hint when a newer release is available.
 
 ## Output
 
@@ -15,6 +16,25 @@ Prints the current version of the `floe` binary and a link to the documentation.
 floe 1.x.x
 Docs: https://www.floe.one/docs
 ```
+
+When a newer release exists, a third line follows:
+
+```
+Update available: v1.x.x  run `floe update` to upgrade
+```
+
+## The update check
+
+`floe version` is the only command that checks for a newer release on its own. `send` and
+`receive` never do, and `floe update` checks only when you run it. The check asks GitHub for
+the latest release tag (`https://api.github.com/repos/jannskiee/floe/releases/latest`) and
+caches the answer for 24 hours in `floe/update-check.json` inside your user config directory
+(`~/.config` on Linux, `~/Library/Application Support` on macOS, `%AppData%` on Windows).
+Delete that file to force a fresh check. When the cache is cold, the request is abandoned
+after one second, so `floe version` never stalls on a slow network.
+
+Set `FLOE_NO_UPDATE_CHECK=1` to skip the check and the hint entirely. Binaries built from
+source report `floe dev` and never check.
 
 ## Alternatives
 
@@ -26,4 +46,5 @@ floe --version
 floe -v
 ```
 
-These print the version number only, without the docs link.
+These print the same single line as the first line of `floe version` (for example
+`floe 1.x.x`). No docs link, and no update hint.

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -9,23 +9,27 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
   <Accordion title="Where do my files go?">
     Your files go directly to the recipient's device. In most cases they never touch a server at all. When a direct path cannot be found (strict corporate firewalls, carrier-grade NAT), Floe automatically falls back to an encrypted TURN relay. Even through a relay, the server sees only encrypted packets and cannot read your files.
 
+    On floe.one that relay is Cloudflare's managed TURN service rather than a Floe machine, so a relayed transfer does transit third-party infrastructure. It carries opaque encrypted packets either way, and if you self-host you point Floe at your own relay instead.
+
     See [How It Works](/how-it-works/signaling) for a full explanation.
   </Accordion>
 
   <Accordion title="Is there a file size limit?">
-    Direct connections have no size limit. Files transfer directly between the two devices and no server bandwidth is consumed.
+    Direct connections have no size limit imposed by Floe. Files transfer directly between the two devices and no server bandwidth is consumed.
 
-    Relay connections are capped at **2 GB per session** to keep the service free. The cap applies in both the web app and the CLI. Most home and mobile network transfers connect directly and have no limit. See [The 2 GB Relay Limit](/how-it-works/2gb-limit) for details and tips on obtaining a direct connection.
+    Relay connections are capped at **2 GB per session** to keep the service free. The cap applies everywhere: the web app, the CLI, and Floe Desktop all enforce it. On Floe Desktop, turning on "Hide my IP address" routes every transfer through the relay, so the cap applies to every transfer while that setting is on. Most home and mobile network transfers connect directly and have no limit. See [The 2 GB Relay Limit](/how-it-works/2gb-limit) for details and tips on obtaining a direct connection.
+
+    One practical note about the browser: a browser receiver holds each incoming file in memory until that file is complete, so a very large file can exhaust a phone or a laptop tab. The CLI and desktop receivers write straight to disk and have no such ceiling, which makes them the better choice for multi-gigabyte transfers.
   </Accordion>
 
   <Accordion title="Can I send multiple files or a whole folder?">
-    Yes. In the browser, select multiple files in the file picker. In the CLI, pass multiple files or folder paths to `floe send`:
+    Yes, with one caveat about folders. In the browser you can select or drop multiple files, but not a folder: the web app has no folder picker, and dropping a folder does not add its contents. The CLI and Floe Desktop can send whole folders. Pass file or folder paths to `floe send`, or drop a folder onto Floe Desktop.
 
     ```bash
     floe send file1.pdf file2.jpg notes/
     ```
 
-    Folder transfers preserve the directory structure. The recipient receives files at the same relative paths.
+    Folder transfers preserve the directory structure when the receiver is the CLI or the desktop app, which rebuild the tree on disk. A browser receiver gets the same files, but as a flat list, because a browser download cannot create folders.
   </Accordion>
 
   <Accordion title="How fast is it?">
@@ -33,11 +37,15 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
   </Accordion>
 
   <Accordion title="How long does the sender have to stay connected?">
-    For the full duration of the transfer. Files stream directly from the sender's device, so the browser tab or CLI process must remain open and active. If the sender closes the tab or cancels mid-transfer, the session ends and any partially received files are incomplete.
+    For the full duration of the transfer. Files stream directly from the sender's device, so the browser tab, the CLI process, or the Floe Desktop window must stay open. The browser and the desktop app both ask the device to stay awake while a transfer is connected. The CLI does not, so check your machine's own sleep settings before a long headless transfer.
+
+    If the sender closes the tab or window, quits, or cancels mid-transfer, the session ends. A CLI or desktop receiver is left with a truncated file on disk. A browser receiver gets no download at all for the file that was in flight, because it only turns a file into a download once the whole file has arrived.
   </Accordion>
 
   <Accordion title="Are my files stored anywhere?">
-    No. Files are never stored on any server. They travel directly between the two devices in real time. Once the session closes, nothing about your transfer is retained.
+    No. Files are never stored on any server. They travel directly between the two devices in real time, and once the session closes the server keeps nothing about them: no file names, no contents, no per-transfer record. If a short code was issued for the room, that code maps to the room ID for up to 10 minutes and is then deleted. The only thing that survives for good is one anonymous number, the running total of bytes Floe has moved (see the counter question below).
+
+    Floe Desktop also keeps a short local list of your recent transfers on your own machine, so you can find where files landed. That list never leaves the device.
   </Accordion>
 </AccordionGroup>
 
@@ -47,21 +55,24 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
   <Accordion title="Which browsers are supported?">
     Any modern browser with WebRTC support works: Chrome, Firefox, Safari, Edge, and most Chromium-based browsers. A secure context (HTTPS or localhost) is required.
 
-    WebRTC is not available in some in-app browsers (the web views embedded in Facebook, Instagram, TikTok, and similar apps). Floe detects these and prompts you to open the page in Chrome or Safari instead.
+    In-app browsers (the web views embedded in Facebook, Messenger, Instagram, TikTok, Snapchat, LINE, X (Twitter), and WeChat, plus generic Android web views) have limited support for file transfers. Floe recognizes these by their user agent and shows a full-screen prompt with instructions for opening the page in Chrome or Safari, plus a button that copies the link. The transfer UI is held back until you leave the in-app browser, so the page does not join the room in the meantime. A "Continue anyway" link lets you try regardless.
   </Accordion>
 
   <Accordion title="I'm on iOS. Why are downloads behaving oddly?">
     On iOS, use **Download ZIP** rather than downloading files individually. This is the most reliable option on Safari and iOS web views. Individual file downloads can behave inconsistently on iOS due to browser sandboxing.
+
+    The ZIP option only appears when a transfer contains more than one file, and only once every file has arrived. A single file has just its own download button, and that is the only way to save it.
   </Accordion>
 
   <Accordion title="What does the connection indicator color mean?">
-    The indicator in the corner of the page shows connection state:
+    The indicator in the transfer card's header shows connection state:
 
     - **Green (Direct):** Files transfer directly between devices, whether they share a network or connect peer-to-peer across the internet. No server involved. No size limit.
     - **Amber (Relay):** Files route through the encrypted TURN relay. The 2 GB cap applies.
-    - **Connecting:** Negotiating the WebRTC connection. This usually takes a few seconds.
+    - **Green (Ready):** Floe has reached the signaling server and is still negotiating the peer-to-peer path. It switches to Direct or Relay within a few seconds of the two sides meeting.
+    - **Red (Offline):** The connection to the signaling server is down. Floe reconnects on its own.
 
-    If the connection stays in "Connecting" for more than 30 seconds, see [Troubleshooting](/troubleshooting).
+    If the indicator stays on "Ready" for more than 30 seconds after both sides have joined, see [Troubleshooting](/troubleshooting).
   </Accordion>
 
   <Accordion title="Why does it say Direct when my phone is on mobile data?">
@@ -72,17 +83,85 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
     Transfer speed on a direct connection is set by the slower of the two internet connections involved (typically the sender's upload speed or the receiver's mobile signal), not by Floe. See [Direct Connection](/how-it-works/direct-connection) for the full story.
   </Accordion>
 
-  <Accordion title="Does turning off Network Relay Fallback stop or cancel my transfer?">
-    No. The toggle only controls whether Floe may fall back to a relay server when a direct connection cannot be established. It is checked once, when the connection is being set up.
+  <Accordion title="Does turning off Network relay fallback stop or cancel my transfer?">
+    This toggle appears on the sending side only. A browser receiver has no relay control at all.
+
+    No, turning it off does not cancel anything. The toggle only controls whether Floe may fall back to a relay server when a direct connection cannot be established. It is checked once, when the connection is being set up.
 
     - If the connection is **direct**, the toggle has no effect. The transfer proceeds whether relay fallback is on or off, because no relay is involved.
-    - If the connection would need a **relay** and the toggle is off, Floe blocks the transfer before any file data moves.
+    - If the connection would need a **relay** and the toggle is off, Floe leaves the relay servers out of its own connection setup, so it can only offer a direct path. Should the path end up relayed anyway, because the other side can still offer a relay of its own, Floe blocks the transfer before any file data moves. The sender is told to enable Network Relay to connect across restrictive networks, and the receiver is told to ask the sender to do it.
 
     The toggle cannot affect a connection that is already established, which is why it is only shown before the share link is created.
   </Accordion>
 
   <Accordion title="Can I enter a short code in the browser to receive?">
-    No. The browser UI does not have a code entry field. To receive in the browser, the recipient must open the full link (or scan the QR code). Short codes are for the CLI only: `floe receive olive-tiger-castle`.
+    No. The browser UI does not have a code entry field. To receive in the browser, the recipient must open the full link (or scan the QR code). Short codes work in the CLI (`floe receive olive-tiger-castle`) and in Floe Desktop, whose receive field accepts either a short code or a full link.
+  </Accordion>
+</AccordionGroup>
+
+## Desktop
+
+<AccordionGroup>
+  <Accordion title="Is there a desktop app?">
+    Yes, in beta for Windows. Floe Desktop is a small native app that speaks the same protocol as the web app and the CLI, so any two Floe clients can transfer to each other. It sends folders without zipping, pastes screenshots and copied files straight from the clipboard, saves received files to a folder you choose, and posts a notification when a transfer finishes.
+
+    Install it from the [download page](https://floe.one/download). It requires Windows 10 or later on an x64 machine, with the Microsoft Edge WebView2 runtime. The Microsoft Store build additionally needs Windows 10 version 2004 (build 19041). See [Install Floe Desktop](/desktop/installation) for the full walkthrough.
+  </Accordion>
+
+  <Accordion title="How do I receive a transfer in the desktop app?">
+    Paste either a short code or a full share link into the receive field and choose where the files should land. Unlike the browser, the desktop app writes files straight to disk and rebuilds any folder structure the sender used. See [Receiving Files with Floe Desktop](/desktop/receiving).
+  </Accordion>
+
+  <Accordion title="What does Hide my IP address do?">
+    It routes every transfer through the encrypted relay so the other side never sees your IP. Because the connection is always relayed, transfers are slower and the 2 GB per-session cap applies to every transfer while the setting is on. Turn it off to send larger files.
+
+    This is the inverse of the browser's "Network relay fallback" checkbox, which permits a relay but prefers a direct path. Floe Desktop has no direct-only mode, and the browser has no relay-only mode. See [Floe Desktop Settings](/desktop/settings).
+  </Accordion>
+
+  <Accordion title="How do I update the desktop app?">
+    Microsoft Store installs update themselves. A build installed from GitHub, including the portable zip, does not: download the current installer and run it over your existing install. There is no in-app updater yet. `floe update` applies to the CLI only and has no effect on Floe Desktop.
+  </Accordion>
+</AccordionGroup>
+
+## CLI
+
+<AccordionGroup>
+  <Accordion title="How do I install the CLI?">
+    See [CLI Installation](/cli/installation) for platform-specific steps. The quick version:
+
+    ```bash macOS and Linux
+    # macOS, with Homebrew
+    brew install --cask jannskiee/tap/floe
+
+    # macOS or Linux, no package manager
+    curl -fsSL https://floe.one/install.sh | sh
+    ```
+
+    ```powershell Windows
+    # winget
+    winget install jannskiee.floe
+
+    # scoop
+    scoop bucket add jannskiee https://github.com/jannskiee/scoop-bucket
+    scoop install floe
+
+    # no package manager
+    irm https://floe.one/install.ps1 | iex
+    ```
+  </Accordion>
+
+  <Accordion title="Do the browser, CLI, and desktop apps all talk to each other?">
+    Yes. All three clients speak the same WebRTC transfer protocol, so any combination works: browser to CLI, CLI to desktop, desktop to browser, and so on. The CLI prints a browser link and the desktop app shows one, either of which any recipient can open, and a browser sender's link can be pasted into `floe receive` or into Floe Desktop's receive field. See the [cross-platform transfers table](/quickstart#cross-platform-transfers).
+  </Accordion>
+
+  <Accordion title="How do I keep the CLI up to date?">
+    Run `floe update` for script and manual installs. For package manager installs, use `brew upgrade floe`, `winget upgrade jannskiee.floe`, or `scoop update floe`. See [Updating](/cli/update).
+  </Accordion>
+
+  <Accordion title="Do both peers need the same version?">
+    No. Floe peers on different versions interoperate, so you do not need to coordinate updates with the person on the other end. A patch or minor difference (for example v1.5.4 sending to v1.5.5) transfers normally.
+
+    Floe negotiates a transfer protocol version separate from the release version. The only time a transfer is blocked is the rare case where a release changes the wire format in a breaking way and the two versions cannot bridge it. If that happens, Floe tells you before any data moves and shows the older side what to do: refresh the page in the browser, or run `floe update` on the CLI. Floe Desktop shows the same engine message, but there you update through the Microsoft Store or by reinstalling from GitHub. See the [Protocol versioning](/reference/architecture#protocol-versioning) reference for how this works.
   </Accordion>
 </AccordionGroup>
 
@@ -90,11 +169,13 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
 
 <AccordionGroup>
   <Accordion title="Do I need an account?">
-    No. Floe requires no account, no sign-up, and no registration. Open [floe.one](https://floe.one) or run the CLI and share the link or short code with your recipient.
+    No. Floe requires no account, no sign-up, and no registration. Open [floe.one](https://floe.one), install Floe Desktop from the [download page](https://floe.one/download), or run the CLI, then share the link or short code with your recipient.
   </Accordion>
 
   <Accordion title="Does Floe collect any data?">
-    The signaling server tracks room IDs and connection metadata only for the duration of the session. No file content, file names, or transfer records are stored. Room state is discarded once both peers disconnect.
+    The signaling server tracks room IDs and connection metadata only for the duration of the session. No file content, file names, or transfer records are stored. Room state is discarded once both peers disconnect. If a short code was issued for the room, that code maps to the room ID for at most 10 minutes and is then deleted, so a room ID can outlive the session by that much. Nothing about the files themselves is ever stored.
+
+    If a transfer falls back to a relay, its encrypted packets pass through Cloudflare's managed TURN service on floe.one, which is infrastructure Floe does not own. The relay cannot read the packets, and a self-hosted instance uses whatever relay you configure.
 
     The one persistent value Floe keeps is a single anonymous total of bytes transferred across all users, shown by the counter on the homepage. It is a plain running number with no file names, no per-transfer records, and no link to you. See [Security and Privacy](/security-privacy) for details.
   </Accordion>
@@ -102,13 +183,13 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
   <Accordion title="What is the counter on the homepage?">
     It is a public, all-time total of how many bytes Floe has helped move across all users. When a transfer finishes, the receiving side reports just the size (never the file name or contents), and that size is added to one shared total. The figure is an honest best-effort metric, not an audited count, and reporting it never slows or blocks your transfer.
 
-    The counter is viewable only in the browser. The CLI receiver contributes to it but never fetches or displays the total. The sender (browser or CLI) never reports.
+    The counter is viewable only in the browser. The CLI and desktop receivers contribute to it but never fetch or display the total. Senders never report, in any client.
   </Accordion>
 
   <Accordion title="Can I opt out of the transfer counter?">
     Yes. The byte-count report is on by default but can be turned off on the receiving side.
 
-    **Browser:** Uncheck "Contribute to global stats" on the receiver view before the transfer completes. The preference is saved in your browser and applies to all future transfers from that device.
+    **Browser:** Uncheck "Contribute to global stats" on the receiver view before the first file arrives. The checkbox is hidden once files start landing. The preference is saved in your browser and applies to all future transfers from that device.
 
     **CLI - single transfer:**
     ```bash
@@ -120,43 +201,12 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
     export FLOE_NO_STATS=1
     ```
 
+    **Desktop:** Open Settings and turn off "Contribute to global stats". The preference is stored with your other Floe Desktop settings and applies to every future transfer you receive.
+
     When opted out, no request is sent to Floe's server and the global counter is not incremented for that transfer. The transfer itself is unaffected.
   </Accordion>
 
   <Accordion title="Is Floe open source?">
-    Yes. The full source for the client, server, and CLI is available on [GitHub](https://github.com/jannskiee/floe) under the MIT license. You can also [self-host](/self-hosting/overview) your own instance on your own infrastructure.
-  </Accordion>
-</AccordionGroup>
-
-## CLI
-
-<AccordionGroup>
-  <Accordion title="How do I install the CLI?">
-    See [CLI Installation](/cli/installation) for platform-specific steps. The quick version:
-
-    ```bash
-    # macOS
-    brew install --cask jannskiee/tap/floe
-
-    # Windows (winget)
-    winget install jannskiee.floe
-
-    # Linux / any OS
-    curl -fsSL https://floe.one/install.sh | sh
-    ```
-  </Accordion>
-
-  <Accordion title="Can a CLI sender transfer to a browser receiver (or vice versa)?">
-    Yes. Browser and CLI clients are fully interoperable. The CLI sender prints a browser link that any recipient can open, and the browser sender's link can be passed directly to `floe receive`. See the [cross-platform transfers table](/quickstart#cross-platform-transfers).
-  </Accordion>
-
-  <Accordion title="How do I keep the CLI up to date?">
-    Run `floe update` for script and manual installs. For package manager installs, use `brew upgrade floe`, `winget upgrade jannskiee.floe`, or `scoop update floe`. See [Updating](/cli/update).
-  </Accordion>
-
-  <Accordion title="Do both peers need the same version?">
-    No. Floe peers on different versions interoperate, so you do not need to coordinate updates with the person on the other end. A patch or minor difference (for example v1.5.4 sending to v1.5.5) transfers normally.
-
-    Floe negotiates a transfer protocol version separate from the release version. The only time a transfer is blocked is the rare case where a release changes the wire format in a breaking way and the two versions cannot bridge it. If that happens, Floe tells you before any data moves and points whichever side is older to `floe update`. See the [Protocol versioning](/reference/architecture#protocol-versioning) reference for how this works.
+    Yes. The full source for the web client, the signaling server, the CLI, and the desktop app is available on [GitHub](https://github.com/jannskiee/floe) under the MIT license. You can also [self-host](/self-hosting/overview) your own instance on your own infrastructure.
   </Accordion>
 </AccordionGroup>

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -7,6 +7,10 @@ When your files go through the Floe TURN relay server, every byte of data passes
 
 To keep Floe free and running for everyone, relay transfers are capped at **2 GB per session**. This limit applies only to relay connections. Direct connections have no limit.
 
+<Note>
+  In the desktop app, turning on [Hide my IP address](/desktop/settings#hide-my-ip-address) forces every transfer through the relay so the other peer never sees your address. The 2 GB cap therefore always applies while it is on. Turn it off to send larger files.
+</Note>
+
 ## How to get a direct connection
 
 These steps increase the likelihood of a direct connection, which has no size limit:
@@ -20,8 +24,12 @@ If both peers are on typical consumer networks, a direct connection will almost 
 
 ## What counts as one session
 
-The 2 GB cap resets if the relay connection drops and reconnects. Each new WebRTC session starts with a fresh counter. However, intentionally cycling sessions to exceed the cap goes against the spirit of the free service.
+A session is one sender and one receiver: a room holds exactly two peers, so a share link cannot be opened by two recipients at once.
+
+The limit is checked once, before any file data moves. When the connection turns out to run through the relay, Floe compares the total size of everything you queued against 2 GB and either allows the whole transfer or refuses it. It is not a running meter that stops you partway, so a 3 GB batch over a relay is declined up front rather than truncated at 2 GB.
+
+Starting a new transfer runs the check again from scratch, so splitting a large batch into transfers of under 2 GB each works. Intentionally cycling sessions to work around the cap goes against the spirit of the free service.
 
 <Accordion title="Technical details">
-  The 2 GB cap is enforced by the Floe apps themselves: the web app, the desktop app, and the CLI all apply the same rule. Once the connection is established, the sender checks the selected route: if it runs through the TURN relay and the queued files total more than 2 GB, the transfer is blocked before any file data moves and an error is displayed. The limit applies per sender session, not per file. Direct connections bypass this check entirely, as no relay bandwidth is consumed. If the route cannot be determined, the sender allows the transfer rather than block a legitimate one.
+  The 2 GB cap is enforced by the Floe apps themselves: the web app, the desktop app, and the CLI all apply the same rule. Once the connection is established, the sender checks the selected route: if it runs through the TURN relay and the queued files total more than 2 GB, the transfer is blocked before any file data moves and an error is displayed. The comparison is strictly greater than the limit, so a payload of exactly 2 GB is allowed. The limit applies per sender session, not per file, and it is sender-side local policy: the receiver runs no size check of its own. Direct connections bypass this check entirely, as no relay bandwidth is consumed. If the route cannot be determined, the sender allows the transfer rather than block a legitimate one.
 </Accordion>

--- a/docs/how-it-works/direct-connection.mdx
+++ b/docs/how-it-works/direct-connection.mdx
@@ -25,9 +25,9 @@ Strict corporate firewalls, university networks, and carrier-grade NAT can block
 <Accordion title="Technical details">
   **ICE (Interactive Connectivity Establishment):** WebRTC uses the ICE protocol to find a usable network path. Each peer gathers a list of "candidates" (IP/port combinations it might be reachable on), including local addresses, server-reflexive addresses from STUN, and relay addresses from TURN. Peers exchange their candidates via the signaling server and try each pair until one works.
 
-  **STUN servers used:** On floe.one, `stun.cloudflare.com:3478` (with an alternate on port 53) from the Cloudflare ICE list. `stun.l.google.com:19302` and `stun1.l.google.com:19302` serve as the fallback when no TURN service is configured. On a self-hosted instance with coturn, the TURN endpoints also double as STUN.
+  **STUN servers used:** On floe.one, one Cloudflare endpoint: `stun.cloudflare.com:3478`. Cloudflare's raw ICE list also contains a STUN entry on port 53, but the signaling server trims the list to one URL per connectivity class before serving it, so clients only ever see the 3478 entry. `stun.l.google.com:19302` and `stun1.l.google.com:19302` serve as the fallback when no TURN service is configured. On a self-hosted instance with coturn, the TURN endpoints also double as STUN.
 
   **Trickle ICE:** Candidates are sent incrementally as they are gathered rather than waiting for the full list. This reduces connection time significantly.
 
-  **Candidate types that produce direct connections:** `host` (same network) or `srflx` (server-reflexive, NAT traversal via STUN). If only `relay` candidates succeed, the connection uses TURN instead.
+  **Candidate types that produce direct connections:** anything other than `relay`. In practice that means `host` (same network), `srflx` (server-reflexive, discovered via STUN), and `prflx` (peer-reflexive, learned during connectivity checks). Floe classifies a connection as relayed only when the nominated candidate pair has a `relay` candidate on one side or the other. Every other outcome counts as direct.
 </Accordion>

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -32,7 +32,7 @@ Even through a relay, your files are protected by **DTLS encryption** built into
 
 ## Disabling relay fallback
 
-If you need to ensure files never pass through a relay, you can disable it. In the browser, toggle off **Network Relay Fallback** before creating the link. In the CLI, pass `--no-relay`:
+If you need to ensure files never pass through a relay, you can disable it. In the browser, toggle off **Network relay fallback** before creating the link (the toggle appears once you have picked files, just above the Create secure link button). In the CLI, pass `--no-relay`:
 
 ```bash
 floe send photo.jpg --no-relay
@@ -41,13 +41,13 @@ floe send photo.jpg --no-relay
 With relay disabled, the transfer fails if a direct path cannot be established.
 
 <Warning>
-  The desktop app has no relay-fallback switch. Its **Hide my IP** setting is the opposite
-  control: it makes the relay the only path, so every transfer is relayed and capped at 2 GB.
-  See [Hide my IP address](/desktop/settings#hide-my-ip-address).
+  The desktop app has no relay-fallback switch. Its **Hide my IP address** setting is the
+  opposite control: it makes the relay the only path, so every transfer is relayed and capped
+  at 2 GB. See [the desktop settings reference](/desktop/settings#hide-my-ip-address).
 </Warning>
 
 <Accordion title="Technical details">
-  **TURN (Traversal Using Relays around NAT):** When ICE negotiation produces only `relay` candidates, both peers connect to the TURN server and the server forwards packets between them. The data is still DTLS-encrypted end-to-end before it reaches the TURN server.
+  **TURN (Traversal Using Relays around NAT):** ICE tries the candidate pairs and nominates one that works. When the nominated pair has a `relay` candidate on either side, traffic goes through the TURN server, which forwards packets between the peers. This is decided by the winning pair, not by an absence of other candidates: host and reflexive candidates are still gathered and offered, they simply did not win. The data is still DTLS-encrypted end-to-end before it reaches the TURN server.
 
   **Credentials:** The signaling server mints short-lived credentials from Cloudflare's Realtime TURN service and hands them to peers via `/api/turn-credentials`. Credentials are valid for up to 24 hours. (Self-hosted deployments can instead use coturn with time-limited HMAC-SHA1 credentials; see the self-hosting guide.)
 

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -3,9 +3,9 @@ title: "How Floe Signaling Works"
 description: "How the Floe signaling server brokers the initial WebRTC handshake between sender and receiver without ever seeing the files being transferred."
 ---
 
-When you create a transfer in Floe, a unique room is created on the signaling server. The sender shares a code or link. When the recipient joins, the two devices introduce themselves through the server and exchange the information they need to connect directly. Once that handshake is complete, the server steps aside.
+When you create a transfer in Floe, your device generates a unique room ID and joins that room on the signaling server. The sender shares a code or link. When the recipient joins the same room, the two devices introduce themselves through the server and exchange the information they need to connect to each other. Once that handshake is complete, the server steps aside.
 
-The signaling server never touches file data, never stores your files or any record of what you send, and plays no part once the WebRTC connection is established. The only thing it keeps is a single anonymous running total of bytes transferred, used for the public counter on the homepage (see below).
+The signaling server never touches file data, never stores your files or any record of what you send, and carries no file data once the WebRTC connection is established. The only thing it keeps is a single anonymous running total of bytes transferred, used for the public counter on the homepage (see below).
 
 ## Connection lifecycle
 
@@ -13,12 +13,12 @@ The signaling server never touches file data, never stores your files or any rec
 2. Both devices join the same room on the signaling server.
 3. The server assigns roles: the first peer to join is the **sender**, the second is the **receiver**.
 4. Peers exchange a WebRTC offer, answer, and ICE candidates through the server.
-5. Once a usable network path is found, a direct data channel opens between the two devices.
-6. The signaling server plays no further part. All file data flows over the data channel.
+5. Once a usable network path is found, the data channel opens between the two devices. On most networks that path is direct. When a strict firewall or carrier-grade NAT blocks a direct path, the channel runs through a [TURN relay](/how-it-works/relay-connection) instead.
+6. The signaling server drops out of the transfer path. Every byte of file data flows over the data channel and never returns to the server. The only later contact about the transfer itself is optional: the receiver can report the transfer's byte count for the public counter, and that can be turned off.
 
 ## What the signaling server does
 
-- Assigns roles: the first peer to join a room becomes the **sender**, the second becomes the **receiver**.
+- Assigns roles: the first peer to join a room becomes the **sender**, the second becomes the **receiver**. A room holds exactly two peers, so a third device trying to join is turned away with `room-full`. A share link cannot be opened by two recipients at once.
 - Relays WebRTC negotiation messages: the initial offer, the answer, and ICE candidates.
 - Issues short-lived TURN credentials when a TURN server is configured.
 - Registers short human-readable codes (e.g. `olive-tiger-castle`) that map to room IDs.
@@ -29,10 +29,10 @@ The signaling server never touches file data, never stores your files or any rec
 - Handle file data of any kind.
 - Store files, file names, transfer content, or logs of what you send or receive.
 - Link the byte total to you. The counter is a single shared number with no per-user or per-transfer records.
-- Persist room or peer information after the session ends.
+- Retain peer information after the session ends. The room entry is dropped as soon as both peers disconnect. A short code stays resolvable until its 10-minute TTL expires, but it maps to nothing except a random room UUID.
 
 <Accordion title="Technical details">
-  **Transports:** Browser clients connect via Socket.IO. CLI clients connect via WebSocket at `/ws`. Both share a single in-memory `rooms` registry (`Map<roomId, [peer, peer]>`), so browser-to-CLI transfers are fully supported.
+  **Transports:** Browser clients connect via Socket.IO. The CLI and the [desktop app](/desktop/installation) connect via WebSocket at `/ws`, using the same signaling client. All of them share a single in-memory `rooms` registry (`Map<roomId, [peer, peer]>`), so any surface can transfer to any other: browser to CLI, browser to desktop, CLI to desktop.
 
   **WebRTC negotiation flow:**
   1. Sender joins the room (`join-room` event) and receives the `sender` role.
@@ -40,21 +40,21 @@ The signaling server never touches file data, never stores your files or any rec
   3. Sender creates an SDP offer and sends it via the `signal` event.
   4. Receiver sets the remote description, creates an SDP answer, and sends it back.
   5. Both peers exchange ICE candidates via `signal` events (trickle ICE).
-  6. Once ICE negotiation completes, the WebRTC data channel opens directly between the peers.
+  6. Once ICE negotiation completes, the WebRTC data channel opens over the nominated candidate pair, either directly between the peers or through a TURN relay.
 
-  **Short codes:** Registered via `POST /api/code` with a room UUID. The server picks three random words from a 288-word list using a cryptographically secure random source (`crypto.randomInt`, not `Math.random`), because the code phrase is the only secret guarding a transfer, and maps them to the room ID with a 10-minute TTL. `GET /api/code/:code` resolves a code back to its room UUID.
+  **Short codes:** Registered via `POST /api/code` with a room UUID. The server picks three random words from a 288-word list using a cryptographically secure random source (`crypto.randomInt`, not `Math.random`), because the code phrase is the only secret guarding a transfer, and maps them to the room ID with a 10-minute TTL. If a generated phrase collides with a code that is still live, the server retries, and in the very unlikely event that ten attempts all collide it issues a four-word phrase instead. `GET /api/code/:code` resolves a code back to its room UUID.
 
-  **TURN credentials:** Issued via `GET /api/turn-credentials`. On floe.one the server mints short-lived credentials (up to 24 hours) from Cloudflare's Realtime TURN service. Self-hosted instances can instead use coturn with HMAC-SHA1 credentials via `TURN_SECRET`, or skip TURN entirely, in which case the endpoint returns public STUN servers only.
+  **TURN credentials:** Issued via `GET /api/turn-credentials`. On floe.one the server mints short-lived credentials (up to 24 hours) from Cloudflare's Realtime TURN service. Self-hosted instances can instead use coturn with HMAC-SHA1 credentials, which requires both `TURN_SECRET` and `TURN_DOMAIN` to be set (setting only one falls through to STUN with no error), or skip TURN entirely, in which case the endpoint returns public STUN servers only.
 
-  **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint; 60 requests per IP per 60 seconds shared across `POST /api/code` and `GET /api/code/:code`; 60 reports per IP per 60 seconds for the stats endpoint. The signaling server also caps the number of simultaneously-live room codes (10000 by default); `POST /api/code` returns `503` when that cap is hit.
+  **Rate limiting:** 30 connections per IP per 60 seconds for Socket.IO and WebSocket; 20 requests per IP per 60 seconds for the TURN credential endpoint; 60 requests per IP per 60 seconds shared across `POST /api/code` and `GET /api/code/:code`; 60 reports per IP per 60 seconds for the stats endpoint. The signaling server also caps the number of registered room codes held in memory (10000 by default), a count that includes expired codes the 60-second sweeper has not cleared yet; `POST /api/code` returns `503` when that cap is hit.
 
-  **Global stats counter:** After a transfer completes, the receiver sends `POST /api/stats/report` with just the byte count. The sender never reports. The server keeps a single anonymous running total (cached in memory, optionally persisted to Upstash Redis) and serves it from `GET /api/stats` for the homepage counter. No file names, contents, or per-transfer records are stored. The total is viewable only in the browser; the CLI receiver contributes but never displays it. Both the browser receiver and CLI receiver can opt out (browser: "Contribute to global stats" toggle; CLI: `--no-report` flag or `FLOE_NO_STATS=1`). See the [architecture reference](/reference/architecture#global-statistics-counter) for details.
+  **Global stats counter:** After a transfer completes, the receiver sends `POST /api/stats/report` with just the byte count. The sender never reports. The server keeps a single anonymous running total (cached in memory, optionally persisted to Upstash Redis) and serves it from `GET /api/stats` for the homepage counter. No file names, contents, or per-transfer records are stored. The total is displayed only in the browser; the CLI and desktop receivers contribute without ever showing it. Every receiver can opt out: the browser has a "Contribute to global stats" toggle, the CLI takes `--no-report` or `FLOE_NO_STATS=1`, and the desktop app has a [Contribute to global stats](/desktop/settings#contribute-to-global-stats) setting that is remembered between runs. When a receiver opts out, no report is sent at all. See the [architecture reference](/reference/architecture#global-statistics-counter) for details.
 
   **Data-channel transfer protocol:** Once the WebRTC data channel opens, the sender runs this sequence for each file:
-  1. Sends a JSON `metadata` message with the filename, size in bytes, and the file's index and total count in the batch.
-  2. Waits for the receiver to reply with a JSON `ack` message. The ack carries a byte offset, so a transfer can resume mid-file.
-  3. Streams the file as binary chunks until the whole file is sent. Both senders size chunks adaptively to what the connection negotiates, up to 256 KB, and apply backpressure-based flow control, pausing when the data channel's send buffer fills.
+  1. Sends a JSON `metadata` message with a per-file id, the filename, the size in bytes, the file's index and total count in the batch, the batch's total byte count, and the sender's protocol version range and release string.
+  2. Waits for the receiver to reply with a JSON `ack` message. The ack carries a byte offset, so a transfer can resume mid-file, plus the receiver's own protocol version range. If the two ranges do not overlap, the receiver sends an `incompatible` message instead of an ack, and both sides stop before any file bytes move with a prompt to update or refresh.
+  3. Streams the file as binary chunks until the whole file is sent. Every sender (the browser, and the shared Go engine behind the CLI and the desktop app) sizes chunks adaptively to what the connection negotiates, up to 256 KB, and applies backpressure-based flow control, pausing when the data channel's send buffer fills.
   4. Sends a JSON `end` message to signal completion.
 
-  For multi-file transfers, this four-step sequence repeats for each file in order.
+  For multi-file transfers, this sequence repeats for each file in order. Once everything is written and verified, a CLI or desktop receiver sends one final `received` message so its sender knows delivery is confirmed and can close cleanly. Browser receivers never send it.
 </Accordion>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Introduction to Floe"
-description: "Floe is a secure, encrypted peer-to-peer file transfer tool that sends files directly between browsers over WebRTC with no accounts and no uploads."
+description: "Floe is a secure, encrypted peer-to-peer file transfer tool that sends files directly between devices over WebRTC, with no accounts and no uploads."
 ---
 
-Floe transfers files directly between devices using WebRTC. Files are end-to-end encrypted and never stored on any server. The signaling server only brokers the initial connection setup. Once both peers are connected, it steps aside.
+Floe transfers files directly between devices using WebRTC. Files are end-to-end encrypted and never stored on any server. The signaling server only brokers the initial connection setup. Once both peers are connected, it steps aside and no file data passes through it.
 
 ## What Floe does
 
 - **Direct, peer-to-peer transfers.** Files travel straight from your device to the recipient's device.
 - **End-to-end encrypted.** Every transfer is encrypted with DTLS. No one, including Floe's servers, can read your files.
-- **No accounts or storage.** No sign-up, no uploads, no data retained after the transfer completes.
-- **No size limit on direct transfers.** Relay connections are capped at 2 GB per session to keep the service free.
+- **No accounts or storage.** No sign-up, no uploads, and no file names or contents ever sent to a server. After a transfer, floe.one adds an anonymous byte count to its public counter, which the receiver can switch off, and the site itself records cookieless aggregate analytics and error reports. The desktop app and the CLI carry no analytics at all. See [Security and Privacy](/security-privacy).
+- **No size limit on direct transfers.** Relay connections are capped at 2 GB per session to keep the service free. A browser receiver holds each incoming file in memory until that file is complete, so very large files are bounded by the receiving device's RAM. The desktop app and the CLI write straight to disk and have no such ceiling.
 - **Browser, desktop, and CLI.** Use the web app at floe.one, Floe Desktop for Windows, or the `floe` command-line tool. All three speak the same protocol, so any two of them can transfer to each other.
 - **Open source and self-hostable.** Run your own instance on your own infrastructure with Docker Compose.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Floe Quick Start"
-description: "Send your first file with Floe in under a minute using the web app at floe.one, with peer-to-peer WebRTC transfer and no signup or install required."
+description: "Send your first file with Floe in under a minute from the browser, Floe Desktop, or the command line, using peer-to-peer WebRTC with no signup required."
 ---
 
 ## Browser
@@ -9,10 +9,10 @@ description: "Send your first file with Floe in under a minute using the web app
 
 1. Open [floe.one](https://floe.one) in your browser.
 2. Drop files onto the page or click to open the file picker. Multiple files are supported.
-3. (Optional) Toggle **Network Relay Fallback** on or off. It is on by default and recommended. When disabled, only direct connections are attempted; transfers may fail on mobile data or restricted networks.
-4. Click **Create Secure Link & Share**.
-5. Floe displays a shareable link and a QR code. Share either with your recipient.
-6. A connection indicator appears in the corner showing the connection state. Once the recipient opens the link, it turns green (Direct) or amber (Relay) and the transfer begins automatically.
+3. (Optional) Toggle **Network relay fallback** on or off. It is on by default and recommended. When disabled, only direct connections are attempted, and transfers may fail if either device is on mobile data or a restricted network.
+4. Click **Create secure link**. The button also shows the file count, for example "Create secure link (3 files)".
+5. Floe displays the shareable link with **Copy** and **Show QR** beside it. Send the link, or click **Show QR** to reveal a QR code the recipient can scan.
+6. A connection indicator sits in the top bar of the transfer card. Read its label rather than the dot alone: **Offline** (red) means your browser is not connected to Floe's signaling server, **Ready** (green) means that signaling connection is up, which happens on page load and does not by itself mean anyone has joined, then **Direct** (green) or **Relay** (amber) once Floe works out the route. A direct connection always starts transferring. A relayed one starts only if you left relay fallback on and the payload is 2 GB or smaller.
 
 ### Receiver
 
@@ -23,12 +23,14 @@ description: "Send your first file with Floe in under a minute using the web app
    - **Download All** triggers individual downloads for every file.
    - **Download ZIP** bundles everything into a single archive.
 
+   **Download All** and **Download ZIP** appear only when the transfer contained more than one file. A single file has just its own download button.
+
 <Tip>
-  On iOS, use Download ZIP for the most reliable experience.
+  On iOS, use **Download ZIP** when the transfer has more than one file. Individual file downloads can behave inconsistently on Safari and iOS web views due to browser sandboxing.
 </Tip>
 
 <Note>
-  The receiver view has a **Contribute to global stats** checkbox (on by default) that adds only this transfer's byte count to Floe's public homepage counter. Uncheck it to opt out. File names and contents are never sent. See [Receiving Files](/web-app/receiving#contribute-to-global-stats).
+  The receiver view has a **Contribute to global stats** checkbox (on by default) that adds only this transfer's byte count to Floe's public homepage counter. It is shown while you wait, before the first file arrives, so uncheck it then. Your choice is saved in the browser and applies to later transfers. File names and contents are never sent. See [Receiving Files](/web-app/receiving#contribute-to-global-stats).
 </Note>
 
 <Note>
@@ -37,11 +39,27 @@ description: "Send your first file with Floe in under a minute using the web app
 
 ---
 
+## Desktop (Windows)
+
+<Steps>
+  <Step title="Install">
+    Get Floe Desktop from the [Microsoft Store](https://apps.microsoft.com/detail/9NBQ8ZQ1065L), or download the installer or the portable zip from [floe.one/download](https://floe.one/download). The app is in beta and Windows only today. The GitHub builds are not code-signed, so SmartScreen warns on first run. See [Install Floe Desktop](/desktop/installation).
+  </Step>
+  <Step title="Send">
+    Stay on the **Send** tab. Drop files onto the window, click **Files** or **Folder** to browse, or press `Ctrl` `V` to paste files copied in File Explorer or an image from the clipboard. Click **Send**. Floe shows a **Room code** and a **Share link**, each with a copy button, plus a **Show QR** toggle. Hand over whichever suits the recipient. See [Sending Files](/desktop/sending).
+  </Step>
+  <Step title="Receive">
+    Switch to the **Receive** tab, paste the code or the link into **Code or link**, optionally pick a **Save to** folder with **Browse** (Downloads by default), then click **Receive**. Files are written straight to disk as they arrive, so there is no size ceiling on a direct connection. See [Receiving Files](/desktop/receiving).
+  </Step>
+</Steps>
+
+---
+
 ## CLI
 
 <Steps>
   <Step title="Install">
-    Download the binary for your platform from [GitHub Releases](https://github.com/jannskiee/floe/releases). See [Installation](/cli/installation) for platform-specific steps.
+    Install with a package manager: `brew install --cask jannskiee/tap/floe` on macOS, `winget install jannskiee.floe` on Windows, or `curl -fsSL https://floe.one/install.sh | sh` on macOS and Linux. See [Installation](/cli/installation) for every option, including scoop, `go install`, and direct binary downloads.
   </Step>
   <Step title="Send">
     ```bash
@@ -60,7 +78,7 @@ description: "Send your first file with Floe in under a minute using the web app
       Waiting for peer...
     ```
 
-    Share the **code** (CLI recipients) or the **link** (browser recipients). The short code is valid for 10 minutes.
+    Share the **link** with anyone. Share the **code** with CLI or desktop recipients, who can paste either form. The short code is valid for 10 minutes.
   </Step>
   <Step title="Receive">
     The recipient runs:
@@ -97,19 +115,24 @@ description: "Send your first file with Floe in under a minute using the web app
 
 ## Cross-platform transfers
 
-The browser and CLI clients are fully interoperable. Any combination of sender and receiver works.
+The browser, desktop, and CLI clients are fully interoperable. Any combination of sender and receiver works.
 
 | Sender | Receiver | How the receiver joins |
 |--------|----------|------------------------|
 | Browser | Browser | Opens the shared link or scans the QR code |
+| Browser | Desktop | Pastes the link into the Receive tab |
 | Browser | CLI | `floe receive <link>` (paste the full URL) |
+| Desktop | Browser | Opens the shared link or scans the QR code |
+| Desktop | Desktop | Pastes the code or the link into the Receive tab |
+| Desktop | CLI | `floe receive <code>` or `floe receive <link>` |
 | CLI | Browser | Opens the shared link or scans the QR code |
+| CLI | Desktop | Pastes the code or the link into the Receive tab |
 | CLI | CLI | `floe receive <code>` or `floe receive <link>` |
 
-**How it works:** The browser connects via Socket.IO and the CLI connects via WebSocket, but both share the same room on the signaling server. Signals (WebRTC offer, answer, ICE candidates) are routed between them automatically. Neither side needs to know which client the other is using.
+**How it works:** The browser connects via Socket.IO, while the CLI and the desktop app connect via WebSocket, but all of them share the same room on the signaling server. Signals (WebRTC offer, answer, ICE candidates) are routed between them automatically. Neither side needs to know which client the other is using.
 
-**Key difference:** The browser can only join a transfer by opening the link directly. There is no short-code entry field in the web UI. The CLI accepts either the short code or the full link.
+**Key difference:** The browser can only join a transfer by opening the link directly. There is no short-code entry field in the web UI, and a browser sender never mints a short code, only a link. The CLI and the desktop app both accept either the short code or the full link.
 
 <Note>
-  Folder transfers are a CLI feature. When you `floe send ./folder`, all files are transferred recursively and the directory structure is preserved on the receiver's end. A browser receiver gets the same files but sees them as a flat list.
+  Folder transfers work in the CLI and the desktop app. Run `floe send ./folder`, or click **Folder** in the desktop send area. All files are transferred recursively, and the directory structure is preserved when the receiver is a CLI or desktop client. A browser receiver gets the same files but sees them as a flat list.
 </Note>

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -12,18 +12,21 @@ This page is a technical reference for contributors and advanced self-hosters. F
 | Client | Next.js 16 (React 19) | 3000 | Browser UI, WebRTC peer (via simple-peer) |
 | Server | Node.js (Express 5, Socket.IO 4, ws 8) | 3001 | Signaling broker, TURN credential issuer |
 | CLI | Go 1.25 (Pion WebRTC v4) | - | Headless sender/receiver |
-| TURN relay | Cloudflare Realtime TURN (floe.one) or self-hosted coturn | 3478, 5349 | Relays encrypted packets when a direct path fails |
+| Desktop | Wails v2 (Go 1.25 backend, React frontend) | - | Windowed sender/receiver. Windows amd64 is the build shipped today |
+| TURN relay | Cloudflare Realtime TURN (floe.one) or self-hosted coturn | 3478 and 5349 (coturn); Cloudflare's own ports, including a TLS URL on 443 | Relays encrypted packets when a direct path fails |
+
+The CLI and the desktop app share one Go transfer engine (`cli/engine/`), joined by the workspace file `go.work`, so they behave identically on the wire. See [Desktop installation](/desktop/installation) for the app itself.
 
 File data never passes through the signaling server, and only end-to-end-encrypted packets ever transit the TURN relay. All file bytes travel over encrypted WebRTC data channels between peers.
 
 ## Signaling transports
 
-The server exposes two transports. Both share the same `rooms` registry (`Map<roomId, [peer, peer]>`) so browser-to-CLI transfers work transparently.
+The server exposes two transports. Both share the same `rooms` registry (`Map<roomId, [peer, peer]>`) so browser-to-CLI and browser-to-desktop transfers work transparently.
 
 | Transport | Path | Used by |
 |-----------|------|---------|
 | Socket.IO | `/socket.io/` | Browser (web app) |
-| WebSocket | `/ws` | CLI |
+| WebSocket | `/ws` | CLI and desktop app |
 
 ## HTTP endpoints
 
@@ -31,15 +34,17 @@ The server exposes two transports. Both share the same `rooms` registry (`Map<ro
 |--------|------|-------------|
 | `GET` | `/` | Status check. Returns `{ "status": "ok", "timestamp": "..." }`. |
 | `GET` | `/health` | Liveness probe. Returns `{ "status": "healthy", "uptime": <seconds> }`. |
-| `GET` | `/api/turn-credentials` | Returns ICE server list. Prefers Cloudflare Realtime TURN when `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN` are set, then self-hosted coturn when `TURN_SECRET` is set, otherwise Google STUN only. Rate-limited to 20 requests per IP per 60 s. |
-| `POST` | `/api/code` | Registers a short code for a room ID. Body: `{ "roomId": "<uuid>" }`. Response: `{ "code": "word-word-word" }`. TTL: 10 minutes. Rate-limited to 60 requests per IP per 60 s (shared with `GET /api/code/:code`, configurable via `MAX_CODE_REQUESTS_PER_IP`). Returns `503` when the live-code count hits `MAX_ACTIVE_CODES` (default 10000). |
+| `GET` | `/api/turn-credentials` | Returns ICE server list. Prefers Cloudflare Realtime TURN when `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN` are set, then self-hosted coturn when `TURN_SECRET` and `TURN_DOMAIN` are both set, otherwise Google STUN only. Rate-limited to 20 requests per IP per 60 s (configurable via `MAX_TURN_REQUESTS_PER_IP`). |
+| `POST` | `/api/code` | Registers a short code for a room ID. Body: `{ "roomId": "<uuid>" }`. Response: `{ "code": "word-word-word" }`. TTL: 10 minutes. Rate-limited to 60 requests per IP per 60 s (shared with `GET /api/code/:code`, configurable via `MAX_CODE_REQUESTS_PER_IP`). Returns `503` when the number of codes held in memory hits `MAX_ACTIVE_CODES` (default 10000). |
 | `GET` | `/api/code/:code` | Resolves a short code to a room ID. Response: `{ "roomId": "<uuid>" }`. Returns 404 if expired or not found. Rate-limited to 60 requests per IP per 60 s (shared with `POST /api/code`, configurable via `MAX_CODE_REQUESTS_PER_IP`). |
 | `GET` | `/api/stats` | Returns the all-time global transfer counter: `{ "totalBytes": <integer> }`. Served from an in-memory cache (no Redis read per request). |
 | `POST` | `/api/stats/report` | Receiver peers report bytes after a completed transfer. Body: `{ "bytes": <positive integer> }`. Response: `{ "totalBytes": <integer> }`. Rate-limited to 60 requests per IP per 60 s; rejects values that are not positive integers or exceed `MAX_REPORT_BYTES` (default 5 TB). |
 
 ### TURN credentials response
 
-On floe.one the endpoint returns short-lived Cloudflare Realtime TURN credentials (`turn.cloudflare.com`). For a self-hosted coturn relay, when `TURN_SECRET` and `TURN_DOMAIN` are set it returns:
+On floe.one the endpoint returns short-lived Cloudflare Realtime TURN credentials (`turn.cloudflare.com`). They are requested with a 24-hour TTL and cached in memory for 12 hours, so a burst of page loads costs one upstream call. Cloudflare's full URL list is trimmed before it is served, down to one STUN URL, one UDP TURN URL, and one TCP-based TURN URL (preferring TLS on port 443). Clients gather ICE candidates per URL per network interface, so redundant URLs multiply connection setup time on machines with VPN or VM adapters.
+
+For a self-hosted coturn relay, when `TURN_SECRET` and `TURN_DOMAIN` are set it returns:
 
 ```json
 [
@@ -49,7 +54,7 @@ On floe.one the endpoint returns short-lived Cloudflare Realtime TURN credential
 ]
 ```
 
-When `TURN_SECRET` is unset:
+When neither Cloudflare nor coturn is configured:
 
 ```json
 [
@@ -62,7 +67,7 @@ For self-hosted coturn, credentials use HMAC-SHA1: `username = "{expiry_unix}:fl
 
 ## Socket.IO events (browser)
 
-### Client to server
+### Client to server (Socket.IO)
 
 | Event | Payload | Description |
 |-------|---------|-------------|
@@ -70,7 +75,7 @@ For self-hosted coturn, credentials use HMAC-SHA1: `username = "{expiry_unix}:fl
 | `signal` | `{ signal, target?, roomId? }` | Forward a WebRTC signal (SDP or ICE candidate) to the other peer. |
 | `ping` | callback function | Keepalive. Server invokes the callback immediately. |
 
-### Server to client
+### Server to client (Socket.IO)
 
 | Event | Payload | Description |
 |-------|---------|-------------|
@@ -81,11 +86,11 @@ For self-hosted coturn, credentials use HMAC-SHA1: `username = "{expiry_unix}:fl
 | `room-full` | `{}` | Room already has two peers. |
 | `error` | `{ message: string }` | Server error. |
 
-## WebSocket messages (CLI, path `/ws`)
+## WebSocket messages (CLI and desktop, path `/ws`)
 
 All messages are JSON objects with a `type` field.
 
-### Client to server
+### Client to server (WebSocket)
 
 | `type` | Other fields | Description |
 |--------|-------------|-------------|
@@ -93,7 +98,7 @@ All messages are JSON objects with a `type` field.
 | `signal` | `signal, roomId: string` | Forward a WebRTC signal. |
 | `ping` | - | Keepalive. Server responds with `{ "type": "pong" }`. |
 
-### Server to client
+### Server to client (WebSocket)
 
 | `type` | Other fields | Description |
 |--------|-------------|-------------|
@@ -110,18 +115,18 @@ All messages are JSON objects with a `type` field.
 | Limit | Value | Applies to |
 |-------|-------|-----------|
 | Connection rate | 30 per IP per 60 s (configurable via `MAX_CONNECTIONS_PER_IP`) | Socket.IO connections and WebSocket `/ws` connections, shared |
-| TURN credential rate | 20 per IP per 60 s | `GET /api/turn-credentials` |
+| TURN credential rate | 20 per IP per 60 s (configurable via `MAX_TURN_REQUESTS_PER_IP`) | `GET /api/turn-credentials` |
 | Code endpoint rate | 60 per IP per 60 s (configurable via `MAX_CODE_REQUESTS_PER_IP`) | `POST /api/code` and `GET /api/code/:code`, shared |
-| Active code cap | 10000 simultaneously-live codes (configurable via `MAX_ACTIVE_CODES`) | `POST /api/code`. Returns `503` when the registry is full. |
+| Active code cap | 10000 registered codes held in memory (configurable via `MAX_ACTIVE_CODES`) | `POST /api/code`. Returns `503` when the registry is full. |
 | Stats report rate | 60 per IP per 60 s | `POST /api/stats/report` |
 
-Counters are tracked in memory (`Map<ip, timestamp[]>`) and cleaned every 60 seconds. Per-IP limits respond with `429`. The active-code cap responds with `503` and applies globally, not per-IP, because it guards the size of the in-memory code registry.
+Counters are tracked in memory (`Map<ip, timestamp[]>`) and cleaned every 60 seconds. The three HTTP limits (TURN, code, stats) respond with `429`. The connection limit is not an HTTP response: a Socket.IO handshake over the limit is rejected in the connection middleware, which the browser sees as a `connect_error`, and a WebSocket over the limit is closed with code `1008`. The active-code cap responds with `503` and applies globally, not per-IP, because it guards the size of the in-memory code registry. That cap counts stored entries rather than genuinely live ones: expired codes are swept once a minute, so the count can briefly include codes that have already expired.
 
 ## Signaling flow
 
-1. Sender calls `POST /api/code` with a UUID room ID to register a short code.
+1. The sender generates a UUID room ID. All three surfaces put it in the fragment of a share link (`#room=<id>`), and browsers never send a fragment to a server, so opening the link keeps the room ID out of request URLs, `Referer` headers, and analytics. The CLI and the desktop app additionally register the room ID with `POST /api/code` to get a short phrase; the web app has no code UI. The signaling server learns the room ID from that code registration, if there is one, and otherwise only when a peer joins in the next step.
 2. Sender joins the room via `join-room`. Server assigns role `sender`.
-3. Sender prints the code and link and waits.
+3. Sender shows the code, link, or QR code and waits.
 4. Receiver joins the same room via `join-room`. Server assigns role `receiver` and emits `user-connected` to the sender.
 5. Sender creates a WebRTC offer and sends it via `signal`.
 6. Receiver receives the offer, creates an answer, and sends it back via `signal`.
@@ -130,7 +135,7 @@ Counters are tracked in memory (`Map<ip, timestamp[]>`) and cleaned every 60 sec
 
 ## Data-channel transfer protocol
 
-Once the WebRTC data channel is open, the sender runs the following sequence for each file. The CLI and browser use the same protocol and are fully interoperable.
+Once the WebRTC data channel is open, the sender runs the following sequence for each file. The browser, the CLI, and the desktop app use the same protocol and are fully interoperable in every direction. The CLI and the desktop app share one implementation (`cli/engine/transfer`).
 
 ### Message types
 
@@ -151,7 +156,7 @@ Once the WebRTC data channel is open, the sender runs the following sequence for
 }
 ```
 
-`pv`, `pvMin`, and `ver` carry the protocol version range and release string (see [Protocol versioning](#protocol-versioning)). They were added in v1.6.0 and are absent on older peers, which are treated as protocol version 1.
+`pv` and `pvMin` carry the protocol version range and are always present; `ver` is the release string (see [Protocol versioning](#protocol-versioning)). All three were added in v1.6.0 and are absent on older peers, which are treated as protocol version 1. `ver` is populated by Go peers (the CLI and the desktop app) and omitted by browser peers.
 
 **Ack (JSON, receiver to sender)**
 
@@ -166,11 +171,11 @@ Once the WebRTC data channel is open, the sender runs the following sequence for
 }
 ```
 
-`offset` supports mid-file resume. In normal operation it is always 0. The ack carries the receiver's own `pv`, `pvMin`, and `ver` so the sender can verify compatibility from its side.
+`offset` supports mid-file resume. In normal operation it is always 0. The ack carries the receiver's own `pv` and `pvMin` so the sender can verify compatibility from its side, plus `ver` when the receiver is a Go peer.
 
 **Binary chunks (raw bytes)**
 
-Both the CLI and the browser size chunks adaptively to the connection's negotiated maximum message size, capped at 256 KB. Chunk size is a local sender choice, not part of the wire protocol; receivers handle any size.
+Both the Go engine (CLI and desktop) and the browser size chunks adaptively to the connection's negotiated maximum message size, capped at 256 KB. Chunk size is a local sender choice, not part of the wire protocol; receivers handle any size.
 
 **End marker (JSON, sender to receiver)**
 
@@ -180,7 +185,7 @@ Both the CLI and the browser size chunks adaptively to the connection's negotiat
 
 **Received confirmation (JSON, receiver to sender)**
 
-After all files are complete, the CLI receiver sends:
+After all files are complete, a Go receiver (the CLI or the desktop app) sends:
 
 ```json
 { "type": "received" }
@@ -190,14 +195,15 @@ This lets the sender exit cleanly instead of polling the SCTP buffer. Browser re
 
 **Incompatible (JSON, receiver to sender)**
 
-Sent in place of the ack when the two peers' protocol version ranges do not overlap (see [Protocol versioning](#protocol-versioning)). It carries a human-readable `reason` plus the receiver's own version range:
+Sent in place of the ack when the two peers' protocol version ranges do not overlap (see [Protocol versioning](#protocol-versioning)). It carries a human-readable `reason` plus the receiver's own version range, and `ver` when the receiver knows its release string. As with metadata and acks, Go receivers populate `ver` and browser receivers omit it.
 
 ```json
 {
   "type": "incompatible",
   "reason": "Cannot transfer: your floe is too old for this peer. ...",
   "pv": 1,
-  "pvMin": 1
+  "pvMin": 1,
+  "ver": "v1.6.0"
 }
 ```
 
@@ -210,8 +216,8 @@ The transfer protocol carries its own version, independent of the floe release v
 - Each peer advertises `pv` (the highest protocol version it speaks) and `pvMin` (the lowest it still supports) in its metadata and ack. Both are 1 today.
 - Two peers are compatible when their ranges overlap: `max(localMin, remoteMin) <= min(localMax, remoteMax)`. They operate at the highest common version.
 - A peer that omits the fields (any release before v1.6.0) is treated as protocol version 1, so all existing peers stay compatible.
-- When the ranges do not overlap, the receiver sends an `incompatible` message and both sides print an actionable message: the older peer is told to run `floe update`, or to ask the other side to update.
-- `ver` is the human release string (for example `v1.6.0`). It is informational only, used for the optional peer-version note, and never gates a transfer.
+- When the ranges do not overlap, the receiver sends an `incompatible` message and both sides print an actionable message. The older peer is told how to update for its surface (`floe update` on the Go surfaces, refresh the page in the browser); the newer peer is told to ask the other side to update.
+- `ver` is the human release string (for example `v1.6.0`). It is optional: Go peers (the CLI and the desktop app) always send it, browser peers never do. It is informational only, used for the optional peer-version note the CLI prints on either side when the two releases differ, and it never gates a transfer.
 
 The constants live in `cli/engine/transfer/protocol.go` (`ProtocolVersion`, `MinProtocolVersion`) and `client/lib/transfer/protocol.ts` (`PROTOCOL_VERSION`, `MIN_PROTOCOL_VERSION`). Bump `ProtocolVersion` only on a breaking wire change; raise `MinProtocolVersion` only when deliberately dropping support for an old wire format.
 
@@ -225,13 +231,13 @@ The four-step sequence (metadata, ack, binary chunks, end) repeats for each file
 
 ## Room codes
 
-Codes are three random words joined by hyphens (e.g. `olive-tiger-castle`), sampled from a 288-word corpus in `server/words.json` using `crypto.randomInt` (a CSPRNG, bias-free), since the code phrase is the only secret guarding a transfer. On collision (extremely rare), a fourth word is appended. Codes expire 10 minutes after registration. The number of simultaneously-live codes is capped by `MAX_ACTIVE_CODES` (default 10000); `POST /api/code` returns `503` when the cap is reached.
+Codes are three random words joined by hyphens (e.g. `olive-tiger-castle`), sampled from a 288-word corpus in `server/words.json` using `crypto.randomInt` (a CSPRNG, bias-free), since the code phrase is the only secret guarding a transfer. On collision the server simply draws a new phrase, up to 10 times; only if all 10 draws collide does it fall back to a four-word phrase. An expired code counts as free. Codes expire 10 minutes after registration. The number of registered codes held in memory is capped by `MAX_ACTIVE_CODES` (default 10000); `POST /api/code` returns `503` when the cap is reached. Expired codes are swept once a minute, so that count can briefly include codes that have already expired.
 
 ## Global statistics counter
 
-The homepage shows a public, all-time counter of total bytes transferred across every Floe user. Because file data never reaches the server, the counter is fed out-of-band: after a transfer completes, the **receiver** reports the number of bytes it received via `POST /api/stats/report`. Only the receiver reports (the browser receiver and the CLI receiver), so each transfer is counted exactly once. The sender never reports, and the data-channel protocol is unchanged.
+The homepage shows a public, all-time counter of total bytes transferred across every Floe user. Because file data never reaches the server, the counter is fed out-of-band: after a transfer completes, the **receiver** reports the number of bytes it received via `POST /api/stats/report`. Only the receiver reports (the browser, CLI, and desktop receivers), so each transfer is counted exactly once. The sender never reports, and the data-channel protocol is unchanged.
 
-The global total is **viewable only in the browser** (`GlobalStats.tsx` on the homepage, polling `GET /api/stats` every 10 seconds). The CLI receiver contributes to the counter but never fetches or displays it.
+The global total is **viewable only in the browser** (`GlobalStats.tsx` on the homepage, polling `GET /api/stats` every 10 seconds). The CLI and desktop receivers contribute to the counter but never fetch or display it.
 
 The server keeps the running total in two places:
 
@@ -242,7 +248,8 @@ If `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are not configured, t
 
 Guardrails are deliberately lightweight. A per-IP rate limit (60 reports per 60 s) and a per-report cap (`MAX_REPORT_BYTES`, default 5 TB) reject abuse and implausible values, but the figure is an honest best-effort metric, not a tamper-proof audited count. The stored value is a single anonymous integer: it carries no file names, no per-transfer records, and no link to any user or IP.
 
-**Opt-out:** Both clients support opting out of the byte-count report. The opt-out is enforced on the receiver side before the HTTP request is made; the server has no role in it.
+**Opt-out:** All three receiving surfaces support opting out of the byte-count report. The opt-out is enforced on the receiver side before the HTTP request is made; the server has no role in it.
 
 - Browser: a "Contribute to global stats" toggle on the receiver view, persisted in `localStorage['floe:report-stats']`. When unchecked, the `fetch` to `/api/stats/report` and the optimistic `floe:bytes-reported` event are both skipped.
 - CLI: `--no-report` flag on `floe receive`, or `FLOE_NO_STATS=1` environment variable. Both gate the report by passing an empty `statsURL` into `ReceiveFiles`, which hits the existing `if serverURL == "" { return }` guard in `reportBytesToServer`.
+- Desktop: a "Contribute to global stats" toggle in [Settings](/desktop/settings), persisted to the desktop config file (with a one-time import from the older `localStorage['floe:report-stats']` value). When it is off, the app passes an empty `statsURL` into the shared engine receiver and hits the same guard as the CLI.

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -9,18 +9,18 @@ Your files travel directly between devices, encrypted end-to-end. Floe's servers
 
 ## What the signaling server does
 
-The signaling server at `api.floe.one` handles one task: helping two devices find each other so they can connect directly.
+The signaling server at `api.floe.one` exists to help two devices find each other so they can connect directly. It never touches the file itself.
 
 It:
 - Assigns each peer a role (sender or receiver) within a room.
 - Relays the WebRTC offer, answer, and ICE candidates that the two devices exchange to establish a connection.
-- Issues short-lived TURN credentials when a TURN server is configured.
+- Issues TURN credentials, valid for 24 hours, when a TURN server is configured. They are not tied to your identity or to an account: on floe.one a single credential set is minted from Cloudflare and served to every client until the cached copy is refreshed.
 - Registers short codes (e.g. `olive-tiger-castle`) that map to room IDs with a 10-minute TTL.
 - Keeps a single anonymous running total of bytes transferred, for the public counter on the homepage (see [Aggregate statistics](#aggregate-statistics) below).
 
 It never:
 - Receives, stores, or inspects file data.
-- Persists room or peer information after the session ends.
+- Persists room or peer information beyond the session, apart from a short code's mapping to its room ID, which stops working 10 minutes after the code is created.
 - Logs what you transfer, your file names, or to whom.
 
 Once the WebRTC data channel is established, the signaling server plays no further part.
@@ -33,7 +33,7 @@ What is recorded: a single cumulative integer (total bytes, the sum across every
 
 What is not recorded: file names, file contents, per-transfer records, who sent or received, or any link to your identity or IP address. The reported figure is just a size, added to one global running total.
 
-The counter is an honest best-effort metric protected by lightweight guardrails (a per-IP rate limit and a per-report size cap). It is not a tamper-proof audited figure, and reporting never blocks or slows a transfer. Self-hosted instances can leave this disabled, in which case nothing is recorded at all.
+The counter is an honest best-effort metric protected by lightweight guardrails (a per-IP rate limit and a per-report size cap). It is not a tamper-proof audited figure, and reporting never blocks or slows a transfer. On a self-hosted instance the counter is local to that server, and without an Upstash Redis database configured it is held in memory only and resets whenever the server restarts. There is no server-side switch that refuses reports, so opting out is a choice each receiver makes on its own device.
 
 **Opting out:** every receiver supports opting out.
 
@@ -43,15 +43,37 @@ The counter is an honest best-effort metric protected by lightweight guardrails 
 
 When opted out, no request is made to the server and the counter is not incremented. The report always goes to whichever signaling server the client is pointed at, so a self-hosted instance feeds its own counter rather than the one on floe.one.
 
+## Error monitoring and analytics
+
+These apply to the floe.one website only. The CLI and the desktop app contain no analytics, no error monitoring, and no telemetry. The only thing either one sends is the optional byte-count report described above, and you can turn that off.
+
+- **Sentry** records application errors and a 10% sample of browser performance traces. It is configured never to attach cookies, headers, or your IP address, and the room secret is stripped out of every error report and breadcrumb before it is sent.
+- **Session replay is not enabled, and will not be added.** A replay reports the page address, and on a receiver page that address contains the room link, which is the only thing protecting a transfer.
+- **Umami** records aggregate, cookieless page views and transfer outcomes (file count, total bytes, direct or relay, success or failure). It is configured to send neither the URL fragment nor the query string, so the room secret never reaches it. It does not track individuals across sessions or sites.
+
+Sentry and Umami are each enabled only when their key is supplied. The published container image sets neither, so a self-hosted instance ships with both off unless you add your own.
+
+See the full [Privacy Policy](https://floe.one/privacy) for the site-wide detail.
+
 ## The room secret stays in the URL fragment
 
-Share links use a URL fragment (`https://floe.one/#room=...`), not a query string. The fragment portion of a URL is handled entirely by the browser and is never sent to any server in HTTP requests. As a result, the room secret is not included in `Referer` headers when you click outbound links, is not visible to server access logs, and is not captured by pageview analytics or third-party trackers. The signaling server only sees the room ID after the browser explicitly joins the room over the WebSocket, and even then, file bytes never reach the server.
+Share links keep the room secret in the URL fragment, after the `#`, never in the query string. A link from the web app or the desktop app looks like `https://floe.one/?s=a1b2c3d4#room=...`, and one from the CLI looks like `https://floe.one/#room=...`. The `?s=` value is a random per-link marker that carries no information. It exists only so that each link is a distinct page, which stops a device that already has Floe open from reusing a stale tab instead of joining the new room.
+
+The fragment portion of a URL is handled entirely by the browser and is never sent to any server in HTTP requests. As a result, the room secret is not included in `Referer` headers when you click outbound links, is not visible to server access logs, and is not captured by pageview analytics or third-party trackers. The signaling server only sees the room ID after the peer explicitly joins the room over its signaling connection, and even then, file bytes never reach the server.
+
+## Browser hardening
+
+floe.one sends a Content-Security-Policy with `frame-ancestors 'none'`, repeated as `X-Frame-Options: DENY` for older browsers, so no other site can embed Floe in an iframe. That matters more here than on a typical site: a receiver page joins its room automatically on load and then answers the sender's offer with its own network candidates, so an invisible embedded copy pointed at an attacker's room could otherwise disclose a visitor's local and public IP addresses without a single click.
+
+The same header set blocks plugin content and `<base>` rewriting, restricts form submissions to floe.one, sends `X-Content-Type-Options: nosniff`, sets `Referrer-Policy: strict-origin-when-cross-origin`, denies camera, microphone, geolocation, payment, and USB access outright, and opts the site out of ad interest cohorts (`interest-cohort=()`). The signaling server sends the standard hardening headers too.
 
 ## What the TURN relay sees
 
 When a direct connection cannot be established (strict firewalls, carrier-grade NAT), Floe routes traffic through a TURN relay server. The relay server acts as a forwarding intermediary. On floe.one, the relay is Cloudflare's Realtime TURN network; self-hosted instances can run their own coturn relay instead.
 
-The relay sees: encrypted DTLS packets.
+Routing through the relay also changes who sees your IP address. On a direct connection, the two devices learn each other's IP addresses. That is how any peer-to-peer connection works: ICE exchanges candidate addresses through the signaling server so the two devices can find a path between them. If you would rather not reveal yours to the person you are transferring with, force the relay path instead, so they see the relay's address rather than yours. The desktop app has a ["Hide my IP address" setting](/desktop/settings#hide-my-ip-address) that does exactly this, trading some speed and the 2 GB session cap for keeping your address behind the relay. The browser and the CLI have no equivalent switch today.
+
+The relay sees: encrypted DTLS packets, plus the connection metadata that being the middle hop entails. It is an endpoint both peers connect to, so it observes both IP addresses and the timing and size of the traffic it forwards. Your infrastructure provider may log that metadata for security purposes.
 
 It does not see: the plaintext contents of those packets. File data is encrypted before it reaches the relay, and decrypted only on the recipient's device. The relay cannot read, store, or inspect your files.
 

--- a/docs/self-hosting/build-time-url.mdx
+++ b/docs/self-hosting/build-time-url.mdx
@@ -17,6 +17,16 @@ The first match wins.
 | 3 | `SOCKET_URL` on the running client container, served from `GET /api/config` | The normal path for a self-hosted instance. |
 | 4 | The page's own origin | When `SOCKET_URL` is empty, which is what you want [behind one domain](/self-hosting/reverse-proxy). |
 
+<Warning>
+  `GET /api/config` is served by the **client**, not the signaling server. If
+  both sit behind one reverse proxy, do not route all of `/api/` to the server,
+  or step 3 always returns 404 and any `SOCKET_URL` you set is silently
+  discarded in favor of step 4. With an empty `SOCKET_URL` step 4 is the answer
+  you wanted anyway, so the mistake stays invisible until the day you set one.
+  See [Run Floe Behind One Domain](/self-hosting/reverse-proxy) for the
+  exact-path rule that keeps `/api/config` on the client.
+</Warning>
+
 ## Changing the address
 
 Set it in `.env` and recreate the container. No rebuild:

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -3,19 +3,19 @@ title: "Self-Hosted Floe Configuration"
 description: "Environment variable reference for a self-hosted Floe instance, covering client build-time URLs, CORS, TURN credentials, and stats persistence."
 ---
 
-All settings live in the `.env` file you copied from `.env.docker.example`.
+Under Docker Compose, every setting below is read from an optional `.env` file next to `docker-compose.yml`. Each one has a working default, so you only need the file to change something. The annotated template is `.env.docker.example`. A few of them behave differently outside Compose, and the rows that do say so.
 
 ## Variables
 
 | Variable | Service | Required | Default | Purpose |
 |----------|---------|----------|---------|---------|
-| `NEXT_PUBLIC_SOCKET_URL` | client (runtime) | No | `http://localhost:3001` | URL the **browser** uses to reach the signaling server. Read at runtime, so changing it needs only `docker compose up -d`, no rebuild. Set it **empty** when both services share one origin behind a [reverse proxy](/self-hosting/reverse-proxy); the browser then uses its own. See [how the client finds the server](/self-hosting/build-time-url). |
+| `NEXT_PUBLIC_SOCKET_URL` | client (runtime) | No | `http://localhost:3001` | URL the **browser** uses to reach the signaling server. Read at runtime, so changing it needs only `docker compose up -d`, no rebuild. Set it **empty** when both services share one origin behind a [reverse proxy](/self-hosting/reverse-proxy); the browser then uses its own. Docker Compose passes this into the client container as `SOCKET_URL`, which is the name the container itself reads, so outside Compose set `SOCKET_URL` directly. See [how the client finds the server](/self-hosting/build-time-url). |
 | `FLOE_IMAGE_TAG` | compose | No | `latest` | Which published image tag to run, for example `1.9.1`, `1.9`, `main`, or `sha-fed7ebb`. See [Container Images](/self-hosting/images). Not to be confused with `FLOE_VERSION`, which belongs to the CLI installer and carries a leading `v`. |
 | `NEXT_PUBLIC_SITE_URL` | client (build) | No | _(none)_ | Canonical public origin of your client (e.g. `https://app.your-domain.com`), used for canonical, Open Graph, JSON-LD, and sitemap URLs. Inlined at build time, so the published image cannot carry it and omits those tags instead of claiming `floe.one`. Set it only when building the client yourself. |
-| `PORT` | server | No | `3001` | **Host** port the signaling server is published on. Inside the container it always listens on 3001; Docker Compose maps `${PORT}` to it. Change this and you must also update `NEXT_PUBLIC_SOCKET_URL` and rebuild the client, or browsers keep dialing the old port. |
+| `PORT` | server | No | `3001` | **Host** port the signaling server is published on. Inside the container it always listens on 3001; Docker Compose maps `${PORT}` to it. Outside Docker this is the port the server process binds directly. Change this and you must also update `NEXT_PUBLIC_SOCKET_URL` to match, then run `docker compose up -d`, or browsers keep dialing the old port. No rebuild is needed, because the client reads that address at runtime. |
 | `CLIENT_PORT` | client | No | `3000` | **Host** port the web client is published on. Inside the container it always listens on 3000. Compose-only; it has no effect outside Docker. |
-| `NODE_ENV` | server | No | `development` | Standard Node.js runtime flag. The Docker image sets this to `production` for you, so this default only applies when you run the server directly with Node. Set it to `production` if you do: Express only suppresses stack traces in its built-in error responses when the value is exactly `production`, and blank counts as unset. |
-| `CLIENT_URL` | server | Yes (prod) | _(none)_ | Frontend origin allowed by CORS. Matched exactly, including scheme and with no trailing slash. Use `https://floe.example.com` for a [one-domain deployment](/self-hosting/reverse-proxy), or `https://app.your-domain.com` when the client has its own subdomain. |
+| `NODE_ENV` | server | No | `development` | Standard Node.js runtime flag. The Docker image sets this to `production` for you, so this default only applies when you run the server directly with Node. Set it to `production` if you do. Floe registers its own final error handler that returns a generic JSON error at every setting, so this is not a stack-trace leak, but `production` is what the published image runs and what Express's own caching expects. |
+| `CLIENT_URL` | server | Yes (prod) | _(none)_ | Frontend origin allowed by CORS. Matched exactly, including scheme and with no trailing slash. Use `https://floe.example.com` for a [one-domain deployment](/self-hosting/reverse-proxy), or `https://app.your-domain.com` when the client has its own subdomain. `https://floe.one`, `https://www.floe.one`, and `http://localhost:3000` are always allowed in addition to whatever you set here. The value governs browser traffic only (HTTP CORS and Socket.IO). Requests with no `Origin` header are allowed too, which is why CLI and desktop peers reach your server regardless of this setting. |
 | `TRUSTED_PROXY_COUNT` | server | No | `1` | Number of trusted reverse-proxy hops in front of the server, used for correct `X-Forwarded-For` parsing and per-IP rate limiting. Use `1` behind a single reverse proxy, `2` behind a proxy plus a CDN, and `0` when the server is exposed directly with no proxy. Docker Compose passes `0` explicitly, because publishing container ports directly is its default. Setting it above your real hop count lets clients forge `X-Forwarded-For` and bypass the rate limits, so set it to `0` deliberately rather than leaving it unset on a directly exposed host. |
 | `MAX_CONNECTIONS_PER_IP` | server | No | `30` | Maximum new connections allowed per IP per 60-second window, shared across Socket.IO and WebSocket. Raise this in staging or test environments that drive many connections from a single IP. |
 | `MAX_TURN_REQUESTS_PER_IP` | server | No | `20` | Maximum `GET /api/turn-credentials` requests per IP per 60-second window. Requests over the cap get `429`, and the client silently falls back to STUN-only. Raise this in CI or staging suites that start many transfers from one IP. |
@@ -31,13 +31,9 @@ All settings live in the `.env` file you copied from `.env.docker.example`.
 
 ## Minimal local configuration
 
-For local testing, only one variable matters:
+For local testing nothing needs setting. Every value has a working default, and the client already points at `http://localhost:3001` with no `.env` file at all.
 
-```env
-NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
-```
-
-Everything else can stay at its default.
+The first case that genuinely needs one is reaching the app from another device on your network, which takes `NEXT_PUBLIC_SOCKET_URL` and `CLIENT_URL` together. See [Quick Start](/self-hosting/quickstart).
 
 ## Production configuration
 

--- a/docs/self-hosting/images.mdx
+++ b/docs/self-hosting/images.mdx
@@ -19,7 +19,7 @@ Both are public, so `docker pull` needs no login.
 | `latest` | The newest release | **The default.** What you get if you change nothing. |
 | `1.9.1` | One exact release | You want to control when you move between versions. |
 | `1.9` | The newest patch of a minor line | You want patches automatically but not minor bumps. |
-| `main` | The latest commit merged to `main` | You want changes before they are released. Every commit is gated behind the full test suite plus a smoke test of the built image. |
+| `main` | The newest build of `client/` or `server/` on `main` | You want changes before they are released. Every commit is gated behind the full test suite plus a smoke test of the built image. A docs-only merge leaves this tag where it is, since it starts no build. |
 | `sha-<short>` | One exact commit, for example `sha-fed7ebb` | You want a build that can never move under you. |
 
 Pin a tag with `FLOE_IMAGE_TAG`:
@@ -75,6 +75,8 @@ Contributors, and anyone who wants their own domain in share previews, add the b
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
+
+This path needs the repository checked out, since the overlay builds from `./client` and `./server`. The compose file alone is not enough.
 
 The overlay tags its output `floe-server:dev` and `floe-client:dev`, so a local build never replaces a pulled image under the same name.
 

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Self-Hosted Floe Operations"
-description: "Day-to-day operations for a self-hosted Floe instance: upgrading containers, viewing logs, monitoring transfers, backing up stats, and rotating TURN keys."
+description: "Day-to-day operations for a self-hosted Floe instance: common Compose commands, updating to the latest images, and the health endpoints to point a monitor at."
 ---
 
 ## Common commands
@@ -21,15 +21,30 @@ docker compose up -d
 
 That pulls the newest [published images](/self-hosting/images) and restarts. Nothing is built locally, so there is no repository to keep in sync.
 
+If you run the optional coturn relay, add its profile to both commands or Compose skips the service entirely, so a new coturn image is never pulled and a stopped relay is never restarted:
+
+```bash
+docker compose --profile turn pull
+docker compose --profile turn up -d
+```
+
+Setting `COMPOSE_PROFILES=turn` in your `.env` applies it to every later `docker compose` command.
+
 <Note>
   Changing `NEXT_PUBLIC_SOCKET_URL` needs only `docker compose up -d`; the client reads it at runtime. See [How the Client Finds the Signaling Server](/self-hosting/build-time-url). `NEXT_PUBLIC_SITE_URL` is the exception: it is written into the page at build time, so the published image omits those tags entirely rather than pointing them at somebody else's domain. See [Container Images](/self-hosting/images) if you want your own.
 </Note>
 
 ## Health endpoints
 
-The signaling server exposes two health endpoints you can use in load balancers or uptime monitors:
+The signaling server exposes two status endpoints:
 
 | Endpoint | Purpose | Response |
 |----------|---------|---------|
 | `GET /health` | Liveness check | `{ "status": "healthy", "uptime": <seconds> }` |
 | `GET /` | Status and timestamp | `{ "status": "ok", "timestamp": "..." }` |
+
+Point a monitor at `/health`. It is the only one of the two that survives a
+[one-domain deployment](/self-hosting/reverse-proxy), where `/` belongs to the
+web client and returns a page rather than JSON. `GET /` on the signaling server
+is reachable only when you address the server directly, on `:3001` or on its own
+subdomain.

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -21,6 +21,22 @@ Those are the ports inside the containers. In production you normally put both
 behind a single domain, so your users never see either one. See
 [Reverse Proxy](/self-hosting/reverse-proxy).
 
+## Who can connect
+
+One instance serves every Floe client. They share one wire protocol, so any two of
+them can transfer with each other on your server.
+
+| Client | How it points at your instance |
+|--------|-------------------------------|
+| Web app | Loads from your `client` container. Nothing for the user to configure. |
+| CLI | `floe send --server https://floe.example.com`. See [Use the Floe CLI with a Self-Hosted Server](/cli/self-hosted-server). |
+| Floe Desktop | Settings, **Advanced**, then **Server address**. **Test** checks the address before you rely on it, and **Use default server** returns the app to `api.floe.one`. See [Desktop Settings](/desktop/settings#server). |
+
+Both peers must be on the same server. Servers do not talk to each other.
+
+`CLIENT_URL` governs browser traffic only. CLI and desktop peers connect over `/ws`,
+which performs no origin check, so they reach your server regardless of that setting.
+
 ## Contents
 
 <CardGroup cols={2}>
@@ -33,6 +49,9 @@ behind a single domain, so your users never see either one. See
   <Card title="Configuration" href="/self-hosting/configuration">
     Environment variable reference for all settings.
   </Card>
+  <Card title="How the Client Finds the Signaling Server" href="/self-hosting/build-time-url">
+    Runtime `SOCKET_URL` resolution, and the one value that is still baked in at build time.
+  </Card>
   <Card title="Reverse Proxy" href="/self-hosting/reverse-proxy">
     Serve the client and signaling server from one domain, with Caddy and nginx examples.
   </Card>
@@ -44,5 +63,8 @@ behind a single domain, so your users never see either one. See
   </Card>
   <Card title="Operations" href="/self-hosting/operations">
     Day-to-day commands, updates, and health checks.
+  </Card>
+  <Card title="Without Docker" href="/self-hosting/without-docker">
+    Run the client and signaling server straight from Node.
   </Card>
 </CardGroup>

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -25,14 +25,14 @@ For a deployment accessible beyond a single machine, follow these steps.
 
     The signaling server uses WebSockets. Make sure your proxy forwards the `Upgrade` and `Connection` headers.
   </Step>
-  <Step title="Set NEXT_PUBLIC_SOCKET_URL and rebuild">
+  <Step title="Set NEXT_PUBLIC_SOCKET_URL">
     In `.env`:
 
     ```env
     NEXT_PUBLIC_SOCKET_URL=https://api.your-domain.com
     ```
 
-    Then restart. No rebuild: the client reads this address at runtime.
+    Then recreate the containers. There is no rebuild: Compose maps this value onto the client container's `SOCKET_URL`, and the browser reads it from `GET /api/config` on every page load.
 
     ```bash
     docker compose up -d
@@ -55,6 +55,17 @@ For a deployment accessible beyond a single machine, follow these steps.
     ```
 
     One reverse proxy is `1`, a CDN in front of that proxy is `2`. The server's own default is `1`; Docker Compose passes `0` explicitly, which is correct only when the container ports are published directly. Setting it higher than your real hop count lets clients forge `X-Forwarded-For` and bypass the per-IP rate limits, so if you expose the server directly with no proxy, set `0` deliberately rather than leaving it unset.
+  </Step>
+  <Step title="Point the CLI and the desktop app at your instance">
+    A split deployment has two addresses, so both clients need both. The CLI takes them as flags, or as `FLOE_SERVER` and `FLOE_WEB` in the environment:
+
+    ```bash
+    floe send --server https://api.your-domain.com --web https://app.your-domain.com photo.jpg
+    ```
+
+    Without `--web`, the share link points at the signaling API rather than the web app, because a self-hosted server is otherwise assumed to serve both from one origin.
+
+    In the desktop app, open Settings, expand **Advanced**, and fill in both **Server address** (`https://api.your-domain.com`) and **Share link address** (`https://app.your-domain.com`), then press **Test**. See [Desktop Settings](/desktop/settings#server).
   </Step>
 </Steps>
 

--- a/docs/self-hosting/quickstart.mdx
+++ b/docs/self-hosting/quickstart.mdx
@@ -23,7 +23,7 @@ description: "Spin up a local Floe instance with Docker Compose in a few minutes
     Docker pulls the [prebuilt images](/self-hosting/images) and starts the client and server containers. Nothing is compiled locally.
   </Step>
   <Step title="Open the app">
-    Open [http://localhost:3000](http://localhost:3000) in your browser. Open the same URL in a second tab (or on another device on the same network), start a transfer in one tab, and join with the room code in the other.
+    Open [http://localhost:3000](http://localhost:3000) in your browser. Pick a file and press **Create secure link**, then paste that link into a second tab to join as the receiver. **Show QR** renders the same link as a scannable code, which is how you receive on a phone once the app is reachable from one (see the note below).
   </Step>
 </Steps>
 
@@ -52,6 +52,8 @@ To support peers behind strict firewalls, symmetric NAT, or CGNAT, add a [TURN r
   ```bash
   docker compose up -d
   ```
+
+  Then open the app at `http://192.168.1.x:3000` on the sending machine too, not `localhost:3000`. The share link and its QR code carry whichever address the page was loaded from, so a sender sitting on `localhost` hands the phone an address that only resolves back to the phone.
 
   No rebuild: the client reads its server address at runtime. `CLIENT_URL` matters as much as the socket URL, because it is the origin the server's CORS check allows, and without it the browser is blocked even though the page loads.
 </Note>

--- a/docs/self-hosting/reverse-proxy.mdx
+++ b/docs/self-hosting/reverse-proxy.mdx
@@ -12,16 +12,22 @@ one value to configure, and share links that work without any extra setup.
 ## Route table
 
 The client and the signaling server claim different paths, so they coexist on one
-origin with no conflicts. Send these paths to the signaling server and everything
-else to the client.
+origin with no conflicts. Route them like this.
 
 | Path | Goes to | Why |
 |------|---------|-----|
 | `/socket.io/` | server `:3001` | Browser signaling. WebSocket upgrade plus HTTP long-polling fallback. |
 | `/ws` | server `:3001` | CLI and desktop signaling. WebSocket upgrade. |
+| `/api/config` | client `:3000` | The client's own runtime config, which tells the browser where the signaling server is. The signaling server has no such route. |
 | `/api/` | server `:3001` | Room codes, TURN credentials, stats. |
 | `/health` | server `:3001` | Health probe. |
 | everything else | client `:3000` | The web app, including `/_next/` assets. |
+
+`/api/config` is the one exception to the `/api/` rule, and it needs its own
+route in both configs below. Send it to the signaling server and it returns 404.
+With the empty socket URL this page recommends below, the browser still lands on
+its own origin, which is the right answer, so the mistake never shows. Any
+instance that sets a non-empty socket URL loses it silently.
 
 <Warning>
   `/ws` is matched by exact string equality on the signaling server. A trailing
@@ -53,6 +59,13 @@ else to the client.
             reverse_proxy localhost:3001
         }
 
+        # The web client serves its own runtime config here, so it has to win
+        # over the /api/* rule above. Caddy orders handle blocks by how specific
+        # the path is, so this beats /api/* wherever you put it in the file.
+        handle /api/config {
+            reverse_proxy localhost:3000
+        }
+
         # Everything else is the web client.
         handle {
             reverse_proxy localhost:3000
@@ -77,6 +90,16 @@ else to the client.
         # Your TLS certificate goes here.
         # ssl_certificate     /etc/letsencrypt/live/floe.example.com/fullchain.pem;
         # ssl_certificate_key /etc/letsencrypt/live/floe.example.com/privkey.pem;
+
+        # The client's own runtime config. An exact-match location outranks the
+        # regex location below, so this stays on the client.
+        location = /api/config {
+            proxy_pass http://127.0.0.1:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
 
         # Signaling server.
         location ~ ^/(socket\.io/|ws$|api/|health$) {
@@ -111,16 +134,20 @@ loaded from, which behind this proxy is already the right answer.
 
 ```env
 NEXT_PUBLIC_SOCKET_URL=
-NEXT_PUBLIC_SITE_URL=https://floe.example.com
 CLIENT_URL=https://floe.example.com
 TRUSTED_PROXY_COUNT=1
+
+# Read only when you build the client yourself, with the build overlay. The
+# default stack pulls a prebuilt image and ignores this line entirely.
+NEXT_PUBLIC_SITE_URL=https://floe.example.com
 ```
 
 ```bash
 docker compose up -d
 ```
 
-`NEXT_PUBLIC_SITE_URL` is the only build-time value here. The published image
+`NEXT_PUBLIC_SITE_URL` is the only build-time value here, which is why the
+comment above tells you the running stack does not read it. The published image
 cannot carry it, so canonical links and share previews are omitted rather than
 pointed somewhere wrong. See [Container Images](/self-hosting/images) to build the
 client with your own domain baked in.
@@ -137,7 +164,7 @@ signaling server. One reverse proxy means `1`. A CDN in front of that proxy mean
 `2`. Setting it higher than your real hop count lets clients forge
 `X-Forwarded-For` and slip past the per-IP rate limits.
 
-## Using the CLI with a one-domain instance
+## Using the CLI and the desktop app with a one-domain instance
 
 One address is all the CLI needs. The share link it prints resolves to the same
 origin, so it opens the web client correctly with no extra flag:
@@ -148,6 +175,22 @@ floe send --server https://floe.example.com photo.jpg
 
 The `--web` flag only exists for split deployments where the client lives on a
 different hostname than the signaling server.
+
+The desktop app takes the same single address. Open Settings, expand
+**Advanced**, put `https://floe.example.com` in **Server address**, and press
+**Test**. The test runs three checks in order: that `/health` answers as a Floe
+signaling server, that the realtime `/ws` connection is accepted, and that
+`GET /api/turn-credentials` returns usable connection details. A proxy that
+forwards only some of those is named in the failure message instead of breaking
+silently later. Leave **Share link address** blank on a one-domain instance and
+the app derives the link from the server address. See
+[Desktop Settings](/desktop/settings#server).
+
+<Note>
+  The test deliberately does not follow redirects, so a proxy that answers
+  `/health` with a 301 is reported as "may be the web app rather than the
+  signaling server" rather than passing.
+</Note>
 
 ## TURN does not go through the proxy
 

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -57,9 +57,20 @@ TURN requires a **public IP address**, a **domain name**, and **TLS certificates
     Edit `coturn/turnserver.conf` and set:
     - `static-auth-secret` to a strong random value (e.g. `openssl rand -hex 32`)
     - `realm` to your TURN hostname (e.g. `turn.your-domain.com`)
-    - `cert` and `pkey` to the paths of your TLS certificate and key
+    - `cert` and `pkey` (both commented out) to the paths of your TLS certificate and key
+    - `external-ip` to the machine's public IP, if the interface itself holds a private address
 
-    See the volume mounts in `docker-compose.yml` for how to make certificates available inside the container.
+    `external-ip` is commented out in the example file, and uncommenting it is the normal case on AWS, GCP, Azure, and any VPS behind 1:1 NAT. Leave it commented out only when the public address is bound directly to the interface. Get it wrong and coturn advertises a relay candidate nobody can route to, so relayed transfers fail with no error message.
+
+    The certificate mount is shipped commented out too. Uncomment it in `docker-compose.yml` so the paths you just set in `turnserver.conf` exist inside the container:
+
+    ```yaml
+    volumes:
+      - ./coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro
+      - ./coturn/certs:/etc/coturn/certs:ro
+    ```
+
+    If you started from the `curl` quickstart rather than a clone, that means editing your downloaded `docker-compose.yml`. Skip it and the signaling server still advertises a `turns:` URL, pointing at a port that cannot complete a TLS handshake.
   </Step>
   <Step title="Match the server environment">
     In `.env`:
@@ -118,3 +129,7 @@ With Cloudflare configured, the response instead contains `turn.cloudflare.com` 
 ## How credentials work
 
 The signaling server generates time-limited credentials using HMAC-SHA1. The username is `{expiry_unix_timestamp}:floeuser` and the password is `base64(HMAC-SHA1(TURN_SECRET, username))`. coturn validates these against the shared secret without needing a database of user accounts.
+
+<Note>
+  Relayed transfers stay capped at 2 GB per session even on a relay you run yourself. The cap is compiled into the browser client, the CLI, and the desktop app, not read from your server, so raising it means building all three from modified source. Direct connections are unaffected and have no size limit. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+</Note>

--- a/docs/self-hosting/without-docker.mdx
+++ b/docs/self-hosting/without-docker.mdx
@@ -7,18 +7,26 @@ If you prefer to run the components without Docker, the complete manual setup st
 
 ## Running each component
 
+The signaling server and the web client are two long-lived processes, so each
+needs its own terminal (or a supervisor, as below). Run each block from the
+repository root.
+
 ```bash
-# Signaling server (Node.js)
+# Signaling server (Node.js). Stays in the foreground.
 cd server
 npm install
 npm start
+```
 
-# Web client (Next.js)
+```bash
+# Web client (Next.js). Stays in the foreground.
 cd client
 pnpm install
 pnpm build
 pnpm start
+```
 
+```bash
 # CLI (optional, for local testing against your server)
 cd cli
 go build ./cmd/floe
@@ -42,7 +50,9 @@ Set at minimum:
 - In `server/.env`: `CLIENT_URL=http://localhost:3000`
 - In `client/.env.local`: `NEXT_PUBLIC_SOCKET_URL=http://localhost:3001`
 
-For anything reachable from the internet, also set `NODE_ENV=production` in `server/.env`. Docker sets it for you; a direct Node run does not, and Express only suppresses stack traces in its built-in error responses when the value is exactly `production`.
+`NEXT_PUBLIC_SOCKET_URL` is inlined when the client is built, so on this path changing it later needs another `pnpm build`. To change the address without rebuilding, leave it unset and set the unprefixed `SOCKET_URL` in the environment of the process that runs `pnpm start` instead; the browser then reads it per request from `/api/config`. See [How the Client Finds the Signaling Server](/self-hosting/build-time-url). Leave both empty when the client and the signaling server share one origin behind a reverse proxy.
+
+Also set `NODE_ENV=production` in `server/.env`. Docker sets it for you; a direct Node run does not. Floe registers its own final error handler that returns a generic JSON error at every setting, so this is not a stack-trace leak. Set it anyway: `production` is what both the published image and `server/.env.example` use, so a direct Node run matches what is tested.
 
 ## Updating an existing deployment
 
@@ -51,11 +61,18 @@ The Docker instructions in [Operations](/self-hosting/operations) assume there i
 ```bash
 cd /path/to/floe
 git pull
+
+# Signaling server
 cd server
 npm ci --omit=dev
+
+# Web client: a compiled build, so it has to be rebuilt
+cd ../client
+pnpm install --frozen-lockfile
+pnpm build
 ```
 
-Then restart the server with whatever supervises it (`pm2 restart <name>`, `systemctl restart <unit>`, or your own runner).
+Then restart both processes with whatever supervises them (`pm2 restart <name>`, `systemctl restart <unit>`, or your own runner). `pnpm start` serves whatever `pnpm build` last produced, so skipping the client rebuild leaves the old client running with nothing to indicate it is stale.
 
 <Warning>
   Reinstall before you restart, and do not skip it. A dependency update that only moves a lockfile changes no source file, so a restart on its own re-executes the same `node_modules` and the update silently does not take effect. The process comes back healthy and the old version is still running.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -8,39 +8,45 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
 ## Sending and receiving
 
 <AccordionGroup>
-  <Accordion title="The page says my browser is not supported">
-    Floe needs WebRTC, which is unavailable in some in-app browsers (the web views embedded in Facebook, Instagram, TikTok, and similar apps). Open the link in a real browser instead: Chrome, Safari, Edge, or Firefox. Floe detects these in-app browsers and prompts you to switch.
+  <Accordion title='Floe says "Open in your browser"'>
+    Floe needs WebRTC, which some in-app browsers (the web views embedded in Facebook, Instagram, TikTok, and similar apps) do not support reliably. Floe detects them and shows an "Open in your browser" screen with steps for your platform. Follow those steps, or tap **Copy link to paste in browser** and open the link in Chrome, Safari, Edge, or Firefox. **Continue anyway** lets you proceed regardless, but the transfer may fail.
   </Accordion>
 
   <Accordion title="The transfer never starts or is stuck connecting">
     Both peers must be present at the same time, and the connection is direct, so a few things can hold it up:
 
-    - The sender must keep their browser tab open for the entire transfer. If the sender closes the tab, the session ends.
-    - The recipient must actually open the shared link (or run `floe receive`). The transfer begins automatically once both sides connect.
-    - On strict networks, a direct path may not be possible. Make sure **Network Relay Fallback** is enabled (it is on by default) so Floe can route through the encrypted relay.
+    - The sender must stay in the session for the entire transfer. If the sender closes the browser tab, quits the desktop app, or stops `floe send`, the session ends.
+    - The recipient must actually open the shared link (or run `floe receive`). In the browser and the desktop app the transfer then begins on its own. `floe receive` asks you to confirm first, so a sender can sit on "Connecting" while the recipient has simply not answered the `Accept? [Y/n]` prompt. Pass `-y` to skip it.
+    - On strict networks, a direct path may not be possible. Relay fallback has to stay on for Floe to route through the encrypted relay. In the browser it is a sender-side setting, shown as the **Network relay fallback** checkbox once the sender has picked files, and it is on by default. If you are the browser recipient you have no such control, so ask the sender to check it. Floe's own error message calls it "Network Relay". On the CLI the equivalent is not passing `--no-relay`, which drops TURN on whichever side passes it. The desktop app has no relay-fallback control at all, so the relay is always available there.
   </Accordion>
 
   <Accordion title="Transfer blocked: relay limit exceeded">
-    Relay connections are capped at **2 GB per session** to keep the service free. Direct connections have no size limit. To get a direct connection:
+    Relay connections are capped at **2 GB per session** to keep the service free. Direct connections have no size limit. Exactly 2 GB is allowed; only more than that is blocked.
+
+    The quickest fix is to remove files until the total is at or under the cap. Otherwise, get a direct connection:
 
     - Use a standard home or personal Wi-Fi network.
     - Disconnect from any VPN.
     - Avoid strict corporate or university networks.
     - Try a personal mobile hotspot.
 
+    In the desktop app, **Hide my IP address** forces every transfer through the relay, so the 2 GB cap applies even on a network that could have connected directly. Turn it off to send more. See [Hide my IP address](/desktop/settings#hide-my-ip-address).
+
     See [The 2 GB Relay Limit](/how-it-works/2gb-limit) for the details.
   </Accordion>
 
   <Accordion title="The transfer is slow">
     Check the connection indicator. **Green (Direct)** is as fast as the slower of the two connections. **Amber (Relay)** routes through a TURN server, so speed depends on relay load and network conditions. To force the faster direct path, follow the steps above to obtain a direct connection.
+
+    Read the label, not just the color. The dot is also green when it says **Ready**, which means the signaling connection is up but the peer-to-peer path is not resolved yet, either because no peer has joined or because WebRTC is still negotiating. **Offline** (red) means signaling itself is down. Neither of those is a slow transfer, and only Direct and Relay carry the explanatory tooltip.
   </Accordion>
 
   <Accordion title="Downloads fail or behave oddly on iOS">
-    On iOS, use **Download ZIP** rather than downloading files individually. It is the most reliable option on Safari and iOS web views.
-  </Accordion>
+    On iOS, when you receive more than one file, use **Download ZIP** rather than saving them one at a time. It is the most reliable option on Safari and iOS web views.
 
-  <Accordion title="My short code does not work">
-    Short codes expire **10 minutes** after the sender starts the session. After that, only the full link works, and only while the sender is still connected. Ask the sender to start a new session for a fresh code.
+    The **Download All** and **Download ZIP** buttons appear only for multi-file transfers, and only once the transfer has finished. A single file is saved from the download button on its own row in the list.
+
+    Zipping holds every file in memory before it writes the archive, so a very large multi-file transfer can run out of memory on a phone. If that happens, use **Download All** or save each file from its row.
   </Accordion>
 </AccordionGroup>
 
@@ -48,27 +54,31 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
 
 <AccordionGroup>
   <Accordion title="The CLI cannot reach the server">
-    The CLI connects to `https://api.floe.one` by default. If you are using a self-hosted instance, pass `--server` with your signaling server URL, and make sure **both** the sender and receiver use the same value. See [Against a Self-Hosted Server](/cli/self-hosted-server).
+    The CLI connects to `https://api.floe.one` by default. If you are using a self-hosted instance, pass `--server` with your signaling server URL, and make sure **both** the sender and receiver use the same value.
+
+    If the CLI is reaching an address you did not ask for, check your environment. `FLOE_SERVER` overrides the default whenever `--server` is not passed, and `FLOE_WEB` does the same for the browser link that `floe send` prints. Check with `$env:FLOE_SERVER` in PowerShell, or `echo $FLOE_SERVER` on macOS and Linux. See [Against a Self-Hosted Server](/cli/self-hosted-server).
   </Accordion>
 
   <Accordion title="A browser recipient cannot join my CLI transfer">
-    A browser can only join by opening the link, not by entering a short code (there is no code field in the web UI). Share the **link** printed by `floe send` with browser recipients, and the **code** with CLI recipients.
+    A browser can only join by opening the link, not by entering a short code (there is no code field in the web UI). Share the **link** printed by `floe send` with browser recipients, and the **code** with CLI or [desktop](/desktop/receiving) recipients, either of which also accepts the link.
   </Accordion>
 
   <Accordion title="The CLI is slow to connect when a VPN or virtual machine is running">
     A VPN (such as Tailscale) or virtualization software (VMware, VirtualBox, WSL, Hyper-V) adds extra network interfaces. The CLI probes each one while establishing the connection, so a machine with several of them can spend longer on "Connecting..." before settling on the working path. The transfer still completes, and the browser app is unaffected.
 
-    The CLI already skips dead auto-config interfaces automatically. If you still see slow connects, pin the CLI to your real interface by name:
+    Floe already ignores link-local addresses (IPv4 169.254.x.x and IPv6 fe80::), which covers dead auto-config adapters and most virtual ones. A VPN adapter with a routable address, such as Tailscale's 100.x range, is not filtered. If you still see slow connects, pin the CLI to your real interface by name:
 
     ```bash
     floe receive olive-tiger-castle --iface Ethernet   # or --iface Wi-Fi
     ```
 
-    Pass `--iface` more than once to allow several interfaces. Temporarily quitting the VPN during a transfer also resolves it.
+    Pass `--iface` more than once to allow several interfaces. The flag is an allowlist, not a preference: only the interfaces you name are used, so drop it again if you move to a different network, or the connection will fail outright rather than merely be slow. Temporarily quitting the VPN during a transfer also resolves it.
   </Accordion>
 
-  <Accordion title="The CLI says the version is incompatible">
-    Peers on different floe versions normally transfer fine, so a small version difference (for example v1.5.4 and v1.5.5) is never a problem. This message only appears if a release changed the transfer protocol in a way the two versions cannot bridge. Whichever side is older should update:
+  <Accordion title="Cannot transfer: your floe is too old for this peer">
+    Floe words this two ways, `Cannot transfer: your floe is too old for this peer` and `Cannot transfer: peer's floe is too old`. Peers on different floe versions normally transfer fine, so a small version difference (for example v1.5.4 and v1.5.5) is never a problem. Either message only appears if a release changed the transfer protocol in a way the two versions cannot bridge.
+
+    The message prints both sides as `You:` and `Peer:`, each with its protocol range and release version. Go by the version strings rather than the labels, and update the older one. When the receiver detects the mismatch it composes the message and the sender prints it unchanged, so a sender can be told "your floe is too old" while it is the receiver that needs updating. In that case the whole message, not just the labels, is written from the receiver's point of view. If both versions look current, update both.
 
     ```bash
     floe update              # script / manual installs
@@ -77,7 +87,44 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
     scoop update floe        # Scoop
     ```
 
-    If you are receiving from a browser, refresh the page to load the latest web client. See [Updating](/cli/update).
+    If you are receiving from a browser, refresh the page to load the latest web client. The desktop app shares the same transfer engine, so it can show the same message. It has no `floe update` command, so update it the way you installed it. From the Microsoft Store, open **Library** then **Get updates**. See [Updating](/cli/update) and [Update](/desktop/installation#update).
+  </Accordion>
+
+  <Accordion title="My short code does not work">
+    Short codes are a CLI and desktop feature. In a browser you share a link instead, so there is no code to troubleshoot.
+
+    Codes expire **10 minutes** after the sender starts the session, and `floe receive` then reports `code "olive-tiger-castle" not found or expired (codes expire after 10 minutes)`, quoting the code you typed. Ask the sender to start a new session for a fresh code.
+
+    Two nearby messages mean something else:
+
+    - `this code is no longer active; ask for a new one`: the code resolved, but nobody is sharing on it. The sender finished or quit, and codes are single use.
+    - `room is full (someone else may already be receiving)`: someone else is already receiving on that code. A room holds exactly two peers.
+  </Accordion>
+</AccordionGroup>
+
+## Desktop app
+
+<AccordionGroup>
+  <Accordion title="Test says the realtime connection was refused">
+    "The server answered, but the realtime connection was refused" means the address is a Floe signaling server but the WebSocket upgrade at `/ws` is not reaching it. That is almost always a reverse proxy that forwards ordinary requests without forwarding the upgrade. See [Run Floe Behind One Domain](/self-hosting/reverse-proxy).
+  </Accordion>
+
+  <Accordion title="Test says the API answered with HTTP 404">
+    "The server is running, but its API answered with HTTP 404" (or another error code) means `/api/` is not being forwarded. Fix it before you use the server, because nothing else reports this failure: relay credentials fall back to public STUN and the short code silently fails to register, so you get a share link with no code and no error. See [Run Floe Behind One Domain](/self-hosting/reverse-proxy).
+  </Accordion>
+
+  <Accordion title="Test says this may be the web app rather than the signaling server">
+    Something answered but not with a health check, which usually means the address points at the web app rather than the signaling server. In the default self-hosted setup the web app is on port 3000 and the signaling server on port 3001, so `http://localhost:3000` produces this and `http://localhost:3001` is what you want. The **Server address** field always wants the signaling server. See [Server](/desktop/settings#server) for what each Test result means.
+
+    Test never follows redirects, so a captive portal or a catch-all rewrite cannot pass itself off as a healthy server.
+  </Accordion>
+
+  <Accordion title="There is no right-click menu setting">
+    The **Windows** section, and with it **Show in right-click menu**, is hidden in the Microsoft Store build. A packaged app cannot register the entry in a way File Explorer would read, and asking for it returns "the right-click menu is not available in the Microsoft Store build". Install the build from GitHub if you need it. See [Choose a channel](/desktop/installation#choose-a-channel).
+  </Accordion>
+
+  <Accordion title="Desktop transfers are capped at 2 GB">
+    **Hide my IP address** sends every transfer through the relay, which is where the 2 GB cap applies, so it is in force even on a network that could have connected directly. The idle screen says so while it is on, and an oversized send fails with "Turn off Hide my IP to send larger files". Turn it off to send more. See [Hide my IP address](/desktop/settings#hide-my-ip-address).
   </Accordion>
 </AccordionGroup>
 
@@ -91,6 +138,10 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
     docker compose up -d
     ```
 
+    <Note>
+      Compose passes that value into the container as `SOCKET_URL`, which is the name the running client actually reads. If you run the client without Compose, set `SOCKET_URL` on the client process. Setting `NEXT_PUBLIC_SOCKET_URL` on an already-built client does nothing, because Next inlines that name at build time.
+    </Note>
+
     Check what the client is actually resolving:
 
     ```bash
@@ -101,11 +152,17 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
   </Accordion>
 
   <Accordion title="Browser requests are blocked by CORS">
-    Set `CLIENT_URL` to your client's public origin (e.g. `https://app.your-domain.com`). It is added to the server's CORS allow-list. `http://localhost:3000` is already allowed by default. See [Production Deployment](/self-hosting/production).
+    Set `CLIENT_URL` to your client's public origin (for example `https://app.your-domain.com`), matching scheme and host exactly, with no trailing slash. It joins the allow-list alongside `http://localhost:3000` and the floe.one origins, which are always permitted.
+
+    A rejected origin does not come back as a recognizable CORS error. The server answers HTTP 500 with `{"error":"Internal server error"}` and logs the stack, while the browser reports a generic CORS failure. If you see that pairing, check `CLIENT_URL` first. See [Production Deployment](/self-hosting/production).
   </Accordion>
 
   <Accordion title="I am being rate limited (429 or Rate limit exceeded)">
-    The server allows 30 connections per IP per 60 seconds (Socket.IO and WebSocket), 20 requests per IP per 60 seconds for TURN credentials, and 60 reports per IP per 60 seconds for the global stats counter. Behind a reverse proxy, set `TRUSTED_PROXY_COUNT` to the number of proxy hops so the server reads real client IPs instead of the proxy IP. See [Configuration](/self-hosting/configuration).
+    The server runs four independent per-IP limiters, each over a 60 second window: 30 connections across Socket.IO and WebSocket (`MAX_CONNECTIONS_PER_IP`), 20 TURN credential requests (`MAX_TURN_REQUESTS_PER_IP`), 60 short-code requests (`MAX_CODE_REQUESTS_PER_IP`), and 60 global-stats reports. The three HTTP limiters answer `429` with `Too many requests`, or `Too many reports` for stats. The connection limiter is not HTTP: it refuses the Socket.IO handshake and closes the WebSocket with the reason `Rate limit exceeded`. In the browser that surfaces as "Too many refreshes. Reconnecting".
+
+    A `503 Server busy, try again shortly` from `POST /api/code` is a different guard. It fires once `MAX_ACTIVE_CODES` (default 10000) codes are live at once, regardless of source IP.
+
+    Behind a reverse proxy, set `TRUSTED_PROXY_COUNT` to the number of proxy hops so the server reads real client IPs instead of the proxy IP. The server defaults to 1, but the Compose stack publishes ports directly and passes 0, so a Compose deployment behind a proxy has to set it explicitly. See [Configuration](/self-hosting/configuration).
   </Accordion>
 
   <Accordion title="The TURN relay is not working">
@@ -113,7 +170,9 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
 
     **Managed Cloudflare TURN:** confirm both `CLOUDFLARE_TURN_KEY_ID` and `CLOUDFLARE_TURN_KEY_API_TOKEN` are set in `.env`, then run `curl http://localhost:3001/api/turn-credentials`. A working setup returns `turn.cloudflare.com` entries with a username and credential. If it returns STUN servers only, one of the two variables is missing or the API token is invalid (roll it in the Cloudflare dashboard under Realtime, then TURN Server).
 
-    **Self-hosted coturn:** the bundled coturn service uses host networking, so it runs on a **Linux host** with a public IP, a domain, and TLS certificates. On macOS or Windows with Docker Desktop, run coturn separately or on a Linux VM. Confirm that `TURN_SECRET` and `TURN_DOMAIN` in `.env` match coturn's `static-auth-secret` and `realm`, then start the stack with `docker compose --profile turn up -d`. See [TURN Relay](/self-hosting/turn-relay).
+    **Self-hosted coturn:** the bundled coturn service uses host networking, so it runs on a **Linux host** with a public IP, a domain, and TLS certificates. On macOS or Windows with Docker Desktop, run coturn separately or on a Linux VM. Confirm that `TURN_SECRET` and `TURN_DOMAIN` in `.env` match coturn's `static-auth-secret` and `realm`, then start the stack with `docker compose --profile turn up -d`.
+
+    If coturn logs `Default realm: localdomain`, it is running on built-in defaults with no auth secret and relaying will silently fail. That happens when `coturn/turnserver.conf` did not exist before the first `docker compose up`, so Docker created a directory at that path. Run `rmdir coturn/turnserver.conf` first, because copying a file onto a directory would succeed and write it inside, then fetch the example config and restart. See [TURN Relay](/self-hosting/turn-relay).
   </Accordion>
 </AccordionGroup>
 

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -10,24 +10,29 @@ When someone sends you files via Floe, they share a link (e.g. `https://floe.one
 Click the link or scan the QR code. The page connects to the signaling server and joins the sender's room automatically. No account or installation is needed.
 
 <Note>
-  Some in-app browsers (embedded in Facebook, Instagram, TikTok, and similar apps) do not support WebRTC. If you open the link inside one of these, Floe detects it and prompts you to open the page in Chrome, Safari, or your default browser instead.
+  Some in-app browsers (embedded in Facebook, Messenger, Instagram, TikTok, Snapchat, LINE, X (Twitter), WeChat, and generic Android WebViews) have limited support for file transfers. Floe recognizes them by user agent, and instead of loading the transfer view it shows a full-screen prompt with steps for opening the page in Chrome or Safari, plus a **Copy link to paste in browser** button. A **Continue anyway** link sits at the bottom, but some features may not work.
 </Note>
 
 ## Connection
 
-Once the page opens, Floe negotiates the WebRTC connection. A connection indicator appears in the corner:
+Once the page opens, Floe joins the room and negotiates the WebRTC connection. While you wait, the card shows a three-step pipeline: **Secure room joined**, **Waiting for the sender to start**, then **Files stream in below**. Each step ticks over as it completes.
 
-| Color | Meaning |
+A status dot sits in the top-right of the transfer card once it is up:
+
+| Label | Meaning |
 |-------|---------|
-| Connecting | Establishing the WebRTC connection (usually a few seconds). |
-| Green - Direct | Connected directly, peer-to-peer. No server involved. |
-| Amber - Relay | Connected via the encrypted TURN relay. |
+| Offline (red) | Not connected to Floe's signaling server yet, or your network dropped. |
+| Ready (green) | Connected to the signaling server. Floe has not yet worked out direct versus relay. |
+| Direct (green) | Connected directly, peer-to-peer. No server involved. |
+| Relay (amber) | Connected via the encrypted TURN relay. |
 
-The transfer begins automatically once the connection is established. You do not need to click anything.
+The dot tracks your own connection to the signaling server until the peer connection resolves, so a green **Ready** does not by itself mean the sender is ready. The ping readout next to the dot is shown to senders only.
+
+The transfer begins on its own, usually a couple of seconds after the connection is established. You do not need to click anything. If it never starts, the sender's side may have blocked it: Floe checks the path before any bytes move, and refuses a relayed connection when the sender turned relay fallback off or queued more than 2 GB. See [Sending Files](/web-app/sending#transfer).
 
 ## Contribute to global stats
 
-While you wait for the transfer, the receiver view shows a **Contribute to global stats** checkbox. It is on by default.
+While you wait for the transfer, the receiver view shows a **Contribute to global stats** checkbox. It is on by default. The checkbox disappears once the first file lands, so set it before the transfer starts.
 
 Floe's homepage has a public, all-time counter of total bytes transferred across every user. When a transfer finishes, the receiving side adds only this transfer's byte count to that shared total. File names, file contents, and identifying information are never sent, and the report never slows or blocks the transfer.
 
@@ -40,29 +45,38 @@ Your choice is saved in your browser and applies to all future transfers from th
 
 ## Download options
 
-When all files arrive, download options appear:
+Each file gets a download button (the download-arrow icon, no label) on its row as soon as it arrives, so you can save files while the rest are still streaming.
+
+When a transfer contains **two or more** files, two extra buttons appear once everything has arrived:
 
 | Option | Behavior |
 |--------|---------|
-| **Download** (per file) | Downloads each file individually. Available for every file. |
-| **Download All** | Triggers individual downloads for every file in the batch. |
-| **Download ZIP** | Bundles all files into a single `.zip` archive and downloads it. |
+| **Download All** | Saves each file individually, roughly one every 300 ms. Your browser may ask you to allow multiple downloads. |
+| **Download ZIP** | Bundles every file into one archive named `floe_transfer_<timestamp>.zip`. Duplicate file names are de-duplicated automatically. |
+
+A single-file transfer shows only that file's own download button.
 
 <Tip>
-  On iOS, use **Download ZIP**. Individual file downloads can behave inconsistently on Safari and iOS web views due to browser sandboxing.
+  On iOS, use **Download ZIP** when the transfer has more than one file. Individual file downloads can behave inconsistently on Safari and iOS web views due to browser sandboxing.
 </Tip>
 
 ## The sender must stay connected
 
-Files stream directly from the sender's device. If the sender closes their browser tab or the CLI process before the transfer completes, the connection drops and you will need to ask them to start a new session.
+Files stream directly from the sender's device. If the sender closes their browser tab, quits Floe Desktop, or stops the CLI process before the transfer completes, the connection drops and you will need to ask them to start a new session.
+
+If your own network blips before the first file arrives, Floe recovers on its own: it re-joins the room as soon as you are back and the sender builds a fresh connection. Once files have started landing, signaling is finished and Floe stops re-joining, so a drop that takes the peer connection with it ends the session and you will need a new link for whatever did not arrive. If the sender's side is the one that dropped before anything arrived, you see **Peer disconnected. Waiting for reconnection** and the transfer does not resume by itself.
+
+Either way, files that already finished stay in the list and remain downloadable.
 
 ## Receiving with the CLI instead
 
 If you prefer the terminal, paste the full link into `floe receive`:
 
 ```bash
-floe receive "https://floe.one/#room=abc123..."
+floe receive "https://floe.one/?s=1a2b3c4d#room=3f2b9c1e-7a4d-4c2e-9b1f-8e6d5c4b3a21"
 ```
+
+Links created in the browser carry a `?s=` nonce; links printed by `floe send` do not. `floe receive` accepts both.
 
 Or use the short code if the sender shares one:
 
@@ -74,7 +88,8 @@ See [floe receive](/cli/receive) for details and flags.
 
 ## If the link does not work
 
-- **"Room not found" or "expired":** Short codes expire after 10 minutes. Full links stay valid as long as the sender's tab is open. Ask the sender to start a new session.
-- **Stuck connecting:** The sender may be behind a strict network. Both peers need to be on compatible networks for a direct connection. Make sure relay fallback is enabled on the sender's side.
+- **"Link Invalid":** the link is expired, malformed, or already in use. A room admits exactly one receiver, so a link someone else has already opened will not work for you. Ask the sender to start a new session.
+- **Short code expired:** short codes come from `floe send` or Floe Desktop and last 10 minutes. Links from the web app carry no code and stay valid as long as the sender's tab is open.
+- **Stuck connecting:** the sender may be behind a strict network. Both peers need to be on compatible networks for a direct connection. The error **Could not connect. Ask the sender to enable "Network Relay" and try again.** covers every failure Floe treats as expected, so the relay is not always the culprit: the sender may have turned their **Network relay fallback** checkbox off (or run `floe send --no-relay`), or they may simply have closed their tab. Ask them to leave relay fallback on and create a new link.
 
 See [Troubleshooting](/troubleshooting) for more help.

--- a/docs/web-app/sending.mdx
+++ b/docs/web-app/sending.mdx
@@ -5,66 +5,83 @@ description: "Send files from the Floe web app at floe.one by generating a share
 
 Open [floe.one](https://floe.one) in any modern browser. No account or installation required.
 
+<Note>
+  In-app browsers (the ones embedded in Facebook, Messenger, Instagram, TikTok, Snapchat, LINE, X (Twitter), WeChat, and generic Android WebViews) have limited support for file transfers. Floe recognizes them by user agent and, instead of loading the transfer card, shows a full-screen prompt to open the page in Chrome or Safari. The card loads only once you move to a real browser or tap **Continue anyway** at the bottom of the prompt, where some features may not work.
+</Note>
+
 ## Add files
 
-Drop files directly onto the page, or click the drop zone to open the file picker. You can add:
+Drop files onto the dashed drop zone inside the transfer card, or click it to open the file picker. Dropping a file anywhere else on the page makes your browser open that file and navigate away from Floe. You can add:
 - A single file of any type.
 - Multiple files at once (the picker accepts multi-select).
+
+Once files are queued, the large drop zone shrinks to an **Add more files** strip above the file list.
 
 There is no file size limit on direct connections. Relay connections are capped at 2 GB per session. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
 
 <Note>
-  Folder transfers are a CLI-only feature. To send a folder from the browser, either zip it first or use `floe send ./folder` from the terminal.
+  Folder transfers are not supported in the browser. To send a folder, zip it first, or use `floe send ./folder` from the terminal, which walks the folder for you. The [Floe Desktop app](/desktop/sending) also has a folder picker.
 </Note>
 
-## Network Relay Fallback toggle
+## Network relay fallback
 
-Below the drop zone is a **Network Relay Fallback** toggle. It is on by default and recommended for most users.
+Once at least one file is queued, a **Network relay fallback** checkbox appears below the file list and directly above the Create secure link button. It is on by default and recommended for most users.
 
 | Setting | Behavior |
 |---------|----------|
 | On (default) | Floe attempts a direct connection first. If that fails, it automatically falls back to the encrypted TURN relay. |
 | Off | Only direct connections are attempted. If a direct path cannot be established, the transfer fails. |
 
-Turn relay off only if you need to ensure files never pass through a relay (for example, for compliance reasons or to transfer very large files over a direct connection).
+Unchecking it shows an amber warning that transfers may fail if either device is on mobile data or a restricted network. The checkbox disappears once you create the link, so set it before you click Create secure link. The choice lasts for the current session only and is not remembered between visits.
+
+Turn relay off only if you need to be certain files never pass through a relay, for example for compliance reasons. You do not need to turn it off to send more than 2 GB: the cap applies only when the connection actually ends up relayed, so leaving fallback on costs a direct transfer nothing.
 
 ## Create the link
 
-Click **Create Secure Link & Share**. Floe connects to the signaling server, assigns a room, and generates two ways to share:
+Click **Create secure link**. The button carries the count you are about to send, for example "Create secure link (3 files)".
 
-- **Link** - a URL containing the room ID (e.g. `https://floe.one/#room=...`). Send this via any messaging app, email, or chat.
-- **QR code** - scan it with a phone camera to open the link instantly. Useful for nearby transfers.
+Your browser generates the room id itself, joins that room on the signaling server, and shows the share panel once the server confirms the join. The panel holds the link, a live status line, and three controls:
 
-The link is valid for as long as your browser tab stays open.
+- **Copy** puts the link on your clipboard.
+- **Show QR** reveals a QR code, which is hidden by default. Scan it with a phone camera to open the link instantly. Press **Hide QR** to collapse it again.
+- **Share** opens your device's native share sheet. It appears only on browsers that expose one, mostly mobile.
+
+The link has the form `https://floe.one/?s=<nonce>#room=<uuid>`. The room id sits in the fragment, so it never reaches the server. The `?s=` nonce only makes each link a distinct page, so scanning a new QR code cannot reuse a stale tab.
+
+The link stays valid for as long as your browser tab is open, but it admits exactly **one** recipient. Once someone has joined the room, anyone else opening the same link gets a "Link Invalid" card. Create a fresh link for each person you want to send to.
 
 ## Connection indicator
 
-Once you share the link, a small connection indicator appears in the corner of the page. Its color tells you what is happening:
+The top-right of the transfer card shows a status dot with a label, plus a live ping readout that only senders see. Hover or tap the info icon next to Direct or Relay for a short in-product explanation.
 
-| Color | Meaning |
+| Label | Meaning |
 |-------|---------|
-| Pulsing (no color) | Waiting for the recipient to open the link. |
-| Green - Direct | Connected directly. Files travel peer-to-peer, no server involved. No size limit. |
-| Amber - Relay | Connected via the encrypted TURN relay. The 2 GB cap applies. |
+| Offline (red) | Not connected to Floe's signaling server, for example in the first moments after page load, or if your network drops. |
+| Ready (green) | Connected to the signaling server. It stays on Ready while you wait for a recipient, and after the recipient connects until Floe has worked out which path the connection took. |
+| Direct (green) | Connected directly. Files travel peer-to-peer, no server involved. No size limit. |
+| Relay (amber) | Connected via the encrypted TURN relay. The 2 GB cap applies. |
+
+The dot tracks your own link to the signaling server until the peer connection resolves, so it does not tell you whether the recipient has arrived. The status line under the share link does that: it reads "Waiting for peer", then "Peer joined. Starting transfer".
 
 ## Transfer
 
-The transfer starts automatically the moment the recipient opens the link. You do not need to click anything.
+The transfer starts on its own a couple of seconds after the recipient opens the link. You do not need to click anything.
+
+Floe checks the path before sending any bytes, so two things can stop it:
+
+- If the only available path is the relay and you turned relay fallback off, the card shows the error **Connection failed. Enable "Network Relay" to connect across restrictive networks.** and the connection is torn down.
+- If the path is relayed and your queue is over 2 GB, the status line reads **Transfer blocked. Relay limit exceeded.** and nothing is sent. Remove files, or move to a network that allows a direct connection.
 
 Keep the browser tab open and active for the entire transfer. If you close or navigate away from the tab, the session ends immediately and the recipient loses the connection.
 
-## Short code
+## Short codes
 
-The sender always sees a short code in the share panel (e.g. `olive-tiger-castle`). This code can be used by a **CLI recipient** to join without opening the link:
+The browser sender does not create a short code. `floe send` and Floe Desktop both register one when the send starts, and both `floe receive` and the Floe Desktop **Receive** tab can resolve one. A browser recipient always needs the full link or the QR code.
 
-```bash
-floe receive olive-tiger-castle
-```
-
-The code expires 10 minutes after the link is created. Browser recipients must use the full link.
+If you want a short code, send from the terminal or from Floe Desktop instead. See [floe send](/cli/send) or [Sending Files with Floe Desktop](/desktop/sending).
 
 ## Tips
 
 - On mobile, keep the browser in the foreground. Background tabs may be throttled and slow the transfer.
-- If the connection indicator stays in "Connecting" for more than 30 seconds, see [Troubleshooting](/troubleshooting).
+- If the status line under the share link stays on "Waiting for peer" for more than 30 seconds after the recipient has opened the link, see [Troubleshooting](/troubleshooting).
 - For large files on a corporate or university network, try a personal mobile hotspot to get a direct connection instead of relay.


### PR DESCRIPTION
## Summary

An audit checked every factual claim on all 31 pages against source, and a second pass independently re-verified each finding and threw out the ones that did not survive. What came back was **155 confirmed defects plus 53 more the verifiers found on their own**, against **7 that were refuted and dropped**. This applies them across 29 pages.

Roughly two fifths are the three-surface gap. The rest have nothing to do with the desktop app, and are the reason this is worth doing on its own.

## A sample of the non-desktop findings

- **`go install ...@latest` does not install the latest release.** The `cli` module has no `cli/vX.Y.Z` tags, so Go resolves the tip of `main`. Confirmed against `proxy.golang.org`, which returns a pseudo-version. The "Verify the install" step that followed it could not work either, because `go install` writes to `GOPATH/bin`.
- **iOS users were told to press Download ZIP**, which is gated on more than one file arriving while the iOS hint fires on one or more. A single-file iOS recipient was being pointed at a button that is not on screen.
- **`floe send ./documents/` silently flattens the folder.** `filepath.Dir` on a trailing slash yields `documents`, so the folder name drops out of every relative path.
- **Two pages said the server never keeps room information after a session**, but the code-to-room mapping outlives it until the 60-second sweeper runs.
- **The security page said the relay sees only encrypted packets**, while the live privacy policy adds that connection metadata may be logged.
- **The stats opt-out was described as available "before the transfer completes"**; the toggle unmounts as soon as the first file lands.
- **The rate-limit answer quoted a string no surface emits.**
- **A one-domain reverse proxy has to route `/api/config` to the client**, not the signaling server, and no page said so.

## The corrections were themselves reviewed

Every page was re-read by an agent that had not written the edit, checking each new claim against source. That caught **22 defects introduced by the corrections**, fixed here too. The sharpest:

- One editor rewrote `web-app/sending.mdx` to say short codes are CLI-only, which `desktop/app.go:602` and `:704` disprove, contradicting three other pages edited in the same batch.
- Another explained the connection badge as **Offline** until a peer joins, when `isConnected` tracks the Socket.IO socket and reads **Ready** from page load.
- A third wrote that the desktop and CLI carry "no telemetry" three lines after saying both report byte counts.

Two page groups came back with no factual errors at all, which is the signal the checkers were discriminating rather than reflexively negative.

Also reconciles two pages that disagreed with each other rather than with the code: `configuration.mdx` still credited `NODE_ENV` with suppressing stack traces, which the explicit error handler added in #239 made false, and `signaling.mdx` and `architecture.mdx` described `MAX_ACTIVE_CODES` as counting different things.

## Test plan

- [x] 36 nav entries match 36 files; 0 broken links, 0 broken heading anchors, 0 broken same-page anchors
- [x] 0 em dashes and 0 smart punctuation across all 36 pages, checked by hand inside JSX blocks
- [x] Frontmatter exactly `title` and `description` on every page, every description inside the house 131 to 167 range
- [x] All component tags balanced, code fences even, no H1s, no duplicate heading anchors
- [x] The 7 refuted findings were not acted on

Docs-only, so the `changes` job skips the heavy suite.

## Merge order

Third of four. Stacked on `docs/desktop-changelog` because it edits pages both earlier branches also touch. After #1 and #2 land, this needs a rebase onto the new `main` before merging, since the repo squash-merges. Ping me and I will do it.
