### PR TITLE
docs: neutralize the assistant send button

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -392,6 +392,24 @@ html:not(.dark) #content-area a.link {
   border-bottom-color: #00A3C9;
 }
 
+/* The assistant bar's circular send button is bg-primary/30 (disabled) and
+   solid primary when armed, which the colors config turns ice (user call,
+   2026-08-09: black or white like every other control). The variable scope
+   keeps the 30 percent disabled alpha intact: light gets a black circle
+   with the stock white arrow, dark gets a white circle, so the arrow flips
+   to near-black there. chat-assistant-send-button is a semantic Mintlify
+   class observed on the button itself. */
+.chat-assistant-send-button {
+  --primary: 17 17 17;
+  --color-primary: rgb(17 17 17);
+  --primary-dark: 255 255 255;
+  --color-primary-dark: rgb(255 255 255);
+}
+
+.dark .chat-assistant-send-button svg {
+  color: rgb(17 17 17);
+}
+
 /* Tooltips (the Copy chip on code blocks and friends), neutral inverted
    instead of ice (user call, 2026-08-09: black or white only, by mode).
    Mintlify paints the chip bg-primary-dark in BOTH modes, which the colors


### PR DESCRIPTION
## Summary

The assistant bar's circular send button was the last control still painted from the primary color, rendering ice in both modes. This scopes the primary variables to the button (semantic class chat-assistant-send-button) so both the disabled 30 percent wash and the armed solid state resolve neutral: black circle with the stock white arrow in light mode, white circle with a near-black arrow in dark mode.

## Test plan

Verified on the local preview by computing the button and arrow colors in both modes (dark: white/30 circle, rgb(17,17,17) arrow; light: black/30 circle, white arrow). Docs-only diff, fast CI path.