### PR TITLE
docs: restore support and acknowledgments, and write the documentation section in prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,11 @@ All three clients can point at a self-hosted server. Configuration, deployment b
 
 ## Documentation
 
-The [documentation](https://www.floe.one/docs) covers all three clients in depth, from your first transfer to a self-hosted deployment. The [FAQ](https://www.floe.one/docs/faq) answers the questions that come up most, from transfer limits to privacy, and the [troubleshooting guide](https://www.floe.one/docs/troubleshooting) starts from the symptom when something will not connect. The [changelog](https://www.floe.one/docs/changelog) tracks every release across web, desktop, and CLI.
+The [documentation](https://www.floe.one/docs) covers all three clients in depth, from your first transfer to a self-hosted deployment.
+
+The [FAQ](https://www.floe.one/docs/faq) answers the questions that come up most, from transfer limits to privacy, and the [troubleshooting guide](https://www.floe.one/docs/troubleshooting) starts from the symptom when something will not connect.
+
+The [changelog](https://www.floe.one/docs/changelog) tracks every release across web, desktop, and CLI.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and 
 
 ## Support
 
-Floe is free and open source. Contributions help cover the ongoing costs of backend infrastructure that keeps the service accessible to everyone. This includes the signaling server for WebRTC connection negotiation and room management, and the TURN relay server that provides encrypted relay for users behind strict firewalls or Carrier-Grade NAT.
+Floe is free and open source. Contributions help cover the ongoing costs of backend infrastructure that keeps the service accessible to everyone. This includes the signaling server for WebRTC connection negotiation and room management, and the TURN relay service that provides encrypted relay for users behind strict firewalls or Carrier-Grade NAT.
 
 **[GitHub Sponsors](https://github.com/sponsors/jannskiee)**\
 **[Ko-fi](https://ko-fi.com/jannskiee)**

--- a/README.md
+++ b/README.md
@@ -72,12 +72,7 @@ All three clients can point at a self-hosted server. Configuration, deployment b
 
 ## Documentation
 
-Everything else lives in the [documentation](https://www.floe.one/docs):
-
-- [Quickstart](https://www.floe.one/docs/quickstart)
-- [FAQ](https://www.floe.one/docs/faq)
-- [Troubleshooting](https://www.floe.one/docs/troubleshooting)
-- [Changelog](https://www.floe.one/docs/changelog)
+The [documentation](https://www.floe.one/docs) covers all three clients in depth, from your first transfer to a self-hosted deployment. The [FAQ](https://www.floe.one/docs/faq) answers the questions that come up most, from transfer limits to privacy, and the [troubleshooting guide](https://www.floe.one/docs/troubleshooting) starts from the symptom when something will not connect. Every release, web, desktop, and CLI alike, is written up in the [changelog](https://www.floe.one/docs/changelog).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ All three clients can point at a self-hosted server. Configuration, deployment b
 
 ## Documentation
 
-The [documentation](https://www.floe.one/docs) covers all three clients in depth, from your first transfer to a self-hosted deployment. The [FAQ](https://www.floe.one/docs/faq) answers the questions that come up most, from transfer limits to privacy, and the [troubleshooting guide](https://www.floe.one/docs/troubleshooting) starts from the symptom when something will not connect. Every release, web, desktop, and CLI alike, is written up in the [changelog](https://www.floe.one/docs/changelog).
+The [documentation](https://www.floe.one/docs) covers all three clients in depth, from your first transfer to a self-hosted deployment. The [FAQ](https://www.floe.one/docs/faq) answers the questions that come up most, from transfer limits to privacy, and the [troubleshooting guide](https://www.floe.one/docs/troubleshooting) starts from the symptom when something will not connect. The [changelog](https://www.floe.one/docs/changelog) tracks every release across web, desktop, and CLI.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,26 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and 
 
 ## Support
 
-Floe is free and open source. Sponsorship covers the signaling and TURN relay infrastructure that keeps the hosted service available to everyone.
+Floe is free and open source. Contributions help cover the ongoing costs of backend infrastructure that keeps the service accessible to everyone. This includes the signaling server for WebRTC connection negotiation and room management, and the TURN relay server that provides encrypted relay for users behind strict firewalls or Carrier-Grade NAT.
 
-**[GitHub Sponsors](https://github.com/sponsors/jannskiee)** · **[Ko-fi](https://ko-fi.com/jannskiee)**
+**[GitHub Sponsors](https://github.com/sponsors/jannskiee)**\
+**[Ko-fi](https://ko-fi.com/jannskiee)**
 
 ## Acknowledgments
 
-Error monitoring is provided by [Sentry](https://sentry.io/for/good/), documentation hosting by [Mintlify](https://mintlify.com/oss-program), and development support by [Anthropic](https://www.anthropic.com)'s open source program. Thanks to these programs for keeping Floe sustainable as an independent project.
+Floe is supported by open source sponsorship programs that donate the tools and infrastructure behind it:
+
+- **Error monitoring** is generously provided by [Sentry](https://sentry.io) through [Sentry for Good](https://sentry.io/for/good/).
+- **Documentation** is generously hosted by [Mintlify](https://mintlify.com) through the [Mintlify OSS Program](https://mintlify.com/oss-program).
+- **Development** is supported by [Claude](https://claude.com/claude-code) through Anthropic's open source program.
+
+Thank you to these programs for helping keep Floe sustainable as an independent open source project.
+
+<p align="center">
+  <a href="https://sentry.io"><img src="https://img.shields.io/badge/Monitored%20by-Sentry-362D59?logo=sentry&logoColor=white" alt="Monitored by Sentry" /></a>
+  <a href="https://mintlify.com"><img src="https://img.shields.io/badge/Docs%20by-Mintlify-18E299?logo=mintlify&logoColor=white" alt="Documentation by Mintlify" /></a>
+  <a href="https://www.anthropic.com"><img src="https://img.shields.io/badge/Sponsored%20by-Anthropic-D97757?logo=anthropic&logoColor=white" alt="Sponsored by Anthropic" /></a>
+</p>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@
 
 ## About
 
-Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted. The only report a client sends about a transfer is an optional, anonymous byte count that powers the public counter, and every client can opt out. The floe.one website itself runs cookieless analytics and error monitoring, detailed in the [security and privacy docs](https://www.floe.one/docs/security-privacy).
+Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted.
+
+The only report a client sends about a transfer is an optional, anonymous byte count that powers the public counter, and every client can opt out. The floe.one website itself runs cookieless analytics and error monitoring, detailed in the [security and privacy docs](https://www.floe.one/docs/security-privacy).
 
 Three clients share one wire protocol: the web app at [floe.one](https://floe.one), a Windows desktop app, and a Go CLI. Send from a browser tab and receive in the desktop app or the CLI, or any other combination, even across different networks.
 
@@ -35,7 +37,9 @@ For the design behind this, see [how it works](https://www.floe.one/how-it-works
 
 ## Quick start
 
-Open [floe.one](https://floe.one), pick a file, and share the generated link or QR code with the receiver. No account or installation required. The [quickstart guide](https://www.floe.one/docs/quickstart) walks through sending and receiving your first file.
+Open [floe.one](https://floe.one), pick a file, and share the generated link or QR code with the receiver. No account or installation required.
+
+The [quickstart guide](https://www.floe.one/docs/quickstart) walks through sending and receiving your first file.
 
 ## Desktop
 
@@ -43,7 +47,9 @@ Floe for Windows 10 and 11 (x64), currently in beta. The Microsoft Store build i
 
 <a href="https://apps.microsoft.com/detail/9NBQ8ZQ1065L"><img src="client/public/ms-store-badge.svg" alt="Download from the Microsoft Store" width="161" height="44" /></a>
 
-Prefer a direct download? An installer and a portable build are on the [download page](https://www.floe.one/download). Setup details are in the [desktop installation guide](https://www.floe.one/docs/desktop/installation).
+Prefer a direct download? An installer and a portable build are on the [download page](https://www.floe.one/download).
+
+Setup details are in the [desktop installation guide](https://www.floe.one/docs/desktop/installation).
 
 ## CLI
 
@@ -55,7 +61,9 @@ winget install jannskiee.floe                 # Windows
 curl -fsSL https://floe.one/install.sh | sh   # Linux and other systems
 ```
 
-Send with `floe send photo.jpg`, receive with `floe receive olive-tiger-castle`, and update in place with `floe update`. Senders in the CLI and the desktop app produce both a short code and a browser link, so the receiver can join from any client.
+Send with `floe send photo.jpg`, receive with `floe receive olive-tiger-castle`, and update in place with `floe update`.
+
+Senders in the CLI and the desktop app produce both a short code and a browser link, so the receiver can join from any client.
 
 Other install channels, checksum verification, and PATH setup are covered in the [CLI installation guide](https://www.floe.one/docs/cli/installation).
 
@@ -68,7 +76,9 @@ curl -fsSLO https://raw.githubusercontent.com/jannskiee/floe/main/docker-compose
 docker compose up -d
 ```
 
-All three clients can point at a self-hosted server. Configuration, deployment behind HTTPS, and the optional TURN relay are covered in [SELF_HOSTING.md](SELF_HOSTING.md) and the [self-hosting docs](https://www.floe.one/docs/self-hosting/overview).
+All three clients can point at a self-hosted server.
+
+Configuration, deployment behind HTTPS, and the optional TURN relay are covered in [SELF_HOSTING.md](SELF_HOSTING.md) and the [self-hosting docs](https://www.floe.one/docs/self-hosting/overview).
 
 ## Documentation
 
@@ -80,7 +90,11 @@ The [changelog](https://www.floe.one/docs/changelog) tracks every release across
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and the pull request process, and open an [issue](https://github.com/jannskiee/floe/issues) for bugs or feature requests. This project follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report a vulnerability, see [SECURITY.md](SECURITY.md).
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, environment variables, and the pull request process.
+
+If you encounter a bug or have a feature suggestion, please open an [issue](https://github.com/jannskiee/floe/issues).
+
+This project follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report a vulnerability, see [SECURITY.md](SECURITY.md).
 
 ## Support
 


### PR DESCRIPTION
## Summary

Three README refinements after #273: the pre-rewrite Support and Acknowledgments sections are restored (fuller sponsorship explanation, per-program bullets, and the three sponsor badges), the Support text now says TURN relay service rather than server (TURN is a managed service since the hosting migration), and the Documentation section is rewritten from a bare link list into prose where each link states why you would click it.

## Test plan

- README-only change; no em dashes introduced; every claim checked against the live docs (FAQ section headings cover transfers through privacy, troubleshooting is symptom-first, the changelog covers all release lines)
- Full CI runs since README.md is outside docs/