### PR TITLE
ci: promote the Docker smoke job into the CI green gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,13 +630,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Every job in this workflow must be listed here, or its failure is
-    # invisible to branch protection. The one exception is a job still
-    # soaking outside the gate (currently docker-smoke); see CLAUDE.md for
-    # the promotion policy. if: always() is load-bearing and must
+    # invisible to branch protection. Nothing is soaking outside the gate
+    # right now; see CLAUDE.md for the promotion policy a new job follows. if: always() is load-bearing and must
     # never become !cancelled(): without always() a failed or cancelled
     # dependency would skip this job, and GitHub counts a skipped required
     # check as passing.
-    needs: [changes, actionlint, build-and-lint, server, cli, desktop, e2e, back-compat]
+    needs: [changes, actionlint, build-and-lint, server, cli, desktop, e2e, back-compat, docker-smoke]
     if: always()
     steps:
       - name: Report dependency results


### PR DESCRIPTION
Adds `docker-smoke` to `ci-green`s `needs` list.

It has run on every code PR since it was added without flaking, and it just earned the promotion: on #256 it was the only check that proved next 16.3.0 with sharp 0.35.3 serves `/_next/image` as webp under pnpm, alpine and standalone. That is the exact pairing that used to fail with `ERR_DLOPEN_FAILED`, and it is why sharp sat pinned at 0.34.5 with an open high-severity advisory.

Outside the gate its failures were invisible to branch protection, so the next regression in image optimization or the self-hosting stack would have merged clean.

This is the promotion path CLAUDE.md describes for a job that has soaked.