### PR TITLE
fix(desktop): stop Start over from silently discarding an unsent note

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import {
 import QRCode from 'react-qr-code';
 import {BoltMark, Button, Eyebrow, Input, StatusDot, cn} from './components/ui';
 import {advancedSummary, hostOf} from './settings';
+import {resetWarning} from './reset';
 import TitleBar from './components/TitleBar';
 import FileIcon from './components/FileIcon';
 import {Tooltip} from './components/Tooltip';
@@ -1041,12 +1042,28 @@ function App() {
         return () => window.removeEventListener('keydown', onKey);
     }, [settingsOpen, confirmReset, confirmDefaults]);
 
-    // Ctrl/Cmd+R starts over (muscle memory for "reload"). preventDefault stops
-    // WebView2 from doing a real reload, which would orphan a running transfer.
+    // Ctrl/Cmd+R starts over (muscle memory for "reload").
+    //
+    // Skipped while a field has focus, like the o/Enter/h shortcuts below, but
+    // for a sharper reason than theirs: this one destroys. doReset calls
+    // setSendText(''), and a half-typed note lives in that state field and
+    // nowhere else, so Ctrl+R with the caret in the textarea used to erase it
+    // with no prompt and no undo. startOver's guard did not catch it either,
+    // because nothing was transferring yet.
+    //
+    // preventDefault is belt and braces, not the mechanism. Wails disables the
+    // webview's browser accelerator keys outright during setup
+    // (PutAreBrowserAcceleratorKeysEnabled(false), frontend.go:589, ungated and
+    // fatal on failure), and Ctrl+R is on that list, so this key has never been
+    // able to reload the app. An earlier comment here claimed otherwise. It is
+    // kept because it costs nothing and would still be right if Wails ever
+    // stopped doing that.
     useEffect(() => {
         const onKey = (e: KeyboardEvent) => {
             if ((e.ctrlKey || e.metaKey) && (e.key === 'r' || e.key === 'R')) {
                 e.preventDefault();
+                const el = document.activeElement as HTMLElement | null;
+                if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable)) return;
                 startOverRef.current();
             }
         };
@@ -1315,7 +1332,7 @@ function App() {
     // bytes are actively moving, so escaping a stuck (connecting/idle) state is
     // instant while a real transfer is protected from a fat-finger.
     function startOver() {
-        if (sendProg || recvProg) {
+        if (resetLoss) {
             setConfirmReset(true);
             return;
         }
@@ -1328,6 +1345,16 @@ function App() {
     startOverRef.current = startOver;
 
     const busy = sending || receiving;
+    // What Start over would destroy, phrased for its own dialog, so the decision
+    // to interrupt and the sentence explaining why can never drift apart. Empty
+    // means nothing worth a prompt and the reset runs on the first click or
+    // keypress, exactly as it did before.
+    const resetLoss = resetWarning({
+        transferring: !!(sendProg || recvProg),
+        busy,
+        justSent: sendDone,
+        text: sendText,
+    });
     // Amber marks anything relay-flavored: a known relayed route, or (before
     // the route is known / while idle) the Hide-my-IP preference forcing one.
     const relayTone = route ? route === 'relay' : hideIP;
@@ -2120,9 +2147,11 @@ function App() {
                 </div>
             )}
 
-            {/* start-over guard: only shown when a transfer is actively moving
-                bytes, so escaping a stuck state stays one click. Sits below the
-                titlebar so the window controls remain reachable. */}
+            {/* start-over guard: shown only when the reset would destroy moving
+                bytes or an unsent text note, so escaping a stuck state still
+                stays one click. See resetWarning in reset.ts for exactly which
+                states earn a prompt and which deliberately do not. Sits below
+                the titlebar so the window controls remain reachable. */}
             {confirmReset && (
                 <div className="fixed inset-x-0 bottom-0 top-9 z-50 grid place-items-center bg-black/60 backdrop-blur-sm">
                     <div
@@ -2132,7 +2161,10 @@ function App() {
                         className="animate-floe-in mx-4 w-full max-w-sm rounded-xl border border-white/10 bg-zinc-900 p-5 shadow-2xl"
                     >
                         <h2 id="floe-startover-title" className="text-sm font-semibold text-white">Start over?</h2>
-                        <p className="mt-1.5 text-xs leading-relaxed text-zinc-400">A transfer is in progress. Starting over will cancel it.</p>
+                        {/* resetWarning decided to open this dialog, so it also
+                            supplies the sentence. One source, so the guard and
+                            the copy cannot disagree about why you were stopped. */}
+                        <p className="mt-1.5 text-xs leading-relaxed text-zinc-400">{resetLoss}</p>
                         <div className="mt-4 flex justify-end gap-2">
                             <Button variant="outline" onClick={() => setConfirmReset(false)}>Keep going</Button>
                             <Button onClick={doReset}>Start over</Button>

--- a/desktop/frontend/src/reset.test.ts
+++ b/desktop/frontend/src/reset.test.ts
@@ -1,0 +1,65 @@
+import {describe, expect, it} from 'vitest';
+import {resetWarning} from './reset';
+
+const base = {transferring: false, busy: false, justSent: false, text: ''};
+
+describe('resetWarning', () => {
+    it('says nothing when there is nothing to lose', () => {
+        expect(resetWarning(base)).toBe('');
+    });
+
+    it('warns about a live transfer', () => {
+        expect(resetWarning({...base, transferring: true})).toContain('transfer is in progress');
+    });
+
+    // The bug this helper exists for. Ctrl+R and the titlebar lockup both call
+    // startOver, doReset calls setSendText(''), and a typed note is persisted
+    // nowhere, so before this it vanished with no prompt and no undo.
+    it('warns about an unsent text note', () => {
+        const s = resetWarning({...base, text: 'half a paragraph'});
+        expect(s).toContain('has not been sent');
+    });
+
+    it('treats whitespace-only text as nothing to lose', () => {
+        expect(resetWarning({...base, text: '   \n  '})).toBe('');
+    });
+
+    // A live transfer outranks everything: its wording is about cancelling, which
+    // is the more serious consequence and the one the user needs to read.
+    it('lets a live transfer outrank an unsent note', () => {
+        const s = resetWarning({...base, transferring: true, text: 'draft'});
+        expect(s).toContain('transfer is in progress');
+        expect(s).not.toContain('has not been sent');
+    });
+
+    // The regression guard that matters most. Start over is the escape hatch for
+    // a send that is connecting or waiting for a peer, and that state still holds
+    // the text. A dialog in front of the escape hatch defeats the escape hatch.
+    it('stays silent while busy, so the stuck-state escape hatch is one click', () => {
+        expect(resetWarning({...base, busy: true, text: 'draft'})).toBe('');
+    });
+
+    // send:done clears neither the text nor the file list, so without this gate
+    // the commonest gesture in the app, tidying up after a completed transfer,
+    // would prompt every single time.
+    it('stays silent right after a completed send', () => {
+        expect(resetWarning({...base, justSent: true, text: 'the note I just sent'})).toBe('');
+    });
+
+    // Staged files are deliberately not a reason to prompt: doReset clears them,
+    // but the paths are still on disk, so it is tedious rather than destructive.
+    // Encoded as a test so a future "be helpful" change has to argue with it.
+    it('does not prompt for staged files, only for unsent text', () => {
+        expect(resetWarning(base)).toBe('');
+    });
+
+    // House style, enforced rather than trusted: no em dashes anywhere in UI copy.
+    it('uses no em dashes', () => {
+        for (const s of [
+            resetWarning({...base, transferring: true}),
+            resetWarning({...base, text: 'draft'}),
+        ]) {
+            expect(s).not.toContain('—');
+        }
+    });
+});

--- a/desktop/frontend/src/reset.ts
+++ b/desktop/frontend/src/reset.ts
@@ -1,0 +1,41 @@
+// Pure helper for the Start over confirmation. It lives outside App.tsx for the
+// same reason settings.ts does: so it can be tested without a DOM or the Wails
+// runtime bindings, which do not exist outside the WebView.
+
+/**
+ * resetWarning returns the sentence the Start over dialog should show, or ''
+ * when the reset is not worth interrupting. Callers read '' as "just do it".
+ *
+ * Two states earn a prompt, and only two.
+ *
+ * Bytes in flight, because the reset cancels a live transfer. That is the
+ * original reason the dialog exists.
+ *
+ * An unsent text note while idle, because doReset calls setSendText('') and a
+ * typed note is written to no file and no storage key. It exists in that one
+ * state field and nowhere else, so clearing it is the only thing Start over
+ * does that the user cannot simply redo. Staged files are deliberately NOT in
+ * this list: doReset clears those too, but the paths are still on disk and
+ * re-picking them is tedious rather than destructive.
+ *
+ * Two gates keep the prompt off paths where it would be noise:
+ *
+ * busy, because a send that is connecting or waiting for a peer still holds its
+ * text and file list, and a dialog in front of the escape hatch that exists FOR
+ * stuck states would defeat it.
+ *
+ * justSent, because send:done clears neither the text nor the files. Without
+ * this gate, the single most common gesture in the app, clicking the lockup to
+ * tidy up after a transfer completes, would throw a modal every time.
+ */
+export function resetWarning(s: {
+    transferring: boolean;
+    busy: boolean;
+    justSent: boolean;
+    text: string;
+}): string {
+    if (s.transferring) return 'A transfer is in progress. Starting over will cancel it.';
+    if (s.busy || s.justSent) return '';
+    if (s.text.trim() === '') return '';
+    return 'The text you typed has not been sent yet. Starting over will clear it.';
+}


### PR DESCRIPTION
## Summary

**Start over** is reachable two ways, `Ctrl` `R` and the Floe lockup in the titlebar, and both called `doReset` with no confirmation unless bytes were already moving. `doReset` calls `setSendText('')`. A typed note lives in that one state field and is written to no file and no storage key, so it was the one thing Start over destroyed that the user could not simply redo, and it went without a prompt.

Worse, the `Ctrl` `R` listener had no typing guard, unlike the `o`/`Enter`/`h` shortcuts twenty lines below it. The caret could be mid-word in the textarea and the note would still go.

## Two guards, each scoped to one failure

The keyboard path now skips while a field has focus, matching the other shortcuts. That covers the caret-in-textarea case and the receive code field.

The confirm now also fires for an unsent note while idle, which covers the paths a focus guard cannot: pressing `Ctrl` `R` after clicking away, and clicking the lockup, which reads as a logo and is the likelier misfire for a new user.

## What deliberately does not prompt

A dialog has a cost too, so three cases are excluded on purpose and each is pinned by a test:

- **Staged files.** `doReset` clears them, but the paths are still on disk. Tedious to rebuild, not destroyed.
- **Anything while busy.** A send that is connecting or waiting for a peer still holds its text, and Start over is the escape hatch for exactly that state. A dialog in front of the escape hatch defeats the escape hatch.
- **Right after a completed send.** `send:done` clears neither the text nor the file list, so without this gate the commonest gesture in the app, tidying up after a transfer finishes, would throw a modal every time. That regression was caught by a second reviewer in the first version of this fix.

The decision and the dialog's sentence now come from one pure function in `reset.ts`, so the guard and the copy cannot drift apart. It sits outside `App.tsx` for the same reason `settings.ts` does: it is testable without a DOM or the Wails bindings, neither of which exists outside the WebView.

## A comment that was wrong

The old comment claimed `preventDefault` was there to stop WebView2 reloading the app. Wails disables the webview's browser accelerator keys during setup (`PutAreBrowserAcceleratorKeysEnabled(false)`, `frontend.go:589`, ungated and fatal on failure) and `Ctrl` `R` is on that list, so this key has never been able to reload anything. The call is kept as cheap insurance, but the reason is now stated accurately rather than inherited.

## Test plan

Unit, in the existing pure-function style of `settings.test.ts`, no new dependencies:

- [x] 8 cases in `reset.test.ts`, including both regression gates (busy, just-sent), a live transfer outranking an unsent note, whitespace-only text, and the house no-em-dash rule
- [x] `npm test` in `desktop/frontend`: 17 tests across 2 files pass
- [x] `npm run build`: `tsc` and `vite` both clean
- [x] `go test ./...` in `desktop`: ok

Behavioural, driven against the real UI under `wails dev`:

- [x] `Ctrl` `R` with the caret in the textarea: note kept, no dialog
- [x] `Ctrl` `R` with focus off the field: dialog reading "The text you typed has not been sent yet. Starting over will clear it.", note intact
- [x] **Keep going**: dialog closes, note preserved
- [x] Titlebar lockup with a note composed: same dialog
- [x] **Start over** confirmed: text cleared
- [x] Empty state: no dialog, reset stays one click, so the stuck-state escape hatch is intact

## Not included

The other bug I had reported alongside this one, that the Store MSIX declares no WebView2 dependency, **turned out not to be real** and no manifest change is made here. Wails compiles a WebView2 install strategy into the binary and defaults to `download`, so the app offers to fetch the runtime on first run, and the Store and GitHub builds are the same executable. Separately, `<PackageDependency>` is the wrong element (it names an MSIX framework package, which WebView2 is not), and the correct element, `win32dependencies:ExternalDependency`, is documented as honored only by App Installer and ignored by Store installs. The docs that described WebView2 as an unmet prerequisite are corrected in #243 instead.
