### PR TITLE
docs: fix the inaccuracies found by the full markdown audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Floe** is a browser-native, peer-to-peer file transfer app built on WebRTC. Four components work together:
+**Floe** is an encrypted, peer-to-peer file transfer app built on WebRTC, with browser, desktop, and CLI surfaces. Four components work together:
 
 - **`client/`** - Next.js 16 (React 19) web app
 - **`server/`** - Node.js signaling server (Express + Socket.IO + WebSocket)
@@ -24,6 +24,8 @@ pnpm install
 pnpm dev         # dev server on :3000
 pnpm build       # production build
 pnpm lint        # ESLint
+pnpm test        # vitest unit suite
+pnpm test:e2e    # Playwright e2e (needs client + server running)
 ```
 
 ### Server (Node.js)
@@ -32,6 +34,7 @@ cd server
 npm install
 npm run dev      # nodemon auto-restart on :3001
 npm start        # production
+npm test         # node --test server.test.js
 ```
 
 ### CLI (Go)
@@ -71,12 +74,18 @@ TURN_DOMAIN=                 # optional coturn hostname
 UPSTASH_REDIS_REST_URL=      # optional, durable global stats counter
 UPSTASH_REDIS_REST_TOKEN=    # optional, pairs with the URL above
 MAX_REPORT_BYTES=            # optional, per-report cap (default 5 TB)
+NODE_ENV=                    # optional, production suppresses stack traces
+TRUSTED_PROXY_COUNT=         # optional, proxy hops for client-IP parsing (default 1; affects every per-IP limiter)
+MAX_CONNECTIONS_PER_IP=      # optional, plus MAX_CODE_REQUESTS_PER_IP, MAX_TURN_REQUESTS_PER_IP,
+MAX_ACTIVE_CODES=            #   see server/.env.example for the full annotated list
 ```
 
 **Client** - copy `client/.env.example` to `client/.env.local`:
 ```
-NEXT_PUBLIC_SOCKET_URL=http://localhost:3001
-NEXT_PUBLIC_SENTRY_DSN=    # optional
+NEXT_PUBLIC_SOCKET_URL=http://localhost:3001  # build-time override; self-hosted Docker resolves at runtime via client/lib/socketUrl.ts
+NEXT_PUBLIC_SITE_URL=         # optional, canonical/OG/sitemap base for self-hosts
+NEXT_PUBLIC_SENTRY_DSN=       # optional (SENTRY_DSN / SENTRY_ORG / SENTRY_PROJECT for the server side)
+NEXT_PUBLIC_UMAMI_WEBSITE_ID= # optional analytics
 ```
 
 ## Architecture
@@ -104,7 +113,7 @@ Relayed (TURN) transfers are capped at 2 GB per session; direct transfers are un
 `GET /api/turn-credentials` returns the ICE server list; called by both client and CLI before connecting. Precedence: **Cloudflare Realtime TURN** when `CLOUDFLARE_TURN_KEY_ID` / `CLOUDFLARE_TURN_KEY_API_TOKEN` are set (what floe.one runs; short-lived credentials minted from Cloudflare's `generate-ice-servers` API, cached in memory ~12h, with STUN and TURN returned as separate entries so the client's relay-off filter can strip TURN while keeping STUN), then self-hosted **coturn** HMAC-SHA1 credentials (24h) when `TURN_SECRET` / `TURN_DOMAIN` are set, otherwise Google STUN only. Cloudflare's full 8-URL list is trimmed to a minimal 3-URL set (one STUN, one UDP TURN, one TLS TURN on 443) by `selectMinimalIceUrls` before serving; clients gather ICE candidates per URL per network interface, so redundant URLs multiply connection-setup time on multi-adapter machines.
 
 ### Global Stats Counter
-A public, all-time counter of total bytes transferred across every Floe user, shown on the homepage (`client/components/GlobalStats.tsx`) with a NumberFlow odometer animation. Because Floe is P2P and file bytes never reach the server, the **receiver** peer reports the byte count out-of-band over HTTP after a completed transfer. Only the receiver reports (browser receiver in `P2PTransfer.tsx`, CLI and desktop receivers via `cli/engine/transfer/receiver.go`), so each transfer is counted exactly once. The sender never reports. The data-channel protocol is unchanged, so no `ProtocolVersion` bump is needed.
+A public, all-time counter of total bytes transferred across every Floe user, shown on the homepage (`client/components/GlobalStats.tsx`) with a NumberFlow odometer animation. Because Floe is P2P and file bytes never reach the server, the **receiver** peer reports the byte count out-of-band over HTTP after a completed transfer. Only the receiver reports (browser receiver via `client/hooks/useTransferAnalytics.ts`, composed by `P2PTransfer.tsx`; CLI and desktop receivers via `cli/engine/transfer/receiver.go`), so each transfer is counted exactly once. The sender never reports. The data-channel protocol is unchanged, so no `ProtocolVersion` bump is needed.
 
 The global total is viewable only in the browser (the `GlobalStats` component on the homepage). The CLI receiver contributes to the counter but never fetches or displays it.
 
@@ -113,7 +122,7 @@ The global total is viewable only in the browser (the `GlobalStats` component on
 - Durability is Upstash Redis over its REST API via native `fetch` (no SDK). `initStats()` seeds `cachedTotal` from Redis on startup. If `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are unset, the counter degrades gracefully to in-memory only (resets to 0 on restart). This is a best-effort vanity metric with lightweight guardrails, not a tamper-proof figure.
 
 **Opt-out:** Both the browser and the CLI receiver support opting out of reporting.
-- Browser: a "Contribute to global stats" toggle on the receiver view (persisted in `localStorage['floe:report-stats']`). When unchecked, neither the `POST /api/stats/report` call nor the optimistic `floe:bytes-reported` event fires.
+- Browser: a "Contribute to global stats" toggle on the receiver view (`client/components/StatsContributionToggle.tsx`, persisted in `localStorage['floe:report-stats']` by `client/hooks/useTransferAnalytics.ts`). When unchecked, neither the `POST /api/stats/report` call nor the optimistic `floe:bytes-reported` event fires.
 - CLI: pass `--no-report` to `floe receive`, or set `FLOE_NO_STATS=1` in the environment. Both gate the report by passing an empty `statsURL` to `ReceiveFiles`, which hits the empty-URL guard at the top of `reportBytesToServer` in `cli/engine/transfer/receiver.go`. No change to `ReceiveFiles` signature or receiver logic.
 
 ### Rate Limiting
@@ -123,8 +132,8 @@ Four independent per-IP limiters, each over a 60s window, tracked in plain `Map`
 `next.config.mjs` sets `reactStrictMode: false`. Strict Mode's double-mount breaks Socket.IO connections and `simple-peer` instances. All socket/peer logic uses refs and cleanup functions to handle component lifecycle correctly.
 
 ### Key Client Modules
-- `client/components/P2PTransfer.tsx` - entire transfer UI (role detection, file selection, progress, download)
-- `client/hooks/useWakeLock.ts` - Screen Wake Lock API wrapper (prevents device sleep during transfers)
+- `client/components/P2PTransfer.tsx` - transfer UI orchestrator; the extracted logic lives in `client/hooks/` (useSignaling, useFileManagement, useDownloadManager, useConnectionType, useTransferAnalytics, useRelayConfiguration, useWakeLock)
+- `client/lib/transfer/` - browser side of the wire protocol (protocol.ts, sender.ts, receiver.ts, verify.ts)
 - `client/lib/transferUtils.ts` - `formatSpeed()` and `formatETA()` used by the progress display
 
 ### Shared Go Engine
@@ -144,7 +153,7 @@ All under `cli/engine/`, imported by both the CLI (`cli/cmd/floe`) and the deskt
 The docs live in `docs/` (Mintlify), git-synced to `main`, and are served at `floe.one/docs` (Mintlify deployment `floe` at base path `/docs`, reverse-proxied through the Vercel app's `next.config.mjs` rewrite to `floe.mintlify.site`; the old `docs.floe.one` 301-redirects there).
 
 - `docs/changelog.mdx` is written by hand and is never auto-generated. Its shape is fixed by the authoring contract in the MDX comment at the top of the file: one timeline for both version lines, `label` is the git tag verbatim (and therefore the anchor, so never edit a shipped one), `description` is the release date, and `tags` come from the fixed set `Web`, `Desktop`, `CLI`, `Self-hosting`, primary surface first. Follow that contract when adding an entry. Changing the contract itself is a restructure and needs its own discussion.
-- `docs/style.css` is auto-loaded by Mintlify on every docs page (no `docs.json` entry, that is how Mintlify works). It holds one rule, which puts separators between the tags in a changelog entry's left gutter, because Mintlify renders them there as bare space-separated text with no delimiter of its own, so `Web CLI Self-hosting` read as one phrase. That rule is the only thing keeping the tags legible, and its selector is undocumented by Mintlify, so if the tag row ever loses its separators that is the first thing to check.
+- `docs/style.css` is auto-loaded by Mintlify on every docs page (no `docs.json` entry, that is how Mintlify works). Since the docs redesign (#269) it carries the full docs CSS (sidebar, theme, landing, code blocks). The changelog tag-separator rule near the top is still the only thing keeping the tags in an entry's left gutter legible (Mintlify renders them as bare space-separated text with no delimiter of its own), and its selector is undocumented by Mintlify, so if the tag row ever loses its separators that is the first thing to check.
 - Docs-only PRs stay fast without dodging branch protection: the `changes` job in `.github/workflows/ci.yml` diffs the PR and, when every changed file is under `docs/`, the heavy jobs skip and the `CI green` check reports success in under a minute, so docs and Mintlify PRs merge quickly without running the client/server/CLI/e2e suite.
 
 Automated doc-maintenance PRs (style, links, SEO) are managed in the Mintlify dashboard. They open PRs against `main`, only edit `docs/**`, and never auto-merge.
@@ -159,7 +168,7 @@ ci.yml also has a `workflow_dispatch` trigger: a dispatched run behaves exactly 
 
 Do not use em dashes in any markdown files or documentation. Use periods, commas, hyphens, or parentheses instead. In `docs/`, Vale checks this (`docs/.vale.ini` plus the `docs/styles/Floe/EmDash.yml` rule, surfaced as the Mintlify Grammar linter CI check), reinforced by the weekly Apply style guide automation.
 
-What Vale actually covers is narrower than this rule: it matches the em dash and en dash characters only, in `docs/` only. An ASCII `--` used as a dash is a human-review matter, because a token for it fires on every CLI flag in the docs. Markdown outside `docs/` has no linter at all.
+What Vale actually covers is narrower than this rule: it matches the em dash and en dash characters only, in `docs/` only. An ASCII `--` used as a dash is a human-review matter, because a token for it fires on every CLI flag in the docs. Markdown outside `docs/` has no style linter (root Prettier can format it, but nothing checks dash usage there).
 
 ## Git Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ cd ..
 go test ./...
 ```
 
-For a live-reload development window, install the [Wails CLI](https://wails.io/docs/gettingstarted/installation) and run `wails dev` from `desktop/`.
+For a live-reload development window, install the [Wails CLI](https://wails.io/docs/gettingstarted/installation) at the version `desktop/go.mod` links against (currently v2.12.0) and run `wails dev` from `desktop/`.
 
 ### Documentation (Only needed if you're changing docs)
 
@@ -158,10 +158,11 @@ Even with the overlay this is a production build with no hot reload, so use it t
 3. If you touched `client/`, ensure the build passes: `pnpm build` (in `client/`)
 4. If you touched `client/`, run the linter: `pnpm lint` (in `client/`)
 5. If you touched `client/`, run its tests: `pnpm test` (in `client/`)
-6. If you touched `cli/`, run its tests: `go test ./...` (in `cli/`)
-7. If you touched `desktop/`, run its tests too: `go test ./...` (in `desktop/`, after building the frontend) and `npm test` (in `desktop/frontend/`)
-8. Write commit messages in the conventional style: a lowercase, imperative subject with an optional scope, for example `fix(client): keep the progress bar visible while verifying` or `docs: clarify the relay cap`. PRs are squash-merged, so the PR title follows the same convention.
-9. Submit a pull request. The template asks for a short summary and a test plan.
+6. If you touched `server/`, run its tests: `npm test` (in `server/`)
+7. If you touched `cli/`, run its tests: `go test ./...` (in `cli/`)
+8. If you touched `desktop/`, run its tests too: `go test ./...` (in `desktop/`, after building the frontend) and `npm test` (in `desktop/frontend/`)
+9. Write commit messages in the conventional style: a lowercase, imperative subject with an optional scope, for example `fix(client): keep the progress bar visible while verifying` or `docs: clarify the relay cap`. PRs are squash-merged, so the PR title follows the same convention.
+10. Submit a pull request. The template asks for a short summary and a test plan. CI runs automatically on the PR, and the `CI green` check must pass before it can merge (docs-only PRs skip the heavy jobs and go green in about a minute).
 
 ---
 

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -45,6 +45,8 @@ cli/
     signaling/         WebSocket signaling client
     ice/               STUN/TURN credential fetch
     code/              short room-code register and resolve
+    serverurl/         normalizes user-supplied server URLs
+    verify/            short authentication string from DTLS fingerprints
   internal/
     selfupdate/        CLI-only self updater (stays private)
 desktop/               Wails app: imports cli/engine/...
@@ -79,7 +81,8 @@ go.work                ties cli + desktop for local dev
 - [x] Drag and drop files onto the window to send
 - [x] Polished UI matching the web app's design: Tailwind v4 (`@tailwindcss/vite`, Vite 3->6 bump)
       + Geist fonts + lucide-react; dark zinc theme, elevated card, segmented tabs, custom toggle,
-      dashed drop zone, mono room code + copy-link, polished progress/verify/status, and a
+      dashed drop zone, mono room code + copy-link, polished progress/status (the verify
+      row was later removed, see 3a), and a
       QR panel behind a Show QR toggle (react-qr-code; shipped, the earlier "deferred" note
       was stale). No Share button on Windows: WebView2 does not expose `navigator.share`,
       and the button is feature-gated on it.
@@ -153,7 +156,8 @@ receiver, which is deliberate (share a link and wait) and cancellable.
 - [x] Release workflow: a plain `desktop-release.yml` on `desktop-v*` tags
       (Windows-only for the beta; GoReleaser adds nothing for a Wails NSIS
       build, and the native-runner matrix waits for the macOS/Linux era)
-- [ ] Windows signing via SignPath Foundation
+- [ ] Code signing for the GitHub builds (no current provider: SignPath Foundation
+      declined; the Store MSIX is already re-signed by Microsoft)
 - [ ] macOS notarization (deferred until the Apple Developer account is funded)
 - [~] Installers: the NSIS .exe and portable zip ship on every `desktop-v*` tag;
       .dmg and .AppImage wait for the macOS/Linux era
@@ -167,7 +171,7 @@ receiver, which is deliberate (share a link and wait) and cancellable.
       below; the old "unpackaged Win32" idea was wrong: the EXE submission path
       requires a purchased certificate and delivers no updates, while only MSIX
       is re-signed free by Microsoft)
-- [x] Homepage download buttons and the /download page (#235), and a five-page "Desktop App"
+- [x] Homepage download buttons and the /download page (#235), and a five-page "Desktop"
       docs group: installation, sending, receiving, settings, keyboard-shortcuts
 
 ## Release history
@@ -212,7 +216,7 @@ is reserved, so `pack.ps1` derives it mechanically as (major+1).minor.patch.0
 wails.json, the exe version resource, and all marketing. At tag time, bump
 wails.json's `productVersion` and the concrete version examples in
 docs/desktop/installation.mdx and docs/desktop/settings.mdx alongside
-`DESKTOP_VERSION` in client/lib/desktopRelease.ts; the release workflow
+`DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE` in client/lib/desktopRelease.ts; the release workflow
 rewrites wails.json only in the runner's working tree, so the committed value
 goes stale otherwise.
 
@@ -231,7 +235,7 @@ binary.
       .msix into a CI artifact (its only consumer is Partner Center; end users
       cannot install unsigned exe-activation packages)
 - [x] b. Tag `desktop-v0.2.0`: GitHub release + MSIX artifact from one tag
-      (released 2026-08-01; all three assets verified live, and the
+      (released 2026-08-02; all three assets verified live, and the
       FloeDesktop_1.2.0.0_x64.msix artifact validated in Partner Center)
 - [x] c. Partner Center submission, PRIVATE audience first (public->private is
       permanently forbidden): upload the .msix, category Utilities & tools >
@@ -270,18 +274,22 @@ streamed to disk with progress, system tray with background receive, OS
 notifications, pairing that interoperates with every surface (the web sends
 link+QR, the CLI code+link, the desktop all three), auto-update, dark mode.
 
-**Differentiators:** OS context-menu "Send with Floe" (right click in Explorer or
-Finder), a LAN fast path via local discovery (mDNS) for full-speed same-network
-transfers, send to self across your own devices, transfer history, resume of
-interrupted transfers, connection verification words (from the PAKE), and a global
-hotkey with screenshot or clipboard send.
+**Differentiators:** OS context-menu "Send with Floe" (shipped on Windows; the
+Finder half waits for macOS), a LAN fast path via local discovery (mDNS) for
+full-speed same-network transfers, send to self across your own devices, transfer
+history (shipped in 0.1.0), resume of interrupted transfers, connection
+verification words (from the PAKE), and a global hotkey with screenshot or
+clipboard send (clipboard paste-to-send shipped in 0.1.0; the global hotkey
+remains).
 
 **Later:** saved contacts and devices, continuous folder sync, multi-peer send.
 
 ## Signing and distribution notes
 
-- Windows: SignPath Foundation (free OSS OV signing), application submitted. The
-  maintainer manages CLI signing separately; desktop signing is wired here.
+- Windows: no free OSS signing route has accepted the project (SignPath Foundation
+  declined). The Store MSIX is re-signed by Microsoft, which is the warning-free
+  channel; GitHub builds ship unsigned, and paid OV signing (for example Certum)
+  stays an option if the GitHub channel ever grows.
 - macOS: Apple Developer ID plus notarization ($99/yr), deferred. Until then, ship
   ad-hoc signed builds with right-click Open instructions.
 - Linux: free. Flathub pins a consistent WebKitGTK runtime, ideal for a Wails app.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## About
 
-Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted. The only report a client sends about a transfer is an optional, anonymous byte count that powers the public counter, and every client can opt out. The floe.one website itself runs cookieless analytics and error monitoring, detailed in the [security and privacy docs](https://www.floe.one/docs/security-privacy).
+Floe is an open-source peer-to-peer file transfer application built on WebRTC. Files stream directly between devices; the signaling server negotiates connections and never stores, inspects, or decrypts file data. When a direct path is blocked, an optional TURN relay bridges the transfer while the data stays end-to-end encrypted. The desktop app and the CLI contain no analytics or telemetry; the only thing either sends is an optional, anonymous byte count that powers the public counter, and you can opt out in any client. The floe.one website itself runs cookieless, aggregate analytics (including anonymous transfer outcomes) and error monitoring, detailed in the [security and privacy docs](https://www.floe.one/docs/security-privacy).
 
 Three clients share one wire protocol: the web app at [floe.one](https://floe.one), a Windows desktop app, and a Go CLI. Send from a browser tab and receive in the desktop app or the CLI, or any other combination, even across different networks.
 
@@ -41,7 +41,7 @@ The [quickstart guide](https://www.floe.one/docs/quickstart) walks through sendi
 
 ## Desktop
 
-Floe for Windows 10 and 11 (x64), currently in beta. The Microsoft Store build is signed and updates automatically.
+Floe for Windows 10 and 11 (x64), currently in beta. The Microsoft Store build is signed by Microsoft and updates automatically.
 
 <a href="https://apps.microsoft.com/detail/9NBQ8ZQ1065L"><img src="client/public/ms-store-badge.svg" alt="Download from the Microsoft Store" width="161" height="44" /></a>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ Please include as much of the following as possible:
 
 ## Scope
 
-This policy covers the Floe web client, signaling server, CLI, and desktop app in this repository. The signaling server brokers connection setup only. File data is transferred directly between peers over encrypted WebRTC data channels and is never stored or inspected by Floe infrastructure.
+This policy covers the Floe web client, signaling server, CLI, and desktop app in this repository. The signaling server brokers connection setup only. File data travels peer-to-peer over end-to-end encrypted WebRTC data channels, directly when possible or through an encrypted TURN relay that cannot read it, and is never stored or inspected by Floe infrastructure.
 
 ## Supported Versions
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -75,9 +75,9 @@ all configured at runtime.
 ## One domain (recommended for production)
 
 You do not need two hostnames. Put the client and the signaling server behind a
-single reverse proxy, route `/socket.io/`, `/ws`, `/api/`, and `/health` to the
-server and everything else to the client, and the whole instance lives at one
-address. That means one certificate and one URL to configure.
+single reverse proxy, route `/socket.io/`, `/ws`, `/api/` (except `/api/config`,
+which belongs to the client), and `/health` to the server and everything else to
+the client, and the whole instance lives at one address. That means one certificate and one URL to configure.
 
 Copy-pasteable Caddy and nginx configuration is in
 [the reverse proxy guide](https://www.floe.one/docs/self-hosting/reverse-proxy).

--- a/desktop/build/README.md
+++ b/desktop/build/README.md
@@ -3,7 +3,8 @@
 What `wails build` and the packaging pipeline read from this directory:
 
 - `bin/` - build output: `floe-desktop.exe` and the NSIS installer
-  `floe-desktop-setup-<version>.exe`.
+  `floe-desktop-amd64-installer.exe` (renamed to `floe-desktop-setup-<version>.exe`
+  on the GitHub release by desktop-release.yml).
 - `windows/` - Windows build inputs: `icon.ico` (regenerated from `appicon.png`
   if deleted), `info.json` (the exe's version resource: right-click the exe,
   Properties, Details), `wails.exe.manifest`, and `installer/` (the NSIS

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -16,7 +16,7 @@ receives from browser peers and CLI peers without any extra setup.
 ## Requirements
 
 - **From the Microsoft Store:** Windows 10 version 2004 (build 19041) or later. The package
-  declares that floor itself.
+  itself declares that minimum version.
 - **From GitHub:** any Windows 10 or later. The installer stops on anything older.
 - **x64.** Both channels ship an x64 build only. The GitHub installer and the portable zip stop
   with an architecture error on a native ARM64 machine.


### PR DESCRIPTION
## Summary

A 12-agent audit of every markdown file surfaced a set of high-confidence inaccuracies; this fixes all of them. Highlights: the README's telemetry sentence now scopes its claim truthfully (the web client's cookieless analytics record anonymous transfer outcomes and are disclosed as such), SECURITY.md's scope acknowledges the TURN relay path instead of claiming all transfers are direct, SELF_HOSTING.md's one-domain route list carves out /api/config (which belongs to the client, matching the reverse-proxy guide), CONTRIBUTING gains the missing server test step and pins the Wails CLI version, DESKTOP.md drops the stale claim that a signing application is pending and marks shipped roadmap items, the build notes name the real NSIS output file, and CLAUDE.md is synced with the current codebase (surfaces framing, test commands, env examples, decomposed client modules, docs/style.css reality).

## Test plan

- Markdown and one docs example line only; no code changes
- Zero em or en dashes across 53 added lines
- Every corrected claim carries file:line evidence from the audit; a re-verification agent reviews the final diff in parallel with CI
- Full CI runs since root markdown is outside docs/