### PR TITLE
docs: redesign the docs (sidebar, theme, landing, code blocks)

### DIFF
--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Floe CLI Flags Reference"
+sidebarTitle: "Flags"
 description: "Complete reference for every floe CLI flag, covering the global server, relay and interface options, the receive and update flags, and the environment variables."
 ---
 

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -30,7 +30,7 @@ Floe reads four environment variables. If you run your own signaling server, set
 
 A flag always beats its variable, so you can override the setting for a single command without unsetting anything:
 
-```bash
+```bash macOS and Linux
 export FLOE_SERVER=https://floe.example.com
 floe send photo.jpg                                # uses floe.example.com
 floe send photo.jpg --server https://api.floe.one  # the flag wins, just this once
@@ -38,7 +38,7 @@ floe send photo.jpg --server https://api.floe.one  # the flag wins, just this on
 
 On Windows PowerShell:
 
-```powershell
+```powershell Windows
 $env:FLOE_SERVER = "https://floe.example.com"
 floe send photo.jpg
 ```
@@ -73,13 +73,13 @@ Errors are ignored, so a failed report never changes the outcome of a transfer. 
 
 To opt out for a single transfer, pass `--no-report`:
 
-```bash
+```bash Terminal
 floe receive olive-tiger-castle --no-report
 ```
 
 To opt out permanently, set `FLOE_NO_STATS=1` in your environment (for example in your shell profile):
 
-```bash
+```bash Terminal
 export FLOE_NO_STATS=1
 floe receive olive-tiger-castle
 ```
@@ -92,26 +92,26 @@ In the desktop app the same choice is the **Contribute to global stats** toggle 
 
 Use a local dev server for both sender and receiver:
 
-```bash
+```bash Terminal
 floe send photo.jpg --server http://localhost:3001
 floe receive olive-tiger-castle --server http://localhost:3001
 ```
 
 Disable relay fallback (direct connections only):
 
-```bash
+```bash Terminal
 floe send photo.jpg --no-relay
 ```
 
 Point the browser link at a custom web client:
 
-```bash
+```bash Terminal
 floe send photo.jpg --server https://api.example.com --web https://app.example.com
 ```
 
 Save received files to a specific folder and auto-accept:
 
-```bash
+```bash Terminal
 floe receive olive-tiger-castle -o ~/Downloads -y
 ```
 

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -20,7 +20,7 @@ standard upgrade command for that tool.
 
 <Tabs>
   <Tab title="macOS">
-    ```bash
+    ```bash Terminal
     brew install --cask jannskiee/tap/floe
     ```
 
@@ -30,7 +30,7 @@ standard upgrade command for that tool.
     and choose Open, or run `xattr -dr com.apple.quarantine $(which floe)`.
   </Tab>
   <Tab title="Windows (winget)">
-    ```powershell
+    ```powershell Terminal
     winget install jannskiee.floe
     ```
 
@@ -40,7 +40,7 @@ standard upgrade command for that tool.
     Microsoft's automated PR review completes (usually a few hours after the tag).
   </Tab>
   <Tab title="Windows (scoop)">
-    ```powershell
+    ```powershell Terminal
     scoop bucket add jannskiee https://github.com/jannskiee/scoop-bucket
     scoop install floe
     ```
@@ -58,13 +58,13 @@ upgrades an existing install in place.
 
 <Tabs>
   <Tab title="macOS / Linux">
-    ```bash
+    ```bash Terminal
     curl -fsSL https://floe.one/install.sh | sh
     ```
 
     To install a specific version, using any tag from the
     [releases page](https://github.com/jannskiee/floe/releases):
-    ```bash
+    ```bash Terminal
     curl -fsSL https://floe.one/install.sh | FLOE_VERSION=vX.Y.Z sh
     ```
 
@@ -73,13 +73,13 @@ upgrades an existing install in place.
     `/usr/local/bin` is not writable and `sudo` is unavailable).
   </Tab>
   <Tab title="Windows (PowerShell)">
-    ```powershell
+    ```powershell Terminal
     irm https://floe.one/install.ps1 | iex
     ```
 
     To install a specific version, using any tag from the
     [releases page](https://github.com/jannskiee/floe/releases):
-    ```powershell
+    ```powershell Terminal
     $env:FLOE_VERSION = "vX.Y.Z"; irm https://floe.one/install.ps1 | iex
     ```
 
@@ -93,7 +93,7 @@ upgrades an existing install in place.
 
 If you have Go 1.25 or later installed:
 
-```bash
+```bash Terminal
 go install github.com/jannskiee/floe/cli/cmd/floe@latest
 ```
 
@@ -112,20 +112,20 @@ package managers and the install script above handle this for you.
 
 ## Verify the install
 
-```bash
+```bash Terminal
 floe version
 ```
 
 Expected output:
 
-```
+```text Output
 floe 1.x.x
 Docs: https://www.floe.one/docs
 ```
 
 If you pinned an older version, a third line appears once the update check completes:
 
-```
+```text Output
 Update available: v1.x.x  run `floe update` to upgrade
 ```
 
@@ -138,7 +138,7 @@ version number.
 If you downloaded an archive directly from the [GitHub Releases page](https://github.com/jannskiee/floe/releases),
 each release includes a `checksums.txt` file. To verify:
 
-```bash
+```bash Terminal
 # Download checksums
 curl -LO "https://github.com/jannskiee/floe/releases/download/vX.Y.Z/checksums.txt"
 
@@ -156,7 +156,7 @@ For package manager installs, use the standard upgrade command (`brew upgrade fl
 
 For script or manual installs, run:
 
-```bash
+```bash Terminal
 floe update
 ```
 
@@ -166,7 +166,7 @@ See [Updating floe](/cli/update) for details.
 
 Requires Go 1.25 or later.
 
-```bash
+```bash Terminal
 git clone https://github.com/jannskiee/floe.git
 cd floe/cli
 go build ./cmd/floe

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Install the Floe CLI"
+sidebarTitle: "Installation"
 description: "Install the floe CLI in one command on macOS, Windows, or Linux to send and receive files peer-to-peer from the terminal without an account."
 ---
 

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "floe receive"
 description: "Use the floe receive command to accept files from a peer over an encrypted WebRTC connection using a share code, with no upload or account needed."
 ---
 
-```bash
+```bash floe receive
 floe receive <code | link>
 ```
 
@@ -14,25 +14,25 @@ Joins an existing transfer session as the receiver. Accepts either a short code 
 
 Receive using a short code:
 
-```bash
+```bash Terminal
 floe receive olive-tiger-castle
 ```
 
 Receive using a full link:
 
-```bash
+```bash Terminal
 floe receive "https://floe.one/#room=abc123..."
 ```
 
 Save to a specific directory:
 
-```bash
+```bash Terminal
 floe receive olive-tiger-castle -o ~/Downloads
 ```
 
 Auto-accept without a confirmation prompt:
 
-```bash
+```bash Terminal
 floe receive olive-tiger-castle -y
 ```
 
@@ -40,7 +40,7 @@ floe receive olive-tiger-castle -y
 
 Running `floe receive olive-tiger-castle -o ~/Downloads`:
 
-```
+```text Output
   Connecting to sender...
   Connected
 
@@ -65,7 +65,7 @@ With no `-o` flag, files save to the current directory.
 
 When the first file's metadata arrives, Floe shows a summary of what is incoming and asks for confirmation:
 
-```
+```text Output
   ─────────────────────────────────────────────────
   Incoming   N files · X MB
   ─────────────────────────────────────────────────

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -1,5 +1,6 @@
 ---
 title: "floe receive command"
+sidebarTitle: "floe receive"
 description: "Use the floe receive command to accept files from a peer over an encrypted WebRTC connection using a share code, with no upload or account needed."
 ---
 

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Use the Floe CLI with a Self-Hosted Server"
+sidebarTitle: "Self-hosted server"
 description: "Point the floe CLI at your own self-hosted Floe signaling server instead of floe.one to send and receive files on your own infrastructure."
 ---
 

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -10,7 +10,7 @@ The `floe` CLI connects to `https://api.floe.one` by default. You can point it a
 
 Both sender and receiver must use the same server:
 
-```bash
+```bash Terminal
 floe send photo.jpg --server https://floe.example.com
 floe receive olive-tiger-castle --server https://floe.example.com
 ```
@@ -23,7 +23,7 @@ prints resolves to the same origin and opens the web client correctly.
 If you always use the same server, set it once in your environment instead of
 repeating the flag on every command:
 
-```bash
+```bash Terminal
 export FLOE_SERVER=https://floe.example.com
 floe send photo.jpg
 ```
@@ -38,7 +38,7 @@ The browser link printed by `floe send` defaults to the same origin as `--server
 If your web client lives somewhere else, such as the two-subdomain layout, override
 it with `--web`:
 
-```bash
+```bash Terminal
 floe send photo.jpg --server https://api.your-domain.com --web https://app.your-domain.com
 ```
 
@@ -49,7 +49,7 @@ server, which serves no web app.
 
 To test against a local instance running on the default ports:
 
-```bash
+```bash Terminal
 # Terminal 1 - sender
 floe send photo.jpg --server http://localhost:3001
 

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "floe send"
 description: "Use the floe send command to share files or folders peer-to-peer from your terminal over an encrypted WebRTC connection, with no upload or account."
 ---
 
-```bash
+```bash floe send
 floe send <file|folder> [file|folder...]
 ```
 
@@ -14,19 +14,19 @@ Starts a transfer session as the sender. Floe registers a short code with the si
 
 Send a single file:
 
-```bash
+```bash Terminal
 floe send report.pdf
 ```
 
 Send multiple files at once:
 
-```bash
+```bash Terminal
 floe send photo.jpg video.mp4 notes.txt
 ```
 
 Send an entire folder (transferred recursively):
 
-```bash
+```bash Terminal
 floe send ./project
 ```
 
@@ -34,7 +34,7 @@ floe send ./project
 
 After running `floe send`, Floe shows a summary of what will be sent, then prints a sharing panel:
 
-```
+```text Output
   Sending   3 files · 11.8 MB
   ─────────────────────────────────────────────────
   Code   olive-tiger-castle
@@ -46,7 +46,7 @@ After running `floe send`, Floe shows a summary of what will be sent, then print
 
 Once the recipient connects, Floe negotiates the WebRTC connection and streams each file with a live progress bar:
 
-```
+```text Output
   Connecting...
   Connected
 
@@ -68,7 +68,7 @@ Share the **code** with CLI recipients or the **link** with browser recipients. 
 
 When you send a folder, Floe walks it recursively and preserves the directory structure on the receiving end. The recipient gets the same relative paths inside their output directory.
 
-```bash
+```bash Terminal
 floe send ./documents
 # Transfers documents/report.pdf, documents/images/photo.jpg, etc.
 # Receiver gets: ./documents/report.pdf, ./documents/images/photo.jpg
@@ -76,7 +76,7 @@ floe send ./documents
 
 A trailing slash changes this. Floe names each file relative to the folder's parent, and a trailing slash makes the folder itself the parent, so the folder name drops out and its contents land directly in the receiver's output directory:
 
-```bash
+```bash Terminal
 floe send ./documents/
 # Receiver gets: ./report.pdf, ./images/photo.jpg
 ```

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -1,5 +1,6 @@
 ---
 title: "floe send command"
+sidebarTitle: "floe send"
 description: "Use the floe send command to share files or folders peer-to-peer from your terminal over an encrypted WebRTC connection, with no upload or account."
 ---
 

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -34,7 +34,7 @@ containing one of those words is treated as package-managed too.
 
 Run the built-in update command:
 
-```bash
+```bash Terminal
 floe update
 ```
 
@@ -50,13 +50,13 @@ and moves the new one into place.
 
 To check for an update without installing:
 
-```bash
+```bash Terminal
 floe update --check
 ```
 
 You can also re-run the original install script at any time to upgrade:
 
-```bash
+```bash Terminal
 # macOS / Linux
 curl -fsSL https://floe.one/install.sh | sh
 
@@ -68,7 +68,7 @@ irm https://floe.one/install.ps1 | iex
 
 When a newer release exists, `floe version` prints an extra line:
 
-```
+```text Output
 Update available: v1.x.x  run `floe update` to upgrade
 ```
 

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update the Floe CLI"
+sidebarTitle: "floe update"
 description: "Keep the floe CLI up to date on macOS, Windows, and Linux using the built-in self-update command or by reinstalling the latest release binary."
 ---
 

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -1,5 +1,6 @@
 ---
 title: "floe version command"
+sidebarTitle: "floe version"
 description: "Print the installed floe CLI version and the docs link, plus a one-line update hint when a newer release exists, so you can confirm which build you are running."
 ---
 

--- a/docs/cli/version.mdx
+++ b/docs/cli/version.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "floe version"
 description: "Print the installed floe CLI version and the docs link, plus a one-line update hint when a newer release exists, so you can confirm which build you are running."
 ---
 
-```bash
+```bash floe version
 floe version
 ```
 
@@ -13,14 +13,14 @@ hint when a newer release is available.
 
 ## Output
 
-```
+```text Output
 floe 1.x.x
 Docs: https://www.floe.one/docs
 ```
 
 When a newer release exists, a third line follows:
 
-```
+```text Output
 Update available: v1.x.x  run `floe update` to upgrade
 ```
 
@@ -41,7 +41,7 @@ source report `floe dev` and never check.
 
 You can also use the root flag:
 
-```bash
+```bash Terminal
 floe --version
 # or
 floe -v

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -45,7 +45,7 @@ receives from browser peers and CLI peers without any extra setup.
 
     Or from a terminal:
 
-    ```powershell
+    ```powershell Terminal
     winget install --id 9NBQ8ZQ1065L --source msstore
     ```
 
@@ -92,7 +92,7 @@ receives from browser peers and CLI peers without any extra setup.
 
 Every GitHub release ships `SHA256SUMS.txt`. To check a file you downloaded:
 
-```powershell
+```powershell PowerShell
 Get-FileHash floe-desktop-setup-0.2.1.exe -Algorithm SHA256
 ```
 

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Install Floe Desktop"
+sidebarTitle: "Installation"
 description: "Install Floe Desktop for Windows from the Microsoft Store or a GitHub release, what differs between the two channels, plus updating and uninstalling."
 ---
 

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Floe Desktop Keyboard Shortcuts"
+sidebarTitle: "Keyboard shortcuts"
 description: "Every keyboard shortcut in Floe Desktop for Windows: adding files, sending, pasting from the clipboard, opening history, settings, and starting over."
 ---
 

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Receiving Files with Floe Desktop"
+sidebarTitle: "Receiving files"
 description: "Receive files in Floe Desktop by entering a room code or share link, choosing where they are saved, and opening them as soon as the transfer finishes."
 ---
 

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -50,7 +50,7 @@ When it finishes you get a Windows notification, and the card shows where the fi
 If a file arrives with a name you already have, Floe does not replace it. It adds a number
 before the extension, the same way browser downloads do:
 
-```
+```text Example
 report.pdf
 report (1).pdf
 report (2).pdf

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sending Files with Floe Desktop"
+sidebarTitle: "Sending files"
 description: "Send files, folders, or a typed note from Floe Desktop on Windows by dragging, pasting, or picking them, then sharing a room code, link, or QR code."
 ---
 

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Floe Desktop Settings"
+sidebarTitle: "Settings"
 description: "Every Floe Desktop setting: where received files are saved, Hide my IP, global stats, the File Explorer entry, and pointing the app at your own server."
 ---
 

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -222,7 +222,7 @@ It deliberately leaves alone:
 
 Settings live in a plain JSON file at `%APPDATA%\floe\desktop.json`:
 
-```json
+```json desktop.json
 {
   "server": "",
   "web": "",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -9,14 +9,24 @@
   },
   "favicon": "/favicon.svg",
   "colors": {
-    "primary": "#111111",
-    "light": "#ffffff",
-    "dark": "#111111"
+    "primary": "#00A3C9",
+    "light": "#B1DDEB",
+    "dark": "#00A3C9"
+  },
+  "background": {
+    "color": {
+      "light": "#FFFFFF",
+      "dark": "#09090b"
+    }
+  },
+  "styling": {
+    "codeblocks": "system"
+  },
+  "icons": {
+    "library": "lucide"
   },
   "fonts": {
-    "family": "Geist",
-    "heading": { "family": "Geist" },
-    "body": { "family": "Geist" }
+    "family": "Geist"
   },
   "appearance": {
     "default": "dark",
@@ -93,18 +103,18 @@
   "navigation": {
     "groups": [
       {
-        "group": "Getting Started",
-        "pages": ["introduction", "quickstart", "faq", "troubleshooting"]
+        "group": "Getting started",
+        "pages": ["introduction", "quickstart"]
       },
       {
-        "group": "Web App",
+        "group": "Web",
         "pages": [
           "web-app/sending",
           "web-app/receiving"
         ]
       },
       {
-        "group": "Desktop App",
+        "group": "Desktop",
         "pages": [
           "desktop/installation",
           "desktop/sending",
@@ -117,19 +127,20 @@
         "group": "CLI",
         "pages": [
           "cli/installation",
-          "cli/update",
           "cli/send",
           "cli/receive",
           "cli/version",
+          "cli/update",
           "cli/flags",
           "cli/self-hosted-server"
         ]
       },
       {
-        "group": "Self-Hosting",
+        "group": "Self-hosting",
         "pages": [
           "self-hosting/overview",
           "self-hosting/quickstart",
+          "self-hosting/without-docker",
           "self-hosting/images",
           "self-hosting/unraid",
           "self-hosting/configuration",
@@ -137,26 +148,29 @@
           "self-hosting/reverse-proxy",
           "self-hosting/production",
           "self-hosting/turn-relay",
-          "self-hosting/operations",
-          "self-hosting/without-docker"
+          "self-hosting/operations"
         ]
       },
       {
-        "group": "How It Works",
+        "group": "How it works",
         "pages": [
           "how-it-works/signaling",
           "how-it-works/direct-connection",
           "how-it-works/relay-connection",
           "how-it-works/2gb-limit",
-          "how-it-works/encryption"
+          "how-it-works/encryption",
+          "security-privacy"
         ]
+      },
+      {
+        "group": "Help",
+        "pages": ["faq", "troubleshooting"]
       },
       {
         "group": "Reference",
         "pages": [
-          "changelog",
-          "security-privacy",
-          "reference/architecture"
+          "reference/architecture",
+          "changelog"
         ]
       }
     ]

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -26,7 +26,7 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
   <Accordion title="Can I send multiple files or a whole folder?">
     Yes, with one caveat about folders. In the browser you can select or drop multiple files, but not a folder: the web app has no folder picker, and dropping a folder does not add its contents. The CLI and Floe Desktop can send whole folders. Pass file or folder paths to `floe send`, or drop a folder onto Floe Desktop.
 
-    ```bash
+    ```bash Terminal
     floe send file1.pdf file2.jpg notes/
     ```
 
@@ -193,12 +193,12 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
     **Browser:** Uncheck "Contribute to global stats" on the receiver view before the first file arrives. The checkbox is hidden once files start landing. The preference is saved in your browser and applies to all future transfers from that device.
 
     **CLI - single transfer:**
-    ```bash
+    ```bash Terminal
     floe receive olive-tiger-castle --no-report
     ```
 
     **CLI - permanent (add to your shell profile):**
-    ```bash
+    ```bash Terminal
     export FLOE_NO_STATS=1
     ```
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Floe FAQ"
+sidebarTitle: "FAQ"
 description: "Answers to common questions about Floe: how peer-to-peer file transfer works, file size limits, privacy, WebRTC, and using Floe without an account."
 ---
 

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -1,5 +1,6 @@
 ---
 title: "The 2 GB Relay Limit"
+sidebarTitle: "2 GB limit"
 description: "Why Floe caps relayed transfers at 2 GB per session, how the limit protects the shared TURN server, and how direct peer-to-peer transfers avoid it."
 ---
 

--- a/docs/how-it-works/direct-connection.mdx
+++ b/docs/how-it-works/direct-connection.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Direct Peer-to-Peer Connection"
+sidebarTitle: "Direct connection"
 description: "How Floe uses STUN and ICE to open a direct WebRTC data channel between two peers so files transfer without ever touching a server."
 ---
 

--- a/docs/how-it-works/encryption.mdx
+++ b/docs/how-it-works/encryption.mdx
@@ -1,5 +1,6 @@
 ---
 title: "End-to-End Encryption in Floe"
+sidebarTitle: "Encryption"
 description: "How Floe uses WebRTC DTLS to end-to-end encrypt every file transfer so neither the signaling server nor the TURN relay can read your data."
 ---
 

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -1,5 +1,6 @@
 ---
 title: "TURN Relay Fallback Connection"
+sidebarTitle: "Relay fallback"
 description: "How Floe falls back to a TURN server as an encrypted bridge when strict NAT or firewalls block a direct peer-to-peer WebRTC connection."
 ---
 

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -35,7 +35,7 @@ Even through a relay, your files are protected by **DTLS encryption** built into
 
 If you need to ensure files never pass through a relay, you can disable it. In the browser, toggle off **Network relay fallback** before creating the link (the toggle appears once you have picked files, just above the Create secure link button). In the CLI, pass `--no-relay`:
 
-```bash
+```bash Terminal
 floe send photo.jpg --no-relay
 ```
 

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How Floe Signaling Works"
+sidebarTitle: "Signaling"
 description: "How the Floe signaling server brokers the initial WebRTC handshake between sender and receiver without ever seeing the files being transferred."
 ---
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -6,8 +6,6 @@ keywords: ["overview", "getting started", "p2p file transfer", "webrtc"]
 boost: 3
 ---
 
----
-
 <Columns cols={2}>
   <Card title="Quickstart" icon="zap" href="/quickstart">
     Send your first file in under a minute.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,37 +1,38 @@
 ---
-title: "Introduction to Floe"
-description: "Floe is a secure, encrypted peer-to-peer file transfer tool that sends files directly between devices over WebRTC, with no accounts and no uploads."
+title: "Your files never make a stop."
+sidebarTitle: "Introduction"
+description: "Floe moves files straight between devices over WebRTC. These docs cover the web app, the desktop app, the CLI, and running your own instance."
+keywords: ["overview", "getting started", "p2p file transfer", "webrtc"]
+boost: 3
 ---
 
-Floe transfers files directly between devices using WebRTC. Files are end-to-end encrypted and never stored on any server. The signaling server only brokers the initial connection setup. Once both peers are connected, it steps aside and no file data passes through it.
+---
 
-## What Floe does
-
-- **Direct, peer-to-peer transfers.** Files travel straight from your device to the recipient's device.
-- **End-to-end encrypted.** Every transfer is encrypted with DTLS. No one, including Floe's servers, can read your files.
-- **No accounts or storage.** No sign-up, no uploads, and no file names or contents ever sent to a server. After a transfer, floe.one adds an anonymous byte count to its public counter, which the receiver can switch off, and the site itself records cookieless aggregate analytics and error reports. The desktop app and the CLI carry no analytics at all. See [Security and Privacy](/security-privacy).
-- **No size limit on direct transfers.** Relay connections are capped at 2 GB per session to keep the service free. A browser receiver holds each incoming file in memory until that file is complete, so very large files are bounded by the receiving device's RAM. The desktop app and the CLI write straight to disk and have no such ceiling.
-- **Browser, desktop, and CLI.** Use the web app at floe.one, Floe Desktop for Windows, or the `floe` command-line tool. All three speak the same protocol, so any two of them can transfer to each other.
-- **Open source and self-hostable.** Run your own instance on your own infrastructure with Docker Compose.
-
-## Use Floe
-
-<CardGroup cols={3}>
-  <Card title="Browser" icon="globe" href="https://floe.one">
-    Open floe.one in any modern browser. No installation required.
+<Columns cols={2}>
+  <Card title="Quickstart" icon="zap" href="/quickstart">
+    Send your first file in under a minute.
   </Card>
-  <Card title="Desktop" icon="desktop" href="/desktop/installation">
-    Floe Desktop for Windows, from the Microsoft Store. Beta.
+  <Card title="Web app" icon="globe" href="/web-app/sending">
+    Send and receive in the browser at floe.one.
+  </Card>
+  <Card title="Desktop app" icon="monitor" href="/desktop/installation">
+    Get Floe Desktop for Windows. Beta.
   </Card>
   <Card title="CLI" icon="terminal" href="/cli/installation">
-    Install the `floe` binary for headless, scriptable transfers.
+    Install the `floe` binary and script your transfers.
   </Card>
-</CardGroup>
+  <Card title="Self-hosting" icon="server" href="/self-hosting/overview">
+    Run your own instance with Docker Compose.
+  </Card>
+  <Card title="Changelog" icon="history" href="/changelog">
+    Every release across web, desktop, and CLI.
+  </Card>
+</Columns>
 
-## Common questions
+---
 
-Common questions about file size, browser support, in-app browsers, iOS, speed, and accounts are answered in the [FAQ](/faq).
+**Encrypted end to end.** DTLS protects every transfer; no one, including Floe's servers, can read your files. See [Security & privacy](/security-privacy).
 
-## Self-hosting
+**No accounts, no uploads.** The signaling server only brokers the connection, then steps aside.
 
-You can run your own Floe instance on your own infrastructure using Docker Compose. See the [Self-Hosting](/self-hosting/overview) section.
+**No size limit on direct transfers.** Relayed sessions are capped at 2 GB to keep the service free. See [the 2 GB limit](/how-it-works/2gb-limit).

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,9 @@
 ---
 title: "Floe Quick Start"
+sidebarTitle: "Quickstart"
 description: "Send your first file with Floe in under a minute from the browser, Floe Desktop, or the command line, using peer-to-peer WebRTC with no signup required."
+keywords: ["quickstart", "get started", "send a file", "first transfer", "setup"]
+boost: 3
 ---
 
 ## Browser

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -65,13 +65,13 @@ boost: 3
     Install with a package manager: `brew install --cask jannskiee/tap/floe` on macOS, `winget install jannskiee.floe` on Windows, or `curl -fsSL https://floe.one/install.sh | sh` on macOS and Linux. See [Installation](/cli/installation) for every option, including scoop, `go install`, and direct binary downloads.
   </Step>
   <Step title="Send">
-    ```bash
+    ```bash Terminal
     floe send photo.jpg
     ```
 
     Floe connects, registers a short code, and prints a sharing panel:
 
-    ```
+    ```text Output
       Sending   photo.jpg · 6.0 MB
       ─────────────────────────────────────────────────
       Code   olive-tiger-castle
@@ -86,13 +86,13 @@ boost: 3
   <Step title="Receive">
     The recipient runs:
 
-    ```bash
+    ```bash Terminal
     floe receive olive-tiger-castle -o ~/Downloads
     ```
 
     Or they can open the link in any browser. Once connected, the CLI shows an incoming summary, a confirmation prompt, and then a live progress bar:
 
-    ```
+    ```text Output
       Connecting to sender...
       Connected
       ─────────────────────────────────────────────────

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Floe Architecture Reference"
+sidebarTitle: "Architecture"
 description: "Reference for the Floe signaling protocol, HTTP endpoints, WebSocket events, and the WebRTC data-channel binary framing used for file transfers."
 ---
 

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -47,7 +47,7 @@ On floe.one the endpoint returns short-lived Cloudflare Realtime TURN credential
 
 For a self-hosted coturn relay, when `TURN_SECRET` and `TURN_DOMAIN` are set it returns:
 
-```json
+```json Response
 [
   { "urls": "stun:turn.your-domain.com:3478" },
   { "urls": "turn:turn.your-domain.com:3478", "username": "...", "credential": "..." },
@@ -57,7 +57,7 @@ For a self-hosted coturn relay, when `TURN_SECRET` and `TURN_DOMAIN` are set it 
 
 When neither Cloudflare nor coturn is configured:
 
-```json
+```json Response
 [
   { "urls": "stun:stun.l.google.com:19302" },
   { "urls": "stun:stun1.l.google.com:19302" }
@@ -142,7 +142,7 @@ Once the WebRTC data channel is open, the sender runs the following sequence for
 
 **Metadata (JSON, sender to receiver)**
 
-```json
+```json Metadata
 {
   "type": "metadata",
   "id": "<uuid>",
@@ -161,7 +161,7 @@ Once the WebRTC data channel is open, the sender runs the following sequence for
 
 **Ack (JSON, receiver to sender)**
 
-```json
+```json Ack
 {
   "type": "ack",
   "id": "<uuid>",
@@ -180,7 +180,7 @@ Both the Go engine (CLI and desktop) and the browser size chunks adaptively to t
 
 **End marker (JSON, sender to receiver)**
 
-```json
+```json End marker
 { "type": "end" }
 ```
 
@@ -188,7 +188,7 @@ Both the Go engine (CLI and desktop) and the browser size chunks adaptively to t
 
 After all files are complete, a Go receiver (the CLI or the desktop app) sends:
 
-```json
+```json Received
 { "type": "received" }
 ```
 
@@ -198,7 +198,7 @@ This lets the sender exit cleanly instead of polling the SCTP buffer. Browser re
 
 Sent in place of the ack when the two peers' protocol version ranges do not overlap (see [Protocol versioning](#protocol-versioning)). It carries a human-readable `reason` plus the receiver's own version range, and `ver` when the receiver knows its release string. As with metadata and acks, Go receivers populate `ver` and browser receivers omit it.
 
-```json
+```json Incompatible
 {
   "type": "incompatible",
   "reason": "Cannot transfer: your floe is too old for this peer. ...",

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Security and Privacy"
+sidebarTitle: "Security & privacy"
 description: "Learn what Floe's signaling server and TURN relay can see, how end-to-end DTLS encryption protects file bytes, and how to opt out of stats."
 ---
 

--- a/docs/self-hosting/build-time-url.mdx
+++ b/docs/self-hosting/build-time-url.mdx
@@ -1,5 +1,6 @@
 ---
 title: "How the Client Finds the Signaling Server"
+sidebarTitle: "Server discovery"
 description: "How a self-hosted Floe web client resolves its signaling server address at runtime with SOCKET_URL, and when a rebuild is still required."
 ---
 

--- a/docs/self-hosting/build-time-url.mdx
+++ b/docs/self-hosting/build-time-url.mdx
@@ -32,7 +32,7 @@ The first match wins.
 
 Set it in `.env` and recreate the container. No rebuild:
 
-```bash
+```bash Terminal
 docker compose up -d
 ```
 
@@ -63,7 +63,7 @@ every self-hosted instance advertising somebody else's site as its canonical.
 
 To put your own domain in them, build the client yourself:
 
-```bash
+```bash Terminal
 NEXT_PUBLIC_SITE_URL=https://files.example.com \
   docker compose -f docker-compose.yml -f docker-compose.build.yml build client
 docker compose -f docker-compose.yml -f docker-compose.build.yml up -d

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -40,7 +40,7 @@ The first case that genuinely needs one is reaching the app from another device 
 
 A typical production `.env` for a deployment with HTTPS and TURN:
 
-```env
+```dotenv .env
 NEXT_PUBLIC_SOCKET_URL=https://api.your-domain.com
 CLIENT_URL=https://app.your-domain.com
 TRUSTED_PROXY_COUNT=1

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Self-Hosted Floe Configuration"
+sidebarTitle: "Configuration"
 description: "Environment variable reference for a self-hosted Floe instance, covering client build-time URLs, CORS, TURN credentials, and stats persistence."
 ---
 

--- a/docs/self-hosting/images.mdx
+++ b/docs/self-hosting/images.mdx
@@ -25,7 +25,7 @@ Both are public, so `docker pull` needs no login.
 
 Pin a tag with `FLOE_IMAGE_TAG`:
 
-```env
+```dotenv .env
 FLOE_IMAGE_TAG=1.10.0
 ```
 
@@ -37,13 +37,13 @@ FLOE_IMAGE_TAG=1.10.0
 
 A tag can be repointed. A digest cannot, so it is the strongest pin:
 
-```bash
+```bash Terminal
 docker buildx imagetools inspect ghcr.io/jannskiee/floe-server:latest
 ```
 
 Take the digest it prints and pin that instead of the tag:
 
-```yaml
+```yaml docker-compose.yml
 services:
   server:
     image: ghcr.io/jannskiee/floe-server@sha256:f7d9ff66...
@@ -55,7 +55,7 @@ Every tag is verified to resolve to a digest that passed a smoke test before it 
 
 Both images are published for **`linux/amd64`** and **`linux/arm64`**. Docker picks the right one automatically, so Raspberry Pi, Oracle Ampere, AWS Graviton, and Apple silicon all work with the same commands as anywhere else.
 
-```bash
+```bash Terminal
 docker buildx imagetools inspect ghcr.io/jannskiee/floe-client:latest
 ```
 
@@ -73,7 +73,7 @@ It lists one entry per platform, so you can confirm your architecture is covered
 
 Contributors, and anyone who wants their own domain in share previews, add the build overlay:
 
-```bash
+```bash Terminal
 docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
 ```
 
@@ -95,7 +95,7 @@ These have to be written into the HTML when the app is built, so a shared image 
 
 To put your own domain in them, build the client yourself:
 
-```bash
+```bash Terminal
 NEXT_PUBLIC_SITE_URL=https://files.example.com \
   docker compose -f docker-compose.yml -f docker-compose.build.yml build client
 docker compose -f docker-compose.yml -f docker-compose.build.yml up -d
@@ -105,7 +105,7 @@ This affects only SEO and link previews. Transfers, the signaling connection, an
 
 ## Updating
 
-```bash
+```bash Terminal
 docker compose pull
 docker compose up -d
 ```

--- a/docs/self-hosting/images.mdx
+++ b/docs/self-hosting/images.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Container Images"
+sidebarTitle: "Container images"
 description: "The prebuilt Floe container images on ghcr.io: names, tags, how to pin a version or a digest, and which architectures are supported."
 ---
 

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Self-Hosted Floe Operations"
+sidebarTitle: "Operations"
 description: "Day-to-day operations for a self-hosted Floe instance: common Compose commands, updating to the latest images, and the health endpoints to point a monitor at."
 ---
 

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -6,7 +6,7 @@ description: "Day-to-day operations for a self-hosted Floe instance: common Comp
 
 ## Common commands
 
-```bash
+```bash Terminal
 docker compose logs -f                  # tail logs for all services
 docker compose ps                       # check container status and health
 docker compose down                     # stop and remove the stack
@@ -15,7 +15,7 @@ docker compose restart server           # restart only the signaling server
 
 ## Update to the latest code
 
-```bash
+```bash Terminal
 docker compose pull
 docker compose up -d
 ```
@@ -24,7 +24,7 @@ That pulls the newest [published images](/self-hosting/images) and restarts. Not
 
 If you run the optional coturn relay, add its profile to both commands or Compose skips the service entirely, so a new coturn image is never pulled and a stopped relay is never restarted:
 
-```bash
+```bash Terminal
 docker compose --profile turn pull
 docker compose --profile turn up -d
 ```

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Self-Hosting Floe Overview"
+sidebarTitle: "Overview"
 description: "Run your own Floe signaling server, web client, and optional TURN relay on your own infrastructure for full control over peer-to-peer file transfer."
 ---
 

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -29,20 +29,20 @@ For a deployment accessible beyond a single machine, follow these steps.
   <Step title="Set NEXT_PUBLIC_SOCKET_URL">
     In `.env`:
 
-    ```env
+    ```dotenv .env
     NEXT_PUBLIC_SOCKET_URL=https://api.your-domain.com
     ```
 
     Then recreate the containers. There is no rebuild: Compose maps this value onto the client container's `SOCKET_URL`, and the browser reads it from `GET /api/config` on every page load.
 
-    ```bash
+    ```bash Terminal
     docker compose up -d
     ```
   </Step>
   <Step title="Set CLIENT_URL">
     In `.env`:
 
-    ```env
+    ```dotenv .env
     CLIENT_URL=https://app.your-domain.com
     ```
 
@@ -51,7 +51,7 @@ For a deployment accessible beyond a single machine, follow these steps.
   <Step title="Set TRUSTED_PROXY_COUNT">
     Set this to the number of proxy hops in front of the signaling server so per-IP rate limiting reads real client IPs instead of proxy IPs:
 
-    ```env
+    ```dotenv .env
     TRUSTED_PROXY_COUNT=1
     ```
 
@@ -60,7 +60,7 @@ For a deployment accessible beyond a single machine, follow these steps.
   <Step title="Point the CLI and the desktop app at your instance">
     A split deployment has two addresses, so both clients need both. The CLI takes them as flags, or as `FLOE_SERVER` and `FLOE_WEB` in the environment:
 
-    ```bash
+    ```bash Terminal
     floe send --server https://api.your-domain.com --web https://app.your-domain.com photo.jpg
     ```
 

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Production Deployment for Self-Hosted Floe"
+sidebarTitle: "Production"
 description: "Deploy a self-hosted Floe instance in production with HTTPS, a reverse proxy, custom domain, WebSocket support, and secure TURN relay credentials."
 ---
 

--- a/docs/self-hosting/quickstart.mdx
+++ b/docs/self-hosting/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Self-Hosting Quick Start"
+sidebarTitle: "Docker quickstart"
 description: "Spin up a local Floe instance with Docker Compose in a few minutes to try self-hosted peer-to-peer file transfer on your own machine before deploying."
 ---
 

--- a/docs/self-hosting/quickstart.mdx
+++ b/docs/self-hosting/quickstart.mdx
@@ -12,13 +12,13 @@ description: "Spin up a local Floe instance with Docker Compose in a few minutes
 
 <Steps>
   <Step title="Download the compose file">
-    ```bash
+    ```bash Terminal
     curl -fsSLO https://raw.githubusercontent.com/jannskiee/floe/main/docker-compose.yml
     ```
     That is the only file you need. There is nothing to clone and no toolchain to install.
   </Step>
   <Step title="Start the stack">
-    ```bash
+    ```bash Terminal
     docker compose up -d
     ```
     Docker pulls the [prebuilt images](/self-hosting/images) and starts the client and server containers. Nothing is compiled locally.
@@ -31,7 +31,7 @@ description: "Spin up a local Floe instance with Docker Compose in a few minutes
 <Tip>
   A `.env` file is optional. Every setting has a working default, so the two commands above are genuinely all you need to try it. To change something, fetch the annotated example alongside the compose file:
 
-  ```bash
+  ```bash Terminal
   curl -fsSL https://raw.githubusercontent.com/jannskiee/floe/main/.env.docker.example -o .env
   ```
 </Tip>
@@ -45,12 +45,12 @@ To support peers behind strict firewalls, symmetric NAT, or CGNAT, add a [TURN r
 <Note>
   The defaults assume the browser and the server are on the same machine. To reach the app from another device on your network, set **both** of these in `.env` to your machine's LAN IP:
 
-  ```env
+  ```dotenv .env
   NEXT_PUBLIC_SOCKET_URL=http://192.168.1.x:3001
   CLIENT_URL=http://192.168.1.x:3000
   ```
 
-  ```bash
+  ```bash Terminal
   docker compose up -d
   ```
 

--- a/docs/self-hosting/reverse-proxy.mdx
+++ b/docs/self-hosting/reverse-proxy.mdx
@@ -44,7 +44,7 @@ instance that sets a non-empty socket URL loses it silently.
     Caddy handles HTTPS certificates and WebSocket upgrades automatically, so the
     whole config is a handful of lines.
 
-    ```caddyfile
+    ```nginx Caddyfile
     floe.example.com {
         # Signaling server: WebSockets, room codes, TURN credentials, health.
         handle /socket.io/* {
@@ -78,7 +78,7 @@ instance that sets a non-empty socket URL loses it silently.
     nginx needs the `Upgrade` and `Connection` headers set explicitly, or the
     WebSocket handshake fails and transfers never start.
 
-    ```nginx
+    ```nginx nginx.conf
     map $http_upgrade $connection_upgrade {
         default upgrade;
         ''      close;
@@ -133,7 +133,7 @@ instance that sets a non-empty socket URL loses it silently.
 Leave the socket URL **empty**. The browser then talks to whatever host it was
 loaded from, which behind this proxy is already the right answer.
 
-```env
+```dotenv .env
 NEXT_PUBLIC_SOCKET_URL=
 CLIENT_URL=https://floe.example.com
 TRUSTED_PROXY_COUNT=1
@@ -143,7 +143,7 @@ TRUSTED_PROXY_COUNT=1
 NEXT_PUBLIC_SITE_URL=https://floe.example.com
 ```
 
-```bash
+```bash Terminal
 docker compose up -d
 ```
 
@@ -170,7 +170,7 @@ signaling server. One reverse proxy means `1`. A CDN in front of that proxy mean
 One address is all the CLI needs. The share link it prints resolves to the same
 origin, so it opens the web client correctly with no extra flag:
 
-```bash
+```bash Terminal
 floe send --server https://floe.example.com photo.jpg
 ```
 
@@ -201,7 +201,7 @@ for the port list and firewall rules.
 
 ## Verify it works
 
-```bash
+```bash Terminal
 # Health check through the proxy.
 curl https://floe.example.com/health
 

--- a/docs/self-hosting/reverse-proxy.mdx
+++ b/docs/self-hosting/reverse-proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Run Floe Behind One Domain"
+sidebarTitle: "Reverse proxy"
 description: "Serve the Floe web client and signaling server from a single domain with a reverse proxy, including copy-pasteable Caddy and nginx configuration for WebSocket support."
 ---
 

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -19,7 +19,7 @@ Cloudflare's Realtime TURN service runs on Cloudflare's global anycast network. 
   <Step title="Set the server environment">
     In `.env`:
 
-    ```env
+    ```dotenv .env
     CLOUDFLARE_TURN_KEY_ID=<your Turn Token ID>
     CLOUDFLARE_TURN_KEY_API_TOKEN=<your API token>
     ```
@@ -42,7 +42,7 @@ TURN requires a **public IP address**, a **domain name**, and **TLS certificates
 
 <Steps>
   <Step title="Create the coturn config">
-    ```bash
+    ```bash Terminal
     curl -fsSL --create-dirs -o coturn/turnserver.conf \
       https://raw.githubusercontent.com/jannskiee/floe/main/coturn/turnserver.conf.example
     ```
@@ -65,7 +65,7 @@ TURN requires a **public IP address**, a **domain name**, and **TLS certificates
 
     The certificate mount is shipped commented out too. Uncomment it in `docker-compose.yml` so the paths you just set in `turnserver.conf` exist inside the container:
 
-    ```yaml
+    ```yaml docker-compose.yml
     volumes:
       - ./coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro
       - ./coturn/certs:/etc/coturn/certs:ro
@@ -76,7 +76,7 @@ TURN requires a **public IP address**, a **domain name**, and **TLS certificates
   <Step title="Match the server environment">
     In `.env`:
 
-    ```env
+    ```dotenv .env
     TURN_SECRET=<same value as static-auth-secret>
     TURN_DOMAIN=turn.your-domain.com
     ```
@@ -97,7 +97,7 @@ TURN requires a **public IP address**, a **domain name**, and **TLS certificates
     </Warning>
   </Step>
   <Step title="Start the stack with the TURN profile">
-    ```bash
+    ```bash Terminal
     docker compose --profile turn up -d
     ```
 
@@ -111,13 +111,13 @@ TURN requires a **public IP address**, a **domain name**, and **TLS certificates
 
 Check that the signaling server returns TURN credentials:
 
-```bash
+```bash Terminal
 curl http://localhost:3001/api/turn-credentials
 ```
 
 When TURN is configured, the response contains `turn:` and `turns:` entries, plus a `stun:` entry pointing at your TURN host:
 
-```json
+```json Output
 [
   { "urls": "stun:turn.your-domain.com:3478" },
   { "urls": "turn:turn.your-domain.com:3478", "username": "...", "credential": "..." },

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Add a TURN Relay to Self-Hosted Floe"
+sidebarTitle: "TURN relay"
 description: "Add a coturn TURN relay to a self-hosted Floe instance so peers behind strict NAT, CGNAT, or corporate firewalls can still complete file transfers."
 ---
 

--- a/docs/self-hosting/unraid.mdx
+++ b/docs/self-hosting/unraid.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Floe on Unraid"
+sidebarTitle: "Unraid"
 description: "Install the Floe web client and signaling server as two coordinated Unraid containers, with direct LAN, single domain, and two hostname configuration examples."
 ---
 

--- a/docs/self-hosting/unraid.mdx
+++ b/docs/self-hosting/unraid.mdx
@@ -37,7 +37,7 @@ as its CORS allow-list entry.
     Set **Client URL** to the URL that browsers will use for the client. With the
     default client port, an example is:
 
-    ```text
+    ```text Client URL
     http://192.168.1.10:3000
     ```
 
@@ -51,7 +51,7 @@ as its CORS allow-list entry.
     Set **Signaling Server URL** to the full origin browsers use to reach
     Floe-Server, including the scheme and the host port, with no trailing slash:
 
-    ```text
+    ```text Signaling Server URL
     http://192.168.1.10:3001
     ```
 
@@ -118,7 +118,7 @@ client and server separately, and enable WebSocket forwarding for the server.
 
 For example:
 
-```text
+```text Template values
 Client URL: https://floe.example.com
 Signaling Server URL: https://floe-api.example.com
 Trusted Proxy Count: 1

--- a/docs/self-hosting/without-docker.mdx
+++ b/docs/self-hosting/without-docker.mdx
@@ -12,14 +12,14 @@ The signaling server and the web client are two long-lived processes, so each
 needs its own terminal (or a supervisor, as below). Run each block from the
 repository root.
 
-```bash
+```bash Terminal
 # Signaling server (Node.js). Stays in the foreground.
 cd server
 npm install
 npm start
 ```
 
-```bash
+```bash Terminal
 # Web client (Next.js). Stays in the foreground.
 cd client
 pnpm install
@@ -27,7 +27,7 @@ pnpm build
 pnpm start
 ```
 
-```bash
+```bash Terminal
 # CLI (optional, for local testing against your server)
 cd cli
 go build ./cmd/floe
@@ -42,7 +42,7 @@ go build ./cmd/floe
 
 Copy and configure the environment files before starting:
 
-```bash
+```bash Terminal
 cp server/.env.example server/.env
 cp client/.env.example client/.env.local
 ```
@@ -59,7 +59,7 @@ Also set `NODE_ENV=production` in `server/.env`. Docker sets it for you; a direc
 
 The Docker instructions in [Operations](/self-hosting/operations) assume there is no repository to keep in sync. Running directly with Node means there is, so pull, reinstall, then restart:
 
-```bash
+```bash Terminal
 cd /path/to/floe
 git pull
 
@@ -81,12 +81,12 @@ Then restart both processes with whatever supervises them (`pm2 restart <name>`,
 
 Confirm the restart landed by checking that uptime reset:
 
-```bash
+```bash Terminal
 curl -s http://localhost:3001/health
 ```
 
 To confirm a specific dependency actually moved, read the installed version rather than trusting the restart:
 
-```bash
+```bash Terminal
 npm --prefix server ls <package-name>
 ```

--- a/docs/self-hosting/without-docker.mdx
+++ b/docs/self-hosting/without-docker.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Run Self-Hosted Floe Without Docker"
+sidebarTitle: "Without Docker"
 description: "Run the Floe signaling server and web client directly with Node.js, pnpm, and Go instead of Docker Compose for custom self-hosted deployments."
 ---
 

--- a/docs/style.css
+++ b/docs/style.css
@@ -53,23 +53,32 @@
 
    The numbers: the navbar lockup is 135x28, and the mark plus wordmark, up to
    but not including the gap before the separator, occupies the first 60.19 of
-   it. The footer renders the image 26px tall, so the full lockup is 125.4px
-   wide there and the part worth keeping is 55.9px. `cover` makes the image
-   fill that narrower box at its natural height instead of shrinking to fit,
-   and `left center` decides which end survives the crop.
+   it. The footer is given an explicit 44px height here (up from the 26px the
+   theme renders naturally; user call, 2026-08-09, matching the prominence of
+   Mintlify's own footer logo), so the full lockup scales to 212.1px wide and
+   the part worth keeping is 60.19 * (44 / 28) = 94.6px. `cover` makes the
+   image fill that narrower box at its scaled height instead of shrinking to
+   fit, and `left center` decides which end survives the crop.
 
    Both footer images are cropped identically, so this needs no light/dark
-   split. If the lockup is ever regenerated at a different width, update 55.9
-   to match: the value is (mark + wordmark width / total width) * 125.4, and
-   getting it wrong is visible immediately in local preview.
+   split. If the lockup is ever regenerated at a different width, update 94.6
+   to match: the value is (mark + wordmark width / total width) * (135 * 44 /
+   28), and getting it wrong is visible immediately in local preview.
 
    `#footer` and `.nav-logo` are both on Mintlify's published hook list, which
    it explicitly documents as subject to change. If the footer ever shows
    "Floe / Docs" again, this rule stopped matching and the selectors moved. */
 #footer img.nav-logo {
-  width: 55.9px;
+  height: 44px;
+  width: 94.6px;
   object-fit: cover;
   object-position: left center;
+  /* The theme top-aligns the logo box, and at the natural 26px that put the
+     logo's centre on the column headers' text line, which is the alignment
+     Mintlify's own footer uses. At 44px the centre drops below that line;
+     -12px measured out to a 0px centre delta against the Product header
+     (-9 from the size difference, -3 from the box's own line metrics). */
+  margin-top: -12px;
 }
 
 /* Raise the footer links to WCAG AA.
@@ -148,13 +157,17 @@
 
 /* The social icon is the one footer link Mintlify ships without rel, so the
    rule above skips it and it stays a 20px box. Centring it in a 24px one
-   squares it up with the text links without moving anything around it. */
+   squares it up with the text links without moving anything around it. The
+   negative margin cancels the 2px of centring inset on the left so the
+   glyph sits optically flush with the logo's bolt above it (the alignment
+   Mintlify's own footer socials have), while the 24px tap box survives. */
 #footer a:has(> svg[aria-hidden='true']) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 24px;
   min-height: 24px;
+  margin-left: -2px;
 }
 
 /* ---- floe.one theme translation (2026-08 docs redesign) ----------------
@@ -162,6 +175,23 @@
    Everything below restyles chrome, not content. The rules above this line
    (changelog tag separators, footer logo crop, footer WCAG fixes) are load-
    bearing and none of the selectors below intersect them. */
+
+/* The active theme-switch chip in the footer carries bg-gray-200/800, and
+   Mintlify's primary-tinted gray scale turns that chip visibly teal
+   (rgb(37,42,43) in dark) next to the neutral footer ground (user call,
+   2026-08-09). Same neutral washes as every other selected state. The
+   legacy footer colour rules earlier in this file deliberately exclude
+   [class*='bg-gray'] buttons, so this pair only touches the chip's ground
+   and text. */
+#footer button[class*='bg-gray'] {
+  background-color: rgb(17 17 17 / 0.08);
+  color: rgb(63 63 70);
+}
+
+.dark #footer button[class*='bg-gray'] {
+  background-color: rgb(255 255 255 / 0.1);
+  color: rgb(212 212 216);
+}
 
 /* Sidebar group headers as floe.one eyebrows.
 
@@ -178,8 +208,8 @@
    lesson above).
 
    The colours are not floe.one's zinc-600 verbatim because that fails WCAG
-   at 11px (2.58:1 on zinc-950). These sit at 5.53:1 light (#65656F on
-   #F7FBFC) and 5.44:1 dark (#85858E on #09090b). */
+   at 11px (2.57:1 on zinc-950). These sit at 5.76:1 light (#65656F on
+   #FFFFFF) and 5.44:1 dark (#85858E on #09090b). */
 #sidebar .sidebar-group-header .sidebar-title {
   font-family: "Geist Mono", ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   font-size: 11px;
@@ -194,9 +224,12 @@
 }
 
 /* The page-header eyebrow (the group name above every H1) gets the same mono
-   treatment. No color override: Mintlify paints it text-primary, which the
-   colors config makes the brand ice #B1DDEB in both modes (user call,
-   2026-08-09: the same ice everywhere), and the eyebrow is one of the few
+   treatment. No color override: Mintlify paints it text-primary per mode,
+   so it renders the glowing ice #00A3C9 in light and the pale ice #B1DDEB
+   in dark. The light value measures 2.97:1 on white, under AA for 11px
+   text; the user saw exactly this rendering and chose it deliberately
+   (2026-08-09, "now i like this color"), so treat that as a recorded
+   accessibility exception, not an oversight. The eyebrow is one of the few
    places floe.one sanctions ice text. .eyebrow is a documented hook. The
    weight matches the sidebar group headers above so the two eyebrow styles
    stay identical. */
@@ -264,6 +297,29 @@
   color: rgb(255 255 255);
 }
 
+/* Inactive TOC entries hover with hover:text-primary, which flashed ice on
+   the way to the neutral active state. Same neutral treatment on hover. */
+#table-of-contents .toc-item > a:hover {
+  color: rgb(17 17 17);
+}
+
+.dark #table-of-contents .toc-item > a:hover {
+  color: rgb(255 255 255);
+}
+
+/* The Tabs component (Install pages, reverse proxy) marks its selected tab
+   with text-primary and a primary underline on the tablist border. Same
+   selected-state doctrine, same variable mechanism as the theme menu: the
+   active tab goes near-black on light and white on dark, inactive tabs keep
+   their own gray classes. tabs-list is the observed data-component-part on
+   the tablist (2026-08-09 DOM). */
+[data-component-part='tabs-list'] {
+  --primary: 17 17 17;
+  --color-primary: rgb(17 17 17);
+  --primary-light: 255 255 255;
+  --color-primary-light: rgb(255 255 255);
+}
+
 /* The theme-switcher menu marks its selected row with text-primary ice, and
    hides the other rows' check marks with text-primary/0, the SAME utility at
    alpha zero. Overriding color directly would therefore reveal a check on
@@ -324,12 +380,109 @@
 }
 
 /* Body-link underlines in ice, light mode only (user call, 2026-08-09: text
-   stays the prose colour, the underline carries the accent, and dark mode
-   keeps the theme's own currentColor underline). The mint theme draws the
-   underline as border-bottom 1px solid in currentColor, so only the border
-   colour is overridden, and only outside .dark. a.link is the class
-   Mintlify puts on content links only; heading anchor glyphs use
-   group/link and do not match. */
+   stays the prose colour, the underline carries the accent). Dark mode is
+   untouched because the theme already paints .dark .link underlines in
+   primary-light, the pale ice, so both modes end up with an ice underline
+   over prose text. Two theme behaviours to know: links inside callouts keep
+   currentColor via the theme's own !important rule (accepted; an ice line
+   inside a tinted callout would clash), and a.link is the class Mintlify
+   puts on content links only; heading anchor glyphs use group/link and do
+   not match. */
 html:not(.dark) #content-area a.link {
   border-bottom-color: #00A3C9;
+}
+
+/* Tooltips (the Copy chip on code blocks and friends), neutral inverted
+   instead of ice (user call, 2026-08-09: black or white only, by mode).
+   Mintlify paints the chip bg-primary-dark in BOTH modes, which the colors
+   config turns saturated ice. text-tooltip-foreground is the one class
+   unique to the tooltip chip (observed 2026-08-09 via mutation capture:
+   div.z-50 > div.text-tooltip-foreground). Classic inversion: black chip
+   with white text on the light page, white chip with black text on dark. */
+.text-tooltip-foreground {
+  background-color: rgb(17 17 17);
+  color: rgb(255 255 255);
+}
+
+.dark .text-tooltip-foreground {
+  background-color: rgb(255 255 255);
+  color: rgb(17 17 17);
+}
+
+/* The copied-state check inside the copy button is text-primary, so it
+   flashed ice after every copy. Same variable trick as the theme menu and
+   the card hover: within the button, primary resolves to neutral, so the
+   check goes black on light and white on dark while the idle icon's own
+   gray classes are untouched. */
+[data-testid='copy-code-button'] {
+  --primary: 17 17 17;
+  --primary-light: 255 255 255;
+  --color-primary: rgb(17 17 17);
+  --color-primary-light: rgb(255 255 255);
+}
+
+/* The changelog version pills (v1.10.0 and friends), neutral like every
+   other selected-state chip (user call, 2026-08-09). The pill is
+   bg-primary/10 text-primary dark:text-primary-light on
+   data-component-part="update-label", the same documented hook family as
+   the update-tag rule at the top of this file. The wash reads --primary in
+   BOTH modes while the text switches variables, so dark needs its own
+   --primary value: without it the wash composites black-on-black and
+   disappears. Light gets black text on a black 10 percent wash, dark gets
+   white on white 10 percent, matching the sidebar's active pill. */
+[data-component-part='update-label'] {
+  --primary: 17 17 17;
+  --primary-light: 255 255 255;
+  --color-primary: rgb(17 17 17);
+  --color-primary-light: rgb(255 255 255);
+}
+
+.dark [data-component-part='update-label'] {
+  --primary: 255 255 255;
+  --color-primary: rgb(255 255 255);
+}
+
+/* The changelog filter chips, selected state. Unselected chips are already
+   neutral gray; selecting one turns it solid bg-primary with white text in
+   BOTH modes (no dark: variant in Mintlify's markup), so the variable trick
+   cannot work here: dark mode needs a white chip, and the baked-in white
+   text would vanish on it. Class-based override instead, scoped to the
+   panel's own id: black chip in light (the white/90 text stays), inverted
+   white chip with near-black text in dark. */
+#changelog-filters button.bg-primary {
+  background-color: rgb(17 17 17);
+}
+
+.dark #changelog-filters button.bg-primary {
+  background-color: rgb(255 255 255);
+  color: rgb(17 17 17);
+}
+
+/* Unselected filter chips, de-tinted. Mintlify derives its gray scale from
+   the primary hue, so with an ice primary its gray-100/gray-900 chips lean
+   visibly teal (rgb(22,27,28) in dark). These neutral washes match the
+   pill treatment used everywhere else; the hover variants keep the step
+   the gray utilities used to provide. The Clear control is also a
+   rounded-full button (revealed once a filter is active), so the
+   font-medium guard keeps it out; the chips themselves are font-normal.
+   Two Mintlify quirks worth knowing here: the panel renders
+   #changelog-filters on two nested divs (a duplicate id in their markup;
+   descendant selectors match either), and the whole panel only exists at
+   xl and up, so these rules have nothing to style on narrower screens. */
+#changelog-filters button.rounded-full:not(.bg-primary):not(.font-medium) {
+  background-color: rgb(17 17 17 / 0.06);
+  color: rgb(63 63 70);
+}
+
+#changelog-filters button.rounded-full:not(.bg-primary):not(.font-medium):hover {
+  background-color: rgb(17 17 17 / 0.1);
+}
+
+.dark #changelog-filters button.rounded-full:not(.bg-primary):not(.font-medium) {
+  background-color: rgb(255 255 255 / 0.08);
+  color: rgb(212 212 216);
+}
+
+.dark #changelog-filters button.rounded-full:not(.bg-primary):not(.font-medium):hover {
+  background-color: rgb(255 255 255 / 0.12);
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -156,3 +156,180 @@
   min-width: 24px;
   min-height: 24px;
 }
+
+/* ---- floe.one theme translation (2026-08 docs redesign) ----------------
+
+   Everything below restyles chrome, not content. The rules above this line
+   (changelog tag separators, footer logo crop, footer WCAG fixes) are load-
+   bearing and none of the selectors below intersect them. */
+
+/* Sidebar group headers as floe.one eyebrows.
+
+   floe.one labels every landing section with an 11px Geist Mono uppercase
+   eyebrow tracked at 0.2em; this carries that identity into the sidebar.
+   #sidebar, .sidebar-group-header, and .sidebar-title are all on Mintlify's
+   documented hook list, so this is the low-risk tier of custom CSS; if the
+   hooks ever move, the headers just revert to the default sans style.
+
+   Geist Mono itself is not loadable through docs.json (fonts has no mono
+   slot), so ui-monospace serves in practice: SF Mono on macOS, Cascadia on
+   Windows. Do not @font-face a root-absolute url() here; the docs live under
+   /docs in production and root-absolute asset paths 404 (the footer-logo
+   lesson above).
+
+   The colours are not floe.one's zinc-600 verbatim because that fails WCAG
+   at 11px (2.58:1 on zinc-950). These sit at 5.53:1 light (#65656F on
+   #F7FBFC) and 5.44:1 dark (#85858E on #09090b). */
+#sidebar .sidebar-group-header .sidebar-title {
+  font-family: "Geist Mono", ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: #65656F;
+}
+
+.dark #sidebar .sidebar-group-header .sidebar-title {
+  color: #85858E;
+}
+
+/* The page-header eyebrow (the group name above every H1) gets the same mono
+   treatment. No color override: Mintlify paints it text-primary, which the
+   colors config makes the brand ice #B1DDEB in both modes (user call,
+   2026-08-09: the same ice everywhere), and the eyebrow is one of the few
+   places floe.one sanctions ice text. .eyebrow is a documented hook. The
+   weight matches the sidebar group headers above so the two eyebrow styles
+   stay identical. */
+.eyebrow {
+  font-family: "Geist Mono", ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
+  font-size: 11px;
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+/* Card icons, neutral in both modes.
+
+   Mintlify paints a Card's icon with the same CSS-mask pattern as the footer
+   social icon, and the mask's colour is bg-primary, which the colors config
+   turns ice. Glyphs in the accent colour read as tinted chrome rather than
+   icons (user call, 2026-08-09), so cards get the neutral treatment instead:
+   near-black on the light cards, white on the dark ones. The ice accent
+   stays reserved for the eyebrows, links, and TOC.
+
+   data-component-part="card-icon" is the same undocumented hook family as
+   the changelog update-tag rule above; if card icons ever go ice again,
+   this selector stopped matching. */
+[data-component-part="card-icon"] svg {
+  background-color: rgb(17 17 17);
+}
+
+.dark [data-component-part="card-icon"] svg {
+  background-color: #FFFFFF;
+}
+
+/* The active sidebar item, back to neutral.
+
+   Mintlify paints the active item bg-primary/10 + text-primary, which the
+   ice colors config turns into a teal-on-ice pill. The user rejected that
+   (2026-08-09) and asked for the gray it had before the redesign, so this
+   reproduces exactly what the old #111111/#ffffff primary rendered: a 10
+   percent neutral wash with near-black text in light, white text in dark.
+   The ice accent stays everywhere else it now lives (eyebrows, TOC, links).
+
+   #sidebar is a documented hook; li[data-active="true"] is the observed
+   active-item shape (2026-08-09 DOM). If the pill ever shows teal again,
+   the li shape moved; re-read the DOM before touching the colors config. */
+#sidebar li[data-active="true"] a {
+  color: rgb(17 17 17);
+  background-color: rgb(17 17 17 / 0.1);
+}
+
+.dark #sidebar li[data-active="true"] a {
+  color: rgb(255 255 255);
+  background-color: rgb(255 255 255 / 0.1);
+}
+
+/* The active TOC entry, same neutral treatment as the sidebar pill (user
+   call, 2026-08-09: selected states stay neutral, ice is for eyebrows).
+   Only the colour is overridden, so Mintlify's own emphasis on the active
+   entry is otherwise untouched; against the gray siblings, near-black (or
+   white in dark) IS the highlight. #table-of-contents and data-active are
+   the same observed hook family as the sidebar pill above. */
+#table-of-contents .toc-item[data-active="true"] > a {
+  color: rgb(17 17 17);
+}
+
+.dark #table-of-contents .toc-item[data-active="true"] > a {
+  color: rgb(255 255 255);
+}
+
+/* The theme-switcher menu marks its selected row with text-primary ice, and
+   hides the other rows' check marks with text-primary/0, the SAME utility at
+   alpha zero. Overriding color directly would therefore reveal a check on
+   every row (tried, shipped for a minute, looked broken), so this redefines
+   the variables the utilities read instead: the selected check and label go
+   neutral, the /0 variants stay invisible, and each mode's utility reads its
+   own variable so no .dark split is needed. The role guard matters: the html
+   root also carries data-theme-preference (it stores the setting), and the
+   bare attribute selector would restyle the whole document. */
+[role='menuitem'][data-theme-preference] {
+  --primary: 17 17 17;
+  --primary-light: 255 255 255;
+  --color-primary: rgb(17 17 17);
+  --color-primary-light: rgb(255 255 255);
+}
+
+/* Navbar links hover neutral, like floe.one's navbar (zinc at rest, plain
+   black or white on hover), instead of the hover:text-primary ice Mintlify
+   puts on the GitHub widget. The span selector is required because the repo
+   name carries its own group-hover colour class, which inheritance from the
+   anchor cannot beat; this stylesheet is unlayered, so it wins over the
+   layered utility on the same element. The masked star icon gets the
+   background-color variant for the same reason as the menu icons above. */
+#navbar a:hover,
+#navbar a:hover span {
+  color: rgb(17 17 17);
+}
+
+.dark #navbar a:hover,
+.dark #navbar a:hover span {
+  color: rgb(255 255 255);
+}
+
+#navbar a:hover svg[class*='forced-colors'] {
+  background-color: rgb(17 17 17);
+}
+
+.dark #navbar a:hover svg[class*='forced-colors'] {
+  background-color: rgb(255 255 255);
+}
+
+/* Card hover ring, neutral instead of ice (user call, 2026-08-09: dark ring
+   in light mode, white in dark, like the pre-redesign monochrome primary).
+   Mintlify's hover utility is hover:border-primary! with !important, and
+   important layered declarations outrank anything this unlayered sheet says
+   about border-color, so the override targets the variables the utility
+   reads instead: scoped to hover, the card resolves primary to neutral.
+   Values are raw RGB triplets because Mintlify defines --primary that way
+   (rgb(var(--primary))); the --color-* aliases cover the Tailwind v4 form. */
+.card:hover {
+  --primary: 17 17 17;
+  --color-primary: rgb(17 17 17);
+}
+
+.dark .card:hover {
+  --primary-light: 255 255 255;
+  --color-primary-light: rgb(255 255 255);
+}
+
+/* Body-link underlines in ice, light mode only (user call, 2026-08-09: text
+   stays the prose colour, the underline carries the accent, and dark mode
+   keeps the theme's own currentColor underline). The mint theme draws the
+   underline as border-bottom 1px solid in currentColor, so only the border
+   colour is overridden, and only outside .dark. a.link is the class
+   Mintlify puts on content links only; heading anchor glyphs use
+   group/link and do not match. */
+html:not(.dark) #content-area a.link {
+  border-bottom-color: #00A3C9;
+}

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -69,7 +69,7 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
 
     Floe already ignores link-local addresses (IPv4 169.254.x.x and IPv6 fe80::), which covers dead auto-config adapters and most virtual ones. A VPN adapter with a routable address, such as Tailscale's 100.x range, is not filtered. If you still see slow connects, pin the CLI to your real interface by name:
 
-    ```bash
+    ```bash Terminal
     floe receive olive-tiger-castle --iface Ethernet   # or --iface Wi-Fi
     ```
 
@@ -81,7 +81,7 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
 
     The message prints both sides as `You:` and `Peer:`, each with its protocol range and release version. Go by the version strings rather than the labels, and update the older one. When the receiver detects the mismatch it composes the message and the sender prints it unchanged, so a sender can be told "your floe is too old" while it is the receiver that needs updating. In that case the whole message, not just the labels, is written from the receiver's point of view. If both versions look current, update both.
 
-    ```bash
+    ```bash Terminal
     floe update              # script / manual installs
     brew upgrade floe        # Homebrew
     winget upgrade jannskiee.floe  # Winget
@@ -135,7 +135,7 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
   <Accordion title="The browser cannot connect to my signaling server">
     Set `NEXT_PUBLIC_SOCKET_URL` in `.env` and recreate the container. No rebuild is needed, because the client reads its server address at runtime:
 
-    ```bash
+    ```bash Terminal
     docker compose up -d
     ```
 
@@ -145,7 +145,7 @@ Most Floe transfers just work. When something goes wrong, it is almost always on
 
     Check what the client is actually resolving:
 
-    ```bash
+    ```bash Terminal
     curl http://localhost:3000/api/config
     ```
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Floe Troubleshooting Guide"
+sidebarTitle: "Troubleshooting"
 description: "Fixes for common Floe issues: stuck connections, failed transfers, invalid room links, TURN relay problems, and self-hosting deployment errors."
 ---
 

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Receiving Files with the Floe Web App"
+sidebarTitle: "Receiving files"
 description: "Open a Floe share link in your browser to receive files peer-to-peer over WebRTC, with no account, install, or server upload required."
 ---
 

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -73,7 +73,7 @@ Either way, files that already finished stay in the list and remain downloadable
 
 If you prefer the terminal, paste the full link into `floe receive`:
 
-```bash
+```bash Terminal
 floe receive "https://floe.one/?s=1a2b3c4d#room=3f2b9c1e-7a4d-4c2e-9b1f-8e6d5c4b3a21"
 ```
 
@@ -81,7 +81,7 @@ Links created in the browser carry a `?s=` nonce; links printed by `floe send` d
 
 Or use the short code if the sender shares one:
 
-```bash
+```bash Terminal
 floe receive olive-tiger-castle
 ```
 

--- a/docs/web-app/sending.mdx
+++ b/docs/web-app/sending.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Sending Files with the Floe Web App"
+sidebarTitle: "Sending files"
 description: "Send files from the Floe web app at floe.one by generating a share link, sending it to your recipient, and streaming files peer-to-peer over WebRTC."
 ---
 


### PR DESCRIPTION
## Summary

Complete redesign of the docs at floe.one/docs, docs-only diff (38 files under `docs/`).

- **Sidebar**: short professional labels via `sidebarTitle` on 36 pages ("Sending files", "floe send" instead of "Sending Files with the Floe Web App", "floe send command"); 8 sentence-case groups reordered into Getting started / Web / Desktop / CLI / Self-hosting / How it works / Help / Reference; group headers restyled as floe.one's 11px mono uppercase eyebrows. Zero slug, URL, or anchor changes.
- **Theme**: floe.one translation. Dark default on `#09090b` with the ice `#B1DDEB` accent; light mode on pure white with the glowing ice `#00A3C9`. Ice is rationed to page eyebrows, link underlines, and focus rings; every interactive and selected state (sidebar pill, TOC, tabs, theme menu, tooltips, copy check, changelog pills and filter chips, hovers) is neutral black/white by mode, and the primary-tinted grays on large chips are de-tinted.
- **Landing**: `introduction.mdx` rewritten as a router hero (tagline H1, 6-card lucide grid, compact value strip).
- **Code blocks**: all 122 fences across 26 pages get Mintlify header-bar titles (Terminal / Output / filenames / command names); the nine `.env` blocks move from the unsupported `env` id to `dotenv` and gain syntax colors; the Caddyfile block uses the nginx grammar (Shiki has no Caddy support); 12 bare transcript fences become `text Output`. Fence lines only, block contents untouched.
- **Footer**: lockup enlarged to 44px, centre-aligned with the column headers, social icon flush beneath it. `footer.links` and the changelog authoring contract are untouched.

## Test plan

- Three verification fleets across the build (research, per-phase gates, final phased QA): render gate (37/37 pages, per-page code-header counts), config gate (docs.json schema-exact, footer byte-identical to main), content gate (per-file diff budgets: frontmatter line + fence lines only outside `introduction.mdx`), CSS audit (legacy changelog/footer rules intact), accessibility table (all neutral states at 5:1 or better; the light ice accent at 2.97:1 is a deliberate, documented choice), independent dark/light/cross-mode design reviews, adversarial re-verifier, and a 22-point decision-ledger critic.
- The adversary's one flagged blocker (eyebrow missing on some locally rendered pages) reproduced only on a stale `mint dev` cache; after a server restart all 37 pages render it. Production Mintlify renders fresh.
- Live checks after merge: sidebar labels, theme colors, code-block headers, changelog tag separators, footer logo on floe.one/docs in both modes.
