### PR TITLE
feat: unify the footer across floe.one and the docs

### DIFF
--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import type { Metadata } from 'next';
 import { ArrowLeft, Zap, Server, ShieldCheck, BookOpen } from 'lucide-react';
 import Link from 'next/link';
+import { Footer } from '@/components/layout/Footer';
 
 // This page is static prose: no hooks, no state, no event handlers, no browser
 // APIs. It carried 'use client' until 2026-07, which forced the whole body into
@@ -18,8 +19,10 @@ export const metadata: Metadata = {
 
 export default function HowItWorks() {
     return (
-        <div className="min-h-dvh bg-zinc-950 text-zinc-100 font-sans p-6 md:p-12">
-            <div className="max-w-3xl mx-auto space-y-8">
+        // Same centering flex shell as / and /download, so the shared <Footer />
+        // gets identical width math on every page that renders it.
+        <div className="flex min-h-dvh flex-col items-center bg-zinc-950 font-sans text-zinc-100 px-[max(1rem,env(safe-area-inset-left),env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-[max(1.5rem,env(safe-area-inset-left),env(safe-area-inset-right))] sm:pb-[max(1.5rem,env(safe-area-inset-bottom))]">
+            <div className="w-full max-w-3xl space-y-8 pt-6 md:pt-12">
                 <div className="space-y-4">
                     <Link
                         href="/"
@@ -142,15 +145,9 @@ export default function HowItWorks() {
                     </div>
                 </div>
 
-                {/* Footer nav */}
-                <div className="pt-4 border-t border-white/5 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-[10px] text-zinc-500 uppercase tracking-wide">
-                    <a href="https://www.floe.one/docs" target="_blank" rel="noreferrer" className="whitespace-nowrap hover:text-white transition-colors">Docs</a>
-                    <span>•</span>
-                    <Link href="/privacy" className="whitespace-nowrap hover:text-white transition-colors">Privacy Policy</Link>
-                    <span>•</span>
-                    <Link href="/terms" className="whitespace-nowrap hover:text-white transition-colors">Terms of Use</Link>
-                </div>
             </div>
+
+            <Footer />
         </div>
     );
 }

--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -35,11 +35,6 @@ export default function PrivacyPolicy() {
             title="Privacy policy"
             updated="Last updated: August 2026"
             toc={toc}
-            footerLinks={[
-                { name: 'Home', href: '/' },
-                { name: 'How it works', href: '/how-it-works' },
-                { name: 'Terms', href: '/terms' },
-            ]}
             intro={
                 <LegalCallout label="The short version" tone="positive">
                     <p>

--- a/client/app/terms/page.tsx
+++ b/client/app/terms/page.tsx
@@ -31,11 +31,6 @@ export default function TermsOfUse() {
             title="Terms of use"
             updated="Effective date: May 2026"
             toc={toc}
-            footerLinks={[
-                { name: 'Home', href: '/' },
-                { name: 'How it works', href: '/how-it-works' },
-                { name: 'Privacy', href: '/privacy' },
-            ]}
             intro={
                 <LegalCallout label="Disclaimer" tone="caution">
                     <p>

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -3,6 +3,9 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Heart } from 'lucide-react';
 
+// The four columns mirror the docs footer in docs/docs.json exactly (same
+// headers, same labels, same destinations), so the two surfaces never drift.
+// Change them together or not at all.
 const columns: {
     label: string;
     links: { name: string; href: string; external?: boolean }[];
@@ -10,27 +13,40 @@ const columns: {
     {
         label: 'Product',
         links: [
+            { name: 'Floe', href: '/' },
             { name: 'Download', href: '/download' },
-            { name: 'How it works', href: '/how-it-works' },
-            { name: 'FAQ', href: '/#faq' },
-            { name: 'Docs', href: 'https://www.floe.one/docs', external: true },
-            { name: 'Changelog', href: 'https://www.floe.one/docs/changelog', external: true },
+            { name: 'How It Works', href: '/how-it-works' },
         ],
     },
     {
-        label: 'CLI',
+        label: 'Documentation',
         links: [
-            { name: 'Installation', href: 'https://www.floe.one/docs/cli/installation', external: true },
-            { name: 'Commands & flags', href: 'https://www.floe.one/docs/cli/flags', external: true },
-            { name: 'Self-hosted server', href: 'https://www.floe.one/docs/cli/self-hosted-server', external: true },
+            { name: 'Quickstart', href: 'https://www.floe.one/docs/quickstart', external: true },
+            { name: 'Web App', href: 'https://www.floe.one/docs/web-app/sending', external: true },
+            { name: 'CLI', href: 'https://www.floe.one/docs/cli/installation', external: true },
+            { name: 'Desktop App', href: 'https://www.floe.one/docs/desktop/installation', external: true },
+            { name: 'Self-Hosting', href: 'https://www.floe.one/docs/self-hosting/overview', external: true },
+            { name: 'FAQ', href: 'https://www.floe.one/docs/faq', external: true },
+            { name: 'Changelog', href: 'https://www.floe.one/docs/changelog', external: true },
         ],
     },
     {
         label: 'Project',
         links: [
             { name: 'GitHub', href: 'https://github.com/jannskiee/floe', external: true },
-            { name: 'Self-hosting', href: 'https://www.floe.one/docs/self-hosting/overview', external: true },
-            { name: 'Security & privacy', href: 'https://www.floe.one/docs/security-privacy', external: true },
+            { name: 'Releases', href: 'https://github.com/jannskiee/floe/releases', external: true },
+            { name: 'Report an Issue', href: 'https://github.com/jannskiee/floe/issues', external: true },
+            { name: 'Contributing', href: 'https://github.com/jannskiee/floe/blob/main/CONTRIBUTING.md', external: true },
+            { name: 'Sponsor', href: 'https://github.com/sponsors/jannskiee', external: true },
+        ],
+    },
+    {
+        label: 'Legal',
+        links: [
+            { name: 'Privacy Policy', href: '/privacy' },
+            { name: 'Terms of Use', href: '/terms' },
+            { name: 'Security Policy', href: 'https://github.com/jannskiee/floe/security/policy', external: true },
+            { name: 'License (MIT)', href: 'https://github.com/jannskiee/floe/blob/main/LICENSE', external: true },
         ],
     },
 ];
@@ -38,10 +54,12 @@ const columns: {
 export function Footer() {
     return (
         <footer className="mt-24 w-full max-w-5xl border-t border-white/[0.06] pt-12 pb-10">
-            {/* lg, not md: at 768 the 12-col split + gap-12 leaves ~112px link
-                columns, NARROWER than the same cells in the sm 3-col layout. */}
+            {/* lg, not md: at 768 the 12-col split + gap-12 would leave ~92px
+                link columns, which cannot hold the one-word DOCUMENTATION
+                header (~114px at 11px mono with 0.2em tracking). Below lg the
+                identity block stacks above a full-width link row instead. */}
             <div className="grid gap-12 lg:grid-cols-12">
-                <div className="lg:col-span-5">
+                <div className="lg:col-span-4">
                     <p className="text-lg font-extrabold tracking-tighter text-white">Floe</p>
                     <p className="mt-3 max-w-xs text-sm leading-relaxed text-zinc-500">
                         Open-source, peer-to-peer file transfer. <span className="whitespace-nowrap">MIT licensed.</span>
@@ -73,7 +91,12 @@ export function Footer() {
                         </a>
                     </div>
                 </div>
-                <div className="grid grid-cols-2 gap-8 sm:grid-cols-3 lg:col-span-7">
+                {/* md, not sm, for the 4-across step: at 640 four tracks are
+                    ~124px, within 10px of the DOCUMENTATION header; from 768
+                    they are 156px+, and at lg the col-span-8 split keeps them
+                    at ~135px or wider. Below md the four columns fall back to
+                    the standard 2x2. */}
+                <div className="grid grid-cols-2 gap-8 md:grid-cols-4 lg:col-span-8">
                     {columns.map((column) => (
                         <div key={column.label}>
                             <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-zinc-600">
@@ -106,16 +129,10 @@ export function Footer() {
                     ))}
                 </div>
             </div>
-            <div className="mt-12 flex flex-col items-center justify-between gap-3 border-t border-white/[0.06] pt-6 text-xs text-zinc-600 sm:flex-row">
+            {/* The Legal column above owns Privacy/Terms now, so the bar keeps
+                only the copyright line. */}
+            <div className="mt-12 border-t border-white/[0.06] pt-6 text-center text-xs text-zinc-600 sm:text-left">
                 <p>&copy; {new Date().getFullYear()} Floe. Built on WebRTC.</p>
-                <div className="flex gap-5">
-                    <Link href="/privacy" className="transition-colors hover:text-zinc-300 focus-visible:outline-2 focus-visible:outline-ice">
-                        Privacy
-                    </Link>
-                    <Link href="/terms" className="transition-colors hover:text-zinc-300 focus-visible:outline-2 focus-visible:outline-ice">
-                        Terms
-                    </Link>
-                </div>
             </div>
         </footer>
     );

--- a/client/components/legal/LegalShell.tsx
+++ b/client/components/legal/LegalShell.tsx
@@ -1,18 +1,19 @@
 import React, { ReactNode } from 'react';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
+import { Footer } from '@/components/layout/Footer';
 
 /**
  * Shared frame for the legal document pages (/privacy, /terms), following the
  * landing design system: mono ice eyebrow, hairline rules, asymmetric 4/8 grid
- * with a sticky on-page nav in the left rail.
+ * with a sticky on-page nav in the left rail. The shared site <Footer /> renders
+ * at the bottom, replacing the private bottom bar this shell used to carry.
  */
 export function LegalShell({
     eyebrow,
     title,
     updated,
     toc,
-    footerLinks,
     intro,
     children,
 }: {
@@ -20,7 +21,6 @@ export function LegalShell({
     title: string;
     updated: string;
     toc: { id: string; label: string }[];
-    footerLinks: { name: string; href: string }[];
     intro?: ReactNode;
     children: ReactNode;
 }) {
@@ -66,20 +66,7 @@ export function LegalShell({
                         <div className={intro ? 'mt-10' : undefined}>{children}</div>
                     </main>
                 </div>
-                <div className="mt-16 flex flex-col items-center justify-between gap-3 border-t border-white/[0.06] pt-6 text-xs text-zinc-600 sm:flex-row">
-                    <p>&copy; {new Date().getFullYear()} Floe. Built on WebRTC.</p>
-                    <div className="flex gap-5">
-                        {footerLinks.map((link) => (
-                            <Link
-                                key={link.name}
-                                href={link.href}
-                                className="transition-colors hover:text-zinc-300"
-                            >
-                                {link.name}
-                            </Link>
-                        ))}
-                    </div>
-                </div>
+                <Footer />
             </div>
         </div>
     );

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -52,15 +52,40 @@
       {
         "header": "Product",
         "items": [
-          { "label": "Floe App", "href": "https://floe.one" },
-          { "label": "How It Works", "href": "https://floe.one/how-it-works" }
+          { "label": "Floe", "href": "https://www.floe.one" },
+          { "label": "Download", "href": "https://www.floe.one/download" },
+          { "label": "How It Works", "href": "https://www.floe.one/how-it-works" }
+        ]
+      },
+      {
+        "header": "Documentation",
+        "items": [
+          { "label": "Quickstart", "href": "https://www.floe.one/docs/quickstart" },
+          { "label": "Web App", "href": "https://www.floe.one/docs/web-app/sending" },
+          { "label": "CLI", "href": "https://www.floe.one/docs/cli/installation" },
+          { "label": "Desktop App", "href": "https://www.floe.one/docs/desktop/installation" },
+          { "label": "Self-Hosting", "href": "https://www.floe.one/docs/self-hosting/overview" },
+          { "label": "FAQ", "href": "https://www.floe.one/docs/faq" },
+          { "label": "Changelog", "href": "https://www.floe.one/docs/changelog" }
+        ]
+      },
+      {
+        "header": "Project",
+        "items": [
+          { "label": "GitHub", "href": "https://github.com/jannskiee/floe" },
+          { "label": "Releases", "href": "https://github.com/jannskiee/floe/releases" },
+          { "label": "Report an Issue", "href": "https://github.com/jannskiee/floe/issues" },
+          { "label": "Contributing", "href": "https://github.com/jannskiee/floe/blob/main/CONTRIBUTING.md" },
+          { "label": "Sponsor", "href": "https://github.com/sponsors/jannskiee" }
         ]
       },
       {
         "header": "Legal",
         "items": [
-          { "label": "Privacy Policy", "href": "https://floe.one/privacy" },
-          { "label": "Terms of Use", "href": "https://floe.one/terms" }
+          { "label": "Privacy Policy", "href": "https://www.floe.one/privacy" },
+          { "label": "Terms of Use", "href": "https://www.floe.one/terms" },
+          { "label": "Security Policy", "href": "https://github.com/jannskiee/floe/security/policy" },
+          { "label": "License (MIT)", "href": "https://github.com/jannskiee/floe/blob/main/LICENSE" }
         ]
       }
     ]

--- a/docs/style.css
+++ b/docs/style.css
@@ -71,3 +71,88 @@
   object-fit: cover;
   object-position: left center;
 }
+
+/* Raise the footer links to WCAG AA.
+
+   Mintlify paints footer links at 50% alpha: gray-950/50 in light, white/50 in
+   dark. Composited over the real footer ground (rgb(255,255,255) light,
+   rgb(14,14,16) dark) that lands on rgb(132,132,132) either way, which is
+   3.74:1 in light. AA wants 4.5:1 for body text, so every footer link on every
+   docs page was failing. Dark was already fine at 5.37:1.
+
+   Measured, 0.56 alpha is the exact break-even in light. This uses 0.62 so a
+   future tweak to the background does not silently drop it back under. Both
+   themes are set explicitly rather than only patching light, so the two stay
+   legible together and neither depends on Mintlify's default.
+
+   No !important is needed: `#footer a` is (1,0,1) against Tailwind's single
+   utility class at (0,1,0), and `.dark #footer a` at (1,1,1) beats the light
+   rule in turn. The Mintlify credit link is excluded here and handled below,
+   because it should stay quieter than the navigation. */
+#footer a:not([href*="mintlify.com"]) {
+  color: rgb(10 10 10 / 0.62);
+}
+
+#footer a:not([href*="mintlify.com"]):hover {
+  color: rgb(10 10 10 / 0.85);
+}
+
+.dark #footer a:not([href*="mintlify.com"]) {
+  color: rgb(255 255 255 / 0.62);
+}
+
+.dark #footer a:not([href*="mintlify.com"]):hover {
+  color: rgb(255 255 255 / 0.85);
+}
+
+/* Mintlify's own credit sits at rgb(159,159,159) on white, which is 2.65:1 and
+   under even the 3:1 floor for non-text. It stays deliberately quieter than the
+   link columns, just no longer invisible. */
+#footer a[href*="mintlify.com"] {
+  color: rgb(110 110 110);
+}
+
+.dark #footer a[href*="mintlify.com"] {
+  color: rgb(140 140 140);
+}
+
+/* The social icon is a CSS mask, so its colour comes from background-color, not
+   color. Mintlify sets `bg-gray-500 dark:bg-gray-600`, which runs the wrong
+   way: the dark variant is the darker one, on the darker ground, giving 2.39:1
+   against the 3:1 that WCAG 1.4.11 wants for a meaningful graphic. Light is
+   already 4.95:1 and is left alone. The aria-hidden guard keeps this off the
+   Mintlify wordmark, which is a real svg rather than a mask. */
+.dark #footer a > svg[aria-hidden='true'] {
+  background-color: rgb(140 140 140);
+}
+
+/* Both inactive theme-switch icons also miss 1.4.11, at 2.39:1 in dark and
+   2.65:1 in light. The active button carries a bg-gray-* chip, so excluding
+   that class leaves the selected state exactly as emphasised as before. */
+#footer button:not([class*='bg-gray']) {
+  color: rgb(110 110 110);
+}
+
+.dark #footer button:not([class*='bg-gray']) {
+  color: rgb(140 140 140);
+}
+
+/* Footer links are 20px tall, so a thumb gets a thin target on a phone. This
+   already passes WCAG 2.5.8 through the spacing exception (36px centre to
+   centre against a 24px circle), so the padding is for comfort rather than
+   conformance. It is padding-block only, so nothing reflows sideways and the
+   16px gap between links is untouched. */
+#footer a[rel='noreferrer'] {
+  padding-block: 2px;
+}
+
+/* The social icon is the one footer link Mintlify ships without rel, so the
+   rule above skips it and it stays a 20px box. Centring it in a 24px one
+   squares it up with the text links without moving anything around it. */
+#footer a:has(> svg[aria-hidden='true']) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  min-height: 24px;
+}


### PR DESCRIPTION
## Summary

One footer content model, rendered by both surfaces: the Mintlify docs footer (`docs/docs.json`) and the floe.one footer (`client/components/layout/Footer.tsx`) now carry the same four columns, and the marketing footer becomes site-wide (it previously rendered on 2 of 5 pages).

| Column | Links |
| --- | --- |
| **Product** | Floe · Download · How It Works |
| **Documentation** | Quickstart · Web App · CLI · Desktop App · Self-Hosting · FAQ · Changelog |
| **Project** | GitHub · Releases · Report an Issue · Contributing · Sponsor |
| **Legal** | Privacy Policy · Terms of Use · Security Policy · License (MIT) |

19 links, all verified live (200), all floe.one destinations on `www` so nothing rides through the apex 307.

## Changes

- **`Footer.tsx`** — four columns from the shared model. Identity/columns rebalanced 5/7 → 4/8: a span-7 cell at `lg` leaves ~113px tracks, 1px under the worst-case unbreakable `DOCUMENTATION` header (~114px at 11px mono, 0.2em tracking); span-8 gives ~135px. The link grid steps 2-across → 4-across at `md` rather than `sm` (640px tracks would be ~124px). Bottom bar drops Privacy/Terms (the Legal column owns them) and keeps only the © line. Identity block untouched.
- **Site-wide footer** — `how-it-works` loses its 3-link mini nav and adopts the same centering shell as `/` and `/download`; `LegalShell` drops its private bottom bar and `footerLinks` prop and mounts the shared Footer for both legal pages. The docs deep-link chip row on how-it-works stays (CTA content, not footer nav).
- **`docs/docs.json`** — Mintlify footer aligned to the same model.
- **`docs/style.css`** — footer accessibility fixes ride along: link contrast **3.74:1 → 5.64:1** in light (was a WCAG AA failure on every docs page) and 5.37 → 7.68:1 in dark; Mintlify credit link 2.65:1 → 5.10:1; the dark-mode social icon token ran the wrong way (2.39:1) and is corrected; all tap targets ≥24px.

Intentional: the homepage `/#faq` footer shortcut is gone — the Navbar FAQ pill still covers it on the homepage, and the Documentation column links the docs FAQ.

## Test plan

- `corepack pnpm lint` / `test` (191/191) / `build` — all green
- Targeted Playwright: `responsive.spec.ts` (5 routes × 17 viewports, 320–2560, no horizontal overflow), `hydration.spec.ts` (all 5 routes), `image-density.spec.ts` — **16/16 pass**
- Docs footer on a local mint build: zero column collisions and zero page overflow at 320/375/640/768/1024/1440 in both themes; `style.css` contrast (0.62 alpha) and 24px tap targets confirmed applied
- All 19 footer links return 200 (GitHub checked with spacing + retry)
- Independent verification by two fresh reviewers: a functional gate (rendered DOM vs the approved table on all 6 pages, independent overflow sweep, diff audit, link liveness) and a design gate (screenshots at 4 viewports × both themes vs "design unchanged, content only")

Full CI (3-OS e2e) runs on this PR since `client/**` is touched.
