### PR TITLE
docs(desktop): correct two WebView2 claims that overstated the facts

### DIFF
--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -19,14 +19,14 @@ receives from browser peers and CLI peers without any extra setup.
 - **From GitHub:** any Windows 10 or later. The installer stops on anything older.
 - **x64.** Both channels ship an x64 build only. The GitHub installer and the portable zip stop
   with an architecture error on a native ARM64 machine.
-- **The Microsoft Edge WebView2 runtime**, which draws the interface. Windows 11 ships it, and
-  Microsoft has been installing it on Windows 10 through Windows Update since 2022, so nearly
-  every machine already has it. You do not normally need to do anything about it.
+- **The Microsoft Edge WebView2 Runtime**, which draws the interface. Windows 11 includes it, and
+  the vast majority of Windows 10 machines already have it. You do not normally need to do
+  anything about it.
 
 <Note>
-  If it is missing, Floe offers to fetch it. The first time you start the app it says the
-  runtime is required and asks to download and install it, then carries on once that finishes.
-  The installer from GitHub also installs it during setup.
+  If it is missing, Floe asks to download and install it when you start the app, then carries on
+  once that finishes. Decline, and Floe closes and asks again the next time you start it. The
+  installer from GitHub also installs it during setup.
 
   One case needs care. If the machine cannot reach Microsoft's download at that moment, because
   it is offline or behind a filtering proxy, the runtime cannot install and Floe cannot start.


### PR DESCRIPTION
## Summary

Two claims in the desktop installation docs overstated what Microsoft actually documents. Both surfaced while writing the WebView2 disclosure for the Microsoft Store listing, where the same wording would have been read by certification reviewers who have Microsoft's own docs to hand.

**"Microsoft has been installing it on Windows 10 through Windows Update since 2022"** is wrong twice:

- **The mechanism.** Microsoft never names Windows Update. The [enterprise doc](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/enterprise) says "The Microsoft Edge browser and WebView2 Runtime are updated using the same update mechanism" and recommends "the default Microsoft Edge updater"; the only Microsoft-named servicing channel is Microsoft Update, via WSUS, which is not Windows Update.
- **The scope.** The [27 June 2022 rollout post](https://blogs.windows.com/msedgedev/2022/06/27/webview2-roll-out-windows-10/) covered consumer Home and Pro devices and states "Managed devices are not included in the rollout". Domain-joined machines did not begin until after 16 January 2023.

The conclusion that sentence drew is well supported, so that half stays. Microsoft's [distribution page](https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution) says "The vast majority of Windows 10 devices have the WebView2 Runtime installed already", which is now what the docs say.

**"The first time you start the app it says the runtime is required"** reads as a one-shot prompt. Wails runs its WebView2 preflight check on every launch, so declining closes Floe and the prompt returns the next time it starts. The new wording says that plainly.

Also capitalises "WebView2 Runtime" to match Microsoft's own product styling.

## Test plan

- Docs-only, so the `changes` job classifies it as such and the heavy jobs skip.
- Vale clean, no em dashes.
- Swept `docs/`, `client/`, `README.md` and `DESKTOP.md` for `through Windows Update`: no other surface carried either claim, so this is not a fix-one-of-two.
- The paragraph immediately below, reworded in #248 to describe the outcome rather than the presentation, is unchanged and still consistent.
