### PR TITLE
fix(desktop): show a dialog instead of vanishing when startup fails

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -155,9 +155,12 @@ jobs:
             $age = (Get-Date) - (Get-Item $f).LastWriteTime
             if ($age.TotalMinutes -gt 30) { Write-Error "stale artifact: $f ($age old)"; exit 1 }
           }
-          # The exe's version strings live under \StringFileInfo\040904b0; the
-          # VarFileInfo translation table is zeroed by a winres quirk, so .NET's
-          # FileVersionInfo defaults read blanks. Query the subblock directly.
+          # The exe's version strings live under \StringFileInfo\040904b0. The
+          # translation table is fine (0x0409/0x04B0); what is missing is a
+          # FileVersion string key, which build/windows/info.json never emits,
+          # and .NET's FileVersionInfo blanks every STRING field when it cannot
+          # find that key during codepage fallback (the numeric VS_FIXEDFILEINFO
+          # parts survive). Query the subblock directly.
           Add-Type @"
           using System;
           using System.Runtime.InteropServices;

--- a/desktop/fatal_other.go
+++ b/desktop/fatal_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// showFatal reports a startup failure on stderr. Floe Desktop ships on Windows
+// only, but the module has to build elsewhere (see contextmenu_other.go), and a
+// non-Windows build is run from a terminal, so stderr is the visible channel
+// there and no dialog is needed.
+func showFatal(title, body string) {
+	fmt.Fprintf(os.Stderr, "%s: %s\n", title, body)
+}

--- a/desktop/fatal_test.go
+++ b/desktop/fatal_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// The failure this whole path exists for: Wails' WebView2 preflight check
+// panics with a bare nil pointer dereference, so the cause text says nothing
+// about WebView2 and only the stack does. If the hint is ever matched against
+// the cause alone, the user gets "runtime error: invalid memory address" and no
+// way to act on it, which is the silent-close bug wearing a dialog.
+func TestFatalMessageFindsWebView2InTheStackNotTheCause(t *testing.T) {
+	cause := errors.New("runtime error: invalid memory address or nil pointer dereference")
+	stack := "goroutine 1 [running]:\n" +
+		"github.com/wailsapp/wails/v2/internal/webview2runtime.DownloadBootstrapper(...)\n" +
+		"\t/pkg/mod/.../webview2runtime/webview2runtime.go:57 +0x1c\n"
+
+	got := fatalMessage(cause, stack)
+
+	if !strings.Contains(got, webview2Hint) {
+		t.Fatalf("expected the WebView2 hint when only the stack names it, got:\n%s", got)
+	}
+	if !strings.Contains(got, "nil pointer dereference") {
+		t.Errorf("expected the underlying cause to survive, got:\n%s", got)
+	}
+}
+
+func TestFatalMessage(t *testing.T) {
+	// hint is exercised by TestFatalMessageFindsWebView2InTheStackNotTheCause;
+	// these cases all drive the cause alone.
+	cases := []struct {
+		name     string
+		cause    any
+		wantHint bool
+		contains string
+	}{
+		{
+			name:     "webview2 named in the cause",
+			cause:    errors.New("WebView2 runtime not installed"),
+			wantHint: true,
+			contains: "WebView2 runtime not installed",
+		},
+		{
+			name:     "matching is case insensitive",
+			cause:    errors.New("failed to locate webview2 loader"),
+			wantHint: true,
+		},
+		{
+			name:     "an unrelated failure gets no hint",
+			cause:    errors.New("bind: address already in use"),
+			wantHint: false,
+			contains: "address already in use",
+		},
+		{
+			name:     "a bare panic value is still reported",
+			cause:    "assignment to entry in nil map",
+			wantHint: false,
+			contains: "assignment to entry in nil map",
+		},
+		{
+			name:     "an empty cause never renders a blank dialog",
+			cause:    errors.New(""),
+			wantHint: false,
+			contains: "unknown error",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := fatalMessage(c.cause, "")
+
+			if !strings.HasPrefix(got, "Floe could not start.") {
+				t.Errorf("every fatal message should open by saying so, got:\n%s", got)
+			}
+			if hasHint := strings.Contains(got, webview2Hint); hasHint != c.wantHint {
+				t.Errorf("WebView2 hint present = %v, want %v, in:\n%s", hasHint, c.wantHint, got)
+			}
+			if c.contains != "" && !strings.Contains(got, c.contains) {
+				t.Errorf("expected message to contain %q, got:\n%s", c.contains, got)
+			}
+		})
+	}
+}

--- a/desktop/fatal_windows.go
+++ b/desktop/fatal_windows.go
@@ -1,0 +1,32 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+// showFatal puts a startup failure on screen. The release binary is linked with
+// -H windowsgui and so has no console: without this, a failure before the window
+// exists kills the process with nothing for the user to read, which reads as the
+// app silently refusing to start.
+//
+// MB_SETFOREGROUND and MB_TOPMOST both matter here. The failure happens before
+// any Floe window exists, so the dialog has no parent to sit in front of and
+// would otherwise be free to open behind whatever the user was looking at.
+func showFatal(title, body string) {
+	caption, err := windows.UTF16PtrFromString(title)
+	if err != nil {
+		return
+	}
+	text, err := windows.UTF16PtrFromString(body)
+	if err != nil {
+		return
+	}
+	// Failure is ignored on purpose: this is the last thing the process does
+	// before exiting, and there is no better channel left to report it on.
+	_, _ = windows.MessageBox(
+		windows.HWND(0),
+		text,
+		caption,
+		windows.MB_OK|windows.MB_ICONERROR|windows.MB_SETFOREGROUND|windows.MB_TOPMOST,
+	)
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1756,7 +1756,9 @@ function App() {
                         <div className="mt-10 space-y-6">
                             {[
                                 {n: '01', title: 'Direct & unlimited', note: 'Direct transfers stream device to device with no size cap. Relay fallback is capped at 2 GB.'},
-                                {n: '02', title: 'End-to-end encrypted', note: 'DTLS and SRTP, the same as a video call.'},
+                                // DTLS alone: data channels are SCTP over DTLS. SRTP carries
+                                // media, which Floe never sends.
+                                {n: '02', title: 'End-to-end encrypted', note: 'DTLS, the same as a video call.'},
                                 {n: '03', title: 'Nothing is stored', note: 'The server only brokers the handshake.'},
                             ].map(({n, title, note}) => (
                                 <div key={n} className="border-l border-white/10 pl-5">

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"embed"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
+	"strings"
 
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -18,7 +21,50 @@ var assets embed.FS
 // build time via -ldflags "-X main.version=v1.0.0"; "dev" for local builds.
 var version = "dev"
 
+const fatalTitle = "Floe"
+
+// The one startup failure a user can actually fix themselves, so it is worth
+// naming explicitly rather than showing them a nil pointer dereference.
+const webview2Hint = "Floe needs the Microsoft WebView2 runtime. " +
+	"If this PC is offline or behind a filtering proxy, install WebView2 from " +
+	"https://developer.microsoft.com/microsoft-edge/webview2/ and start Floe again."
+
+// fatalMessage turns a panic value or an error into text a user can act on.
+//
+// hint is searched alongside the cause because the failure we most want to
+// explain carries no useful text of its own: when the WebView2 runtime is
+// missing and its download cannot be reached, Wails' preflight check panics
+// with a bare nil pointer dereference, and only the stack names the package.
+func fatalMessage(cause any, hint string) string {
+	detail := strings.TrimSpace(fmt.Sprint(cause))
+	if detail == "" {
+		detail = "unknown error"
+	}
+	msg := "Floe could not start.\n\n" + detail
+	// Joined with a newline rather than concatenated: a bare join could match
+	// across the seam, on a cause ending "webview" and a hint starting "2".
+	if strings.Contains(strings.ToLower(detail+"\n"+hint), "webview2") {
+		msg += "\n\n" + webview2Hint
+	}
+	return msg
+}
+
 func main() {
+	// A release build is linked with -H windowsgui, so it has no console and a
+	// panic escaping main would end the process with nothing on screen. Wails
+	// runs its WebView2 preflight check before any window exists, and a
+	// transport failure fetching the runtime panics inside it, so this is a
+	// reachable path rather than a theoretical one. The stack still goes to
+	// stderr for `wails dev`, where a console does exist.
+	defer func() {
+		if r := recover(); r != nil {
+			stack := debug.Stack()
+			fmt.Fprintf(os.Stderr, "panic: %v\n\n%s", r, stack)
+			showFatal(fatalTitle, fatalMessage(r, string(stack)))
+			os.Exit(1)
+		}
+	}()
+
 	// Create an instance of the app structure
 	app := NewApp()
 
@@ -60,7 +106,12 @@ func main() {
 		},
 	})
 
+	// Exit non-zero as well as showing the dialog: the previous println went to
+	// a console the release build does not have, and falling out of main left
+	// the process reporting success on a failed start.
 	if err != nil {
-		println("Error:", err.Error())
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		showFatal(fatalTitle, fatalMessage(err, ""))
+		os.Exit(1)
 	}
 }

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -29,10 +29,9 @@ receives from browser peers and CLI peers without any extra setup.
   The installer from GitHub also installs it during setup.
 
   One case needs care. If the machine cannot reach Microsoft's download at that moment, because
-  it is offline or behind a filtering proxy, Floe closes after the prompt without an
-  explanation. If that happens, install
-  [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) yourself and start Floe
-  again.
+  it is offline or behind a filtering proxy, the runtime cannot install and Floe cannot start.
+  Install [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) yourself, then
+  start Floe again.
 </Note>
 
 ## Choose a channel


### PR DESCRIPTION
## Summary

The release binary is linked with `-H windowsgui`, so it has no console. Any failure before the window existed ended the process with nothing on screen: `println("Error:", ...)` wrote to a console that is not there, and a panic escaping `main` printed a stack nobody could read.

The reachable case is WebView2. Wails runs its runtime preflight check before creating any window, and a transport failure fetching the bootstrapper panics inside it. `wails v2.12.0 webview2runtime.go:57` registers `defer resp.Body.Close()` above the `if err != nil`, and evaluating that method value dereferences the nil response at defer-registration time. The whole chain from `main` to that line is synchronous with no goroutine hop, so a `recover` in `main` does reach it.

A user who is offline or behind a filtering proxy saw Floe close after the runtime prompt with no explanation. That also reads badly against Microsoft Store policy 10.4.2 on apps closing unexpectedly.

Both paths now end in a message box and a non-zero exit. The panic value on its own is useless there (`invalid memory address or nil pointer dereference`), so the WebView2 hint is matched against the stack as well as the cause, and `fatal_test.go` gates exactly that.

**Scope, stated plainly:** this covers panics on the main goroutine and the `wails.Run` error return. Wails' own `log.Fatal` and `os.Exit` paths inside `internal/frontend/desktop/windows`, and panics on goroutines it spawns, still exit silently. Those are upstream and are not addressed here.

### Three things found alongside, fixed rather than left

- The sidebar said data channels are encrypted with "DTLS and SRTP". SRTP carries media, which Floe never sends; data channels are SCTP over DTLS. `pion/srtp` is an unused indirect dependency, and every other surface (`docs/how-it-works/encryption.mdx`, the web app, the CLI) was already correct, so this was the only wrong copy.
- `docs/desktop/installation.mdx` described the bug being fixed here, telling readers Floe "closes after the prompt without an explanation". Docs publish on merge while the binary only changes on a `desktop-v*` tag, so the replacement states the outcome without describing how the failure presents, and is true on both sides of that gap.
- The release workflow's comment blamed a zeroed `VarFileInfo` translation table for .NET reading blank version strings. The table is fine (`0x0409/0x04B0`, confirmed against the shipped binary). What is absent is a `FileVersion` string key, which is why `FileVersionInfo` blanks the string fields during codepage fallback. The direct subblock query the comment guards is correct and stays.

## Test plan

- `desktop`: `go vet ./...` and `go test -count=1 ./...` pass, with 6 new cases over `fatalMessage` including the gate where only the stack names WebView2.
- `desktop/frontend`: `tsc`, `vite build`, and 17 vitest tests pass.
- Cross-build: `GOOS=linux` and `GOOS=darwin` vet clean, so `fatal_other.go` compiles and the build tags are mutually exclusive.
- Simulated end to end: built with `-ldflags "-H windowsgui"`, injected a panic into `main`, confirmed the dialog renders (title "Floe", correct body and hint) and the process exits 1. Injection removed before commit; `FLOE_SIMULATE_STARTUP_PANIC` appears in no source file.
- No CI job executes the desktop binary, and no test calls `showFatal`, so nothing can block on a modal.

## Follow-up, not in this PR

The Microsoft Store listing does not disclose the WebView2 dependency anywhere (checked the expanded Description, all seven Features, and System Requirements). That is a Store policy 10.2.4 gap worth closing on the next submission. The listing screenshots also still carry the "DTLS and SRTP" line this PR corrects.
