### PR TITLE
fix(self-hosting): move the published images back to Node 24 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,18 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    # A Node major is never Dependabot's call. Only even-numbered Node releases
+    # become LTS; odd ones are roughly eight-month previews that reach end of
+    # life with no security patches and never get one. Dependabot cannot see
+    # that distinction, so in #227 it moved both images 24 -> 25 and the
+    # published images spent two months on a runtime that died on 2026-06-01.
+    # Minor and patch bumps of the same major are still wanted, and security
+    # advisories ignore this block entirely. Majors move by hand, when the next
+    # even release reaches Active LTS (26 does so on 2026-10-28).
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       docker-deps:
         patterns:

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -11,7 +11,7 @@
 # without rebuilding. It defaults to empty for exactly that reason.
 
 # ---- Builder ---------------------------------------------------------------
-FROM node:25-alpine AS builder
+FROM node:24-alpine AS builder
 
 # Pin pnpm to package.json's `packageManager` version so `--frozen-lockfile`
 # matches the lockfile exactly. pnpm 11.x needs Node 22+ (it uses the node:sqlite
@@ -54,7 +54,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 RUN pnpm build
 
 # ---- Runner ----------------------------------------------------------------
-FROM node:25-alpine AS runner
+FROM node:24-alpine AS runner
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,7 @@
 # touches file data. It binds 0.0.0.0:$PORT (default 3001) and reads its config
 # from environment variables (see server/.env.example).
 
-FROM node:25-alpine
+FROM node:24-alpine
 
 # dumb-init reaps zombies and forwards SIGTERM/SIGINT so the server's graceful
 # shutdown handlers fire cleanly on `docker stop`.


### PR DESCRIPTION
## Summary

**Node 25 reached end of life on 2026-06-01.** Both published images have been built on it since #227, so `ghcr.io/jannskiee/floe-server:main` and `floe-client:main` have been shipping an unsupported runtime for over two months. This moves them back to Node 24.

| | Status today | Supported until |
|---|---|---|
| **Node 24** | Active LTS | 2028-04-30 |
| Node 25 | **End of life** since 2026-06-01 | never again |

Only even-numbered Node releases become LTS. Odd ones are roughly eight-month previews.

## How it got in

Dependabot cannot see the LTS distinction. It saw a newer tag, and the `docker` group carried no `update-types` restriction to keep a major out, so the bump arrived inside a routine monthly PR and read like every other one. The `npm` group already restricts itself to minor and patch for a related reason; `docker` never did.

## The guard

`dependabot.yml` now refuses node majors outright rather than merely keeping them out of the group. Which major is correct is a question about the LTS calendar, not about semver, so it is not a decision to delegate.

- Minor and patch bumps of the same major still arrive as before.
- Security advisories bypass an `ignore` block entirely, so CVE response is unaffected.
- The next move is by hand, to 26, once it reaches Active LTS on **2026-10-28**.

## Why now

This blocks `v1.10.0`. That tag republishes both images as `latest`, which would hand the end-of-life runtime to every self-hoster who does not pin a version. It also contradicts the shipped `v1.9.0` changelog entry, which tells readers the images run "Node 24, the Active LTS".

## Test plan

- Nothing depended on 25: neither `client/package.json` nor `server/package.json` declares an `engines` field, and both images ran 24 for the whole life of the project until #227.
- `node:24-alpine` confirmed present in the registry (manifest HEAD returns 200).
- `dependabot.yml` parsed with a YAML parser; the `docker` entry resolves to `ignore: [{dependency-name: node, update-types: [version-update:semver-major]}]`.
- Release dates taken from `nodejs/Release` `schedule.json`, not from memory.
- CI's Docker job builds both images, which is the real check on the base image swap.