### PR TITLE
fix(docs): make the Vale em-dash check actually run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,9 @@ ci.yml also has a `workflow_dispatch` trigger: a dispatched run behaves exactly 
 
 ## Writing Style
 
-Do not use em dashes (--) in any markdown files or documentation. Use periods, commas, hyphens, or parentheses instead. In `docs/`, this is enforced deterministically by Vale (`docs/.vale.ini` plus the `docs/styles/Floe/EmDash.yml` rule, surfaced as the Mintlify Grammar linter CI check) and reinforced by the weekly Apply style guide automation.
+Do not use em dashes in any markdown files or documentation. Use periods, commas, hyphens, or parentheses instead. In `docs/`, Vale checks this (`docs/.vale.ini` plus the `docs/styles/Floe/EmDash.yml` rule, surfaced as the Mintlify Grammar linter CI check), reinforced by the weekly Apply style guide automation.
+
+What Vale actually covers is narrower than this rule: it matches the em dash and en dash characters only, in `docs/` only. An ASCII `--` used as a dash is a human-review matter, because a token for it fires on every CLI flag in the docs. Markdown outside `docs/` has no linter at all.
 
 ## Git Conventions
 

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -1,9 +1,16 @@
 StylesPath = styles
 MinAlertLevel = error
 
+; Lint .mdx with the Markdown parser. This section is the whole reason the
+; check works: a format association is only valid in a top-level [formats]
+; block. Written as a bare "mdx = md" inside the glob section below, Vale
+; parses it as a rule toggle instead, leaves .mdx on its native MDX parser,
+; and that parser hard-errors on the angle-bracket placeholders this repo
+; uses in prose (<url>, <version>, <uuid>, <short>) and on changelog.mdx.
+; A single E100 aborts the entire run, so for months this check reported
+; "There was an error running Vale" and linted nothing at all.
+[formats]
+mdx = md
+
 [*.{md,mdx}]
 BasedOnStyles = Floe
-mdx = md
-; Ignore JSX components and {expressions} so Vale does not choke on MDX
-TokenIgnores = (\{[^}]*\}), (</?[A-Za-z][^>]*/?>)
-BlockIgnores = (?s) *(<[A-Z][A-Za-z]*[^>]*>.*?</[A-Z][A-Za-z]*>)

--- a/docs/styles/Floe/EmDash.yml
+++ b/docs/styles/Floe/EmDash.yml
@@ -4,3 +4,4 @@ level: error
 nonword: true
 tokens:
   - '—'
+  - '–'


### PR DESCRIPTION
The Mintlify grammar check has been reporting `There was an error running Vale` on every docs PR for months. A `neutral` conclusion is not a failure, and the check is not in the branch ruleset, so nobody noticed. It has been linting nothing.

Checked on #226, #245, #249 and #255: all four report the same error.

## Cause

`mdx = md` sat inside the `[*.{md,mdx}]` glob section, where Vale reads any bare `key = value` as a rule toggle rather than a format association. `vale ls-config` shows `Checks: ["mdx"]` and `Formats: {}`.

With no association, `.mdx` stays on Vale's native MDX parser, which hard-errors on the angle-bracket placeholders this repo uses in prose (`<url>`, `<version>`, `<uuid>`, `<short>`) and on `changelog.mdx`. A single `E100` aborts the entire run.

`TokenIgnores` and `BlockIgnores` could not help. They filter content after parsing, and the parse is what failed.

Moving the line into a top-level `[formats]` section is the fix. Deleting it is not enough, the association has to exist.

## Why both ignore patterns go

Once the Markdown parser is in use they are redundant, and they were worse than redundant: measured against the real docs, **either one alone** hid every capitalized JSX component body from the linter. That is **893 of 2125 prose lines, 42%**, including 96% of `faq.mdx`, 93% of `troubleshooting.mdx` and 91% of `changelog.mdx`.

## Verified with vale 3.17.1 against the real docs

| | result |
|---|---|
| before | `E100 [changelog.mdx] Runtime error`, execution stopped, exit 1 |
| after | `0 errors, 0 warnings and 0 suggestions in 37 files`, exit 0 |
| fixture | **3 errors, exit 1**: a plain paragraph, a `<Note>` body, and a `<Step>` body |

The two component cases are exactly what the old config was blind to. Blast radius is zero: there is not a single em dash or en dash in `docs/` today, so this is config-only.

## Also

En dash joins the token list. Zero occurrences today, so it costs nothing and closes the obvious substitution. ASCII `--` is deliberately left out: it fires on every CLI flag in the docs, four false positives and no true ones.

`CLAUDE.md` overstated this in both directions, calling it deterministic enforcement while writing the rule with the ASCII form the check never matched. It now says what is actually covered.

## Not included

Promoting this check into the `main-protection` ruleset. It failed silently for months, so it should run visibly and non-blocking for a few docs PRs first. It cannot join `CI green`s `needs` list, since it is not a job in `ci.yml`.