### PR TITLE
fix(client): turn off standalone output on Vercel

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -3,9 +3,18 @@ import { withSentryConfig } from '@sentry/nextjs';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     // Emit a self-contained production server (.next/standalone) so the Docker
-    // image can run with only the built output — no full node_modules at runtime.
-    // Vercel ignores this flag, so the hosted deploy is unaffected.
-    output: 'standalone',
+    // image can run with only the built output, no full node_modules at runtime.
+    // client/Dockerfile copies .next/standalone and runs its server.js, so this
+    // is load-bearing for the published ghcr.io image.
+    //
+    // Off on Vercel, and that is not an optimisation. Vercel's builder injects a
+    // deployment adapter, and since Next 16.3.0 an adapter suppresses
+    // .next/next-server.js.nft.json (vercel/next.js#93684) while the standalone
+    // copy step still reads it unguarded, so the build dies with ENOENT after
+    // compiling successfully. Vercel ignores the standalone directory anyway.
+    // See vercel/next.js#96646. The previous comment here claimed Vercel ignored
+    // the flag entirely, which was true until 16.3.0 and is what let this ship.
+    output: process.env.VERCEL ? undefined : 'standalone',
 
     // React Strict Mode intentionally double-mounts components in development
     // to surface side-effect bugs. This would create two Socket.io connections


### PR DESCRIPTION
Every production deployment has failed since next 16.3.0 landed in #256. floe.one is up but frozen on the last good build, and nothing can ship until this merges.

```
Running onBuildComplete from Vercel
Error: ENOENT: no such file or directory, open '/vercel/path0/client/.next/next-server.js.nft.json'
```

## Cause

Vercel's builder injects a deployment adapter. next 16.3.0 stopped emitting `next-server.js.nft.json` whenever an adapter is configured ([vercel/next.js#93684](https://github.com/vercel/next.js/pull/93684), "Adapters don't read these files"), but `copyTracedFiles`, the step that populates `.next/standalone`, still opens it unguarded. Adapter plus `output: 'standalone'` is a guaranteed ENOENT on 16.3.0.

Next's own team hit this in [vercel/next.js#93915](https://github.com/vercel/next.js/pull/93915) and fixed it by dropping standalone from the fixture, noting it is "meaningless on Vercel deployments (the standalone directory is ignored)". There is an open issue, [vercel/next.js#96646](https://github.com/vercel/next.js/issues/96646), carrying this exact one-line remedy. No fix is queued in any 16.3.1 canary.

## Reproduced and verified locally

A two-line stub adapter plus `NEXT_ADAPTER_PATH` reproduces Vercel's builder without Vercel:

| adapter | `VERCEL` | result |
|---|---|---|
| yes | unset | **ENOENT, exit 1**, identical to production |
| yes | `1` | exit 0, no standalone directory, which is correct |
| no | unset | exit 0, `.next/standalone/server.js` present, 1507 files |

The third row is the one that matters for self-hosting.

## Why the Docker image is safe

`client/Dockerfile` copies `.next/standalone` and runs its `server.js`. Nothing in `.github/`, `docker-compose*.yml`, or either Dockerfile sets `VERCEL`, so every non-Vercel build keeps standalone output unchanged. `Docker (self-hosting stack)` on this PR is the check to watch.

## Why nothing caught it

CI runs a bare `next build` with no adapter, so it passes. The Vercel project's Ignored Build Step skips every preview build, so production is the first place Vercel ever builds this code. That combination is worth revisiting separately.

Reverting next is the alternative, but it would reopen Dependabot alert #80 (sharp, high, runtime) which #256 just closed, with no upstream fix in sight.