### PR TITLE
feat(client): three-tier responsive navbar

### DIFF
--- a/client/app/download/DownloadCta.tsx
+++ b/client/app/download/DownloadCta.tsx
@@ -1,40 +1,24 @@
-'use client';
-
-import React, { useSyncExternalStore } from 'react';
-import Link from 'next/link';
+import React from 'react';
 import Image from 'next/image';
-import { detectOs, type VisitorOs } from '@/lib/detectOs';
 import { DESKTOP_STORE_URL } from '@/lib/desktopRelease';
 
 /**
- * The hero CTA row. On Windows (the only OS the beta runs on) the official
- * Microsoft Store badge stands alone; on other platforms a web-app pill leads
- * and the badge follows for the visitor's Windows machine elsewhere. The
- * server renders the Windows arrangement and the client corrects on
- * hydration; both arrangements share the same single-row flex container, so
- * the swap never reflows the page.
+ * The hero CTA row: the official Microsoft Store badge, alone, on every
+ * platform.
+ *
+ * A web-app pill used to lead here for non-Windows visitors, which meant the
+ * primary action on the download page sent them back to the page they had just
+ * come from. Removing it also removes the reason this file was a client
+ * island: the OS sniff, the useSyncExternalStore snapshot split it needed to
+ * stay hydration-safe, and the two-arrangement swap all existed only to decide
+ * whether to render that pill.
  *
  * The badge is Microsoft's own "Get it from Microsoft" asset (en-US dark
  * variant), self-hosted from /public so the page makes no external requests.
- * Brand rules: never recolor or redraw it, keep it at its native aspect
- * ratio, and do not shrink it below ~120px wide. The Store page URL works in
- * any browser on any OS, so the badge stays clickable everywhere.
+ * Brand rules: never recolor or redraw it, keep it at its native aspect ratio,
+ * and do not shrink it below ~120px wide. The Store page URL works in any
+ * browser on any OS, so the badge stays clickable everywhere.
  */
-
-type NavigatorWithUAData = Navigator & { userAgentData?: { platform?: string } };
-
-// The visitor's OS never changes during a visit, so this "store" never emits:
-// useSyncExternalStore is used purely for its SSR-safe snapshot split, the same
-// idiom CliTerminal uses for prefers-reduced-motion.
-const subscribeNever = () => () => {};
-const getOsSnapshot = (): VisitorOs => {
-    const nav = navigator as NavigatorWithUAData;
-    return detectOs(navigator.userAgent, nav.userAgentData?.platform);
-};
-const getServerOsSnapshot = (): VisitorOs => 'windows';
-
-const pillClass =
-    'inline-flex items-center justify-center rounded-full bg-white px-4 py-2 text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice';
 
 // The badge ships at 161x44 and is rendered at 220x60 (same ratio): the hero
 // action of the page, so it carries more weight than the pill it replaced.
@@ -44,50 +28,27 @@ const pillClass =
 const badgeClass =
     'inline-flex items-center opacity-95 transition hover:opacity-100 focus-visible:outline-2 focus-visible:outline-ice';
 
-function StoreBadge({ source }: { source: string }) {
-    return (
-        <a
-            href={DESKTOP_STORE_URL}
-            target="_blank"
-            rel="noreferrer"
-            data-umami-event="download-desktop"
-            data-umami-event-file="store"
-            data-umami-event-source={source}
-            className={badgeClass}
-        >
-            <Image
-                src="/ms-store-badge.svg"
-                alt="Get Floe Desktop from the Microsoft Store"
-                width={220}
-                height={60}
-                priority
-                unoptimized
-            />
-        </a>
-    );
-}
-
 export function DownloadCta() {
-    const os = useSyncExternalStore(subscribeNever, getOsSnapshot, getServerOsSnapshot);
-    const windowsArrangement = os === 'windows';
-
     return (
-        <div className="flex min-h-[60px] flex-wrap items-center justify-center gap-x-5 gap-y-3">
-            {windowsArrangement ? (
-                <StoreBadge source="hero-primary" />
-            ) : (
-                <>
-                    <Link
-                        href="/"
-                        data-umami-event="download-page-webapp"
-                        data-umami-event-source="hero-primary"
-                        className={pillClass}
-                    >
-                        Open the web app
-                    </Link>
-                    <StoreBadge source="hero-secondary" />
-                </>
-            )}
+        <div className="flex items-center justify-center">
+            <a
+                href={DESKTOP_STORE_URL}
+                target="_blank"
+                rel="noreferrer"
+                data-umami-event="download-desktop"
+                data-umami-event-file="store"
+                data-umami-event-source="hero-primary"
+                className={badgeClass}
+            >
+                <Image
+                    src="/ms-store-badge.svg"
+                    alt="Get Floe Desktop from the Microsoft Store"
+                    width={220}
+                    height={60}
+                    priority
+                    unoptimized
+                />
+            </a>
         </div>
     );
 }

--- a/client/app/download/page.tsx
+++ b/client/app/download/page.tsx
@@ -102,9 +102,11 @@ export default function Download() {
 
             <main className="w-full max-w-5xl">
                 {/* Hero: static server HTML; only the CTA row is a client island */}
-                {/* pt-24/28, not 28/32: the fixed navbar ends around 74px, so the old
-                    values left ~55px of dead space before the first word. */}
-                <div className="flex flex-col items-center pt-24 text-center sm:pt-28">
+                {/* pt-28 flat: the fixed navbar ends at about 82px below sm (44px
+                    touch targets) and 74px above it, so the narrow viewport is the
+                    one that needs the larger clearance. pt-32 would put back the
+                    ~55px of dead space this was trimmed to remove. */}
+                <div className="flex flex-col items-center pt-28 text-center">
                     {/* text-ice, not zinc-100: every other eyebrow on the site is either the
                         ice accent (SectionHeader, and the privacy/terms page hero) or quiet
                         zinc-500. At zinc-100 this one rendered the exact same value as the h1

--- a/client/app/download/page.tsx
+++ b/client/app/download/page.tsx
@@ -101,7 +101,10 @@ export default function Download() {
             <Navbar />
 
             <main className="w-full max-w-5xl">
-                {/* Hero: static server HTML; only the CTA row is a client island */}
+                {/* Hero: static server HTML throughout. The CTA row used to be a
+                    client island so it could sniff the OS and lead non-Windows
+                    visitors with a web-app pill; that pill is gone, so the whole
+                    page is server-rendered again. */}
                 {/* pt-24/28, not 28/32: the fixed navbar ends around 74px, so the old
                     values left ~55px of dead space before the first word. */}
                 <div className="flex flex-col items-center pt-24 text-center sm:pt-28">

--- a/client/app/download/page.tsx
+++ b/client/app/download/page.tsx
@@ -102,11 +102,12 @@ export default function Download() {
 
             <main className="w-full max-w-5xl">
                 {/* Hero: static server HTML; only the CTA row is a client island */}
-                {/* pt-28 flat: the fixed navbar ends at about 82px below sm (44px
-                    touch targets) and 74px above it, so the narrow viewport is the
-                    one that needs the larger clearance. pt-32 would put back the
-                    ~55px of dead space this was trimmed to remove. */}
-                <div className="flex flex-col items-center pt-28 text-center">
+                {/* The fixed navbar ends at 78px below sm (a 54px pill under 24px of
+                    nav padding, the pill being taller there for 44px touch targets)
+                    and at 74px above it. 6.5rem/7rem puts the first word 26px under
+                    each, which is the gap this hero has always had. A flat pt-28
+                    would have been 34px below sm: 8px of fold spent on nothing. */}
+                <div className="flex flex-col items-center pt-[6.5rem] text-center sm:pt-28">
                     {/* text-ice, not zinc-100: every other eyebrow on the site is either the
                         ice accent (SectionHeader, and the privacy/terms page hero) or quiet
                         zinc-500. At zinc-100 this one rendered the exact same value as the h1

--- a/client/app/download/page.tsx
+++ b/client/app/download/page.tsx
@@ -20,8 +20,11 @@ import {
 // lib/desktopRelease so a release bump touches exactly one file.
 export const metadata: Metadata = {
     title: 'Download | Floe',
+    // No "or use Floe in your browser" clause: the page's only CTA is the Store
+    // badge and its body carries no route to "/", so promising a browser option
+    // here would be advertising something this page does not offer.
     description:
-        'Get Floe Desktop for Windows from the Microsoft Store (beta), install the CLI, or use Floe in your browser: free, encrypted, peer-to-peer file transfer.',
+        'Get Floe Desktop for Windows from the Microsoft Store (beta), or install the floe CLI: free, encrypted, peer-to-peer file transfer.',
     alternates: { canonical: '/download' },
 };
 

--- a/client/app/download/page.tsx
+++ b/client/app/download/page.tsx
@@ -102,12 +102,9 @@ export default function Download() {
 
             <main className="w-full max-w-5xl">
                 {/* Hero: static server HTML; only the CTA row is a client island */}
-                {/* The fixed navbar ends at 78px below sm (a 54px pill under 24px of
-                    nav padding, the pill being taller there for 44px touch targets)
-                    and at 74px above it. 6.5rem/7rem puts the first word 26px under
-                    each, which is the gap this hero has always had. A flat pt-28
-                    would have been 34px below sm: 8px of fold spent on nothing. */}
-                <div className="flex flex-col items-center pt-[6.5rem] text-center sm:pt-28">
+                {/* pt-24/28, not 28/32: the fixed navbar ends around 74px, so the old
+                    values left ~55px of dead space before the first word. */}
+                <div className="flex flex-col items-center pt-24 text-center sm:pt-28">
                     {/* text-ice, not zinc-100: every other eyebrow on the site is either the
                         ice accent (SectionHeader, and the privacy/terms page hero) or quiet
                         zinc-500. At zinc-100 this one rendered the exact same value as the h1

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -18,7 +18,10 @@ export default function Home() {
 
             {/* Near-full-viewport hero: the next section's top hairline peeks at the
                 fold as the scroll cue, while its content stays below it */}
-            <section className="relative flex min-h-[calc(100dvh-2rem)] w-full flex-col items-center justify-center pb-14 pt-24 sm:pt-28">
+            {/* pt-28 flat, no sm: step. The pill is taller below sm than above it
+                now (44px touch targets vs the old 32px), so the narrow viewport
+                needs the larger clearance, not the smaller one. */}
+            <section className="relative flex min-h-[calc(100dvh-2rem)] w-full flex-col items-center justify-center pb-14 pt-28">
                 <div className="mx-auto max-w-3xl text-center mb-8 space-y-4">
                     <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tighter text-white lg:text-9xl drop-shadow-2xl">
                         Floe

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -18,13 +18,7 @@ export default function Home() {
 
             {/* Near-full-viewport hero: the next section's top hairline peeks at the
                 fold as the scroll cue, while its content stays below it */}
-            {/* Both values are the navbar's bottom edge plus 26px, which is the gap
-                this hero has always had. The pill is 54px tall below sm (44px touch
-                targets vs the old 26-32px) and 50px above it, and the nav's own
-                pt is 24px, so the edge sits at 78px then 74px. 6.5rem/7rem keeps the
-                gap constant instead of spending the difference on dead space: a flat
-                pt-28 cost a 320x568 phone 8px of fold for nothing. */}
-            <section className="relative flex min-h-[calc(100dvh-2rem)] w-full flex-col items-center justify-center pb-14 pt-[6.5rem] sm:pt-28">
+            <section className="relative flex min-h-[calc(100dvh-2rem)] w-full flex-col items-center justify-center pb-14 pt-24 sm:pt-28">
                 <div className="mx-auto max-w-3xl text-center mb-8 space-y-4">
                     <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tighter text-white lg:text-9xl drop-shadow-2xl">
                         Floe

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -18,10 +18,13 @@ export default function Home() {
 
             {/* Near-full-viewport hero: the next section's top hairline peeks at the
                 fold as the scroll cue, while its content stays below it */}
-            {/* pt-28 flat, no sm: step. The pill is taller below sm than above it
-                now (44px touch targets vs the old 32px), so the narrow viewport
-                needs the larger clearance, not the smaller one. */}
-            <section className="relative flex min-h-[calc(100dvh-2rem)] w-full flex-col items-center justify-center pb-14 pt-28">
+            {/* Both values are the navbar's bottom edge plus 26px, which is the gap
+                this hero has always had. The pill is 54px tall below sm (44px touch
+                targets vs the old 26-32px) and 50px above it, and the nav's own
+                pt is 24px, so the edge sits at 78px then 74px. 6.5rem/7rem keeps the
+                gap constant instead of spending the difference on dead space: a flat
+                pt-28 cost a 320x568 phone 8px of fold for nothing. */}
+            <section className="relative flex min-h-[calc(100dvh-2rem)] w-full flex-col items-center justify-center pb-14 pt-[6.5rem] sm:pt-28">
                 <div className="mx-auto max-w-3xl text-center mb-8 space-y-4">
                     <h1 className="text-5xl sm:text-7xl font-extrabold tracking-tighter text-white lg:text-9xl drop-shadow-2xl">
                         Floe

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -853,7 +853,12 @@ export function P2PTransfer() {
                                     onDragOver={handleDragOver}
                                     onDragLeave={handleDragLeave}
                                     onDrop={handleDrop}
-                                    className={`group relative mt-2 flex flex-col items-center justify-center rounded-xl border border-dashed p-10 transition-all sm:p-14 ${isDragging
+                                    // text-center, not just items-center: items-center
+                                    // centres each <p> as a box, but its text still sets
+                                    // to the start edge, so the moment the hint wraps the
+                                    // second line hangs left under a centred first one.
+                                    // It wraps below about 430px, which is most phones.
+                                    className={`group relative mt-2 flex flex-col items-center justify-center rounded-xl border border-dashed p-10 text-center transition-all sm:p-14 ${isDragging
                                         ? 'border-ice bg-ice/[0.04]'
                                         : 'border-white/15 hover:border-ice/40 hover:bg-white/[0.02]'
                                         }`}

--- a/client/components/landing/DesktopSection.tsx
+++ b/client/components/landing/DesktopSection.tsx
@@ -50,8 +50,7 @@ export function DesktopSection() {
                             Get the desktop app
                         </Link>
                         <p className="mt-3 font-mono text-[11px] uppercase tracking-[0.2em] text-zinc-600">
-                            v{DESKTOP_VERSION} beta · Windows ·{' '}
-                            <span className="whitespace-nowrap">macOS and Linux planned</span>
+                            v{DESKTOP_VERSION} beta · Windows
                         </p>
                     </div>
                 </div>

--- a/client/components/layout/FAQSection.tsx
+++ b/client/components/layout/FAQSection.tsx
@@ -95,7 +95,7 @@ export const FAQSection = () => {
                             >
                                 download page
                             </a>
-                            . macOS and Linux builds are planned.
+                            .
                         </p>
                     }
                 />

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -76,7 +76,7 @@ export const Navbar = () => {
                 element child, since they locate the pill from there. */}
             <div
                 data-nav-pill
-                className="pointer-events-auto flex items-center gap-1 max-[359px]:gap-0.5 rounded-full border border-white/10 bg-zinc-900/70 p-1.5 max-[359px]:p-1 shadow-2xl backdrop-blur-xl"
+                className="pointer-events-auto flex items-center gap-1 rounded-full border border-white/10 bg-zinc-900/70 p-1.5 shadow-2xl backdrop-blur-xl"
             >
                 {isHome ? (
                     /* Button with hard-nav: forces full reload, clearing all peer/transfer state */
@@ -88,7 +88,7 @@ export const Navbar = () => {
                         // still announces on change via the aria-live span below.
                         aria-label="Floe home"
                         title={status.label}
-                        className="flex items-center gap-2 rounded-full px-2.5 max-[359px]:px-2 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
+                        className="flex items-center gap-2 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         <span className="relative flex h-2.5 w-2.5 items-center justify-center" aria-hidden="true">
                             <span className={`absolute inset-0 rounded-full ${status.color} opacity-40 blur-[2px] transition-colors duration-500`} />
@@ -103,7 +103,7 @@ export const Navbar = () => {
                        a plain link, no status dot, no status text. */
                     <Link
                         href="/"
-                        className="flex items-center rounded-full px-2.5 max-[359px]:px-2 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
+                        className="flex items-center rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         Floe
                     </Link>
@@ -133,7 +133,7 @@ export const Navbar = () => {
                         );
                     })}
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-1 max-[359px]:mx-0" />
+                <div className="h-4 w-px bg-white/10 mx-1" />
                 {/* Destinations, split from the section anchors: Download then Docs
                     side by side, then the GitHub pill keeps its filled endpoint
                     treatment. */}
@@ -156,17 +156,17 @@ export const Navbar = () => {
                         href="https://www.floe.one/docs"
                         target="_blank"
                         rel="noreferrer"
-                        className="rounded-full px-2.5 max-[359px]:px-1 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice"
+                        className="rounded-full px-2.5 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         Docs
                     </a>
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-1 max-[359px]:mx-0" />
+                <div className="h-4 w-px bg-white/10 mx-1" />
                 <a
                     href="https://github.com/jannskiee/floe"
                     target="_blank"
                     rel="noreferrer"
-                    className="flex items-center gap-1.5 rounded-full bg-white px-2.5 max-[359px]:px-2 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
+                    className="flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
                 >
                     <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor" aria-hidden="true">
                         <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -13,11 +13,24 @@ const STATUS: Record<ConnectionStatus, { color: string; label: string }> = {
     offline: { color: 'bg-red-500', label: 'Not connected' },
 };
 
-// Section anchors on the homepage, in document order (drives the scroll-spy).
-const SECTIONS = [
+/**
+ * Section anchors on the homepage, in document order (drives the scroll-spy).
+ *
+ * `wide` holds an anchor back to lg. The 640-1023px band has to seat the two
+ * destinations as well, and it is mostly landscape phones and half-snapped
+ * desktop windows rather than tablets. CLI and Desktop are the two that yield:
+ * both point at something you cannot do at that size anyway (run a terminal,
+ * install a Windows app), while About and FAQ are audience-neutral.
+ *
+ * The gate is pure CSS. The observer below watches the page <section> elements,
+ * which render at every width, so a held-back anchor just carries a highlight
+ * nobody can see. Filtering this array by viewport instead would mean matchMedia
+ * in an effect, which is the markup-swapping e2e/hydration.spec.ts fails on.
+ */
+const SECTIONS: { id: string; label: string; wide?: boolean }[] = [
     { id: 'about', label: 'About' },
-    { id: 'cli', label: 'CLI' },
-    { id: 'desktop', label: 'Desktop' },
+    { id: 'cli', label: 'CLI', wide: true },
+    { id: 'desktop', label: 'Desktop', wide: true },
     { id: 'faq', label: 'FAQ' },
 ];
 
@@ -68,15 +81,36 @@ export const Navbar = () => {
     };
 
     const status = STATUS[connectionStatus];
+    const onDownload = pathname === '/download';
 
     return (
         <nav aria-label="Main" className="fixed top-0 left-0 right-0 z-50 flex justify-center pb-6 pt-[calc(1.5rem+env(safe-area-inset-top))] pointer-events-none">
             {/* data-nav-pill is the stable hook for e2e/responsive.spec.ts and
                 e2e/screenshot-matrix.mjs. Both also assert this stays <nav>'s only
-                element child, since they locate the pill from there. */}
+                element child, since they locate the pill from there.
+
+                The pill hugs its content at every width, so the overflow guard
+                below never engages normally; it is the net for a font fallback, a
+                minimum-font-size setting or browser zoom. Three companions are
+                load-bearing and each is silently fatal alone:
+                  min-w-0        a flex item's automatic minimum size beats
+                                 max-width, so without this the cap does nothing.
+                  [&>*]:shrink-0 otherwise the children squash and wrap to two rows
+                                 instead of scrolling. Pinning the direct children
+                                 pins the whole tree.
+                  scroll-p-1.5   when a scroller engages, browsers align the focused
+                                 child's border box flush with the scrollport edge,
+                                 putting its 2px focus ring outside the clip.
+                calc(100%...) not 100vw: <nav> is fixed left-0 right-0 so it already
+                spans the client width, while 100vw includes the Windows classic
+                scrollbar and would shove the capsule ~15px off-centre.
+                The scrollbar is hidden rather than styled: the custom-scrollbar
+                utility in globals.css paints a visible 6px bar, which is right for
+                the CLI terminal and wrong inside a 56px control strip. Keyboard
+                users still reach every item by Tab, and focus scrolls into view. */}
             <div
                 data-nav-pill
-                className="pointer-events-auto flex items-center gap-1 rounded-full border border-white/10 bg-zinc-900/70 p-1.5 shadow-2xl backdrop-blur-xl"
+                className="pointer-events-auto flex min-w-0 max-w-[calc(100%-1.5rem)] items-center gap-1 overflow-x-auto overscroll-x-contain scroll-p-1.5 whitespace-nowrap rounded-full border border-white/10 bg-zinc-900/70 p-1 shadow-2xl backdrop-blur-xl sm:p-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0"
             >
                 {isHome ? (
                     /* Button with hard-nav: forces full reload, clearing all peer/transfer state */
@@ -88,7 +122,7 @@ export const Navbar = () => {
                         // still announces on change via the aria-live span below.
                         aria-label="Floe home"
                         title={status.label}
-                        className="flex items-center gap-2 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
+                        className="flex min-h-11 items-center gap-2 rounded-full px-2.5 py-1.5 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-4 sm:py-2"
                     >
                         <span className="relative flex h-2.5 w-2.5 items-center justify-center" aria-hidden="true">
                             <span className={`absolute inset-0 rounded-full ${status.color} opacity-40 blur-[2px] transition-colors duration-500`} />
@@ -103,23 +137,28 @@ export const Navbar = () => {
                        a plain link, no status dot, no status text. */
                     <Link
                         href="/"
-                        className="flex items-center rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
+                        className="flex min-h-11 items-center rounded-full px-2.5 py-1.5 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-4 sm:py-2"
                     >
                         Floe
                     </Link>
                 )}
-                {/* Section anchors are scroll shortcuts: below sm they cost more
-                    width than the 320-568px pill can afford (the fixed pill just
-                    clips), so phones show brand + destinations only. */}
+                {/* Section anchors are scroll shortcuts on a page the visitor is
+                    already scrolling, so on phones they yield the width to the two
+                    destinations: below sm the pill is brand + Download + Docs +
+                    GitHub. */}
                 <div className="hidden sm:block h-4 w-px bg-white/10 mx-1" />
                 <div className="hidden sm:flex items-center gap-1">
                     {SECTIONS.map((section) => {
                         // No sub-sm variants here: the container never renders below sm.
-                        const pillClass = `rounded-full px-3.5 py-2 text-sm font-medium transition focus-visible:outline-2 focus-visible:outline-ice ${
+                        const pillClass = [
+                            'rounded-full px-3.5 py-2 text-sm font-medium transition focus-visible:outline-2 focus-visible:outline-ice',
+                            section.wide ? 'hidden lg:block' : '',
                             activeSection === section.id
                                 ? 'bg-white/[0.07] text-zinc-100'
-                                : 'text-zinc-400 hover:bg-white/10 hover:text-white'
-                        }`;
+                                : 'text-zinc-400 hover:bg-white/10 hover:text-white',
+                        ]
+                            .filter(Boolean)
+                            .join(' ');
                         // On the homepage the pills smooth-scroll; elsewhere they are real
                         // links back to the homepage anchors (middle-click friendly).
                         return isHome ? (
@@ -133,19 +172,23 @@ export const Navbar = () => {
                         );
                     })}
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-1" />
+                <div className="h-4 w-px bg-white/10 mx-0.5 sm:mx-1" />
                 {/* Destinations, split from the section anchors: Download then Docs
                     side by side, then the GitHub pill keeps its filled endpoint
                     treatment. */}
                 <div className="flex items-center gap-0.5 sm:gap-1">
-                    {/* md: on purpose: the extra pill clips the untested 640-767px band,
-                        and phone visitors cannot run the Windows build anyway (footer +
-                        the homepage Desktop section carry discovery below md). */}
+                    {/* Visible at every width. This was md-only on the theory that a
+                        phone visitor cannot run the Windows build, but that left the
+                        page unreachable from the header on every phone, so the surface
+                        most people arrive on offered no route to the desktop app at
+                        all. The width it costs below sm is paid for by holding the
+                        four section anchors back. */}
                     <Link
                         href="/download"
                         data-umami-event="nav-download"
-                        className={`hidden md:block rounded-full px-3.5 py-2 text-sm font-medium transition focus-visible:outline-2 focus-visible:outline-ice ${
-                            pathname === '/download'
+                        aria-current={onDownload ? 'page' : undefined}
+                        className={`inline-flex min-h-11 items-center justify-center rounded-full px-2 py-1.5 text-xs font-medium transition focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-3.5 sm:py-2 sm:text-sm ${
+                            onDownload
                                 ? 'bg-white/[0.07] text-zinc-100'
                                 : 'text-zinc-400 hover:bg-white/10 hover:text-white'
                         }`}
@@ -156,22 +199,28 @@ export const Navbar = () => {
                         href="https://www.floe.one/docs"
                         target="_blank"
                         rel="noreferrer"
-                        className="rounded-full px-2.5 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice"
+                        className="inline-flex min-h-11 items-center justify-center rounded-full px-2 py-1.5 text-xs font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-3.5 sm:py-2 sm:text-sm"
                     >
                         Docs
                     </a>
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-1" />
+                <div className="h-4 w-px bg-white/10 mx-0.5 sm:mx-1" />
+                {/* The one control whose shape changes at the breakpoint: a 44x44
+                    squircle while its label is sr-only, the labelled white pill once
+                    the label shows. Below sm it is deliberately the quiet control, so
+                    Download is the only bright thing on a phone. */}
                 <a
                     href="https://github.com/jannskiee/floe"
                     target="_blank"
                     rel="noreferrer"
-                    className="flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
+                    className="inline-flex size-11 items-center justify-center gap-1.5 rounded-xl bg-white/10 text-xs font-bold text-white transition hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-ice sm:size-auto sm:rounded-full sm:bg-white sm:px-4 sm:py-2 sm:text-sm sm:text-black sm:hover:bg-zinc-200"
                 >
                     <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor" aria-hidden="true">
                         <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
                     </svg>
-                    {/* sr-only below sm keeps the accessible name when only the icon shows */}
+                    {/* sr-only below sm keeps the accessible name when only the icon
+                        shows. It is position:absolute, so it is not a flex item and
+                        adds no gap: the square really is 44px, not 44 plus a gap. */}
                     <span className="sr-only sm:not-sr-only">GitHub</span>
                 </a>
             </div>

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -86,8 +86,10 @@ export const Navbar = () => {
     return (
         <nav aria-label="Main" className="fixed top-0 left-0 right-0 z-50 flex justify-center pb-6 pt-[calc(1.5rem+env(safe-area-inset-top))] pointer-events-none">
             {/* data-nav-pill is the stable hook for e2e/responsive.spec.ts and
-                e2e/screenshot-matrix.mjs. Both also assert this stays <nav>'s only
-                element child, since they locate the pill from there.
+                e2e/screenshot-matrix.mjs. Both also assert this stays the only
+                element child of nav[aria-label="Main"], because <nav> is
+                `flex justify-center`: a sibling would push the capsule off centre,
+                and a wrapper would move the centring away from the measured box.
 
                 The pill hugs its content at every width, so the overflow guard
                 below never engages normally; it is the net for a font fallback, a
@@ -110,7 +112,7 @@ export const Navbar = () => {
                 users still reach every item by Tab, and focus scrolls into view. */}
             <div
                 data-nav-pill
-                className="pointer-events-auto flex min-w-0 max-w-[calc(100%-1.5rem)] items-center gap-1 overflow-x-auto overscroll-x-contain scroll-p-1.5 whitespace-nowrap rounded-full border border-white/10 bg-zinc-900/70 p-1.5 shadow-2xl backdrop-blur-xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0"
+                className="pointer-events-auto flex min-w-0 max-w-[calc(100%-1.5rem)] items-center gap-1 max-[359px]:gap-0.5 overflow-x-auto overscroll-x-contain scroll-p-1.5 whitespace-nowrap rounded-full border border-white/10 bg-zinc-900/70 p-1.5 max-[359px]:p-1 shadow-2xl backdrop-blur-xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0"
             >
                 {isHome ? (
                     /* Button with hard-nav: forces full reload, clearing all peer/transfer state */
@@ -122,7 +124,7 @@ export const Navbar = () => {
                         // still announces on change via the aria-live span below.
                         aria-label="Floe home"
                         title={status.label}
-                        className="flex items-center gap-2 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
+                        className="flex items-center gap-2 rounded-full px-2.5 max-[359px]:px-2 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         <span className="relative flex h-2.5 w-2.5 items-center justify-center" aria-hidden="true">
                             <span className={`absolute inset-0 rounded-full ${status.color} opacity-40 blur-[2px] transition-colors duration-500`} />
@@ -137,7 +139,7 @@ export const Navbar = () => {
                        a plain link, no status dot, no status text. */
                     <Link
                         href="/"
-                        className="flex items-center rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
+                        className="flex items-center rounded-full px-2.5 max-[359px]:px-2 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         Floe
                     </Link>
@@ -172,7 +174,7 @@ export const Navbar = () => {
                         );
                     })}
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-1" />
+                <div className="h-4 w-px bg-white/10 mx-1 max-[359px]:mx-0" />
                 {/* Destinations, split from the section anchors: Download then Docs
                     side by side, then the GitHub pill keeps its filled endpoint
                     treatment. */}
@@ -187,7 +189,7 @@ export const Navbar = () => {
                         href="/download"
                         data-umami-event="nav-download"
                         aria-current={onDownload ? 'page' : undefined}
-                        className={`rounded-full px-2.5 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium transition focus-visible:outline-2 focus-visible:outline-ice ${
+                        className={`rounded-full px-2.5 max-[359px]:px-1 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium transition focus-visible:outline-2 focus-visible:outline-ice ${
                             onDownload
                                 ? 'bg-white/[0.07] text-zinc-100'
                                 : 'text-zinc-400 hover:bg-white/10 hover:text-white'
@@ -199,24 +201,24 @@ export const Navbar = () => {
                         href="https://www.floe.one/docs"
                         target="_blank"
                         rel="noreferrer"
-                        className="rounded-full px-2.5 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice"
+                        className="rounded-full px-2.5 max-[359px]:px-1 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         Docs
                     </a>
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-1" />
+                <div className="h-4 w-px bg-white/10 mx-1 max-[359px]:mx-0" />
                 <a
                     href="https://github.com/jannskiee/floe"
                     target="_blank"
                     rel="noreferrer"
-                    className="flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
+                    className="flex items-center gap-1.5 rounded-full bg-white px-2.5 max-[359px]:px-2 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
                 >
                     <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor" aria-hidden="true">
                         <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
                     </svg>
                     {/* sr-only below sm keeps the accessible name when only the mark
                         shows. It is position:absolute, so it is not a flex item and
-                        adds no gap: the hit area really is 44px, not 44 plus a gap. */}
+                        adds no gap: the chip stays 34x26, not 34 plus a gap. */}
                     <span className="sr-only sm:not-sr-only">GitHub</span>
                 </a>
             </div>

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -71,7 +71,13 @@ export const Navbar = () => {
 
     return (
         <nav aria-label="Main" className="fixed top-0 left-0 right-0 z-50 flex justify-center pb-6 pt-[calc(1.5rem+env(safe-area-inset-top))] pointer-events-none">
-            <div className="pointer-events-auto flex items-center gap-1 max-[359px]:gap-0.5 rounded-full border border-white/10 bg-zinc-900/70 p-1.5 max-[359px]:p-1 shadow-2xl backdrop-blur-xl">
+            {/* data-nav-pill is the stable hook for e2e/responsive.spec.ts and
+                e2e/screenshot-matrix.mjs. Both also assert this stays <nav>'s only
+                element child, since they locate the pill from there. */}
+            <div
+                data-nav-pill
+                className="pointer-events-auto flex items-center gap-1 max-[359px]:gap-0.5 rounded-full border border-white/10 bg-zinc-900/70 p-1.5 max-[359px]:p-1 shadow-2xl backdrop-blur-xl"
+            >
                 {isHome ? (
                     /* Button with hard-nav: forces full reload, clearing all peer/transfer state */
                     <button

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -110,7 +110,7 @@ export const Navbar = () => {
                 users still reach every item by Tab, and focus scrolls into view. */}
             <div
                 data-nav-pill
-                className="pointer-events-auto flex min-w-0 max-w-[calc(100%-1.5rem)] items-center gap-1 overflow-x-auto overscroll-x-contain scroll-p-1.5 whitespace-nowrap rounded-full border border-white/10 bg-zinc-900/70 p-1 shadow-2xl backdrop-blur-xl sm:p-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0"
+                className="pointer-events-auto flex min-w-0 max-w-[calc(100%-1.5rem)] items-center gap-1 overflow-x-auto overscroll-x-contain scroll-p-1.5 whitespace-nowrap rounded-full border border-white/10 bg-zinc-900/70 p-1.5 shadow-2xl backdrop-blur-xl [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0"
             >
                 {isHome ? (
                     /* Button with hard-nav: forces full reload, clearing all peer/transfer state */
@@ -122,7 +122,7 @@ export const Navbar = () => {
                         // still announces on change via the aria-live span below.
                         aria-label="Floe home"
                         title={status.label}
-                        className="flex min-h-11 items-center gap-2 rounded-full px-2.5 py-1.5 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-4 sm:py-2"
+                        className="flex items-center gap-2 rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         <span className="relative flex h-2.5 w-2.5 items-center justify-center" aria-hidden="true">
                             <span className={`absolute inset-0 rounded-full ${status.color} opacity-40 blur-[2px] transition-colors duration-500`} />
@@ -137,7 +137,7 @@ export const Navbar = () => {
                        a plain link, no status dot, no status text. */
                     <Link
                         href="/"
-                        className="flex min-h-11 items-center rounded-full px-2.5 py-1.5 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-4 sm:py-2"
+                        className="flex items-center rounded-full px-2.5 py-1.5 sm:px-4 sm:py-2 text-sm font-extrabold tracking-tighter text-white transition hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         Floe
                     </Link>
@@ -172,7 +172,7 @@ export const Navbar = () => {
                         );
                     })}
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-0.5 sm:mx-1" />
+                <div className="h-4 w-px bg-white/10 mx-1" />
                 {/* Destinations, split from the section anchors: Download then Docs
                     side by side, then the GitHub pill keeps its filled endpoint
                     treatment. */}
@@ -187,7 +187,7 @@ export const Navbar = () => {
                         href="/download"
                         data-umami-event="nav-download"
                         aria-current={onDownload ? 'page' : undefined}
-                        className={`inline-flex min-h-11 items-center justify-center rounded-full px-2 py-1.5 text-xs font-medium transition focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-3.5 sm:py-2 sm:text-sm ${
+                        className={`rounded-full px-2.5 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium transition focus-visible:outline-2 focus-visible:outline-ice ${
                             onDownload
                                 ? 'bg-white/[0.07] text-zinc-100'
                                 : 'text-zinc-400 hover:bg-white/10 hover:text-white'
@@ -199,44 +199,21 @@ export const Navbar = () => {
                         href="https://www.floe.one/docs"
                         target="_blank"
                         rel="noreferrer"
-                        className="inline-flex min-h-11 items-center justify-center rounded-full px-2 py-1.5 text-xs font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0 sm:px-3.5 sm:py-2 sm:text-sm"
+                        className="rounded-full px-2.5 py-1.5 sm:px-3.5 sm:py-2 text-xs sm:text-sm font-medium text-zinc-400 transition hover:bg-white/10 hover:text-white focus-visible:outline-2 focus-visible:outline-ice"
                     >
                         Docs
                     </a>
                 </div>
-                <div className="h-4 w-px bg-white/10 mx-0.5 sm:mx-1" />
-                {/* Below sm the target and the mark are deliberately different sizes.
-                    The anchor is a transparent 44x44 hit area, and the white shape
-                    inside it is the original 34x26 stadium, which is the compact
-                    endpoint this header has always had. Sizing the whole control to
-                    the touch target made a filled circle that nearly spanned the
-                    pill's height and read as a different, much louder button.
-
-                    From sm up the chip drops its own fill and collapses to the mark's
-                    own size, and the white moves to the anchor, which grows the label
-                    beside it. One control that gains a label, not two buttons.
-                    (Deliberately not display:contents for that collapse: it is the
-                    tidier mechanism but Tailwind did not emit the sm: variant of it
-                    here, and a box that quietly stops existing is a poor thing to
-                    depend on when a transparent one behaves identically.) */}
+                <div className="h-4 w-px bg-white/10 mx-1" />
                 <a
                     href="https://github.com/jannskiee/floe"
                     target="_blank"
                     rel="noreferrer"
-                    className="group inline-flex size-11 items-center justify-center rounded-full text-xs font-bold transition focus-visible:outline-2 focus-visible:outline-ice sm:size-auto sm:gap-1.5 sm:bg-white sm:px-4 sm:py-2 sm:text-sm sm:text-black sm:hover:bg-zinc-200"
+                    className="flex items-center gap-1.5 rounded-full bg-white px-2.5 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
                 >
-                    <span className="flex items-center rounded-full bg-white px-2.5 py-1.5 text-black transition group-hover:bg-zinc-200 sm:bg-transparent sm:px-0 sm:py-0 sm:group-hover:bg-transparent">
-                        {/* px-2.5 py-1.5 around a 14px mark is the original endpoint
-                            geometry: 34x26, wider than it is tall, so rounded-full
-                            reads as a stadium rather than a circle. Squaring it off
-                            (size-8) changed the shape, not just the scale.
-                            sm:px-0/sm:py-0, not sm:p-0: Tailwind orders the padding
-                            shorthand ahead of the longhands, so the shorthand would
-                            have lost to px-2.5 at every width. */}
-                        <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor" aria-hidden="true">
-                            <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-                        </svg>
-                    </span>
+                    <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor" aria-hidden="true">
+                        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+                    </svg>
                     {/* sr-only below sm keeps the accessible name when only the mark
                         shows. It is position:absolute, so it is not a flex item and
                         adds no gap: the hit area really is 44px, not 44 plus a gap. */}

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -206,16 +206,24 @@ export const Navbar = () => {
                 </div>
                 <div className="h-4 w-px bg-white/10 mx-0.5 sm:mx-1" />
                 {/* The one control whose shape changes at the breakpoint: a 44x44
-                    squircle while its label is sr-only, the labelled white pill once
-                    the label shows. Below sm it is deliberately the quiet control, so
-                    Download is the only bright thing on a phone. */}
+                    white circle while its label is sr-only, the labelled white pill
+                    once the label shows. The fill is the same white at both widths on
+                    purpose, so the endpoint reads as one control that grows a label
+                    rather than two different buttons. An earlier pass made this a
+                    translucent squircle below sm to leave Download as the only bright
+                    thing on a phone; that lost the endpoint treatment entirely, so the
+                    white is back and Download stays a text pill. */}
                 <a
                     href="https://github.com/jannskiee/floe"
                     target="_blank"
                     rel="noreferrer"
-                    className="inline-flex size-11 items-center justify-center gap-1.5 rounded-xl bg-white/10 text-xs font-bold text-white transition hover:bg-white/20 focus-visible:outline-2 focus-visible:outline-ice sm:size-auto sm:rounded-full sm:bg-white sm:px-4 sm:py-2 sm:text-sm sm:text-black sm:hover:bg-zinc-200"
+                    className="inline-flex size-11 items-center justify-center gap-1.5 rounded-full bg-white text-xs font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice sm:size-auto sm:px-4 sm:py-2 sm:text-sm"
                 >
-                    <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor" aria-hidden="true">
+                    {/* 20px below sm, 14px from sm up. The glyph carries the whole
+                        control on a phone, where there is no label beside it, and at
+                        14px in a 44px circle it read as a dot in a field of white.
+                        From sm up it sits next to the word, where 14px is right. */}
+                    <svg viewBox="0 0 24 24" className="size-5 flex-shrink-0 sm:size-3.5" fill="currentColor" aria-hidden="true">
                         <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
                     </svg>
                     {/* sr-only below sm keeps the accessible name when only the icon

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -206,11 +206,11 @@ export const Navbar = () => {
                 </div>
                 <div className="h-4 w-px bg-white/10 mx-0.5 sm:mx-1" />
                 {/* Below sm the target and the mark are deliberately different sizes.
-                    The anchor is a transparent 44x44 hit area, and the white circle
-                    inside it is only 32px, which is the compact endpoint this header
-                    has always had. Sizing the whole control to the touch target made a
-                    filled circle that nearly spanned the pill's height and read as a
-                    different, much louder button.
+                    The anchor is a transparent 44x44 hit area, and the white shape
+                    inside it is the original 34x26 stadium, which is the compact
+                    endpoint this header has always had. Sizing the whole control to
+                    the touch target made a filled circle that nearly spanned the
+                    pill's height and read as a different, much louder button.
 
                     From sm up the chip drops its own fill and collapses to the mark's
                     own size, and the white moves to the anchor, which grows the label
@@ -225,11 +225,15 @@ export const Navbar = () => {
                     rel="noreferrer"
                     className="group inline-flex size-11 items-center justify-center rounded-full text-xs font-bold transition focus-visible:outline-2 focus-visible:outline-ice sm:size-auto sm:gap-1.5 sm:bg-white sm:px-4 sm:py-2 sm:text-sm sm:text-black sm:hover:bg-zinc-200"
                 >
-                    <span className="flex size-8 items-center justify-center rounded-full bg-white text-black transition group-hover:bg-zinc-200 sm:size-auto sm:bg-transparent sm:group-hover:bg-transparent">
-                        {/* 16px in the 32px circle, 14px beside the label. The glyph
-                            carries the control alone on a phone, so it wants the
-                            larger of the two. */}
-                        <svg viewBox="0 0 24 24" className="size-4 flex-shrink-0 sm:size-3.5" fill="currentColor" aria-hidden="true">
+                    <span className="flex items-center rounded-full bg-white px-2.5 py-1.5 text-black transition group-hover:bg-zinc-200 sm:bg-transparent sm:px-0 sm:py-0 sm:group-hover:bg-transparent">
+                        {/* px-2.5 py-1.5 around a 14px mark is the original endpoint
+                            geometry: 34x26, wider than it is tall, so rounded-full
+                            reads as a stadium rather than a circle. Squaring it off
+                            (size-8) changed the shape, not just the scale.
+                            sm:px-0/sm:py-0, not sm:p-0: Tailwind orders the padding
+                            shorthand ahead of the longhands, so the shorthand would
+                            have lost to px-2.5 at every width. */}
+                        <svg viewBox="0 0 24 24" className="h-3.5 w-3.5 flex-shrink-0" fill="currentColor" aria-hidden="true">
                             <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
                         </svg>
                     </span>

--- a/client/components/layout/Navbar.tsx
+++ b/client/components/layout/Navbar.tsx
@@ -205,30 +205,37 @@ export const Navbar = () => {
                     </a>
                 </div>
                 <div className="h-4 w-px bg-white/10 mx-0.5 sm:mx-1" />
-                {/* The one control whose shape changes at the breakpoint: a 44x44
-                    white circle while its label is sr-only, the labelled white pill
-                    once the label shows. The fill is the same white at both widths on
-                    purpose, so the endpoint reads as one control that grows a label
-                    rather than two different buttons. An earlier pass made this a
-                    translucent squircle below sm to leave Download as the only bright
-                    thing on a phone; that lost the endpoint treatment entirely, so the
-                    white is back and Download stays a text pill. */}
+                {/* Below sm the target and the mark are deliberately different sizes.
+                    The anchor is a transparent 44x44 hit area, and the white circle
+                    inside it is only 32px, which is the compact endpoint this header
+                    has always had. Sizing the whole control to the touch target made a
+                    filled circle that nearly spanned the pill's height and read as a
+                    different, much louder button.
+
+                    From sm up the chip drops its own fill and collapses to the mark's
+                    own size, and the white moves to the anchor, which grows the label
+                    beside it. One control that gains a label, not two buttons.
+                    (Deliberately not display:contents for that collapse: it is the
+                    tidier mechanism but Tailwind did not emit the sm: variant of it
+                    here, and a box that quietly stops existing is a poor thing to
+                    depend on when a transparent one behaves identically.) */}
                 <a
                     href="https://github.com/jannskiee/floe"
                     target="_blank"
                     rel="noreferrer"
-                    className="inline-flex size-11 items-center justify-center gap-1.5 rounded-full bg-white text-xs font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice sm:size-auto sm:px-4 sm:py-2 sm:text-sm"
+                    className="group inline-flex size-11 items-center justify-center rounded-full text-xs font-bold transition focus-visible:outline-2 focus-visible:outline-ice sm:size-auto sm:gap-1.5 sm:bg-white sm:px-4 sm:py-2 sm:text-sm sm:text-black sm:hover:bg-zinc-200"
                 >
-                    {/* 20px below sm, 14px from sm up. The glyph carries the whole
-                        control on a phone, where there is no label beside it, and at
-                        14px in a 44px circle it read as a dot in a field of white.
-                        From sm up it sits next to the word, where 14px is right. */}
-                    <svg viewBox="0 0 24 24" className="size-5 flex-shrink-0 sm:size-3.5" fill="currentColor" aria-hidden="true">
-                        <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-                    </svg>
-                    {/* sr-only below sm keeps the accessible name when only the icon
+                    <span className="flex size-8 items-center justify-center rounded-full bg-white text-black transition group-hover:bg-zinc-200 sm:size-auto sm:bg-transparent sm:group-hover:bg-transparent">
+                        {/* 16px in the 32px circle, 14px beside the label. The glyph
+                            carries the control alone on a phone, so it wants the
+                            larger of the two. */}
+                        <svg viewBox="0 0 24 24" className="size-4 flex-shrink-0 sm:size-3.5" fill="currentColor" aria-hidden="true">
+                            <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+                        </svg>
+                    </span>
+                    {/* sr-only below sm keeps the accessible name when only the mark
                         shows. It is position:absolute, so it is not a flex item and
-                        adds no gap: the square really is 44px, not 44 plus a gap. */}
+                        adds no gap: the hit area really is 44px, not 44 plus a gap. */}
                     <span className="sr-only sm:not-sr-only">GitHub</span>
                 </a>
             </div>

--- a/client/e2e/responsive.spec.ts
+++ b/client/e2e/responsive.spec.ts
@@ -122,6 +122,9 @@ async function assertNavbarFits(page: Page, label: string, expectPill: boolean) 
             scrollWidth: pill.scrollWidth,
             clientWidth: pill.clientWidth,
             navChildren: pill.parentElement?.childElementCount ?? -1,
+            parentIsMainNav:
+                pill.parentElement?.tagName === 'NAV' &&
+                pill.parentElement.getAttribute('aria-label') === 'Main',
         };
     });
     if (!r) {
@@ -140,10 +143,20 @@ async function assertNavbarFits(page: Page, label: string, expectPill: boolean) 
             `[${label}] navbar pill content overflows its own box (scrollWidth=${r.scrollWidth} clientWidth=${r.clientWidth}, innerWidth=${r.innerWidth})`
         )
         .toBeLessThanOrEqual(r.clientWidth + 1);
-    // The pill must stay <nav>'s only element child: both this guard and
-    // e2e/screenshot-matrix.mjs locate it from there, and a stray sibling would
-    // make querySelector pick the wrong element while still passing.
-    expect.soft(r.navChildren, `[${label}] <nav> should have exactly one element child`).toBe(1);
+    // The pill must remain the direct, only child of nav[aria-label="Main"].
+    // Both halves matter and neither is about the selector: [data-nav-pill] finds
+    // the right element regardless. What breaks is the geometry. <nav> is
+    // `flex justify-center` with `pointer-events-none`, so a sibling would push
+    // the capsule off centre, and a wrapper would silently move the centring one
+    // level away from the thing being measured. Asserting the parent's identity
+    // as well as its child count is what makes the wrapper case fail: a count of
+    // 1 alone is satisfied by any container.
+    expect
+        .soft(r.parentIsMainNav, `[${label}] pill's parent should be nav[aria-label="Main"]`)
+        .toBe(true);
+    expect
+        .soft(r.navChildren, `[${label}] nav[aria-label="Main"] should have exactly one element child`)
+        .toBe(1);
 }
 
 async function sweepViewports(page: Page, route: string, checkNavbar = false) {

--- a/client/e2e/responsive.spec.ts
+++ b/client/e2e/responsive.spec.ts
@@ -125,7 +125,9 @@ async function assertNavbarFits(page: Page, label: string, expectPill: boolean) 
         };
     });
     if (!r) {
-        expect(r, `[${label}] expected a [data-nav-pill] element and found none`).not.toBeNull();
+        if (expectPill) {
+            expect(r, `[${label}] expected a [data-nav-pill] element and found none`).not.toBeNull();
+        }
         return;
     }
     expect.soft(r.left, `[${label}] navbar pill left edge`).toBeGreaterThanOrEqual(-1);

--- a/client/e2e/responsive.spec.ts
+++ b/client/e2e/responsive.spec.ts
@@ -19,10 +19,13 @@ const VIEWPORTS = [
     { width: 414, height: 896 },   // iPhone XR / 11
     { width: 430, height: 932 },   // iPhone Pro Max
     { width: 568, height: 320 },   // iPhone SE landscape (short height)
+    { width: 639, height: 900 },   // one below the sm tier boundary
+    { width: 640, height: 960 },   // sm tier boundary: Windows 11 3-column snap on 1920
     { width: 844, height: 390 },   // iPhone 12-15 landscape
     { width: 768, height: 1024 },  // iPad portrait
     { width: 820, height: 1180 },  // iPad Air portrait
-    { width: 1024, height: 768 },  // iPad landscape
+    { width: 1023, height: 768 },  // one below the lg tier boundary
+    { width: 1024, height: 768 },  // lg tier boundary / iPad landscape
     { width: 1280, height: 800 },  // small laptop
     { width: 1366, height: 768 },  // most common laptop
     { width: 1440, height: 900 },  // laptop
@@ -95,19 +98,50 @@ async function assertNoHorizontalOverflow(page: Page, label: string) {
 /**
  * The navbar is position:fixed, so an overflowing pill never shows up in
  * document scrollWidth — measure it directly instead.
+ *
+ * The pill caps itself with max-width and scrolls internally rather than poking
+ * off-screen, which makes its bounding box incapable of exceeding the viewport.
+ * The edge assertions below are therefore kept only as a cheap sanity net; the
+ * assertion that can actually still fail is scrollWidth vs clientWidth, i.e.
+ * "did the content outgrow the cap". Anything that widens the tiers past the
+ * viewport shows up there and nowhere else.
+ *
+ * Callers pass expectPill so a missing pill is a hard failure on routes that
+ * must have one. The old version returned early on null, so any change to the
+ * pill's selector or element type silently retired this whole guard.
  */
-async function assertNavbarFits(page: Page, label: string) {
+async function assertNavbarFits(page: Page, label: string, expectPill: boolean) {
     const r = await page.evaluate(() => {
-        const pill = document.querySelector('nav > div');
+        const pill = document.querySelector('[data-nav-pill]');
         if (!pill) return null;
         const rect = pill.getBoundingClientRect();
-        return { left: rect.left, right: rect.right, innerWidth: window.innerWidth };
+        return {
+            left: rect.left,
+            right: rect.right,
+            innerWidth: window.innerWidth,
+            scrollWidth: pill.scrollWidth,
+            clientWidth: pill.clientWidth,
+            navChildren: pill.parentElement?.childElementCount ?? -1,
+        };
     });
-    if (!r) return; // route without the navbar
+    if (!r) {
+        expect(r, `[${label}] expected a [data-nav-pill] element and found none`).not.toBeNull();
+        return;
+    }
     expect.soft(r.left, `[${label}] navbar pill left edge`).toBeGreaterThanOrEqual(-1);
     expect
         .soft(r.right, `[${label}] navbar pill right edge (innerWidth=${r.innerWidth})`)
         .toBeLessThanOrEqual(r.innerWidth + 1);
+    expect
+        .soft(
+            r.scrollWidth,
+            `[${label}] navbar pill content overflows its own box (scrollWidth=${r.scrollWidth} clientWidth=${r.clientWidth}, innerWidth=${r.innerWidth})`
+        )
+        .toBeLessThanOrEqual(r.clientWidth + 1);
+    // The pill must stay <nav>'s only element child: both this guard and
+    // e2e/screenshot-matrix.mjs locate it from there, and a stray sibling would
+    // make querySelector pick the wrong element while still passing.
+    expect.soft(r.navChildren, `[${label}] <nav> should have exactly one element child`).toBe(1);
 }
 
 async function sweepViewports(page: Page, route: string, checkNavbar = false) {
@@ -116,7 +150,7 @@ async function sweepViewports(page: Page, route: string, checkNavbar = false) {
         await page.waitForTimeout(150); // let reflow + transitions settle
         const label = `${route} @ ${vp.width}x${vp.height}`;
         await assertNoHorizontalOverflow(page, label);
-        if (checkNavbar) await assertNavbarFits(page, label);
+        if (checkNavbar) await assertNavbarFits(page, label, true);
     }
 }
 
@@ -210,7 +244,7 @@ test('sender flow stays inside the viewport at 320 and 390 wide', async ({ page 
 
         const label = `sender flow @ ${vp.width}x${vp.height}`;
         await assertNoHorizontalOverflow(page, label);
-        await assertNavbarFits(page, label);
+        await assertNavbarFits(page, label, true);
 
         // QR panel open is the share card's widest state.
         await page.getByRole('button', { name: 'Toggle QR code' }).click();

--- a/client/e2e/screenshot-matrix.mjs
+++ b/client/e2e/screenshot-matrix.mjs
@@ -62,9 +62,21 @@ const overflowEval = () => {
             }
         }
     }
-    const pill = document.querySelector('nav > div');
+    // The pill caps itself with max-width and scrolls internally, so its bounding
+    // box can no longer exceed the viewport. scroll vs client is the figure that
+    // still moves when the tiers outgrow the space.
+    const pill = document.querySelector('[data-nav-pill]');
     const nav = pill
-        ? (() => { const r = pill.getBoundingClientRect(); return { left: Math.round(r.left), right: Math.round(r.right) }; })()
+        ? (() => {
+            const r = pill.getBoundingClientRect();
+            return {
+                left: Math.round(r.left),
+                right: Math.round(r.right),
+                scroll: pill.scrollWidth,
+                client: pill.clientWidth,
+                children: pill.parentElement ? pill.parentElement.childElementCount : -1,
+            };
+        })()
         : null;
     return { innerWidth, doc: doc.scrollWidth, body: body.scrollWidth, offenders, nav };
 };
@@ -89,7 +101,12 @@ async function capture(page, name, vp) {
     const r = await page.evaluate(overflowEval);
     const file = `${name}--${KEY(vp)}.png`;
     await page.screenshot({ path: join(OUT, file), fullPage: true });
-    const navBad = r.nav && (r.nav.left < -1 || r.nav.right > r.innerWidth + 1);
+    const navBad =
+        r.nav &&
+        (r.nav.left < -1 ||
+            r.nav.right > r.innerWidth + 1 ||
+            r.nav.scroll > r.nav.client + 1 ||
+            r.nav.children !== 1);
     const docBad = r.doc > r.innerWidth + 1 || r.body > r.innerWidth + 1;
     index.push({ file, page: name, ...vp, ...r, flag: navBad || docBad ? 'OVERFLOW' : 'ok' });
     process.stdout.write(`${navBad || docBad ? '!! ' : '   '}${file}  doc=${r.doc}/${r.innerWidth}${r.nav ? ` nav=[${r.nav.left},${r.nav.right}]` : ''}\n`);


### PR DESCRIPTION
## Summary

The site header had two tiers and jumped between them violently. Measured on the live site, the pill went from 196px at 639px wide (30.7% of the viewport, with more empty space either side of it than the pill itself occupied) to 569px at 640px (89.0%) in a single CSS pixel, then stepped up again at 768px. The densest layout debuted at the narrowest viewport that could host it.

640 and 768 are also the two worst numbers available. Windows 11's three-column snap layout on a 1920x1080 desktop produces 640/640/640, and a half-snapped 1536-wide desktop produces exactly 768. Those are the first and second most common desktop resolutions.

Below 640px, five destinations were unreachable by any route at all. There is no menu, drawer or overflow anywhere in the app, so `/download` simply did not exist on any phone.

### Three tiers, gated purely by CSS

| Width | Contents |
|---|---|
| 320-639 | Floe, Download, Docs, GitHub |
| 640-1023 | + About, FAQ; GitHub gains its label |
| 1024+ | + CLI, Desktop (identical to today) |

Download moves from `md`-only to always visible. CLI and Desktop are the two anchors held back to `lg`: both point at something you cannot do at that size anyway (run a terminal, install a Windows app), while About and FAQ are audience-neutral. The 640-1023 band is mostly landscape phones and half-snapped desktop windows, not tablets.

Header height, spacing and control sizing are deliberately unchanged from what ships today, including the sub-360 compact tier. The pill is 42px tall below 359, 46px to 639 and 50px above, controls are 32/28/26px, and hero clearance is 26px then 38px. **This PR differs from production in content only.**

### Measured result on `/`

| Viewport | Before | After |
|---|---|---|
| 320 | 148px, 46.2% | 214px, 66.9% |
| 390 | 196px, 50.2% | 274px, 70.3% |
| 639 | 196px, **30.7%** | 274px, 42.9% |
| 640 | 569px, **89.0%** | 527px, 82.3% |
| 768 | 667px, **86.9%** | 527px, 68.6% |
| 1024 | 667px, 65.1% | 667px, 65.1% (unchanged) |
| 1280 | 667px, 52.1% | 667px, 52.1% (unchanged) |

The second step at 768 is gone and the curve is monotonic within each tier. The side gutter previously exceeded the pill's own width from 588px to 639px, which is what made it read as debris rather than as a designed element. That now happens nowhere below 2560px.

### Also in this PR

- **The layout guard is rebuilt first, against the unmodified navbar.** Adding a max-width cap to the pill would have made the old assertion mathematically unfailable, and `overflow-x` would have hidden every navbar descendant from the overflow report. The guard now asserts `scrollWidth` against `clientWidth`, which is the figure that still moves when the tiers outgrow the space, plus the pill's parent identity and child count. It was verified to actually go red under a runtime-only mutation, where the old assertion stayed green in 12 of 12 cases.
- **The web-app pill is removed from the download hero.** With Download now in the header at every width, it made a loop: the homepage sent you to `/download` and the primary action there sent you straight back. Removing it also removed the OS sniff, the `useSyncExternalStore` snapshot split that kept the sniff hydration-safe, and the `'use client'` boundary. The download hero is server-rendered end to end again.
- **The macOS and Linux roadmap claim is dropped** from the desktop section's version line and the FAQ answer, and the version line loses its trailing separator.
- **The `/download` meta description no longer advertises a browser option the page does not offer.**
- **The drop zone hint centres when it wraps.** `items-center` centres each paragraph as a box but leaves its text set to the start edge, so the second line hung left below about 430px. Pre-existing.

## Test plan

- `pnpm lint` clean. Two `no-location-assign-relative-destination` warnings are pre-existing on main: both `window.location.href` sites exist there, this PR changes neither line, and the rule arrived with main's own `eslint-config-next` 16.3.0 bump. The hard navigation is deliberate and documented, since it clears peer and socket state that `router.push()` would preserve.
- `pnpm test`: 19 files, 191 tests.
- `pnpm exec playwright test`: responsive, hydration and image-density all pass, including four new tier-boundary viewports (639, 640, 1023, 1024).
- `pnpm build` succeeds.
- Geometry measured on the running branch at 39 widths across both routes via a same-origin `srcdoc` harness: no internal overflow at any width from 320 up, no side gutter wider than the pill below 2560, and `nav[aria-label="Main"]` has exactly one element child everywhere.
- Verified under a raised browser minimum font size at 320px, the case the restored compact tier protects: 16px gives 244/244 and 20px gives 280/280, with no overflow. Without the compact tier the same test overflowed at 304/294 and pushed the GitHub control past the pill edge into a deliberately hidden scroller.
- Audited by eleven independent reviewers covering links, copy accuracy, QA suites, accessibility, footer, visual regression, code, SEO, runtime console and network, plus adversarial verification and merge readiness. Zero blockers.

## Known and deliberate

- At 640-1023 the scroll-spy tracks the CLI and Desktop sections while their anchors are hidden, so no anchor is highlighted while those sections are on screen. Fixing it needs width-aware JavaScript, which is the `matchMedia`-in-an-effect pattern `e2e/hydration.spec.ts` exists to catch.
- Touch targets stay at 26-32px, matching production. They meet SC 2.5.8 (AA) and not SC 2.5.5 (AAA), exactly as today.
- `lib/detectOs.ts` now has no callers. Left in place with its unit tests rather than deleted.
- `/how-it-works`, `/privacy` and `/terms` render neither Navbar nor Footer. That is pre-existing, site-wide, and the best follow-up available, but it does not belong in a header PR.
