### PR TITLE
chore(deps): move the js-yaml override to 4.3.1

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   flatted: ^3.4.2
   brace-expansion@1: ^1.1.18
   brace-expansion@5: ^5.0.9
-  js-yaml: ^4.3.0
+  js-yaml: ^4.3.1
 
 importers:
 
@@ -2582,8 +2582,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -3798,7 +3798,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5993,7 +5993,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -30,4 +30,4 @@ overrides:
   # Both lines are dev tooling that never ships.
   brace-expansion@1: ^1.1.18
   brace-expansion@5: ^5.0.9
-  js-yaml: ^4.3.0
+  js-yaml: ^4.3.1


### PR DESCRIPTION
Closes Dependabot alert #111, the last open alert on the repository. GHSA-5p4m-2wfm-xmqj is quadratic CPU consumption resolving `!!omap`, patched in 4.3.1.

`client/pnpm-workspace.yaml` already declared `js-yaml: ^4.3.0`, which 4.3.1 satisfies, so only the frozen lockfile was holding it at 4.3.0. Pinning the floor makes the intent explicit and stops a later lockfile refresh silently dropping back under the advisory.

Scope is exactly two files and six lines: the override, and the two `js-yaml@` entries in the lockfile. No other package resolves differently.

`js-yaml` reaches this tree only through eslint config-array, so it is dev tooling that never ships to a user.