### PR TITLE
chore: true up the community docs and site copy for all three surfaces

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,6 +37,28 @@ body:
       required: false
 
   - type: dropdown
+    id: surface
+    attributes:
+      label: Where were you using Floe?
+      options:
+        - Web app (floe.one)
+        - Desktop app (Windows)
+        - CLI
+        - Self-hosted server
+        - Not sure
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Desktop app: Settings > About. CLI: `floe --version`. Skip for the web app."
+      placeholder: e.g., desktop-v0.2.2 or v1.10.0
+    validations:
+      required: false
+
+  - type: dropdown
     id: device
     attributes:
       label: Device

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Question
+  - name: Questions and ideas
     url: https://github.com/jannskiee/floe/discussions
-    about: Ask questions in Discussions instead of opening an issue
+    about: Ask a question or float an idea in Discussions. Bug reports and concrete feature requests belong in issues.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Summary
+
+<!-- What does this change, and why? One or two sentences is plenty. -->
+
+## Test plan
+
+<!-- How did you verify it? Commands you ran, pages you checked, or "docs only". -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at paredesjancarlo99@gmail.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Floe
 
-Thank you for your interest in contributing! All contributions are welcome.
+Thank you for your interest in contributing! All contributions are welcome. This project follows the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Getting Started
 
@@ -18,6 +18,13 @@ Floe has four parts: a **Next.js client**, a **Node.js signaling server**, a **G
 
 For most contributions (UI, pages, components), you only need to run the client. Point it at the live signaling server at `api.floe.one` so you do not need to run a server locally.
 
+### Prerequisites
+
+- **Node.js 22 or newer** for the client and the signaling server (CI runs Node 22).
+- **pnpm 11** for the client. The repo pins `pnpm@11.1.2` through the `packageManager` field, so either run `corepack enable` once (Corepack ships with Node and picks up the pinned version automatically) or install it directly with `npm install -g pnpm@11`.
+- **Go 1.25 or newer** for the CLI and the desktop app.
+- **Docker** (optional) for the full-stack Compose setup below.
+
 ### Client Only (Recommended for most contributors)
 
 ```bash
@@ -34,15 +41,17 @@ Open [http://localhost:3000](http://localhost:3000). With `NEXT_PUBLIC_SOCKET_UR
 
 ### Client + Server (Only needed if you're changing server code)
 
+Run each terminal from the repository root.
+
 ```bash
 # Terminal 1 - Server
-cd floe/server
+cd server
 cp .env.example .env
 npm install
 npm start
 
 # Terminal 2 - Client
-cd floe/client
+cd client
 cp .env.example .env.local
 # NEXT_PUBLIC_SOCKET_URL is already http://localhost:3001 (the .env.example default)
 pnpm install
@@ -51,8 +60,10 @@ pnpm dev
 
 ### CLI (Only needed if you're changing CLI code)
 
+From the repository root:
+
 ```bash
-cd floe/cli
+cd cli
 go build ./cmd/floe
 go test ./...
 ```
@@ -61,8 +72,10 @@ go test ./...
 
 Build the frontend first: the Go build embeds `desktop/frontend/dist`, which is not checked in, so Go commands in `desktop/` fail on a fresh clone until it exists.
 
+From the repository root:
+
 ```bash
-cd floe/desktop/frontend
+cd desktop/frontend
 npm install
 npm run build
 npm test
@@ -78,11 +91,11 @@ For a live-reload development window, install the [Wails CLI](https://wails.io/d
 The documentation site lives in `docs/` and is built with [Mintlify](https://mintlify.com).
 
 ```bash
-cd floe/docs
-npx mintlify dev
+cd docs
+npx mintlify dev --port 3333
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to preview the docs locally.
+Open [http://localhost:3333](http://localhost:3333) to preview the docs locally. The `--port` flag matters when the client dev server is already running: both default to port 3000.
 
 ### Full stack with Docker (no local toolchain needed)
 
@@ -125,6 +138,7 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 | `MAX_CONNECTIONS_PER_IP` | No | Connection rate limit ceiling per IP per 60 seconds (default: `30`). Raise in staging or test environments. |
 | `MAX_CODE_REQUESTS_PER_IP` | No | Rate limit for the `/api/code` endpoints per IP per 60 seconds (default: `60`), shared across registering and resolving codes. Raise in CI or staging. |
 | `MAX_ACTIVE_CODES` | No | Maximum number of simultaneously-live room codes (default: `10000`). `POST /api/code` returns `503` when the cap is reached. |
+| `MAX_TURN_REQUESTS_PER_IP` | No | Rate limit for `GET /api/turn-credentials` per IP per 60 seconds (default: `20`). Raise in CI or staging. |
 | `CLOUDFLARE_TURN_KEY_ID` | No | Turn Token ID of a Cloudflare Realtime TURN key. With the API token below, enables managed TURN with no extra infrastructure. Takes precedence over the coturn variables. |
 | `CLOUDFLARE_TURN_KEY_API_TOKEN` | No | API token that pairs with `CLOUDFLARE_TURN_KEY_ID`. Keep it secret. |
 | `TURN_SECRET` | No | Shared secret for self-hosted coturn HMAC credentials, used only when the Cloudflare variables are unset. Omit both options to use STUN-only (direct connections). |
@@ -146,14 +160,15 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 5. Run client tests: `pnpm test` (in `client/`)
 6. Run CLI tests: `go test ./...` (in `cli/`)
 7. If you touched `desktop/`, run its tests too: `go test ./...` (in `desktop/`, after building the frontend) and `npm test` (in `desktop/frontend/`)
-8. Submit a pull request with a clear title and description
+8. Write commit messages in the conventional style: a lowercase, imperative subject with an optional scope, for example `fix(client): keep the progress bar visible while verifying` or `docs: clarify the relay cap`. PRs are squash-merged, so the PR title follows the same convention.
+9. Submit a pull request. The template asks for a short summary and a test plan.
 
 ---
 
 ## Code Style
 
 - TypeScript for all new client code
-- Follow the existing formatting (Prettier is configured)
+- Match the formatting of the surrounding code, and lint before pushing: `pnpm lint` (in `client/`)
 - Keep components focused and readable
 
 ---
@@ -171,6 +186,6 @@ Open an issue and describe what you'd like and why it would be useful.
 
 ## Questions
 
-Feel free to open an issue. We are happy to help.
+Ask in [Discussions](https://github.com/jannskiee/floe/discussions). For bugs and concrete feature requests, open an issue. We are happy to help.
 
 Thank you for contributing!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ For most contributions (UI, pages, components), you only need to run the client.
 
 ### Prerequisites
 
-- **Node.js 22 or newer** for the client and the signaling server (CI runs Node 22).
-- **pnpm 11** for the client. The repo pins `pnpm@11.1.2` through the `packageManager` field, so either run `corepack enable` once (Corepack ships with Node and picks up the pinned version automatically) or install it directly with `npm install -g pnpm@11`.
+- **Node.js 22 or newer** for the client and the signaling server (CI tests the client on Node 22 and the server on Node 20).
+- **pnpm 11** for the client. The repo pins `pnpm@11.1.2` through the `packageManager` field: install it directly with `npm install -g pnpm@11`, or run `corepack enable` once (Corepack ships with Node 22 and picks up the pinned version automatically; on Windows run it from an elevated terminal).
 - **Go 1.25 or newer** for the CLI and the desktop app.
 - **Docker** (optional) for the full-stack Compose setup below.
 
@@ -48,7 +48,7 @@ Run each terminal from the repository root.
 cd server
 cp .env.example .env
 npm install
-npm start
+npm run dev
 
 # Terminal 2 - Client
 cd client
@@ -109,7 +109,7 @@ The overlay tags its output `floe-client:dev` and `floe-server:dev`, so a local 
 
 Without the overlay, `docker compose up -d` pulls the prebuilt images from ghcr.io and ignores your working tree entirely, which is what a self-hoster wants but almost never what a contributor wants.
 
-This is aimed at **self-hosting** (running your own instance) rather than active development, since the client image is a production build. See [SELF_HOSTING.md](SELF_HOSTING.md) for configuration and deployment details.
+Even with the overlay this is a production build with no hot reload, so use it to verify a change against the full stack in one shot, not as a development loop. For running your own instance, see [SELF_HOSTING.md](SELF_HOSTING.md).
 
 ---
 
@@ -155,10 +155,10 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 
 1. Create a new branch: `git checkout -b your-branch-name`
 2. Make your changes
-3. Ensure the build passes: `pnpm build` (in `client/`)
-4. Run the linter: `pnpm lint` (in `client/`)
-5. Run client tests: `pnpm test` (in `client/`)
-6. Run CLI tests: `go test ./...` (in `cli/`)
+3. If you touched `client/`, ensure the build passes: `pnpm build` (in `client/`)
+4. If you touched `client/`, run the linter: `pnpm lint` (in `client/`)
+5. If you touched `client/`, run its tests: `pnpm test` (in `client/`)
+6. If you touched `cli/`, run its tests: `go test ./...` (in `cli/`)
 7. If you touched `desktop/`, run its tests too: `go test ./...` (in `desktop/`, after building the frontend) and `npm test` (in `desktop/frontend/`)
 8. Write commit messages in the conventional style: a lowercase, imperative subject with an optional scope, for example `fix(client): keep the progress bar visible while verifying` or `docs: clarify the relay cap`. PRs are squash-merged, so the PR title follows the same convention.
 9. Submit a pull request. The template asks for a short summary and a test plan.
@@ -168,7 +168,7 @@ This is aimed at **self-hosting** (running your own instance) rather than active
 ## Code Style
 
 - TypeScript for all new client code
-- Match the formatting of the surrounding code, and lint before pushing: `pnpm lint` (in `client/`)
+- Match the formatting of the surrounding code (Prettier is configured repo-wide), and lint before pushing: `pnpm lint` (in `client/`)
 - Keep components focused and readable
 
 ---

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -155,10 +155,13 @@ receiver, which is deliberate (share a link and wait) and cancellable.
       build, and the native-runner matrix waits for the macOS/Linux era)
 - [ ] Windows signing via SignPath Foundation
 - [ ] macOS notarization (deferred until the Apple Developer account is funded)
-- [ ] Build .dmg, .exe/.msi (NSIS), and .AppImage; attach to the same release
+- [~] Installers: the NSIS .exe and portable zip ship on every `desktop-v*` tag;
+      .dmg and .AppImage wait for the macOS/Linux era
 
 ### Phase 5 - Distribution
-- [ ] Homebrew Cask, Winget, Scoop (existing shared repos)
+- [~] Winget already resolves the Store listing (`winget install --id 9NBQ8ZQ1065L
+      --source msstore`); a community winget-pkgs manifest, Homebrew Cask, and
+      Scoop wait for signed builds and their platforms
 - [ ] Flathub, .deb/.rpm
 - [x] Microsoft Store as MSIX, the primary Windows channel (see the Store plan
       below; the old "unpackaged Win32" idea was wrong: the EXE submission path
@@ -167,12 +170,15 @@ receiver, which is deliberate (share a link and wait) and cancellable.
 - [x] Homepage download buttons and the /download page (#235), and a five-page "Desktop App"
       docs group: installation, sending, receiving, settings, keyboard-shortcuts
 
-## Release plan (0.1.0 beta)
+## Release history
 
-The verified order for the first public desktop release (research + independent
-checks, 2026-07-31). Steps 1-3 shipped the GitHub beta; the plan then pivoted
+Current release: `desktop-v0.2.2` (Microsoft Store 9NBQ8ZQ1065L + GitHub
+pre-release), shipped 2026-08-08.
+
+The list below is the verified order the first public release (0.1.0 beta)
+actually followed. Steps 1-3 shipped the GitHub beta; the plan then pivoted
 to the Microsoft Store as the primary Windows channel (see the Store plan
-below), which replaces the old steps 4-8.
+below), which replaced the old steps 4-8.
 
 - [x] 1. Pre-tag fixes: one exe name (`floe-desktop`), product info block in
       wails.json, per-user NSIS install (no UAC prompt), uninstaller deletes the
@@ -203,7 +209,12 @@ the exe/zip serve Store-blocked machines and are the hotfix/rollback path
 Versioning: the MSIX Identity Version's first octet cannot be 0 and the fourth
 is reserved, so `pack.ps1` derives it mechanically as (major+1).minor.patch.0
 (0.2.0 -> 1.2.0.0, 1.0.0 -> 2.0.0.0). The product's own 0.x string stays in
-wails.json, the exe version resource, and all marketing.
+wails.json, the exe version resource, and all marketing. At tag time, bump
+wails.json's `productVersion` and the concrete version examples in
+docs/desktop/installation.mdx and docs/desktop/settings.mdx alongside
+`DESKTOP_VERSION` in client/lib/desktopRelease.ts; the release workflow
+rewrites wails.json only in the runner's working tree, so the committed value
+goes stale otherwise.
 
 Packaged-build behavior (verified empirically 2026-08-02 on a loose-layout
 package of this app): the app's HKCU registry writes are virtualized into the
@@ -256,7 +267,8 @@ binary.
 
 **Must have (v1):** drag and drop send, folder send without zipping, receive
 streamed to disk with progress, system tray with background receive, OS
-notifications, the same code/link/QR pairing as web and CLI, auto-update, dark mode.
+notifications, pairing that interoperates with every surface (the web sends
+link+QR, the CLI code+link, the desktop all three), auto-update, dark mode.
 
 **Differentiators:** OS context-menu "Send with Floe" (right click in Explorer or
 Finder), a LAN fast path via local discovery (mDNS) for full-speed same-network

--- a/README.md
+++ b/README.md
@@ -5,152 +5,97 @@
 <h1 align="center">Floe</h1>
 
 <p align="center">
-  <strong>Secure, encrypted peer-to-peer file transfer</strong>
+  <strong>Encrypted peer-to-peer file transfer for the browser, desktop, and command line</strong>
 </p>
 
 <p align="center">
-  <a href="https://github.com/jannskiee/floe/releases/latest"><img src="https://img.shields.io/github/v/release/jannskiee/floe" alt="Latest release" /></a>
+  <a href="https://github.com/jannskiee/floe/releases/latest"><img src="https://img.shields.io/github/v/release/jannskiee/floe?filter=v*&label=CLI" alt="CLI release" /></a>
+  <a href="https://github.com/jannskiee/floe/releases"><img src="https://img.shields.io/github/v/release/jannskiee/floe?filter=desktop-v*&label=Windows&include_prereleases" alt="Desktop release" /></a>
   <a href="https://github.com/jannskiee/floe/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/jannskiee/floe/ci.yml?branch=main&label=build" alt="Build status" /></a>
   <a href="https://github.com/jannskiee/floe/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License" /></a>
-  <a href="https://github.com/jannskiee/floe/issues"><img src="https://img.shields.io/github/issues/jannskiee/floe" alt="Issues" /></a>
   <a href="https://github.com/jannskiee/floe/stargazers"><img src="https://img.shields.io/github/stars/jannskiee/floe?style=social" alt="Stars" /></a>
-  <a href="https://github.com/jannskiee/floe/network/members"><img src="https://img.shields.io/github/forks/jannskiee/floe?style=social" alt="Forks" /></a>
 </p>
 
 <p align="center">
   <a href="https://floe.one">Try Floe</a> ·
-  <a href="https://floe.one/how-it-works">How It Works</a> ·
   <a href="https://www.floe.one/docs">Documentation</a> ·
+  <a href="#desktop">Desktop</a> ·
   <a href="#cli">CLI</a> ·
-  <a href="#self-hosting">Self-Hosting</a> ·
+  <a href="#self-hosting">Self-hosting</a> ·
   <a href="#contributing">Contributing</a>
 </p>
 
 ## About
 
-Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices with no server storage, no accounts, and no registration required. When a direct path is unavailable due to network restrictions, a TURN relay server bridges the connection while maintaining end-to-end encryption.
+Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted. The only telemetry is an optional, anonymous byte-count report that powers the public transfer counter, and every client [can opt out](https://www.floe.one/docs/security-privacy).
 
-A signaling server (`api.floe.one`) handles WebRTC negotiation and issues short-lived TURN credentials. It does not handle file data. No component in Floe's infrastructure stores, decrypts, or inspects transferred files.
+Three clients share one wire protocol: the web app at [floe.one](https://floe.one), a Windows desktop app, and a Go CLI. Send from a browser tab and receive in the desktop app or the CLI, or any other combination, even across different networks.
 
-## Quick Start
+For the design behind this, see [how it works](https://www.floe.one/how-it-works) and the [technical reference](https://www.floe.one/docs/how-it-works/signaling).
 
-[floe.one](https://floe.one) runs entirely in your browser. Open it, pick a file, and share the code or link. No account or installation required.
+## Quick start
 
-New to Floe? The [Quick Start guide](https://www.floe.one/docs/quickstart) walks through sending and receiving your first file.
+Open [floe.one](https://floe.one), pick a file, and share the generated link or QR code with the receiver. No account or installation required. The [quickstart guide](https://www.floe.one/docs/quickstart) walks through sending and receiving your first file.
 
-## How It Works
+## Desktop
 
-Files transfer directly between devices using WebRTC. A signaling server handles connection setup, then steps aside once both peers are connected. When a direct path cannot be established, an optional TURN relay bridges the connection with encrypted data that is never stored.
+Floe for Windows 10 and 11 (x64), currently in beta. The Microsoft Store build is signed and updates automatically.
 
-For a plain-language overview, visit [floe.one/how-it-works](https://floe.one/how-it-works). For the full technical reference covering signaling, ICE and NAT traversal, encryption, and relay fallback, see the [documentation](https://www.floe.one/docs/how-it-works/signaling).
+<a href="https://apps.microsoft.com/detail/9NBQ8ZQ1065L"><img src="client/public/ms-store-badge.svg" alt="Download from the Microsoft Store" width="161" height="44" /></a>
+
+Prefer a direct download? An installer and a portable build are on the [download page](https://www.floe.one/download). Setup details are in the [desktop installation guide](https://www.floe.one/docs/desktop/installation).
 
 ## CLI
 
-Floe provides a command-line interface for transferring files from headless devices, servers, and automated workflows. The CLI connects to the same signaling infrastructure as the web app. Browser-to-CLI and CLI-to-browser transfers are fully supported.
-
-### Install
-
-**macOS**
-```sh
-brew install --cask jannskiee/tap/floe
-```
-
-**Windows**
-```powershell
-winget install jannskiee.floe
-# or: scoop bucket add jannskiee https://github.com/jannskiee/scoop-bucket && scoop install floe
-```
-
-**Linux / any OS**
-```sh
-curl -fsSL https://floe.one/install.sh | sh
-# Windows PowerShell: irm https://floe.one/install.ps1 | iex
-```
-
-No runtime or dependencies required. For Go devs: `go install github.com/jannskiee/floe/cli/cmd/floe@latest`. For all install options, checksum verification, and PATH setup, see the [installation guide](https://www.floe.one/docs/cli/installation).
-
-### Update
+Send and receive from terminals, servers, and scripts.
 
 ```sh
-floe update              # for script / manual installs
-brew upgrade floe        # Homebrew
-winget upgrade jannskiee.floe  # Winget
-scoop update floe        # Scoop
+brew install --cask jannskiee/tap/floe        # macOS
+winget install jannskiee.floe                 # Windows
+curl -fsSL https://floe.one/install.sh | sh   # Linux and other systems
 ```
 
-### Usage
+Send with `floe send photo.jpg`, receive with `floe receive olive-tiger-castle`, and update in place with `floe update`. Senders in the CLI and the desktop app produce both a short code and a browser link, so the receiver can join from any client.
 
-**Send a file:**
-```sh
-floe send photo.jpg
-```
+Other install channels, checksum verification, and PATH setup are covered in the [CLI installation guide](https://www.floe.one/docs/cli/installation).
 
-**Send multiple files or a folder:**
-```sh
-floe send file1.txt file2.pdf folder/
-```
+## Self-hosting
 
-**Receive:**
-```sh
-floe receive olive-tiger-castle
-```
-
-The sender's terminal will display a room code and a browser link. The receiver can join using either the code (CLI) or the link (browser).
-
-After a successful transfer, the receiver reports only the total byte count to Floe's signaling server to power the public "transferred globally" counter on the homepage. No file names or contents are included. The sender never reports. To opt out:
-
-```sh
-floe receive olive-tiger-castle --no-report   # single transfer
-FLOE_NO_STATS=1 floe receive ...              # permanent (add to shell profile)
-```
-
-The global total is visible only in the browser. The CLI contributes to it but never displays it.
-
-For all commands, flags, and advanced usage, see the [documentation](https://www.floe.one/docs).
-
-## Self-Hosting
-
-Prefer to run your own instance instead of using `floe.one`? Prebuilt images are published to ghcr.io, so the full stack comes up in two commands with no clone and no toolchain:
+Prefer your own infrastructure? Prebuilt images on ghcr.io bring up the full stack in two commands, with no clone and no toolchain:
 
 ```sh
 curl -fsSLO https://raw.githubusercontent.com/jannskiee/floe/main/docker-compose.yml
 docker compose up -d
 ```
 
-This runs the client on `:3000` and the signaling server on `:3001` (STUN-only, which works on most networks). See **[SELF_HOSTING.md](SELF_HOSTING.md)** for configuration, production deployment behind HTTPS, and the optional TURN relay.
+All three clients can point at a self-hosted server. Configuration, deployment behind HTTPS, and the optional TURN relay are covered in [SELF_HOSTING.md](SELF_HOSTING.md) and the [self-hosting docs](https://www.floe.one/docs/self-hosting/overview).
+
+## Documentation
+
+Everything else lives in the [documentation](https://www.floe.one/docs):
+
+- [Quickstart](https://www.floe.one/docs/quickstart)
+- [FAQ](https://www.floe.one/docs/faq)
+- [Troubleshooting](https://www.floe.one/docs/troubleshooting)
+- [Changelog](https://www.floe.one/docs/changelog)
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, environment variables, and the pull request process.
-
-If you encounter a bug or have a feature suggestion, please open an [issue](https://github.com/jannskiee/floe/issues).
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and the pull request process, and open an [issue](https://github.com/jannskiee/floe/issues) for bugs or feature requests. This project follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## Support
 
-Floe is free and open source. Contributions help cover the ongoing costs of backend infrastructure that keeps the service accessible to everyone. This includes the signaling server for WebRTC connection negotiation and room management, and the TURN relay server that provides encrypted relay for users behind strict firewalls or Carrier-Grade NAT.
+Floe is free and open source. Sponsorship covers the signaling and TURN relay infrastructure that keeps the hosted service available to everyone.
 
-**[GitHub Sponsors](https://github.com/sponsors/jannskiee)**\
-**[Ko-fi](https://ko-fi.com/jannskiee)**
+**[GitHub Sponsors](https://github.com/sponsors/jannskiee)** · **[Ko-fi](https://ko-fi.com/jannskiee)**
 
 ## Acknowledgments
 
-Floe is supported by open source sponsorship programs that donate the tools and infrastructure behind it:
-
-- **Error monitoring** is generously provided by [Sentry](https://sentry.io) through [Sentry for Good](https://sentry.io/for/good/).
-- **Documentation** is generously hosted by [Mintlify](https://mintlify.com) through the [Mintlify OSS Program](https://mintlify.com/oss-program).
-- **Development** is supported by [Claude](https://claude.com/claude-code) through Anthropic's open source program.
-
-Thank you to these programs for helping keep Floe sustainable as an independent open source project.
-
-<p align="center">
-  <a href="https://sentry.io"><img src="https://img.shields.io/badge/Monitored%20by-Sentry-362D59?logo=sentry&logoColor=white" alt="Monitored by Sentry" /></a>
-  <a href="https://mintlify.com"><img src="https://img.shields.io/badge/Docs%20by-Mintlify-18E299?logo=mintlify&logoColor=white" alt="Documentation by Mintlify" /></a>
-  <a href="https://www.anthropic.com"><img src="https://img.shields.io/badge/Sponsored%20by-Anthropic-D97757?logo=anthropic&logoColor=white" alt="Sponsored by Anthropic" /></a>
-</p>
+Error monitoring is provided by [Sentry](https://sentry.io/for/good/), documentation hosting by [Mintlify](https://mintlify.com/oss-program), and development support by [Anthropic](https://www.anthropic.com)'s open source program. Thank you for keeping Floe sustainable as an independent project.
 
 ## License
 
-This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.
+MIT License, Copyright Jan Carlo Paredes. See [LICENSE](LICENSE) for details.
 
 <p align="center">
   <sub>Open source. Built for everyone.</sub>

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## About
 
-Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted. The only telemetry is an optional, anonymous byte-count report that powers the public transfer counter, and every client [can opt out](https://www.floe.one/docs/security-privacy).
+Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted. The only report a client sends about a transfer is an optional, anonymous byte count that powers the public counter, and every client can opt out. The floe.one website itself runs cookieless analytics and error monitoring, detailed in the [security and privacy docs](https://www.floe.one/docs/security-privacy).
 
 Three clients share one wire protocol: the web app at [floe.one](https://floe.one), a Windows desktop app, and a Go CLI. Send from a browser tab and receive in the desktop app or the CLI, or any other combination, even across different networks.
 
@@ -91,7 +91,7 @@ Floe is free and open source. Sponsorship covers the signaling and TURN relay in
 
 ## Acknowledgments
 
-Error monitoring is provided by [Sentry](https://sentry.io/for/good/), documentation hosting by [Mintlify](https://mintlify.com/oss-program), and development support by [Anthropic](https://www.anthropic.com)'s open source program. Thank you for keeping Floe sustainable as an independent project.
+Error monitoring is provided by [Sentry](https://sentry.io/for/good/), documentation hosting by [Mintlify](https://mintlify.com/oss-program), and development support by [Anthropic](https://www.anthropic.com)'s open source program. Thanks to these programs for keeping Floe sustainable as an independent project.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Please include as much of the following as possible:
 
 - A description of the vulnerability and its impact
 - Steps to reproduce it
-- The affected component (client, server, or CLI)
+- The affected component (web client, signaling server, CLI, or desktop app)
 - Any relevant logs, screenshots, or proof of concept
 
 ## What to Expect
@@ -24,8 +24,8 @@ Please include as much of the following as possible:
 
 ## Scope
 
-This policy covers the Floe web client, signaling server, and CLI in this repository. The signaling server brokers connection setup only. File data is transferred directly between peers over encrypted WebRTC data channels and is never stored or inspected by Floe infrastructure.
+This policy covers the Floe web client, signaling server, CLI, and desktop app in this repository. The signaling server brokers connection setup only. File data is transferred directly between peers over encrypted WebRTC data channels and is never stored or inspected by Floe infrastructure.
 
 ## Supported Versions
 
-Security fixes are applied to the latest release on the `main` branch. Please make sure you are using the most recent version before reporting an issue.
+Security fixes land on `main` and ship in the next release of the affected component. Floe has two release lines: the CLI releases as `v*` tags (the repository's Latest release) and the desktop app releases as `desktop-v*` pre-release tags, while the web client at floe.one always runs the newest `main`. Please make sure you are on the most recent release of the component you are reporting against.

--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -46,7 +46,8 @@ export default function HowItWorks() {
                     </div>
                     <p className="text-zinc-300 leading-relaxed">
                         Floe uses a technology called <strong>WebRTC</strong> to send your files directly from
-                        one browser to another. Think of it like handing a USB drive to someone. It
+                        one device to another, whether each side is a browser tab, the desktop app, or
+                        the CLI. Think of it like handing a USB drive to someone. It
                         happens over the internet, in real time. In most cases, no one else is in the middle.
                         <br /><br />
                         In some network situations, a secure relay server acts as a bridge. Either way,

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -19,7 +19,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
     title: 'Floe',
     description:
-        'Send files directly to anyone. No uploads, no accounts, end-to-end encrypted. Works on any device, any browser.',
+        'Send files directly to anyone. No uploads, no accounts, end-to-end encrypted. Works in your browser, as a Windows desktop app, or from the CLI.',
     metadataBase,
     // Left unconditional on purpose. Next passes a RELATIVE canonical through
     // verbatim when metadataBase is null, so this stays a valid self-referencing

--- a/client/components/landing/HowItWorksSection.tsx
+++ b/client/components/landing/HowItWorksSection.tsx
@@ -10,7 +10,7 @@ const steps: { index: string; title: string; body: ReactNode }[] = [
     {
         index: '02',
         title: 'Share either one',
-        body: 'Your peer opens the link in any browser, scans the QR, or pastes the link into the CLI. No account on either side.',
+        body: 'Your peer opens the link in any browser, scans the QR, or pastes the link into the desktop app or the CLI. No account on either side.',
     },
     {
         index: '03',

--- a/client/components/landing/HowItWorksSection.tsx
+++ b/client/components/landing/HowItWorksSection.tsx
@@ -5,19 +5,12 @@ const steps: { index: string; title: string; body: ReactNode }[] = [
     {
         index: '01',
         title: 'Drop your files',
-        body: (
-            <>
-                You get a link and a short code like{' '}
-                <code className="font-mono text-[12px] text-zinc-300">olive-tiger-castle</code>. The
-                room id rides the URL fragment, which never appears in page requests, server logs,
-                or analytics.
-            </>
-        ),
+        body: 'You get a share link and a QR code. The room id rides the URL fragment, which never appears in page requests, server logs, or analytics.',
     },
     {
         index: '02',
         title: 'Share either one',
-        body: 'Your peer opens the link in any browser, or types the code into the CLI. No account on either side.',
+        body: 'Your peer opens the link in any browser, scans the QR, or pastes the link into the CLI. No account on either side.',
     },
     {
         index: '03',

--- a/client/components/landing/PrivacySection.tsx
+++ b/client/components/landing/PrivacySection.tsx
@@ -5,7 +5,7 @@ import { SectionHeader, sectionClass } from './SectionHeader';
 const handled: ReactNode[] = [
     'WebRTC offers, answers, and ICE candidates',
     'The room id that pairs two devices, held in memory while the room is open',
-    'A short room code that expires after 10 minutes',
+    'A short room code when the sender uses the CLI or desktop app, expiring after 10 minutes',
     'Short-lived TURN relay credentials',
     'One anonymous running total of bytes for the public counter',
     // The lede promises this is the COMPLETE list, so the per-IP rate limiting in

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,56 +1,41 @@
 # Floe Desktop
 
-## About
+The Windows desktop app: a Wails v2 (Go) shell around the shared `cli/engine`
+transfer core, with a React + TypeScript + Tailwind frontend in `frontend/`.
+Project settings live in `wails.json`
+(reference: https://wails.io/docs/reference/project-config).
 
-The Floe desktop app: Wails (Go) shell around the shared `cli/engine` transfer core, with a
-React + TypeScript + Tailwind frontend.
+## Build and develop
 
-You can configure the project by editing `wails.json`. More information about the project settings can be found
-here: https://wails.io/docs/reference/project-config
+Build the frontend first, always: `main.go` embeds `frontend/dist`, which is not
+checked in, so every Go command here fails on a fresh clone until it exists.
 
-## Docs to write at desktop launch
+```
+cd frontend
+npm install
+npm run build
+npm test
 
-Settings descriptions state what each setting does and the one consequence that changes a
-decision. The facts below are the ones that genuinely do not fit a settings row, so they must land
-on a desktop settings docs page before or with the first desktop release. Anything already covered
-in the UI has been removed from this list; keep it that way, so it stays an accurate statement of
-what is still missing.
+cd ..
+go test ./...
+wails dev      # live development window with hot reload
+wails build    # production build -> build/bin/floe-desktop.exe
+```
 
-- **Hide my IP, the relay cap.** Why relayed sessions stop at 2 GB while direct transfers are
-  uncapped, and that an oversized relayed transfer is refused before any bytes move rather than
-  failing partway.
-- **Hide my IP against a self-hosted server.** Relay-only requires TURN. If a custom server offers
-  none, ICE falls back to public STUN, the relay-only connection finds no candidates, and the
-  transfer dies with a generic WebRTC error. This is the highest-value item on the list.
-- **Global stats, who reports.** Only the receiving side reports, and only on a completed
-  transfer. Opt-out parity with the browser toggle and the CLI `--no-report` / `FLOE_NO_STATS`.
-  Note the counter follows the configured server, so a self-hoster's bytes go to their own server,
-  not floe.one.
-- **Right-click menu, how it is installed.** A per-user registry entry needing no administrator
-  approval, scoped to files rather than folders.
-- **Save folder, name collisions.** An arriving file never overwrites an existing one; it is kept
-  as `name (1).ext`. Worth documenting precisely, because a user told "nothing is overwritten"
-  who then cannot find the file by its original name is worse off than one told nothing.
-- **Custom server, reachability.** What "people on floe.one cannot connect to you" means in
-  practice, and that reaching you still requires the room id.
-- **Share link address.** The recommended self-host topology is one address serving both the API
-  and the web app; when a split setup needs this field.
-- **Transfer protocol.** Compatibility is a range overlap, not an exact match, and the check runs
-  before any file data moves.
-- **Reset all settings, what it covers.** It restores the save folder, both privacy switches and
-  the two server addresses. It leaves the transfer history, the files already received, and the
-  Windows right-click menu alone. The right-click exclusion is deliberate and should not be
-  "fixed": that entry is registry state, enabling it writes the running executable's path, and
-  clearing its marker without re-registering would make the app write the registry silently on the
-  next launch. See the comment on resetAllSettings in App.tsx.
+`wails dev` also serves the app at http://localhost:34115, where a normal
+browser can call the bound Go methods from devtools. Note that `wails build`
+can exit 0 on a silent failure; check that the executable's timestamp changed.
 
-## Live Development
+## Where things are documented
 
-To run in live development mode, run `wails dev` in the project directory. This will run a Vite development
-server that will provide very fast hot reload of your frontend changes. If you want to develop in a browser
-and have access to your Go methods, there is also a dev server that runs on http://localhost:34115. Connect
-to this in your browser, and you can call your Go code from devtools.
+User-facing behavior lives in the five-page desktop docs group
+(`docs/desktop/`): installation, sending, receiving, settings, and
+keyboard-shortcuts. The pre-launch list of facts that had to reach those pages
+shipped with them, including the relay cap and Hide my IP (sending, settings),
+save-folder name collisions (receiving), who reports global stats (receiving),
+the right-click Explorer entry and what Reset covers (settings), and
+self-hosted server reachability (settings).
 
-## Building
-
-To build a redistributable, production mode package, use `wails build`.
+Release status, the Store plan, and the roadmap live in `DESKTOP.md` at the
+repository root. The Microsoft Store packaging pipeline lives in `build/msix/`
+(see `build/README.md`).

--- a/desktop/build/README.md
+++ b/desktop/build/README.md
@@ -1,35 +1,18 @@
-# Build Directory
+# Build assets
 
-The build directory is used to house all the build files and assets for your application. 
+What `wails build` and the packaging pipeline read from this directory:
 
-The structure is:
-
-* bin - Output directory
-* darwin - macOS specific files
-* windows - Windows specific files
-
-## Mac
-
-The `darwin` directory holds files specific to Mac builds.
-These may be customised and used as part of the build. To return these files to the default state, simply delete them
-and
-build with `wails build`.
-
-The directory contains the following files:
-
-- `Info.plist` - the main plist file used for Mac builds. It is used when building using `wails build`.
-- `Info.dev.plist` - same as the main plist file but used when building using `wails dev`.
-
-## Windows
-
-The `windows` directory contains the manifest and rc files used when building with `wails build`.
-These may be customised for your application. To return these files to the default state, simply delete them and
-build with `wails build`.
-
-- `icon.ico` - The icon used for the application. This is used when building using `wails build`. If you wish to
-  use a different icon, simply replace this file with your own. If it is missing, a new `icon.ico` file
-  will be created using the `appicon.png` file in the build directory.
-- `installer/*` - The files used to create the Windows installer. These are used when building using `wails build`.
-- `info.json` - Application details used for Windows builds. The data here will be used by the Windows installer,
-  as well as the application itself (right click the exe -> properties -> details)
-- `wails.exe.manifest` - The main application manifest file.
+- `bin/` - build output: `floe-desktop.exe` and the NSIS installer
+  `floe-desktop-setup-<version>.exe`.
+- `windows/` - Windows build inputs: `icon.ico` (regenerated from `appicon.png`
+  if deleted), `info.json` (the exe's version resource: right-click the exe,
+  Properties, Details), `wails.exe.manifest`, and `installer/` (the NSIS
+  project).
+- `msix/` - the Microsoft Store pipeline: the `AppxManifest.xml` template, the
+  Store icon assets plus `gen-assets.ps1`, and `pack.ps1`, which packs the
+  built exe into an UNSIGNED `.msix` for Partner Center. The Store re-signs it
+  on publication; end users cannot install the unsigned package. Both CI's
+  packaging smoke job and `desktop-release.yml` run this script.
+- `darwin/` - Wails' default macOS plist templates. Unused: macOS builds have
+  not shipped.
+- `appicon.png` / `appicon.svg` - the source icon.

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1546,10 +1546,10 @@ function App() {
                                 <section className="space-y-2">
                                     <Eyebrow as="h3">Privacy</Eyebrow>
                                     {/* Both rows state the benefit first, then the cost, because a
-                                        toggle described only by its cost reads as a trap. What is
-                                        still missing (why the relay caps at 2 GB, that only the
-                                        RECEIVER reports, relay-only failing on a server with no
-                                        TURN) is on the launch list in desktop/README.md. */}
+                                        toggle described only by its cost reads as a trap. The
+                                        details left out here (why the relay caps at 2 GB, that only
+                                        the RECEIVER reports, relay-only failing on a server with no
+                                        TURN) live in the desktop docs: sending and settings. */}
                                     <div className={cn(cardClass, insetHairline)}>
                                         <SettingRow
                                             checked={hideIP}

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -5,7 +5,7 @@
   "info": {
     "companyName": "Jan Carlo Paredes",
     "productName": "Floe",
-    "productVersion": "0.1.0",
+    "productVersion": "0.2.2",
     "copyright": "(c) 2026 Jan Carlo Paredes",
     "comments": "Peer-to-peer file transfer"
   },

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -93,7 +93,7 @@ receives from browser peers and CLI peers without any extra setup.
 Every GitHub release ships `SHA256SUMS.txt`. To check a file you downloaded:
 
 ```powershell PowerShell
-Get-FileHash floe-desktop-setup-0.2.1.exe -Algorithm SHA256
+Get-FileHash floe-desktop-setup-0.2.2.exe -Algorithm SHA256
 ```
 
 Compare the result with the matching line in `SHA256SUMS.txt`. Store installs need no check:
@@ -102,7 +102,7 @@ the Store verifies the package signature itself.
 ## Check the version
 
 Open **Settings** (the gear in the title bar, or `Ctrl` `,`) and look at the **About** section.
-**App version** reads the release tag, for example `desktop-v0.2.1`. A build you compiled
+**App version** reads the release tag, for example `desktop-v0.2.2`. A build you compiled
 yourself reads `dev`.
 
 That section also shows the transfer protocol version and which signaling server the app is

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -182,7 +182,7 @@ This mirrors the CLI's `--web` flag. See
 
 ### App version
 
-The release you are running, for example `desktop-v0.2.1`. A build you compiled yourself reads
+The release you are running, for example `desktop-v0.2.2`. A build you compiled yourself reads
 `dev`.
 
 ### Transfer protocol


### PR DESCRIPTION
## Summary

One visibility pass so the repository front door, community docs, landing copy, and internal trackers describe Floe as it ships today: web app, Windows desktop app, and CLI. The README previously never mentioned the desktop app, the Store, or the download page, and told browser users to "share the code or link" when web senders only mint links. The issue chooser's Question link pointed at a Discussions tab that did not exist.

## Changes

- **README.md** - rewritten as a short overview that points to the docs: all three surfaces with install paths (Microsoft Store badge for desktop), labeled release badges per release line, accurate link/QR versus code semantics, and self-hosting, contributing, and security pointers
- **CONTRIBUTING.md** - prerequisites (Node, pnpm 11 via corepack or npm, Go 1.25), setup blocks that start from the repository root, `npm run dev` for server work, a mintlify port hint, the missing `MAX_TURN_REQUESTS_PER_IP` row, a scoped PR checklist, commit conventions, and questions routed to the newly enabled Discussions
- **.github/** - new pull request template; the bug report form gains a surface dropdown and a version field; the issue chooser's Question link now points at a Discussions tab that exists
- **CODE_OF_CONDUCT.md** - Contributor Covenant v2.1
- **SECURITY.md** - covers the desktop app and names both release lines
- **docs/desktop/** - version examples bumped to the shipped 0.2.2
- **client/** - landing and metadata copy no longer promise web senders a room code, and the site description mentions the desktop app and CLI
- **DESKTOP.md, desktop/README.md, desktop/build/README.md, desktop/wails.json** - trackers caught up with what shipped, `build/msix/` documented, and `productVersion` bumped to 0.2.2 (the release workflow still stamps the tag value at build time)

## Test plan

- `corepack pnpm lint` and `corepack pnpm build` in `client/` (build with `NEXT_PUBLIC_SOCKET_URL` set, matching CI); client vitest hits a local `ERR_PACKAGE_IMPORT_NOT_DEFINED` startup error that reproduces identically on a pristine `origin/main` checkout, so it is environmental and this PR's CI run is the arbiter
- Every URL in the changed files answers 200 (github-family links verified via the API)
- Zero em or en dashes across all added lines
- CONTRIBUTING.md keeps the `#development-setup` anchor that docs/self-hosting/without-docker.mdx deep-links
- Issue forms validate against the issue-forms schema shape (unique ids, distinct non-empty dropdown options)
- wails.json's `productVersion` line still matches the grep in ci.yml and desktop-release.yml; the desktop CI job packs identity 1.2.2.0
- Full CI (3-OS e2e) runs on this PR since `client/` is touched
