### PR TITLE
docs: use "different from" consistently

### DIFF
--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -44,7 +44,7 @@ floe send photo.jpg
 
 Trailing slashes are trimmed, so `https://floe.example.com/` and `https://floe.example.com` behave the same.
 
-Set `FLOE_WEB` only when your web app runs on a different host than your signaling server. Leave it unset and share links point at the same host as your server, which is what you want when one domain serves both. The only exceptions are Floe's own deployment and the local dev pair, which are special-cased to their web hosts as described under `--web` above.
+Set `FLOE_WEB` only when your web app runs on a different host from your signaling server. Leave it unset and share links point at the same host as your server, which is what you want when one domain serves both. The only exceptions are Floe's own deployment and the local dev pair, which are special-cased to their web hosts as described under `--web` above.
 
 ## `floe receive` flags
 

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -112,7 +112,7 @@ If you point Floe at your own server, the report goes to that server rather than
 
 | Message | What it means |
 |---|---|
-| Could not resolve ... | The code was mistyped, has passed its 10 minutes, or belongs to a different server than the one you are on. |
+| Could not resolve ... | The code was mistyped, has passed its 10 minutes, or belongs to a different server from the one you are on. |
 | This code is no longer active; ask for a new one | The code is still valid but nobody is sharing with it. The transfer already finished, or the sender closed Floe. |
 | Room is full (someone else may already be receiving) | Someone already joined with this code. A room takes one receiver, so ask for a new code. |
 

--- a/docs/self-hosting/reverse-proxy.mdx
+++ b/docs/self-hosting/reverse-proxy.mdx
@@ -174,7 +174,7 @@ floe send --server https://floe.example.com photo.jpg
 ```
 
 The `--web` flag only exists for split deployments where the client lives on a
-different hostname than the signaling server.
+different hostname from the signaling server.
 
 The desktop app takes the same single address. Open Settings, expand
 **Advanced**, put `https://floe.example.com` in **Server address**, and press


### PR DESCRIPTION
#226 changed one `different ... than` to `from` and left three behind, including `docs/cli/flags.mdx:47`, which is the CLI twin of the desktop sentence it edited. The two pages would have described the same feature with different grammar.

- `docs/cli/flags.mdx:47` different host than
- `docs/desktop/receiving.mdx:115` different server than
- `docs/self-hosting/reverse-proxy.mdx:177` different hostname than

Three words. No meaning changes.