### PR TITLE
ci: pin the GoReleaser binary instead of tracking the v2 range

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,19 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
-          version: '~> v2'
+          # Exact version, not a '~> v2' range, for two reasons. A range downloads
+          # whatever 2.x exists when a tag is pushed, and that binary runs in the
+          # step carrying TAP_GITHUB_TOKEN, so a concrete version is the only thing
+          # keeping an unreviewed release out of here. A range also resolves the tag
+          # through goreleaser.com/releases.json, a non-GitHub host whose answer is
+          # concatenated straight into the download URL; an exact semver skips that
+          # lookup entirely. The action checksums the download either way, but
+          # checksums.txt ships from the release it verifies, so it catches a
+          # corrupted download rather than a bad release.
+          # v2.17.1 built v1.10.0, so this changes nothing about today's output.
+          # Dependabot keeps `uses:` refs current but not action inputs, so bump
+          # this line by hand when a release needs a newer GoReleaser.
+          version: 'v2.17.1'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`release.yml` pins the goreleaser-action to a commit SHA, but passed `version: '~> v2'`, so the GoReleaser **binary** was still resolved at run time to whatever 2.x happened to be newest. That binary runs in the step carrying `TAP_GITHUB_TOKEN`, a PAT with write access to the shared `homebrew-tap`, `scoop-bucket`, and `winget-pkgs` fork, which are reused by every project. Each release adopted a new GoReleaser with no review, and nothing recorded which one ran.

A range costs more than it first appears. Reading the action at the SHA we pin (`f06c13b`), `getReleaseTag()` only short-circuits when the version is a concrete semver. With a range it falls through to `resolveVersion()`, which fetches `goreleaser.com/releases.json`, a non-GitHub host, and the tag it returns is concatenated into the download URL. An exact version skips that lookup entirely, so the release path talks only to github.com.

The action checksums the download either way, but `checksums.txt` ships from the release it verifies, so it guards against a corrupted download rather than a bad release. (Its cosign path exists but no-ops here, since `cosign` is not on the runner's PATH.)

This pins `v2.17.1`, the version that actually built v1.10.0, so the shipped output does not change.

## Test plan

Run against the exact pinned binary, SHA-256 verified against the published `checksums.txt`:

- `goreleaser check`: 1 configuration file validated, exit 0
- `goreleaser release --snapshot --clean`: exit 0, producing 6 binaries, 6 archives, `checksums.txt`, and the winget, Homebrew cask, and Scoop manifests
- `actionlint` v1.7.12 across all workflows: exit 0

`release.yml` is tag-triggered, so CI cannot exercise it on a PR. The snapshot run above is the closest equivalent short of cutting a release.

## Notes

Dependabot keeps `uses:` refs current but not action inputs, so this line is bumped by hand. That is recorded in a comment at the call site so the next reader does not assume it is automated.

GoReleaser's releases report `immutable: true`, so the pinned assets cannot be swapped after the fact. The pin's job is choosing *which* release runs, not protecting the one that does.
