### PR TITLE
fix(desktop): stop Start over discarding notes it never sent

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -555,7 +555,8 @@ function App() {
     const prevModeRef = useRef<Mode>('send');
     // Whether the full-screen settings view covers the transfer UI.
     const [settingsOpen, setSettingsOpen] = useState(false);
-    // Whether the "start over while transferring?" confirm overlay is showing.
+    // Whether the "start over?" confirm overlay is showing. Not only about a live
+    // transfer: see resetWarning in reset.ts for every state that raises it.
     const [confirmReset, setConfirmReset] = useState(false);
     // Whether the "reset all settings?" confirm overlay is showing. Deliberately
     // NOT named confirmReset: that one guards Start over, which clears the
@@ -612,6 +613,12 @@ function App() {
     const [sendProg, setSendProg] = useState<{pct: number; label: string} | null>(null);
     const [sendDone, setSendDone] = useState(false);
     const [sentCount, setSentCount] = useState(0);
+    // The note the last COMPLETED send put on the wire, '' when that send was
+    // files. Start over compares the box against it: send:done leaves the
+    // textarea mounted and still full, so this is the only way to tell "the note
+    // I just sent is sitting there" (no prompt) from "I have started typing the
+    // next one" (prompt, because that text lives in this field and nowhere else).
+    const [sentText, setSentText] = useState('');
     const [peerConnected, setPeerConnected] = useState(false);
     const [filesOpen, setFilesOpen] = useState(false);
     const sendStart = useRef<Marker>(null);
@@ -619,6 +626,10 @@ function App() {
     // Snapshot of the sent file names, readable from the once-registered
     // send:done closure (which must not touch React state directly).
     const sentNamesRef = useRef<string[]>([]);
+    // The text handed to the engine by the send in flight, '' for a file send.
+    // Same once-registered-closure rule as sentNamesRef above: send:done reads
+    // this rather than sendText, which it would only ever see as '' from mount.
+    const outgoingTextRef = useRef('');
     // Total bytes of the in-flight send, harvested from progress events for the
     // history entry (same once-registered-closure rule: refs only).
     const sendBytesRef = useRef(0);
@@ -867,6 +878,12 @@ function App() {
             setSending(false);
             setSendDone(true);
             setSendStatus('');
+            // Record what went out, so Start over can tell the note that was
+            // delivered from one typed afterwards. Only a completed send writes
+            // this, so a failed or cancelled one leaves the note unsent and it
+            // keeps its prompt. Guarded on non-empty because a file send must not
+            // erase the record of a note that really did go out earlier.
+            if (outgoingTextRef.current) setSentText(outgoingTextRef.current);
             const names = sentNamesRef.current;
             setHistory((prev) => [{kind: 'send' as const, names, count: names.length, bytes: sendBytesRef.current || undefined, at: Date.now()}, ...prev].slice(0, HISTORY_CAP));
         });
@@ -874,6 +891,12 @@ function App() {
             if (sendCancel.current) return;
             setSendStatus('Error: ' + msg + serverNote());
             setSending(false);
+            // The progress row goes with the transfer. Left behind it froze
+            // on screen at whatever percent it died at, and worse, kept Start
+            // over's "a transfer is in progress" branch true for a dead
+            // transfer, which then outranked and hid the unsent-note warning.
+            // cancel() has always done this; the error path never did.
+            setSendProg(null);
             // The room is dead after an error; drop the stale code and link.
             setSendCode('');
             setSendLink('');
@@ -1199,9 +1222,12 @@ function App() {
         if (sendKind === 'text') {
             setSentCount(1);
             sentNamesRef.current = ['message.txt'];
+            outgoingTextRef.current = sendText;
         } else {
             setSentCount(files.length);
             sentNamesRef.current = files.map((f) => baseName(f) || f);
+            // A file send puts no text on the wire, so it must not claim any.
+            outgoingTextRef.current = '';
         }
         setPeerConnected(false);
         setFilesOpen(false);
@@ -1239,7 +1265,6 @@ function App() {
             const dir = await ReceiveByCode(code.trim(), output.trim(), hideIP, reportStats);
             setRecvDir(dir);
             setRecvDone(true);
-            setRecvProg(null);
             setRecvStatus('');
             const names = recvNamesRef.current;
             setHistory((prev) => [{kind: 'recv' as const, names, count: names.length, dir, bytes: recvBytesRef.current || undefined, at: Date.now()}, ...prev].slice(0, HISTORY_CAP));
@@ -1247,6 +1272,11 @@ function App() {
             setRecvStatus(recvCancel.current ? 'Cancelled.' : 'Error: ' + e + serverNote());
         } finally {
             setReceiving(false);
+            // Every exit clears the progress row, not just the successful one.
+            // On failure it used to stay frozen on screen and keep Start over
+            // convinced a transfer was still running, which showed the cancel
+            // warning for a dead transfer and hid the unsent-note one behind it.
+            setRecvProg(null);
         }
     }
 
@@ -1303,6 +1333,7 @@ function App() {
         setFiles([]);
         setSendKind('files');
         setSendText('');
+        setSentText('');
         setSendCode('');
         setSendLink('');
         setSendStatus(INITIAL_SEND_STATUS);
@@ -1314,6 +1345,7 @@ function App() {
         setFilesOpen(false);
         sendStart.current = null;
         sentNamesRef.current = [];
+        outgoingTextRef.current = '';
 
         // Receive
         setCode('');
@@ -1328,9 +1360,12 @@ function App() {
         setRoute('');
     }
 
-    // startOver is the Floe-lockup / Ctrl+R action. It confirms first only when
-    // bytes are actively moving, so escaping a stuck (connecting/idle) state is
-    // instant while a real transfer is protected from a fat-finger.
+    // startOver is the Floe-lockup / Ctrl+R action. It confirms first when the
+    // reset would destroy something the user cannot get back: bytes actually
+    // moving, or a note in the box that has not gone out. Everything else resets
+    // on the first click or keypress, so escaping a stuck (connecting/idle)
+    // state stays instant. resetWarning in reset.ts owns that decision and
+    // supplies the sentence, so do not restate its rules here.
     function startOver() {
         if (resetLoss) {
             setConfirmReset(true);
@@ -1352,8 +1387,8 @@ function App() {
     const resetLoss = resetWarning({
         transferring: !!(sendProg || recvProg),
         busy,
-        justSent: sendDone,
         text: sendText,
+        sentText,
     });
     // Amber marks anything relay-flavored: a known relayed route, or (before
     // the route is known / while idle) the Hide-my-IP preference forcing one.

--- a/desktop/frontend/src/reset.test.ts
+++ b/desktop/frontend/src/reset.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, it} from 'vitest';
 import {resetWarning} from './reset';
 
-const base = {transferring: false, busy: false, justSent: false, text: ''};
+const base = {transferring: false, busy: false, text: '', sentText: ''};
 
 describe('resetWarning', () => {
     it('says nothing when there is nothing to lose', () => {
@@ -43,7 +43,47 @@ describe('resetWarning', () => {
     // the commonest gesture in the app, tidying up after a completed transfer,
     // would prompt every single time.
     it('stays silent right after a completed send', () => {
-        expect(resetWarning({...base, justSent: true, text: 'the note I just sent'})).toBe('');
+        const note = 'the note I just sent';
+        expect(resetWarning({...base, text: note, sentText: note})).toBe('');
+    });
+
+    // The gate above is a claim about the note in the box, not a memory that some
+    // send finished. The textarea stays mounted and editable after send:done, so
+    // this is the "sent one note, started typing the next" state: the text on
+    // screen has never left this machine. It used to be wiped with no prompt,
+    // because the old justSent flag could not tell the two apart.
+    it('warns once the box holds a different note from the one that went out', () => {
+        const s = resetWarning({...base, text: 'note two', sentText: 'note one'});
+        expect(s).toContain('has not been sent');
+    });
+
+    // The same loss through a different door, and the note is not even on screen
+    // for this one: type a note, switch to Files, send files. A file send puts no
+    // text on the wire, so sentText is '' and the note is still unsent.
+    it('warns about a note typed before a file send', () => {
+        const s = resetWarning({...base, text: 'a note nobody has received', sentText: ''});
+        expect(s).toContain('has not been sent');
+    });
+
+    // Compared trimmed on both sides, so pressing Enter at the end of the note
+    // you just sent is not a new note and does not earn a prompt.
+    it('treats trailing whitespace on the sent note as the same note', () => {
+        expect(resetWarning({...base, text: '  note one\n', sentText: 'note one'})).toBe('');
+    });
+
+    // The empty-box guard shares a line with the sentText compare, so clearing the
+    // box after a send stays silent whatever went out. Nothing in it, nothing to lose.
+    it('stays silent when the box has been emptied since the send', () => {
+        expect(resetWarning({...base, text: '', sentText: 'note one'})).toBe('');
+    });
+
+    // A transfer that has stopped is not a transfer. The error paths clear their
+    // progress objects now, so a failed send lands here rather than in the
+    // transferring branch, which used to claim an idle app was mid-transfer and
+    // hide the note warning underneath a sentence about cancelling.
+    it('sees the unsent note under a transfer that has already failed', () => {
+        const s = resetWarning({...base, text: 'the note the failed send was carrying'});
+        expect(s).toContain('has not been sent');
     });
 
     // Staged files are deliberately not a reason to prompt: doReset clears them,

--- a/desktop/frontend/src/reset.ts
+++ b/desktop/frontend/src/reset.ts
@@ -9,33 +9,62 @@
  * Two states earn a prompt, and only two.
  *
  * Bytes in flight, because the reset cancels a live transfer. That is the
- * original reason the dialog exists.
+ * original reason the dialog exists. "In flight" means a progress object that
+ * has not been cleared, so every path that ends a transfer (done, cancel,
+ * error) has to null its progress or this branch keeps firing for a transfer
+ * that died minutes ago, and outranks the note warning while it does.
  *
- * An unsent text note while idle, because doReset calls setSendText('') and a
- * typed note is written to no file and no storage key. It exists in that one
- * state field and nowhere else, so clearing it is the only thing Start over
+ * A note in the box that has not gone out, because doReset calls setSendText('')
+ * and a typed note is written to no file and no storage key. It exists in that
+ * one state field and nowhere else, so clearing it is the only thing Start over
  * does that the user cannot simply redo. Staged files are deliberately NOT in
  * this list: doReset clears those too, but the paths are still on disk and
  * re-picking them is tedious rather than destructive.
  *
- * Two gates keep the prompt off paths where it would be noise:
+ * sentText is what the last completed send actually put on the wire, and
+ * comparing the box against it is what makes that judgement exact. This used to
+ * be a justSent boolean, which asked "did a send finish?" rather than "is this
+ * the note that went?". Those are different questions, and the gap between them
+ * was two states where the box held something nobody had sent and Start over
+ * destroyed it in silence: a note typed after a completed send (the textarea
+ * stays mounted and editable once send:done lands), and a note typed and then
+ * abandoned in favour of sending files, which is not even on screen at the
+ * time. Compared trimmed, so a trailing newline on the note you just sent is
+ * not a new note.
  *
- * busy, because a send that is connecting or waiting for a peer still holds its
- * text and file list, and a dialog in front of the escape hatch that exists FOR
- * stuck states would defeat it.
+ * Only a completed send may write sentText, which is what separates "delivered"
+ * from "attempted": a send that fails or is cancelled leaves the note unsent,
+ * and it still earns its prompt.
  *
- * justSent, because send:done clears neither the text nor the files. Without
- * this gate, the single most common gesture in the app, clicking the lockup to
- * tidy up after a transfer completes, would throw a modal every time.
+ * busy is the one gate that keeps the prompt off a path where it would be
+ * noise, because a send that is connecting or waiting for a peer still holds
+ * its text and file list, and a dialog in front of the escape hatch that exists
+ * FOR stuck states would defeat it.
+ *
+ * Two omissions that are decisions rather than oversights, written down so
+ * nobody has to guess.
+ *
+ * The room code typed on the Receive tab is not an input here. doReset clears
+ * it, but unlike a note it is a reference to something that still exists
+ * elsewhere: the sender's screen, the message it arrived in, usually the
+ * clipboard. That puts it with staged files rather than with the note.
+ *
+ * There is no receive-side twin of sentText. A finished receive says nothing
+ * about a note staged on the Send tab, so gating on one would suppress a
+ * warning that is simply true.
  */
 export function resetWarning(s: {
     transferring: boolean;
     busy: boolean;
-    justSent: boolean;
     text: string;
+    sentText: string;
 }): string {
     if (s.transferring) return 'A transfer is in progress. Starting over will cancel it.';
-    if (s.busy || s.justSent) return '';
-    if (s.text.trim() === '') return '';
+    if (s.busy) return '';
+    const t = s.text.trim();
+    // Trimmed on both sides, like the emptiness test it shares a line with: a
+    // note that differs from the one that went out by trailing whitespace is
+    // not lost work.
+    if (t === '' || t === s.sentText.trim()) return '';
     return 'The text you typed has not been sent yet. Starting over will clear it.';
 }

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -40,6 +40,15 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
+<Update label="Unreleased" tags={["Desktop"]}>
+  **Start over stops losing notes it never sent, and stops claiming a dead transfer is running**
+
+  - Fixed **Start over** still discarding a typed note without asking, in the two cases the 0.2.2 fix missed. Typing a new note after a send completed, and typing a note then switching to Files and sending those instead, both left text in the box that had never gone anywhere, and both were cleared with no prompt. Floe now compares the box against what the last completed send actually put on the wire, so a note only counts as sent while it is still exactly the note that went out. Tidying up after a send with the sent note still in the box is unchanged and still silent, as is starting over while a connection is being set up.
+  - Fixed a failed transfer leaving its progress bar frozen on screen underneath the error, on both the sending and the receiving side.
+  - Fixed **Start over** offering to cancel a transfer that had already failed. The stale progress bar above was also what the confirmation read, so after a failure it warned about cancelling a transfer that was already over, and that warning hid the one about the unsent note behind it.
+  - No transfer-protocol change.
+</Update>
+
 <Update label="v1.10.0" description="2026-08-08" tags={["CLI", "Web", "Self-hosting"]}>
   **Stalled transfers now fail with a reason, and received files are never overwritten**
 

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -17,16 +17,24 @@ description: "Every keyboard shortcut in Floe Desktop for Windows: adding files,
 
 ## Behaviour worth knowing
 
-**Most shortcuts pause while you type.** `Ctrl` `O`, `Ctrl` `Enter`, `Ctrl` `V` and `Ctrl` `H`
-do nothing while the cursor is in a text field, so typing a room code or a note is never
-interrupted and nothing fires twice.
+**Most shortcuts pause while you type.** `Ctrl` `O`, `Ctrl` `Enter`, `Ctrl` `V`, `Ctrl` `H` and
+`Ctrl` `R` do nothing while the cursor is in a text field, so typing a room code or a note is
+never interrupted, nothing fires twice, and a half-typed note is never wiped mid-word.
 
-**Two fire from anywhere.** `Ctrl` `,` opens Settings, the way a preferences shortcut normally
-does. `Ctrl` `R` starts over, and it is not held back while you type.
+**One fires from anywhere.** `Ctrl` `,` opens Settings, the way a preferences shortcut normally
+does.
 
 <Warning>
-  `Ctrl` `R` only asks for confirmation when a transfer is actually moving data. Pressing it
-  while you are composing a text note clears the note with no warning.
+  `Ctrl` `R` asks for confirmation in two cases: when a transfer is actually moving data, and
+  when the text box holds a note that has not been sent. The unsent-note prompt covers both
+  paths to Start over, the shortcut itself and clicking the Floe lockup in the titlebar. The
+  dialog reads "The text you typed has not been sent yet. Starting over will clear it."
+
+  A note counts as sent only while the box still holds exactly what went out, so typing a new
+  one after a send prompts again, and so does a note you typed and then abandoned in favour of
+  sending files. Staged files never prompt on their own, because the originals are untouched on
+  disk, and neither does a send or a receive that is still connecting, so Start over stays a
+  one-click escape from a stuck connection.
 </Warning>
 
 **`Ctrl` `R` does not reload the app.** In a browser that key reloads the page, which here

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -23,8 +23,11 @@ There are four ways to stage files, and you can mix them:
 | `Ctrl` `V` | Pastes files you copied in File Explorer, or an image from the clipboard. |
 
 Everything you add appears in a list under **Files**. Remove a single entry with the `X` on its
-row. `Ctrl` `R` starts over, which clears the selection along with everything else on the card,
-and only asks first if a transfer is already moving bytes.
+row. `Ctrl` `R` starts over, which clears the selection along with everything else on the card.
+It asks first if a transfer is already moving bytes, or if the text box holds a note that has
+not been sent (the dialog reads "The text you typed has not been sent yet. Starting over will
+clear it."). Clicking the Floe lockup in the titlebar starts over too, with the same
+confirmations, but only the shortcut is held back while you are typing.
 
 Adding the same path twice does nothing, so dragging a file you already staged is safe. One
 edge worth knowing: if you add a folder **and** a file that lives inside it, that file is sent


### PR DESCRIPTION
## Summary

Four defects in the desktop **Start over** guard, found while verifying the docs prose in #271 against the source. Two of them silently destroy typed text, which is the bug class #247 was opened to fix.

**Notes destroyed with no prompt.** `resetWarning` gated the unsent-note confirmation on a `justSent` boolean fed from `sendDone`. That answers "did a send finish?" when the guard needs "is this the note that went out?". Two reachable states held text nobody had sent while the gate stayed shut:

- Send a note, then type a new one in the same box. The textarea stays mounted after `send:done` (`!sending && sendKind === 'text'`) and its `onChange` only calls `setSendText`, so `sendDone` is still true and `doReset` clears the new note without asking.
- Type a note, switch to **Files**, send files. `sendDone` goes true from the file send, and the note is not even on screen at that point.

The guard now takes `sentText`, the note the last **completed** send put on the wire, and prompts whenever the box differs from it (compared trimmed). Only `send:done` writes it, which separates delivered from attempted, so a failed or cancelled send leaves the note unsent and it keeps its prompt.

Both deliberate quiet cases are preserved and still pinned by tests: tidying up with the sent note still in the box, and the `busy` escape hatch out of a connection that will not settle.

**Frozen progress bar, and a confirmation that lied.** `send:error` never cleared `sendProg` and the receive `catch` never cleared `recvProg`. After any mid-transfer failure the progress bar stayed on screen frozen at the percentage it died at, and `transferring` latched true, so Start over offered to cancel a transfer that was already over. Because that branch returns first, it also hid the unsent-note warning behind it. `cancel()` has always cleared these; the error paths now match.

**Two stale comments.** `App.tsx:558` and the `startOver` comment both still described the pre-#247 behaviour. These matter more than usual: the Mintlify "Update from code changes" automation regenerates docs from them, so leaving them stale reproduces the wrong docs.

### Rejected alternatives, recorded so they are not retried

- **Record `sentText` at send start.** `sendDone` is cleared by four file-staging handlers (`addFiles`, `pickFiles`, `pickSendFolder`, `removeFile`), so sending a note and then merely staging a file would re-arm the prompt with copy claiming that note had never been sent.
- **Clear `sendDone` on keystroke.** Its only other reader gates the "Sent N items" receipt, which would vanish as soon as you typed.
- **Tighten `transferring` to `(sending && sendProg) || (receiving && recvProg)`.** On cancel-then-restart, the dead attempt's late event clears the flag while the new transfer's progress events arrive, so the conjunctive form would skip the confirmation *during a live transfer*. Fixing the two error paths restores the invariant with no false negative, so the predicate is left alone.

## Relationship to #271

This supersedes #271. Both touch the same two doc sentences, and this branch is cut from `main`, so it rewrites them from the original text straight to the post-fix wording. Simplest path is to merge this and close #271; merging #271 first will conflict here and I will rebase.

## Test plan

- `npm test` in `desktop/frontend`: 22 passed. Five new `reset.test.ts` cases cover the note-after-send case, the note-before-a-file-send case, trailing-whitespace drift, the emptied box, and the unsent note under an already-failed transfer.
- `npm run build` (runs `tsc`) clean. `sentText` is a required field, so the type checker gates every call site and fixture.
- The eight existing cases pass untouched, including the load-bearing `busy` escape-hatch guard and the staged-files guard.

Manual, against a CLI peer, killing it mid-transfer to produce a real failure:

**Must prompt**
1. Send a note, type a different note, click the lockup.
2. Type a note, switch to Files, send a file, click the lockup.
3. Kill a transfer mid-flight, type a note, click the lockup: the dialog must be the unsent-note one, not "a transfer is in progress".

**Must stay silent**
4. Send a note, do not touch the box, click the lockup.
5. Send a note, add a trailing newline only, click the lockup.
6. Send a note, then stage a file, click the lockup. This is the case the rejected design got wrong.
7. Click the lockup while a send is still waiting for the receiver.
8. Press `Ctrl` `R` with the caret in the textarea: nothing happens.

Also confirm the frozen progress bar is gone after a failure on both the send and the receive side.
