### PR TITLE
fix(client): stop the service worker freezing /docs and RSC payloads

### DIFF
--- a/client/lib/serviceWorker.test.ts
+++ b/client/lib/serviceWorker.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Guards the caching policy in public/sw.js.
+ *
+ * This lives in lib/ rather than beside its subject because vitest.config.ts
+ * collects only lib/**\/*.test.ts, and public/sw.js is a classic script served
+ * verbatim to the browser: there is nothing to import. So it is read as text and
+ * evaluated in a fresh function scope per test. A `new Function` body's scope
+ * chain is the global scope alone, which is what makes the stubs below reachable
+ * from its free `self`, `caches` and `fetch` references, and what keeps its
+ * top-level consts out of this file.
+ *
+ * The worker has exactly two outcomes for any request: it calls respondWith and
+ * answers from the Cache API, or it returns and lets the browser fetch the URL
+ * as if no worker were registered. So "respondWith was never called" is a
+ * complete statement of "this URL is not cached", not a proxy for one.
+ */
+const SW_SOURCE = readFileSync(
+    fileURLToPath(new URL('../public/sw.js', import.meta.url)),
+    'utf8'
+);
+
+const ORIGIN = 'https://www.floe.one';
+const NETWORK_BODY = 'from the network';
+
+// The name v4 shipped. An allowlist only reaches an already-installed visitor if
+// the name changed, because activate purges by name and nothing else evicts.
+const PREVIOUS_CACHE_NAME = 'floe-cache-v4';
+
+interface FakeRequest {
+    url: string;
+    method: string;
+    mode: string;
+}
+
+interface FakeResponse {
+    status: number;
+    body: string;
+    clone(): FakeResponse;
+}
+
+function makeResponse(body: string, status = 200): FakeResponse {
+    return { status, body, clone: () => makeResponse(body, status) };
+}
+
+/**
+ * Enough of CacheStorage to run the worker. Two properties of the real API are
+ * load-bearing and reproduced on purpose:
+ *
+ *   - cache.addAll takes relative paths, which the spec resolves against the
+ *     worker's own location. That is why a precached '/' is findable at all.
+ *   - Matching is by URL and method. A request's mode is NOT part of the key,
+ *     which is why a navigation finds the entry addAll stored as an ordinary
+ *     request. The offline fallback depends entirely on that.
+ */
+function createCacheStorage() {
+    const stores = new Map<string, Map<string, FakeResponse>>();
+    const opened: string[] = [];
+    const precached: string[] = [];
+    const key = (url: string) => new URL(url, `${ORIGIN}/sw.js`).href;
+
+    function entriesFor(name: string) {
+        const existing = stores.get(name);
+        if (existing) return existing;
+        const created = new Map<string, FakeResponse>();
+        stores.set(name, created);
+        return created;
+    }
+
+    const cacheStorage = {
+        open: async (name: string) => {
+            opened.push(name);
+            const target = entriesFor(name);
+            return {
+                addAll: async (urls: string[]) => {
+                    for (const url of urls) {
+                        precached.push(url);
+                        target.set(key(url), makeResponse(`precached ${url}`));
+                    }
+                },
+                put: async (request: FakeRequest, response: FakeResponse) => {
+                    target.set(key(request.url), response);
+                },
+            };
+        },
+        match: async (request: FakeRequest) => {
+            for (const target of stores.values()) {
+                const hit = target.get(key(request.url));
+                if (hit) return hit;
+            }
+            return undefined;
+        },
+        keys: async () => [...stores.keys()],
+        delete: async (name: string) => stores.delete(name),
+    };
+
+    return { cacheStorage, stores, opened, precached, entriesFor };
+}
+
+function loadServiceWorker() {
+    const listeners = new Map<string, (event: unknown) => void>();
+    const { cacheStorage, stores, opened, precached, entriesFor } = createCacheStorage();
+    const fetchMock = vi.fn(async () => makeResponse(NETWORK_BODY));
+    const skipWaiting = vi.fn();
+    const claim = vi.fn();
+
+    vi.stubGlobal('self', {
+        addEventListener: (type: string, handler: (event: unknown) => void) => {
+            listeners.set(type, handler);
+        },
+        location: new URL(`${ORIGIN}/sw.js`),
+        skipWaiting,
+        clients: { claim },
+    });
+    vi.stubGlobal('caches', cacheStorage);
+    vi.stubGlobal('fetch', fetchMock);
+
+    new Function(SW_SOURCE)();
+
+    return { listeners, stores, opened, precached, entriesFor, fetchMock, skipWaiting, claim };
+}
+
+type Worker = ReturnType<typeof loadServiceWorker>;
+
+/**
+ * Fires one fetch event. An empty result means the worker declined the request,
+ * so the browser goes to the network on its own.
+ */
+function dispatchFetch(
+    sw: Worker,
+    url: string,
+    mode = 'cors',
+    method = 'GET'
+): Promise<FakeResponse>[] {
+    const handled: Promise<FakeResponse>[] = [];
+    const listener = sw.listeners.get('fetch');
+    if (!listener) throw new Error('sw.js registered no fetch listener');
+    const request: FakeRequest = { url, method, mode };
+    listener({
+        request,
+        respondWith: (promise: Promise<FakeResponse>) => {
+            handled.push(promise);
+        },
+    });
+    return handled;
+}
+
+async function dispatchLifecycle(sw: Worker, type: 'install' | 'activate') {
+    const pending: Promise<unknown>[] = [];
+    const listener = sw.listeners.get(type);
+    if (!listener) throw new Error(`sw.js registered no ${type} listener`);
+    listener({
+        waitUntil: (promise: Promise<unknown>) => {
+            pending.push(promise);
+        },
+    });
+    await Promise.all(pending);
+}
+
+/**
+ * The worker writes to the cache without awaiting it, deliberately, so a slow
+ * write never delays the response. Asserting on the write means draining those
+ * microtasks first.
+ */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+let sw: Worker;
+
+beforeEach(() => {
+    sw = loadServiceWorker();
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('service worker registration', () => {
+    it('registers install, activate and fetch listeners', () => {
+        expect([...sw.listeners.keys()].sort()).toEqual(['activate', 'fetch', 'install']);
+    });
+
+    it('takes over open tabs instead of waiting for them to close', async () => {
+        await dispatchLifecycle(sw, 'install');
+        await dispatchLifecycle(sw, 'activate');
+        expect(sw.skipWaiting).toHaveBeenCalledTimes(1);
+        expect(sw.claim).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('install', () => {
+    it('precaches the documents that must survive going offline', async () => {
+        await dispatchLifecycle(sw, 'install');
+        expect(sw.precached).toEqual(['/', '/download', '/how-it-works', '/privacy', '/terms']);
+    });
+
+    it('does not precache the GitHub mark, which no page requests directly', async () => {
+        // The footer renders it through next/image, so the browser asks for
+        // /_next/image?url=%2Fgithub-mark-white.png. A precached copy of the raw
+        // file could never be matched.
+        await dispatchLifecycle(sw, 'install');
+        expect(sw.precached).not.toContain('/github-mark-white.png');
+    });
+
+    it('writes to a cache name the previous release did not use', async () => {
+        // Without a rename, an existing visitor keeps every entry the old
+        // denylist wrongly stored, and the fix never reaches the people it is for.
+        await dispatchLifecycle(sw, 'install');
+        expect(sw.opened[0]).not.toBe(PREVIOUS_CACHE_NAME);
+    });
+});
+
+describe('activate', () => {
+    it('deletes every cache except the current one', async () => {
+        await dispatchLifecycle(sw, 'install');
+        const current = sw.opened[0];
+        sw.entriesFor(PREVIOUS_CACHE_NAME).set(`${ORIGIN}/docs/changelog`, makeResponse('stale'));
+        sw.entriesFor('floe-cache-v3').set(`${ORIGIN}/_next/image?url=x`, makeResponse('stale'));
+
+        await dispatchLifecycle(sw, 'activate');
+
+        expect([...sw.stores.keys()]).toEqual([current]);
+    });
+});
+
+describe('URLs the worker must leave alone', () => {
+    const NOT_CACHED: [string, string][] = [
+        // A reverse-proxy rewrite onto a Mintlify deployment we do not version.
+        ['a proxied docs page', `${ORIGIN}/docs/changelog`],
+        ['the docs index', `${ORIGIN}/docs`],
+        ['a docs RSC payload', `${ORIGIN}/docs/changelog?_rsc=J6c4qteBDi_nDJmH`],
+        // Proves the docs guard outranks the /_next/static allowlist. This is
+        // Mintlify's build output, and its hashes are not our promise to keep.
+        ['a docs build asset', `${ORIGIN}/docs/_next/static/chunks/mintlify.js`],
+        // A live optimizer whose output changes with the source and the config.
+        ['the image optimizer', `${ORIGIN}/_next/image?url=%2Fgithub-mark-white.png&w=32&q=75`],
+        // Names chunks from the deployment that produced it, so a cached copy is
+        // the stale-bundle error lib/staleBundle.ts cannot reload its way out of.
+        ['our own RSC payload', `${ORIGIN}/download?_rsc=1a2b3c4d`],
+        ['the runtime config endpoint', `${ORIGIN}/api/config`],
+        ['a signaling API route', `${ORIGIN}/api/turn-credentials`],
+        ['socket.io polling', `${ORIGIN}/socket.io/?EIO=4&transport=polling`],
+        ['sitemap.xml', `${ORIGIN}/sitemap.xml`],
+        ['robots.txt', `${ORIGIN}/robots.txt`],
+        ['the web app manifest', `${ORIGIN}/manifest.webmanifest`],
+        ['a hash-suffixed icon route', `${ORIGIN}/icon.svg?f7a1c2b9`],
+        ['a public image', `${ORIGIN}/og.png`],
+        ['the CLI install script', `${ORIGIN}/install.sh`],
+        ['another host entirely', 'https://api.floe.one/api/turn-credentials'],
+        ['build output on another host', 'https://cdn.example.com/_next/static/chunks/a.js'],
+    ];
+
+    for (const [label, url] of NOT_CACHED) {
+        it(`passes ${label} straight to the network`, () => {
+            expect(dispatchFetch(sw, url)).toHaveLength(0);
+        });
+    }
+
+    it('ignores non-GET requests to an otherwise cacheable path', () => {
+        expect(dispatchFetch(sw, `${ORIGIN}/_next/static/chunks/a.js`, 'cors', 'POST')).toHaveLength(0);
+    });
+});
+
+describe('/_next/static is the only cache-first path', () => {
+    const CACHED: [string, string][] = [
+        ['a build chunk', `${ORIGIN}/_next/static/chunks/4f2a91c3.js`],
+        ['a build stylesheet', `${ORIGIN}/_next/static/css/9b1c0e.css`],
+        ['a self-hosted next/font file', `${ORIGIN}/_next/static/media/geist-a1b2c3.woff2`],
+    ];
+
+    for (const [label, url] of CACHED) {
+        it(`caches ${label}, whose filename is a hash of its bytes`, async () => {
+            const handled = dispatchFetch(sw, url);
+            expect(handled).toHaveLength(1);
+            await expect(handled[0]).resolves.toMatchObject({ body: NETWORK_BODY });
+        });
+    }
+
+    it('serves a repeat request from the cache without a second network hit', async () => {
+        const url = `${ORIGIN}/_next/static/chunks/4f2a91c3.js`;
+
+        await dispatchFetch(sw, url)[0];
+        await flush();
+        expect(sw.fetchMock).toHaveBeenCalledTimes(1);
+
+        await expect(dispatchFetch(sw, url)[0]).resolves.toMatchObject({ body: NETWORK_BODY });
+        expect(sw.fetchMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('navigations', () => {
+    it('prefers the network over a cached copy', async () => {
+        await dispatchLifecycle(sw, 'install');
+
+        const handled = dispatchFetch(sw, `${ORIGIN}/`, 'navigate');
+        expect(handled).toHaveLength(1);
+        await expect(handled[0]).resolves.toMatchObject({ body: NETWORK_BODY });
+        expect(sw.fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes the cached copy from the network answer', async () => {
+        await dispatchLifecycle(sw, 'install');
+        const current = sw.opened[0];
+
+        await dispatchFetch(sw, `${ORIGIN}/`, 'navigate')[0];
+        await flush();
+
+        expect(sw.stores.get(current)?.get(`${ORIGIN}/`)).toMatchObject({ body: NETWORK_BODY });
+    });
+
+    it('falls back to the precache when the network is gone', async () => {
+        await dispatchLifecycle(sw, 'install');
+        sw.fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+        const handled = dispatchFetch(sw, `${ORIGIN}/download`, 'navigate');
+        expect(handled).toHaveLength(1);
+        // addAll stored this under an ordinary request. Finding it from a
+        // navigation is the spec property the whole fallback rests on.
+        await expect(handled[0]).resolves.toMatchObject({ body: 'precached /download' });
+    });
+
+    it('leaves docs navigations alone, not just docs subresources', () => {
+        // The guard has to sit above the navigate branch, or every docs page
+        // lands in the cache and only a rename can evict it.
+        expect(dispatchFetch(sw, `${ORIGIN}/docs/changelog`, 'navigate')).toHaveLength(0);
+        expect(dispatchFetch(sw, `${ORIGIN}/docs`, 'navigate')).toHaveLength(0);
+    });
+
+    it('does not mistake a route that merely starts with the letters docs', () => {
+        // A bare startsWith('/docs') would swallow both of these, which are ours.
+        expect(dispatchFetch(sw, `${ORIGIN}/docsomething`, 'navigate')).toHaveLength(1);
+        expect(dispatchFetch(sw, `${ORIGIN}/docs-archive`, 'navigate')).toHaveLength(1);
+    });
+});

--- a/client/lib/serviceWorker.test.ts
+++ b/client/lib/serviceWorker.test.ts
@@ -44,12 +44,18 @@ interface FakeRequest {
 
 interface FakeResponse {
     status: number;
+    ok: boolean;
     body: string;
     clone(): FakeResponse;
 }
 
 function makeResponse(body: string, status = 200): FakeResponse {
-    return { status, body, clone: () => makeResponse(body, status) };
+    return {
+        status,
+        ok: status >= 200 && status < 300,
+        body,
+        clone: () => makeResponse(body, status),
+    };
 }
 
 /**
@@ -256,6 +262,7 @@ describe('URLs the worker must leave alone', () => {
         ['the runtime config endpoint', `${ORIGIN}/api/config`],
         ['a signaling API route', `${ORIGIN}/api/turn-credentials`],
         ['socket.io polling', `${ORIGIN}/socket.io/?EIO=4&transport=polling`],
+        ['socket.io behind a proxy prefix', `${ORIGIN}/app/socket.io/?EIO=4`],
         ['sitemap.xml', `${ORIGIN}/sitemap.xml`],
         ['robots.txt', `${ORIGIN}/robots.txt`],
         ['the web app manifest', `${ORIGIN}/manifest.webmanifest`],
@@ -322,6 +329,22 @@ describe('navigations', () => {
         await flush();
 
         expect(sw.stores.get(current)?.get(`${ORIGIN}/`)).toMatchObject({ body: NETWORK_BODY });
+    });
+
+    it('does not let a bad answer overwrite the offline copy', async () => {
+        // A captive portal answering 200 with its login page, or an edge 5xx
+        // during a deploy, would otherwise become this visitor's offline
+        // fallback until the next cache rename.
+        await dispatchLifecycle(sw, 'install');
+        const current = sw.opened[0];
+        sw.fetchMock.mockResolvedValueOnce(makeResponse('captive portal login', 503));
+
+        await dispatchFetch(sw, `${ORIGIN}/download`, 'navigate')[0];
+        await flush();
+
+        expect(sw.stores.get(current)?.get(`${ORIGIN}/download`)).toMatchObject({
+            body: 'precached /download',
+        });
     });
 
     it('falls back to the precache when the network is gone', async () => {

--- a/client/lib/serviceWorker.test.ts
+++ b/client/lib/serviceWorker.test.ts
@@ -14,9 +14,12 @@ import { fileURLToPath } from 'node:url';
  * top-level consts out of this file.
  *
  * The worker has exactly two outcomes for any request: it calls respondWith and
- * answers from the Cache API, or it returns and lets the browser fetch the URL
- * as if no worker were registered. So "respondWith was never called" is a
- * complete statement of "this URL is not cached", not a proxy for one.
+ * takes the request over, or it returns and lets the browser fetch the URL as if
+ * no worker were registered. Only the first path can ever reach the Cache API,
+ * so "respondWith was never called" is a complete statement of "this URL is not
+ * cached", not a proxy for one. (Taking a request over does not imply answering
+ * from cache: the navigate branch and a /_next/static miss both answer from the
+ * network through respondWith.)
  */
 const SW_SOURCE = readFileSync(
     fileURLToPath(new URL('../public/sw.js', import.meta.url)),
@@ -26,8 +29,11 @@ const SW_SOURCE = readFileSync(
 const ORIGIN = 'https://www.floe.one';
 const NETWORK_BODY = 'from the network';
 
-// The name v4 shipped. An allowlist only reaches an already-installed visitor if
-// the name changed, because activate purges by name and nothing else evicts.
+// The name v4 shipped. The rename is NOT what makes the routing fix take effect:
+// the guards return before any cache read, so a v4 visitor stops being served
+// stale entries the moment v5 activates, whatever the cache is called. The
+// rename is what reclaims those entries from disk, because activate purges by
+// name and nothing else ever evicts.
 const PREVIOUS_CACHE_NAME = 'floe-cache-v4';
 
 interface FakeRequest {
@@ -205,8 +211,9 @@ describe('install', () => {
     });
 
     it('writes to a cache name the previous release did not use', async () => {
-        // Without a rename, an existing visitor keeps every entry the old
-        // denylist wrongly stored, and the fix never reaches the people it is for.
+        // The routing change alone already stops those entries being served.
+        // The rename is what evicts them from disk, since activate purges by
+        // name and nothing else ever does.
         await dispatchLifecycle(sw, 'install');
         expect(sw.opened[0]).not.toBe(PREVIOUS_CACHE_NAME);
     });
@@ -230,6 +237,13 @@ describe('URLs the worker must leave alone', () => {
         // A reverse-proxy rewrite onto a Mintlify deployment we do not version.
         ['a proxied docs page', `${ORIGIN}/docs/changelog`],
         ['the docs index', `${ORIGIN}/docs`],
+        // Measured on the live site: /DOCS/changelog and /Docs/changelog both
+        // return the docs with a 200, byte for byte identical to the lowercase
+        // spelling. The routing in front of the worker is case-insensitive, so
+        // the guard has to be too.
+        ['an all-caps docs path', `${ORIGIN}/DOCS/changelog`],
+        ['a mixed-case docs path', `${ORIGIN}/Docs/changelog`],
+        ['a mixed-case docs index', `${ORIGIN}/Docs`],
         ['a docs RSC payload', `${ORIGIN}/docs/changelog?_rsc=J6c4qteBDi_nDJmH`],
         // Proves the docs guard outranks the /_next/static allowlist. This is
         // Mintlify's build output, and its hashes are not our promise to keep.
@@ -326,6 +340,13 @@ describe('navigations', () => {
         // lands in the cache and only a rename can evict it.
         expect(dispatchFetch(sw, `${ORIGIN}/docs/changelog`, 'navigate')).toHaveLength(0);
         expect(dispatchFetch(sw, `${ORIGIN}/docs`, 'navigate')).toHaveLength(0);
+    });
+
+    it('leaves case-variant docs navigations alone too', () => {
+        // A case-sensitive guard would miss these and the navigate branch would
+        // cache them, which is the leak the whole change exists to close.
+        expect(dispatchFetch(sw, `${ORIGIN}/DOCS/changelog`, 'navigate')).toHaveLength(0);
+        expect(dispatchFetch(sw, `${ORIGIN}/Docs/changelog`, 'navigate')).toHaveLength(0);
     });
 
     it('does not mistake a route that merely starts with the letters docs', () => {

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -75,12 +75,15 @@ self.addEventListener('fetch', (event) => {
     // spelling the server already honours.
     const path = url.pathname.toLowerCase();
 
-    // Match a whole path segment rather than a substring. Still loose enough to
-    // survive a reverse proxy mounting the transport under a prefix, but it no
-    // longer matches an unrelated route that merely contains the letters, and it
-    // clears the CodeQL incomplete-url-substring-sanitization warning this line
-    // has carried since it was written.
-    if (path.split('/').includes('socket.io')) return;
+    // Match a whole path segment by equality rather than testing the path for a
+    // substring. Still loose enough to survive a reverse proxy mounting the
+    // transport under a prefix, but it no longer matches an unrelated route that
+    // merely contains the letters. Equality is also what gets CodeQL off this
+    // line: 'socket.io' reads as a hostname to
+    // js/incomplete-url-substring-sanitization, so any substring test against it
+    // is flagged even though this only ever inspects a pathname, and only ever
+    // to decide whether to skip caching.
+    if (path.split('/').some((segment) => segment === 'socket.io')) return;
     // Never cache API traffic. /api/config carries the runtime server address, so
     // a cached copy would pin the client to a stale one forever. Behind a
     // one-domain reverse proxy the signaling server's own /api/ routes are

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -1,16 +1,40 @@
 // Bump on any change to what is cached OR to the response headers, because the
-// Cache API stores whole responses, headers included, and everything except a
-// navigation is served cache-first. Without a bump, returning visitors keep
-// pre-change headers on those assets indefinitely. v4 carries the first
-// security-header set the site has ever sent.
-const CACHE_NAME = 'floe-cache-v4';
+// Cache API stores whole responses, headers included. Without a bump, returning
+// visitors keep pre-change copies indefinitely. The bump is also the only purge
+// this worker has: the activate handler below deletes every cache that is not
+// the current one, so renaming is how a bad entry gets evicted from a machine
+// we cannot reach.
+//
+// v5 replaces a denylist with an allowlist. v4 served every same-origin
+// non-navigation GET cache-first and forever, which froze three classes of URL
+// that are dynamic at a fixed address:
+//
+//   /docs        a reverse-proxy rewrite onto a Mintlify deployment we do not
+//                version (see the rewrites in next.config.mjs). Measured on the
+//                live site, this pinned docs pages to a deployment three
+//                releases old across 230 entries, and a visitor had no way to
+//                recover short of clearing site data.
+//   /_next/image a live optimizer whose output changes with the source file and
+//                with the images config.
+//   ?_rsc=       the payloads the App Router fetches on client-side navigation.
+//                These are worse than stale text: a cached payload names chunks
+//                from the deployment that produced it, which is exactly the
+//                stale-bundle error lib/staleBundle.ts reloads to escape, and a
+//                reload cannot clear the Cache API. The worker was manufacturing
+//                the failure that module exists to recover from, then disabling
+//                its remedy.
+const CACHE_NAME = 'floe-cache-v5';
+
+// Navigations only. These are the documents that must still render with no
+// network, served by the fallback in the navigate branch below. /github-mark-white.png
+// used to sit here and was never once a hit: the footer renders it through
+// next/image, so the URL the browser actually asks for is /_next/image?url=...
 const STATIC_ASSETS = [
     '/',
     '/download',
     '/how-it-works',
     '/privacy',
     '/terms',
-    '/github-mark-white.png',
 ];
 
 self.addEventListener('install', (event) => {
@@ -40,13 +64,25 @@ self.addEventListener('fetch', (event) => {
     const url = new URL(request.url);
 
     if (request.method !== 'GET') return;
+    if (url.hostname !== self.location.hostname) return;
     if (url.pathname.includes('socket.io')) return;
     // Never cache API traffic. /api/config carries the runtime server address, so
     // a cached copy would pin the client to a stale one forever. Behind a
     // one-domain reverse proxy the signaling server's own /api/ routes are
-    // same-origin too, and the cache-first branch below would freeze those.
+    // same-origin too. The allowlist at the bottom would exclude these anyway,
+    // but the guard stays explicit because lib/socketUrl.ts documents it as a
+    // guarantee its callers depend on.
     if (url.pathname.startsWith('/api/')) return;
-    if (url.hostname !== self.location.hostname) return;
+
+    // The docs are a reverse-proxy rewrite, which makes a third-party site
+    // same-origin and therefore ours to break. Mintlify ships its own HTML, its
+    // own RSC payloads and its own build output, all of which change whenever it
+    // redeploys and none of which we version. This has to sit ABOVE the navigate
+    // branch, or docs pages get cached as navigations and only a rename evicts
+    // them. The predicate mirrors the two rewrite rules in next.config.mjs
+    // exactly, rather than a bare prefix test that would also swallow a future
+    // route like /docsomething.
+    if (url.pathname === '/docs' || url.pathname.startsWith('/docs/')) return;
 
     if (request.mode === 'navigate') {
         event.respondWith(
@@ -62,6 +98,18 @@ self.addEventListener('fetch', (event) => {
         );
         return;
     }
+
+    // Cache-first is only ever correct for a URL whose bytes cannot change, and
+    // /_next/static is the one path where Next guarantees that: the filename
+    // carries a hash of the contents, so a changed file gets a new URL instead
+    // of a new answer at the old one. That covers the JS chunks, the CSS, and the
+    // self-hosted next/font woff2 files under /_next/static/media.
+    //
+    // Everything else on this origin is dynamic at a fixed address, including
+    // /_next/image, the ?_rsc= payloads, sitemap.xml, robots.txt, the web app
+    // manifest and the hash-suffixed icon routes. All of it goes to the network
+    // exactly as it would with no worker registered at all.
+    if (!url.pathname.startsWith('/_next/static/')) return;
 
     event.respondWith(
         caches.match(request).then((cachedResponse) => {

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -65,14 +65,24 @@ self.addEventListener('fetch', (event) => {
 
     if (request.method !== 'GET') return;
     if (url.hostname !== self.location.hostname) return;
-    if (url.pathname.includes('socket.io')) return;
+
+    // Compare paths case-insensitively, because the routing in front of us is.
+    // Measured: /DOCS/changelog and /Docs/changelog both return the docs with a
+    // 200, byte for byte identical to /docs/changelog. A case-sensitive guard
+    // would let those through to the navigate branch and cache them, which is
+    // the exact leak this file exists to close. Every prefix tested below is a
+    // lowercase literal, so lowercasing the path can only widen a match to a
+    // spelling the server already honours.
+    const path = url.pathname.toLowerCase();
+
+    if (path.includes('socket.io')) return;
     // Never cache API traffic. /api/config carries the runtime server address, so
     // a cached copy would pin the client to a stale one forever. Behind a
     // one-domain reverse proxy the signaling server's own /api/ routes are
     // same-origin too. The allowlist at the bottom would exclude these anyway,
     // but the guard stays explicit because lib/socketUrl.ts documents it as a
     // guarantee its callers depend on.
-    if (url.pathname.startsWith('/api/')) return;
+    if (path.startsWith('/api/')) return;
 
     // The docs are a reverse-proxy rewrite, which makes a third-party site
     // same-origin and therefore ours to break. Mintlify ships its own HTML, its
@@ -82,7 +92,7 @@ self.addEventListener('fetch', (event) => {
     // them. The predicate mirrors the two rewrite rules in next.config.mjs
     // exactly, rather than a bare prefix test that would also swallow a future
     // route like /docsomething.
-    if (url.pathname === '/docs' || url.pathname.startsWith('/docs/')) return;
+    if (path === '/docs' || path.startsWith('/docs/')) return;
 
     if (request.mode === 'navigate') {
         event.respondWith(
@@ -109,7 +119,7 @@ self.addEventListener('fetch', (event) => {
     // /_next/image, the ?_rsc= payloads, sitemap.xml, robots.txt, the web app
     // manifest and the hash-suffixed icon routes. All of it goes to the network
     // exactly as it would with no worker registered at all.
-    if (!url.pathname.startsWith('/_next/static/')) return;
+    if (!path.startsWith('/_next/static/')) return;
 
     event.respondWith(
         caches.match(request).then((cachedResponse) => {

--- a/client/public/sw.js
+++ b/client/public/sw.js
@@ -75,7 +75,12 @@ self.addEventListener('fetch', (event) => {
     // spelling the server already honours.
     const path = url.pathname.toLowerCase();
 
-    if (path.includes('socket.io')) return;
+    // Match a whole path segment rather than a substring. Still loose enough to
+    // survive a reverse proxy mounting the transport under a prefix, but it no
+    // longer matches an unrelated route that merely contains the letters, and it
+    // clears the CodeQL incomplete-url-substring-sanitization warning this line
+    // has carried since it was written.
+    if (path.split('/').includes('socket.io')) return;
     // Never cache API traffic. /api/config carries the runtime server address, so
     // a cached copy would pin the client to a stale one forever. Behind a
     // one-domain reverse proxy the signaling server's own /api/ routes are
@@ -98,10 +103,18 @@ self.addEventListener('fetch', (event) => {
         event.respondWith(
             fetch(request)
                 .then((response) => {
-                    const responseClone = response.clone();
-                    caches.open(CACHE_NAME).then((cache) => {
-                        cache.put(request, responseClone);
-                    });
+                    // Only refresh the offline copy from an answer worth keeping.
+                    // Without this, a captive portal answering 200 with its login
+                    // page, or an edge 5xx during a deploy, overwrites the
+                    // precached document and becomes this visitor's offline
+                    // fallback until the next cache rename. An opaqueredirect is
+                    // excluded too, since its ok is false.
+                    if (response.ok) {
+                        const responseClone = response.clone();
+                        caches.open(CACHE_NAME).then((cache) => {
+                            cache.put(request, responseClone);
+                        });
+                    }
                     return response;
                 })
                 .catch(() => caches.match(request))

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Changelog"
 description: "Release history for Floe: every user-visible change to the web app at floe.one, the Floe Desktop app for Windows, and the floe command-line tool."
+rss: true
 ---
 
 {/*

--- a/docs/style.css
+++ b/docs/style.css
@@ -16,9 +16,13 @@
 
    The selector is NOT documented by Mintlify, which explicitly disclaims the
    stability of its styling hooks. Verified against the rendered DOM of
-   floe.one/docs/changelog on 2026-08-08: 36 update-tag spans, exactly matching
+   floe.one/docs/changelog on 2026-08-08: 43 update-tag spans, exactly matching
    the tag strings in the MDX, and distinct from the filter-panel chips. If the
    separators ever vanish, re-read the rendered DOM and update this selector.
+
+   Take that count on a hard reload. This note first recorded 36, which was the
+   number a stale service-worker copy of the page rendered, not the number in the
+   MDX at the time. See client/public/sw.js, whose v5 stops caching /docs at all.
 
    The separator hangs off the END of each tag but the last, rather than the
    start of each tag but the first. Both render identically on one line, but


### PR DESCRIPTION
﻿## Summary

**This is a service worker change, so read the rollback note at the bottom before merging.**

Clicking "Changelog" in the docs sidebar did nothing, or showed content from weeks ago. The cause was not Mintlify. `client/public/sw.js` is registered from the origin root with no `scope`, so it controls all of `www.floe.one`, and since the docs subpath migration that includes `/docs`, which is a reverse-proxy rewrite and therefore same-origin. Everything that was not a document navigation was served cache-first, forever, with no expiry and no revalidation.

Measured in a browser on the live site, same URL key `/docs/changelog?_rsc=J6c4qteBDi_nDJmH`:

| source | bytes | Mintlify deployment | content |
| --- | --- | --- | --- |
| service worker cache | 141,741 | `dpl_HerRhu...` | had `Unreleased`, no v1.10.0 |
| network | 159,584 | `dpl_Evckus...` | current |

230 `/docs` entries were cached across three different deployments. The origin and the proxy were healthy and current throughout, which is why this never showed up in any server-side check.

### It was not only /docs

The same branch froze `/_next/image` (a live optimizer), `sitemap.xml`, `robots.txt`, the web app manifest, and the App Router's own `?_rsc=` payloads for floe.one's own pages.

That last one is worse than stale text and is the reason this is worth fixing properly. A cached `?_rsc=` payload names chunks from the deployment that produced it, which is exactly the stale-chunk error `client/lib/staleBundle.ts` reloads to escape. A reload cannot clear the Cache API, so the navigate branch returned fresh HTML while the cached payload threw the same error again, and the 10 second debounce then suppressed the retry. The worker was manufacturing the failure that module exists to recover from, and then disabling its remedy.

## What changed

`sw.js` v5 replaces the denylist with an allowlist:

```
non-GET                  -> network
cross-host               -> network
socket.io                -> network
/api/                    -> network
/docs, /docs/...         -> network            <- new
mode === 'navigate'      -> network-first, precache fallback  (unchanged)
/_next/static/...        -> cache-first        <- the allowlist
everything else          -> network            <- new
```

Cache-first now applies only to `/_next/static`, the one path where Next fingerprints the filename with a hash of the contents, so a changed file gets a new URL rather than a new answer at the old one. The `/docs` guard sits above the navigate branch on purpose: below it, docs pages still get cached as navigations. Its predicate mirrors the two rewrite rules in `next.config.mjs` exactly rather than a bare prefix test, so a future `/docsomething` route is not swept up.

Renaming the cache to `floe-cache-v5` is the purge. `activate` already deletes every cache that is not the current one, so returning visitors lose the roughly 15 MB of frozen entries on their next load.

Also drops `/github-mark-white.png` from the precache. It could never be a hit, because the footer requests it through `next/image`.

Two docs fixes ride along: `rss: true` on the changelog, whose feed existed at `/docs/changelog/rss.xml` but was advertised nowhere, and a correction to `docs/style.css`, whose "36 update-tag spans" note recorded what a stale cached copy of the page rendered rather than what was in the MDX (41 at that commit, 43 today).

## Test plan

`client/lib/serviceWorker.test.ts` is new and is the first test this file has ever had. It reads the worker as text, evaluates it against a fake `self`, `caches` and `fetch`, and asserts the whole routing table. The worker has exactly two outcomes per request, so "respondWith was never called" is a complete statement of "not cached".

- 33 cases pass against v5.
- **16 of the 33 fail against v4**, so the test genuinely guards the behaviour rather than describing it.

End-to-end A/B against a local production build (`next start`, since the worker only registers when `NODE_ENV === 'production'`):

1. **Baseline, v4.** Visited a docs page and clicked Changelog. 43 `/docs` entries landed in `floe-cache-v4`. Overwrote the cached RSC payload with an equal-length marker (`v1.10.0` to `v9.99.9`, so the Flight length prefixes stay valid), then navigated away and clicked Changelog again. The page rendered `v9.99.9`. Bug reproduced deterministically.
2. **Upgrade.** With the poisoned v4 cache still installed, deployed v5 and let the browser do its normal update check. `floe-cache-v4` was deleted and replaced by `floe-cache-v5` with no user action.
3. **After.** Same click. The marker was gone, real `v1.10.0` and `desktop-v0.2.2` rendered, and the cache held 0 `/docs` entries, 0 `?_rsc=` payloads and 0 `/_next/image` entries.
4. **Allowlist.** After browsing the app, the cache held exactly 14 `/_next/static` entries plus the 5 precached navigations, and nothing else.
5. **Offline.** Stopped the server and reloaded `/download`. It still rendered from the precache.

`pnpm lint` exits 0 (`sw.js` is linted), `pnpm test` passes 185 tests across 19 files, `pnpm build` succeeds.

## Rollback

**Forward-fix, not a Vercel rollback.** Rolling v5 back to v4 would make v4's `activate` delete the v5 cache and start refilling the over-broad one, re-introducing the exact staleness. If v5 itself turns out to be broken, ship a `/sw.js` with no fetch handler that purges all caches and calls `self.registration.unregister()`. A broken worker can never make itself unreachable, because the browser fetches `/sw.js` for update checks with service-workers mode `none`.

Propagation is at most two page loads: `register()` triggers a soft update on every load, and `skipWaiting()` plus `clients.claim()` mean the new worker takes over without waiting for tabs to close.

A bad worker here cannot touch WebRTC data channels or the Socket.IO WebSocket (neither is dispatched to fetch handlers), anything cross-origin, the CLI, the desktop app, or first-time visitors.

## Follow-up found while testing, not fixed here

`client/components/ServiceWorkerRegistration.tsx` attaches its `load` listener inside `useEffect`. When hydration finishes after the `load` event has already fired, which is the common case on a fast or warm load, the listener is attached too late and the worker never registers at all. Reproduced locally: `readyState` was `complete`, zero registrations, and dispatching a synthetic `load` immediately produced one. It does not undermine this PR, because returning visitors already hold a registration that auto-updates, but it means some first-time visitors never get a worker. Worth its own change.

## Changes made after independent review

An adversarial review pass ran against the first commit. Three things came out of it:

- **The `/docs` guard was case-sensitive; the rewrite it mirrors is not.** Measured on production: `/DOCS/changelog` and `/Docs/changelog` both return the docs with a 200, byte for byte identical to the lowercase spelling, because Next compiles custom-route sources case-insensitively while filesystem routes stay case-sensitive. A miscased docs navigation would have fallen through to the navigate branch and been cached. All path guards now compare a lowercased path; every prefix they test is a lowercase literal, so this can only widen a match to a spelling the server already honours. Four cases added to the test.
- **CodeQL.** `js/incomplete-url-substring-sanitization` on the `socket.io` guard. The alert is pre-existing and was the only open one on `main` (at `sw.js:43` there); moving the line made CodeQL re-attribute it to this PR. Fixed rather than dismissed, by comparing whole path segments for equality instead of testing the path for a substring, which is also more precise and still survives a reverse proxy mounting the transport under a prefix. Merging this takes the repo to zero open alerts.
- **The navigate branch cached any answer, including non-200.** Pre-existing, and it undercut the one guarantee the precache exists to give: a captive portal answering 200 with its login page, or an edge 5xx during a deploy, would replace the precached document and become that visitor's offline fallback until the next cache rename. Now gated on `response.ok`, which also excludes an opaqueredirect.

Two review findings were deliberately not acted on. Offline availability of `/_next/image` rasters and `/ms-store-badge.svg` is genuinely lost, but both are decorative or already-inert offline (the badge links to an external Microsoft URL), and re-adding them to a cache-first allowlist would reintroduce the exact pathology this change exists to kill, since neither has an immutability contract. Losing offline client-side navigation and offline docs reading is the intended trade, not a cost: both existed only as an accident of the denylist, and what offline docs served was third-party content pinned to a dead deployment.
