### PR TITLE
docs: rejoin readme paragraphs that read better as one

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@
 
 ## About
 
-Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted.
-
-The only report a client sends about a transfer is an optional, anonymous byte count that powers the public counter, and every client can opt out. The floe.one website itself runs cookieless analytics and error monitoring, detailed in the [security and privacy docs](https://www.floe.one/docs/security-privacy).
+Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted. The only report a client sends about a transfer is an optional, anonymous byte count that powers the public counter, and every client can opt out. The floe.one website itself runs cookieless analytics and error monitoring, detailed in the [security and privacy docs](https://www.floe.one/docs/security-privacy).
 
 Three clients share one wire protocol: the web app at [floe.one](https://floe.one), a Windows desktop app, and a Go CLI. Send from a browser tab and receive in the desktop app or the CLI, or any other combination, even across different networks.
 
@@ -47,9 +45,7 @@ Floe for Windows 10 and 11 (x64), currently in beta. The Microsoft Store build i
 
 <a href="https://apps.microsoft.com/detail/9NBQ8ZQ1065L"><img src="client/public/ms-store-badge.svg" alt="Download from the Microsoft Store" width="161" height="44" /></a>
 
-Prefer a direct download? An installer and a portable build are on the [download page](https://www.floe.one/download).
-
-Setup details are in the [desktop installation guide](https://www.floe.one/docs/desktop/installation).
+Prefer a direct download? An installer and a portable build are on the [download page](https://www.floe.one/download). Setup details are in the [desktop installation guide](https://www.floe.one/docs/desktop/installation).
 
 ## CLI
 
@@ -63,9 +59,7 @@ curl -fsSL https://floe.one/install.sh | sh   # Linux and other systems
 
 Send with `floe send photo.jpg`, receive with `floe receive olive-tiger-castle`, and update in place with `floe update`.
 
-Senders in the CLI and the desktop app produce both a short code and a browser link, so the receiver can join from any client.
-
-Other install channels, checksum verification, and PATH setup are covered in the [CLI installation guide](https://www.floe.one/docs/cli/installation).
+Senders in the CLI and the desktop app produce both a short code and a browser link, so the receiver can join from any client. Other install channels, checksum verification, and PATH setup are covered in the [CLI installation guide](https://www.floe.one/docs/cli/installation).
 
 ## Self-hosting
 
@@ -76,23 +70,17 @@ curl -fsSLO https://raw.githubusercontent.com/jannskiee/floe/main/docker-compose
 docker compose up -d
 ```
 
-All three clients can point at a self-hosted server.
-
-Configuration, deployment behind HTTPS, and the optional TURN relay are covered in [SELF_HOSTING.md](SELF_HOSTING.md) and the [self-hosting docs](https://www.floe.one/docs/self-hosting/overview).
+All three clients can point at a self-hosted server. Configuration, deployment behind HTTPS, and the optional TURN relay are covered in [SELF_HOSTING.md](SELF_HOSTING.md) and the [self-hosting docs](https://www.floe.one/docs/self-hosting/overview).
 
 ## Documentation
 
 The [documentation](https://www.floe.one/docs) covers all three clients in depth, from your first transfer to a self-hosted deployment.
 
-The [FAQ](https://www.floe.one/docs/faq) answers the questions that come up most, from transfer limits to privacy, and the [troubleshooting guide](https://www.floe.one/docs/troubleshooting) starts from the symptom when something will not connect.
-
-The [changelog](https://www.floe.one/docs/changelog) tracks every release across web, desktop, and CLI.
+The [FAQ](https://www.floe.one/docs/faq) answers the questions that come up most, from transfer limits to privacy, and the [troubleshooting guide](https://www.floe.one/docs/troubleshooting) starts from the symptom when something will not connect. The [changelog](https://www.floe.one/docs/changelog) tracks every release across web, desktop, and CLI.
 
 ## Contributing
 
-Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, environment variables, and the pull request process.
-
-If you encounter a bug or have a feature suggestion, please open an [issue](https://github.com/jannskiee/floe/issues).
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, environment variables, and the pull request process. If you encounter a bug or have a feature suggestion, please open an [issue](https://github.com/jannskiee/floe/issues).
 
 This project follows the [Code of Conduct](CODE_OF_CONDUCT.md). To report a vulnerability, see [SECURITY.md](SECURITY.md).
 


### PR DESCRIPTION
## Summary

Hand-tuned paragraph spacing in the README: six spots where the one-thought-per-paragraph split went too far are rejoined (About's telemetry note, Desktop's setup line, the CLI channels line, Self-hosting's config pointer, the FAQ+changelog sentences, and Contributing's first two rows). No word, link, or markdown token changes; verified word-identical to main by an independent check.

## Test plan

- Formatting-only diff (6 insertions, 18 deletions, all blank-line joins)
- Token stream and non-whitespace bytes verified identical to main
- Full CI runs since README.md is outside docs/