### PR TITLE
fix(desktop): harden transfers around failure, cancel, and restart

### DIFF
--- a/cli/engine/transfer/cleanup_test.go
+++ b/cli/engine/transfer/cleanup_test.go
@@ -1,0 +1,324 @@
+// Partial-file cleanup tests: a receive that fails or is interrupted must not
+// leave a half-written file behind under its final name, while completed files
+// and successful transfers keep everything. Driven with raw senders over real
+// in-process pion pairs (see loopback_test.go for the harness); timeout vars
+// are shrunk per test and restored via t.Cleanup, set BEFORE the receiver
+// goroutine starts, matching watchdog_test.go.
+package transfer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// listDir returns the recursive file names under dir, for "nothing left
+// behind" assertions that also catch de-collided names and stray subfiles.
+func listDir(t *testing.T, dir string) []string {
+	t.Helper()
+	var names []string
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			rel, _ := filepath.Rel(dir, path)
+			names = append(names, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return names
+}
+
+// TestReceiverStallMidFileRemovesPartial: the mid-file stall watchdog fires
+// and the partial file must be deleted, not left at its final name.
+func TestReceiverStallMidFileRemovesPartial(t *testing.T) {
+	oldIdle, oldStall := receiveIdleTimeout, receiveStallTimeout
+	receiveIdleTimeout = 5 * time.Second
+	receiveStallTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { receiveIdleTimeout = oldIdle; receiveStallTimeout = oldStall })
+
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	meta := `{"type":"metadata","id":"c-1","fileName":"stall.bin","fileSize":4096,"index":1,"total":1,"totalBytes":4096}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil || !strings.Contains(err.Error(), "stall") {
+			t.Fatalf("expected a stall error, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+	if left := listDir(t, outDir); len(left) != 0 {
+		t.Fatalf("expected an empty output dir after a stalled receive, found %v", left)
+	}
+}
+
+// TestReceiverShortEndRemovesPartial: an "end" marker with a short byte count
+// closes the handle before the integrity check, so the truncated file needs
+// its own removal on that path.
+func TestReceiverShortEndRemovesPartial(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	meta := `{"type":"metadata","id":"c-2","fileName":"short.bin","fileSize":4096,"index":1,"total":1,"totalBytes":4096}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+	if err := sender.SendText(`{"type":"end"}`); err != nil {
+		t.Fatalf("SendText end: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil || !strings.Contains(err.Error(), "incomplete file") {
+			t.Fatalf("expected an incomplete-file error, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+	if left := listDir(t, outDir); len(left) != 0 {
+		t.Fatalf("expected the truncated file to be removed, found %v", left)
+	}
+}
+
+// TestReceiverCloseMidFileRemovesPartial: the sender's channel closes while a
+// file is half-written; the deferred cleanup must remove the partial.
+func TestReceiverCloseMidFileRemovesPartial(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	meta := `{"type":"metadata","id":"c-3","fileName":"cut.bin","fileSize":4096,"index":1,"total":1,"totalBytes":4096}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+	// Give the chunk time to land before the close races it.
+	time.Sleep(300 * time.Millisecond)
+	if err := sender.Close(); err != nil {
+		t.Fatalf("sender close: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil || !strings.Contains(err.Error(), "connection closed mid-transfer") {
+			t.Fatalf("expected a connection-closed error, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+	if left := listDir(t, outDir); len(left) != 0 {
+		t.Fatalf("expected an empty output dir after a cut receive, found %v", left)
+	}
+}
+
+// TestReceiverSuccessKeepsFile pins the other side of the contract: the
+// cleanup must never remove a completed file on the success path.
+func TestReceiverSuccessKeepsFile(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	meta := `{"type":"metadata","id":"c-4","fileName":"ok.bin","fileSize":4,"index":1,"total":1,"totalBytes":4}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	if err := sender.Send(make([]byte, 4)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+	if err := sender.SendText(`{"type":"end"}`); err != nil {
+		t.Fatalf("SendText end: %v", err)
+	}
+	// Close so the receiver's post-completion grace wait ends immediately.
+	time.Sleep(300 * time.Millisecond)
+	_ = sender.Close()
+
+	select {
+	case err := <-recvErr:
+		if err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "ok.bin"))
+	if err != nil {
+		t.Fatalf("completed file missing after success: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("completed file has %d bytes, want 4", len(got))
+	}
+}
+
+// TestReceiverMidBatchFailureKeepsCompletedFiles: when file 2 of a batch is
+// interrupted, file 1 must survive intact and only the in-flight partial is
+// removed.
+func TestReceiverMidBatchFailureKeepsCompletedFiles(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	m1 := `{"type":"metadata","id":"c-5a","fileName":"first.bin","fileSize":4,"index":1,"total":2,"totalBytes":4100}`
+	if err := sender.SendText(m1); err != nil {
+		t.Fatalf("SendText metadata 1: %v", err)
+	}
+	if err := sender.Send(make([]byte, 4)); err != nil {
+		t.Fatalf("Send chunk 1: %v", err)
+	}
+	if err := sender.SendText(`{"type":"end"}`); err != nil {
+		t.Fatalf("SendText end 1: %v", err)
+	}
+	m2 := `{"type":"metadata","id":"c-5b","fileName":"second.bin","fileSize":4096,"index":2,"total":2,"totalBytes":4100}`
+	if err := sender.SendText(m2); err != nil {
+		t.Fatalf("SendText metadata 2: %v", err)
+	}
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk 2: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if err := sender.Close(); err != nil {
+		t.Fatalf("sender close: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil || !strings.Contains(err.Error(), "connection closed mid-transfer") {
+			t.Fatalf("expected a connection-closed error, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+
+	got, err := os.ReadFile(filepath.Join(outDir, "first.bin"))
+	if err != nil {
+		t.Fatalf("completed first.bin missing after mid-batch failure: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("first.bin has %d bytes, want 4", len(got))
+	}
+	if left := listDir(t, outDir); len(left) != 1 || left[0] != "first.bin" {
+		t.Fatalf("expected only first.bin to remain, found %v", left)
+	}
+}
+
+// TestReceiverAbandonedFileCleanedOnNextMetadata: a second metadata while a
+// file is still open (no "end") must close and delete the abandoned partial,
+// not leak the handle or leave the half-written file.
+func TestReceiverAbandonedFileCleanedOnNextMetadata(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	mA := `{"type":"metadata","id":"c-6a","fileName":"abandoned.bin","fileSize":4096,"index":1,"total":2,"totalBytes":4100}`
+	if err := sender.SendText(mA); err != nil {
+		t.Fatalf("SendText metadata A: %v", err)
+	}
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk A: %v", err)
+	}
+	// No "end" for A: the sender abandons it and starts B.
+	mB := `{"type":"metadata","id":"c-6b","fileName":"kept.bin","fileSize":4,"index":2,"total":2,"totalBytes":4100}`
+	if err := sender.SendText(mB); err != nil {
+		t.Fatalf("SendText metadata B: %v", err)
+	}
+	if err := sender.Send(make([]byte, 4)); err != nil {
+		t.Fatalf("Send chunk B: %v", err)
+	}
+	if err := sender.SendText(`{"type":"end"}`); err != nil {
+		t.Fatalf("SendText end B: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if err := sender.Close(); err != nil {
+		t.Fatalf("sender close: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		// B completed but A never did, so the batch ends short: 1 of 2 files.
+		if err == nil || !strings.Contains(err.Error(), "after 1 of 2 files") {
+			t.Fatalf("expected a 1-of-2-files close error, got: %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+
+	got, err := os.ReadFile(filepath.Join(outDir, "kept.bin"))
+	if err != nil {
+		t.Fatalf("completed kept.bin missing: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("kept.bin has %d bytes, want 4", len(got))
+	}
+	if left := listDir(t, outDir); len(left) != 1 || left[0] != "kept.bin" {
+		t.Fatalf("expected only kept.bin to remain (abandoned.bin cleaned), found %v", left)
+	}
+}

--- a/cli/engine/transfer/cleanup_test.go
+++ b/cli/engine/transfer/cleanup_test.go
@@ -322,3 +322,124 @@ func TestReceiverAbandonedFileCleanedOnNextMetadata(t *testing.T) {
 		t.Fatalf("expected only kept.bin to remain (abandoned.bin cleaned), found %v", left)
 	}
 }
+
+// TestReceiverIncomingHookFiresBeforeFirstByte: OnIncoming must fire exactly
+// once, with the batch summary, strictly before any OnProgress call.
+func TestReceiverIncomingHookFiresBeforeFirstByte(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	// Both callbacks run on the receive loop goroutine, so an unlocked slice
+	// is safe; the test reads it only after the receive returns.
+	var events []string
+	var got IncomingInfo
+	opts := ReceiveOptions{
+		OnIncoming: func(inc IncomingInfo) {
+			events = append(events, "incoming")
+			got = inc
+		},
+		OnProgress: func(Progress) {
+			events = append(events, "progress")
+		},
+	}
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFilesWithOptions(dc, outDir, true, "", "", opts)
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	meta := `{"type":"metadata","id":"c-7","fileName":"a.txt","fileSize":4,"index":1,"total":1,"totalBytes":4}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	if err := sender.Send(make([]byte, 4)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+	if err := sender.SendText(`{"type":"end"}`); err != nil {
+		t.Fatalf("SendText end: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	_ = sender.Close()
+
+	select {
+	case err := <-recvErr:
+		if err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ReceiveFilesWithOptions did not return")
+	}
+
+	if len(events) == 0 || events[0] != "incoming" {
+		t.Fatalf("expected the incoming hook to fire before any progress, got sequence %v", events)
+	}
+	if n := countOf(events, "incoming"); n != 1 {
+		t.Fatalf("incoming hook fired %d times, want exactly 1", n)
+	}
+	if got.Files != 1 || got.TotalBytes != 4 || got.FirstName != "a.txt" {
+		t.Fatalf("incoming payload = %+v, want Files=1 TotalBytes=4 FirstName=a.txt", got)
+	}
+}
+
+// TestReceiverIncomingHookLegacyFallback: a sender that predates totalBytes
+// still yields the single file's size in the incoming summary.
+func TestReceiverIncomingHookLegacyFallback(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	var got IncomingInfo
+	fired := 0
+	opts := ReceiveOptions{
+		OnIncoming: func(inc IncomingInfo) { fired++; got = inc },
+	}
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFilesWithOptions(dc, outDir, true, "", "", opts)
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	// No totalBytes field, like a pre-1.6.0 sender.
+	meta := `{"type":"metadata","id":"c-8","fileName":"old.bin","fileSize":4,"index":1,"total":1}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	if err := sender.Send(make([]byte, 4)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+	if err := sender.SendText(`{"type":"end"}`); err != nil {
+		t.Fatalf("SendText end: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	_ = sender.Close()
+
+	select {
+	case err := <-recvErr:
+		if err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("ReceiveFilesWithOptions did not return")
+	}
+	if fired != 1 {
+		t.Fatalf("incoming hook fired %d times, want 1", fired)
+	}
+	if got.TotalBytes != 4 {
+		t.Fatalf("legacy fallback TotalBytes = %d, want the file size 4", got.TotalBytes)
+	}
+}
+
+func countOf(list []string, want string) int {
+	n := 0
+	for _, s := range list {
+		if s == want {
+			n++
+		}
+	}
+	return n
+}

--- a/cli/engine/transfer/cleanup_test.go
+++ b/cli/engine/transfer/cleanup_test.go
@@ -379,6 +379,9 @@ func TestReceiverIncomingHookFiresBeforeFirstByte(t *testing.T) {
 	if n := countOf(events, "incoming"); n != 1 {
 		t.Fatalf("incoming hook fired %d times, want exactly 1", n)
 	}
+	if n := countOf(events, "progress"); n < 1 {
+		t.Fatalf("no progress events fired, so the before-progress ordering claim is vacuous: %v", events)
+	}
 	if got.Files != 1 || got.TotalBytes != 4 || got.FirstName != "a.txt" {
 		t.Fatalf("incoming payload = %+v, want Files=1 TotalBytes=4 FirstName=a.txt", got)
 	}
@@ -431,6 +434,105 @@ func TestReceiverIncomingHookLegacyFallback(t *testing.T) {
 	}
 	if got.TotalBytes != 4 {
 		t.Fatalf("legacy fallback TotalBytes = %d, want the file size 4", got.TotalBytes)
+	}
+}
+
+// TestReceiverDecollidedPartialRemoved pins that cleanup removes the file the
+// receiver actually created, not a path recomputed from the sender's name: a
+// completed "dup.bin" must survive while the interrupted second "dup.bin"
+// (on disk as "dup (1).bin") is removed.
+func TestReceiverDecollidedPartialRemoved(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	m1 := `{"type":"metadata","id":"c-9a","fileName":"dup.bin","fileSize":4,"index":1,"total":2,"totalBytes":4100}`
+	if err := sender.SendText(m1); err != nil {
+		t.Fatalf("SendText metadata 1: %v", err)
+	}
+	if err := sender.Send(make([]byte, 4)); err != nil {
+		t.Fatalf("Send chunk 1: %v", err)
+	}
+	if err := sender.SendText(`{"type":"end"}`); err != nil {
+		t.Fatalf("SendText end 1: %v", err)
+	}
+	m2 := `{"type":"metadata","id":"c-9b","fileName":"dup.bin","fileSize":4096,"index":2,"total":2,"totalBytes":4100}`
+	if err := sender.SendText(m2); err != nil {
+		t.Fatalf("SendText metadata 2: %v", err)
+	}
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk 2: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if err := sender.Close(); err != nil {
+		t.Fatalf("sender close: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+	got, err := os.ReadFile(filepath.Join(outDir, "dup.bin"))
+	if err != nil {
+		t.Fatalf("completed dup.bin missing (cleanup removed the wrong file?): %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("dup.bin has %d bytes, want the completed 4", len(got))
+	}
+	if left := listDir(t, outDir); len(left) != 1 || left[0] != "dup.bin" {
+		t.Fatalf(`expected only the completed dup.bin ("dup (1).bin" removed), found %v`, left)
+	}
+}
+
+// TestReceiverNestedFolderPartialRemoved: a partial inside a folder transfer's
+// subdirectory is removed too (the empty directories stay, by design).
+func TestReceiverNestedFolderPartialRemoved(t *testing.T) {
+	sender, recvCh, closeFn := newConnectedPair(t)
+	defer closeFn()
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		dc := <-recvCh
+		recvErr <- ReceiveFiles(dc, outDir, true, "", "")
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+
+	meta := `{"type":"metadata","id":"c-10","fileName":"sub/dir/part.bin","fileSize":4096,"index":1,"total":1,"totalBytes":4096}`
+	if err := sender.SendText(meta); err != nil {
+		t.Fatalf("SendText metadata: %v", err)
+	}
+	if err := sender.Send(make([]byte, 1024)); err != nil {
+		t.Fatalf("Send chunk: %v", err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if err := sender.Close(); err != nil {
+		t.Fatalf("sender close: %v", err)
+	}
+
+	select {
+	case err := <-recvErr:
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReceiveFiles did not return")
+	}
+	if left := listDir(t, outDir); len(left) != 0 {
+		t.Fatalf("expected no files under the folder tree, found %v", left)
 	}
 }
 

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -59,6 +59,22 @@ func reportBytesToServer(serverURL string, byteCount int64) {
 	resp.Body.Close()
 }
 
+// IncomingInfo describes a transfer at the moment its first metadata arrives,
+// before any file is created, any ack is sent, or any byte lands on disk.
+type IncomingInfo struct {
+	Files      int    `json:"files"`      // total files in the batch
+	TotalBytes int64  `json:"totalBytes"` // batch size; falls back to the single file's size, 0 when the sender predates totalBytes
+	FirstName  string `json:"firstName"`  // sender-supplied name of the first file (display only, NOT the on-disk name)
+}
+
+// ReceiveOptions carries the optional callbacks for GUI clients. The zero
+// value is the CLI behavior: terminal progress bar, no incoming preview.
+// Callbacks run synchronously on the receive loop, so keep them fast.
+type ReceiveOptions struct {
+	OnProgress ProgressFunc
+	OnIncoming func(IncomingInfo)
+}
+
 // ReceiveFiles handles the full receiving side of the Floe protocol.
 // It blocks until all files are received. Files are written to outputDir.
 // If autoAccept is false, the user is prompted before receiving begins.
@@ -67,13 +83,22 @@ func reportBytesToServer(serverURL string, byteCount int64) {
 // serverURL is the signaling server base URL used to report transfer stats;
 // pass "" to skip reporting (e.g. in tests).
 func ReceiveFiles(dc *webrtc.DataChannel, outputDir string, autoAccept bool, localVer string, serverURL string) error {
-	return ReceiveFilesWithProgress(dc, outputDir, autoAccept, localVer, serverURL, nil)
+	return ReceiveFilesWithOptions(dc, outputDir, autoAccept, localVer, serverURL, ReceiveOptions{})
 }
 
 // ReceiveFilesWithProgress is ReceiveFiles with a progress callback for GUI
 // clients. When onProgress is non-nil, per-chunk progress is reported through it
 // and the terminal progress bar is suppressed.
 func ReceiveFilesWithProgress(dc *webrtc.DataChannel, outputDir string, autoAccept bool, localVer string, serverURL string, onProgress ProgressFunc) error {
+	return ReceiveFilesWithOptions(dc, outputDir, autoAccept, localVer, serverURL, ReceiveOptions{OnProgress: onProgress})
+}
+
+// ReceiveFilesWithOptions is the full-featured receive entry point; the other
+// two delegate here. opts.OnIncoming, when set, fires exactly once as the
+// first metadata arrives, after the protocol compatibility check and before
+// any file is created or acked.
+func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccept bool, localVer string, serverURL string, opts ReceiveOptions) error {
+	onProgress := opts.OnProgress
 	// msgCh collects ALL incoming data channel messages.
 	// We use a channel so the OnMessage callback (goroutine) feeds a sequential loop.
 	msgCh := make(chan webrtc.DataChannelMessage, 256)
@@ -270,6 +295,14 @@ func ReceiveFilesWithProgress(dc *webrtc.DataChannel, outputDir string, autoAcce
 					fmt.Println()
 					PrintBox([][2]string{{"Incoming", incomingLabel}})
 					fmt.Println()
+
+					if opts.OnIncoming != nil {
+						tb := info.TotalBytes
+						if info.Total == 1 && tb == 0 {
+							tb = info.FileSize // legacy sender: the single file's size is still known
+						}
+						opts.OnIncoming(IncomingInfo{Files: info.Total, TotalBytes: tb, FirstName: info.FileName})
+					}
 
 					if !autoAccept {
 						fmt.Print("  Accept? [Y/n] ")

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -105,11 +105,22 @@ func ReceiveFilesWithProgress(dc *webrtc.DataChannel, outputDir string, autoAcce
 	filesReceived := 0
 	waitingForFirst := true
 
-	// If the transfer is interrupted (peer disconnect or error) before the
-	// "end" marker closes the current file, ensure the handle is still released.
+	// If the transfer is interrupted (peer disconnect, stall, or error) before
+	// the "end" marker completes the current file, release the handle and
+	// delete the partial: a half-written file left at its final name is
+	// indistinguishable from a complete one, and it keeps that name claimed so
+	// a retry lands at "name (1)". Success is safe because the "end" handler
+	// closes and nils currentFile before any return, so anything still non-nil
+	// here is a partial by definition; files that completed earlier in the
+	// batch are never touched. Close before Remove (Windows refuses to delete
+	// an open file), and Remove is best-effort so a sharing violation from an
+	// AV scanner never masks the real transfer error. Directories created for
+	// folder transfers are left in place.
 	defer func() {
 		if currentFile != nil {
+			name := currentFile.Name()
 			currentFile.Close()
+			_ = os.Remove(name)
 		}
 	}()
 
@@ -204,6 +215,16 @@ func ReceiveFilesWithProgress(dc *webrtc.DataChannel, outputDir string, autoAcce
 				info, err := parseMetadata(string(msg.Data))
 				if err != nil {
 					continue
+				}
+				// A second metadata while a file is still open means the sender
+				// abandoned the current file without an "end". Close and delete
+				// the partial before starting the next one, or the handle leaks
+				// and the half-written file survives at its final name.
+				if currentFile != nil {
+					name := currentFile.Name()
+					currentFile.Close()
+					_ = os.Remove(name)
+					currentFile = nil
 				}
 				currentInfo = info
 				bytesReceived = 0
@@ -311,8 +332,12 @@ func ReceiveFilesWithProgress(dc *webrtc.DataChannel, outputDir string, autoAcce
 
 					// Integrity guard: a short byte count means the transfer was
 					// truncated (e.g. the sender closed early). Fail loudly rather
-					// than leave a corrupt file that looks complete.
+					// than leave a corrupt file that looks complete. The handle is
+					// already closed and nil'd above (required before Remove on
+					// Windows), so the interrupt cleanup cannot see this truncated
+					// file; delete it here.
 					if bytesReceived != currentInfo.FileSize {
+						_ = os.Remove(finalPath)
 						return fmt.Errorf("incomplete file %q: received %d of %d bytes",
 							currentInfo.FileName, bytesReceived, currentInfo.FileSize)
 					}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -550,6 +550,14 @@ func (a *App) transferActive(g uint64) bool {
 // unblocks a sender waiting for a receiver (via PeerLeft); closing the peer
 // connection unblocks a stuck WebRTC setup (via the connection-state error).
 // Safe to call when nothing is running.
+//
+// Ordering contract: it cancels whatever attempt is live when it EXECUTES, so
+// a caller must not dispatch a new StartSend/ReceiveByCode until this call has
+// been issued and processed; two unawaited bridge calls fired in the same tick
+// have no cross-call ordering guarantee, and a reordered pair would cancel the
+// new attempt instead of the old one. The UI satisfies this trivially (the
+// user's next click is far behind the cancel dispatch); programmatic drivers
+// must await CancelTransfer before starting the next transfer.
 func (a *App) CancelTransfer() {
 	a.mu.Lock()
 	a.cancelled = true

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -911,7 +911,13 @@ func (a *App) receiveByCode(g uint64, codeOrLink string, outputDir string, hideI
 		lastEmit = time.Now()
 		emit("recv:progress", p)
 	}
-	if err := transfer.ReceiveFilesWithProgress(dc, absOutput, true, version, statsURL, onProgress); err != nil {
+	opts := transfer.ReceiveOptions{
+		OnProgress: onProgress,
+		// Fires once as the sender's first metadata arrives, before any byte
+		// lands: the UI shows what is incoming while the transfer starts.
+		OnIncoming: func(inc transfer.IncomingInfo) { emit("recv:incoming", inc) },
+	}
+	if err := transfer.ReceiveFilesWithOptions(dc, absOutput, true, version, statsURL, opts); err != nil {
 		return "", fmt.Errorf("transfer failed: %w", err)
 	}
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -67,16 +67,28 @@ func filterFileArgs(args []string) []string {
 	return out
 }
 
+// closer is the one method CancelTransfer needs from the signaling client and
+// the peer connection. An interface so unit tests can register recorders.
+type closer interface{ Close() }
+
 // App struct
 type App struct {
 	ctx context.Context
 
-	// mu guards the handles to the in-flight transfer's signaling and peer
-	// connections so CancelTransfer can close them from the UI goroutine to
-	// unblock a send/receive that is waiting for a peer or stuck connecting.
-	mu      sync.Mutex
-	curSC   *signaling.Client
-	curConn *peer.Connection
+	// mu guards the transfer generation and the handles to the in-flight
+	// transfer's signaling and peer connections so CancelTransfer can close
+	// them from the UI goroutine. gen is the id of the transfer that owns the
+	// slots: a transfer goroutine carries the gen it was born with, and every
+	// setter, clear, wake release, event emit, and toast refuses once a newer
+	// transfer has begun or the user cancelled. A cancelled or superseded
+	// goroutine can therefore never clobber a live transfer's handles (the old
+	// bug: cancel, instantly restart, and up to 30 seconds later the dead
+	// goroutine's deferred clear wiped the live transfer's cancel handles).
+	mu        sync.Mutex
+	gen       uint64
+	cancelled bool // the OWNING generation was cancelled by the user
+	curSC     closer
+	curConn   closer
 
 	// wake keeps the machine awake for the duration of a connected transfer
 	// (Windows only; a no-op on other platforms). See wake.go.
@@ -90,6 +102,10 @@ type App struct {
 	// toggles. Written from the UI goroutine when the user saves Settings and read
 	// from the transfer goroutine, so it is guarded by mu like everything else here.
 	cfg appConfig
+
+	// notifyFn is the test seam for OS notifications; nil means the real Wails
+	// runtime notification (see notify).
+	notifyFn func(title, body string)
 }
 
 // NewApp creates a new App application struct
@@ -274,9 +290,26 @@ func (a *App) ContextMenuEnabled() bool {
 }
 
 // notify sends a best-effort OS notification. Failures are ignored so a transfer
-// outcome never depends on the notification succeeding.
+// outcome never depends on the notification succeeding. notifyFn is the test
+// seam: nil means the real Wails runtime notification.
 func (a *App) notify(title, body string) {
+	if a.notifyFn != nil {
+		a.notifyFn(title, body)
+		return
+	}
 	_ = runtime.SendNotification(a.ctx, runtime.NotificationOptions{Title: title, Body: body})
+}
+
+// notifyTransferFailed sends the failure toast unless the transfer was
+// cancelled by the user or superseded by a newer attempt: a cancel is not a
+// failure, and a dead attempt must not toast over the live one. The body is
+// deliberately generic (the toast matters exactly when the window is
+// backgrounded); the in-app status line carries the mapped detail.
+func (a *App) notifyTransferFailed(g uint64, title string) {
+	if !a.transferActive(g) {
+		return
+	}
+	a.notify(title, "The transfer did not complete. Open Floe to see what happened.")
 }
 
 // EngineProtocolVersion returns the wire protocol version of the embedded engine.
@@ -451,33 +484,75 @@ func relayOpts(hideIP bool) []peer.Option {
 	return nil
 }
 
-// setSignaling / setConn register the in-flight connections so CancelTransfer
-// can reach them; clearTransfer resets them when the transfer goroutine returns.
-func (a *App) setSignaling(sc *signaling.Client) {
+// beginTransfer claims the transfer slots for a new attempt and returns its
+// generation tag. Any previous attempt is superseded from this moment: its
+// setters, clear, wake release, emits, and toasts all become no-ops. The old
+// goroutine's own defers still close the handles it holds.
+func (a *App) beginTransfer() uint64 {
 	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.gen++
+	a.cancelled = false
+	a.curSC, a.curConn = nil, nil
+	return a.gen
+}
+
+// setSignaling / setConn register a handle for generation g so CancelTransfer
+// can reach it. They return false when g no longer owns the slots (superseded
+// by a newer transfer) or was cancelled; the caller must bail out immediately
+// and let its own deferred Close release the handle. Refusing on cancelled
+// also closes the window where a cancel lands between the two setters and the
+// goroutine would otherwise park un-interruptibly in WebRTC setup for up to
+// 30 seconds holding an orphaned connection.
+func (a *App) setSignaling(g uint64, sc closer) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if g != a.gen || a.cancelled {
+		return false
+	}
 	a.curSC = sc
-	a.mu.Unlock()
+	return true
 }
 
-func (a *App) setConn(conn *peer.Connection) {
+func (a *App) setConn(g uint64, conn closer) bool {
 	a.mu.Lock()
+	defer a.mu.Unlock()
+	if g != a.gen || a.cancelled {
+		return false
+	}
 	a.curConn = conn
-	a.mu.Unlock()
+	return true
 }
 
-func (a *App) clearTransfer() {
+// clearTransfer releases the slots iff generation g still owns them, so a
+// superseded goroutine's deferred clear cannot wipe a live transfer's handles.
+func (a *App) clearTransfer(g uint64) {
 	a.mu.Lock()
-	a.curSC = nil
-	a.curConn = nil
-	a.mu.Unlock()
+	defer a.mu.Unlock()
+	if g != a.gen {
+		return
+	}
+	a.curSC, a.curConn = nil, nil
 }
 
-// CancelTransfer aborts the current send or receive by closing its signaling and
-// peer connections. Closing the signaling client unblocks a sender waiting for a
-// receiver (via PeerLeft); closing the peer connection unblocks a stuck WebRTC
-// setup (via the connection-state error). Safe to call when nothing is running.
+// transferActive reports whether generation g is still the live, uncancelled
+// transfer. It gates event emits and toasts so a cancelled or superseded
+// attempt goes silent instead of talking over its successor.
+func (a *App) transferActive(g uint64) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return g == a.gen && !a.cancelled
+}
+
+// CancelTransfer aborts the current send or receive: it marks the owning
+// generation cancelled (suppressing its failure toast and late events) and
+// closes its signaling and peer connections. Closing the signaling client
+// unblocks a sender waiting for a receiver (via PeerLeft); closing the peer
+// connection unblocks a stuck WebRTC setup (via the connection-state error).
+// Safe to call when nothing is running.
 func (a *App) CancelTransfer() {
 	a.mu.Lock()
+	a.cancelled = true
 	sc, conn := a.curSC, a.curConn
 	a.mu.Unlock()
 	if conn != nil {
@@ -503,7 +578,10 @@ func (a *App) StartSend(paths []string, hideIP bool) error {
 			return fmt.Errorf("cannot read %s: %w", p, err)
 		}
 	}
-	go a.runSend(paths, hideIP)
+	// Claim the generation synchronously so a cancel arriving right after the
+	// click targets this attempt, not the previous one.
+	g := a.beginTransfer()
+	go a.runSend(g, paths, hideIP)
 	return nil
 }
 
@@ -535,21 +613,40 @@ func (a *App) StartSendText(text string, hideIP bool) error {
 	if err != nil {
 		return fmt.Errorf("could not stage the text: %w", err)
 	}
+	// Claimed after staging succeeds so a staging failure supersedes nothing.
+	g := a.beginTransfer()
 	go func() {
 		defer cleanup()
-		a.runSend([]string{path}, hideIP)
+		a.runSend(g, []string{path}, hideIP)
 	}()
 	return nil
 }
 
-func (a *App) runSend(paths []string, hideIP bool) {
+func (a *App) runSend(g uint64, paths []string, hideIP bool) {
 	// Release any sleep inhibitor on every exit (success, error, cancel, panic).
-	// Idempotent: a no-op if we never acquired it (e.g. no receiver ever joined).
-	defer a.wake.release()
+	// Owner-tagged: a no-op if we never acquired it or a newer transfer holds it.
+	defer a.wake.release(g)
+	defer a.clearTransfer(g)
+
+	// emit forwards an event to the UI unless this attempt was cancelled or
+	// superseded, so a dead goroutine's late events cannot talk over the live
+	// transfer (the frontend's own ref guard resets on the next attempt and
+	// cannot close this on its own).
+	emit := func(event string, payload any) {
+		if !a.transferActive(g) {
+			return
+		}
+		runtime.EventsEmit(a.ctx, event, payload)
+	}
 
 	fail := func(err error) {
+		if !a.transferActive(g) {
+			return // user cancelled, or a newer attempt owns the UI
+		}
 		runtime.EventsEmit(a.ctx, "send:error", err.Error())
-		a.notify("Floe - send failed", err.Error())
+		// The status line above carries the detail; the toast stays generic
+		// because raw engine errors read like stack traces in a notification.
+		a.notifyTransferFailed(g, "Floe - send failed")
 	}
 
 	roomID := uuid.New().String()
@@ -570,8 +667,9 @@ func (a *App) runSend(paths []string, hideIP bool) {
 		return
 	}
 	defer sc.Close()
-	a.setSignaling(sc)
-	defer a.clearTransfer()
+	if !a.setSignaling(g, sc) {
+		return // cancelled or superseded before we registered; the defer closes sc
+	}
 
 	if err := sc.JoinRoom(roomID); err != nil {
 		fail(fmt.Errorf("failed to join room: %w", err))
@@ -604,7 +702,7 @@ func (a *App) runSend(paths []string, hideIP bool) {
 		codePhrase = ""
 	}
 	link := shareLink(web, uuid.New().String()[:8], roomID)
-	runtime.EventsEmit(a.ctx, "send:code", map[string]string{"code": codePhrase, "link": link})
+	emit("send:code", map[string]string{"code": codePhrase, "link": link})
 
 	// Wait for a receiver to join. This wait is intentionally unbounded (you may
 	// share a link and wait) — CancelTransfer closes sc to abort it via PeerLeft.
@@ -617,12 +715,12 @@ func (a *App) runSend(paths []string, hideIP bool) {
 		fail(fmt.Errorf("server error: %s", errMsg))
 		return
 	}
-	runtime.EventsEmit(a.ctx, "send:status", "Peer connected. Sending...")
+	emit("send:status", "Peer connected. Sending...")
 
 	// A peer is connected: keep the machine awake through WebRTC setup and the
 	// data transfer. Placed here, not at the top, so the unbounded wait for a
 	// receiver above never holds a laptop awake on an unanswered share link.
-	a.wake.acquire()
+	a.wake.acquire(g)
 
 	// Set up WebRTC as the initiator and send.
 	conn, err := peer.New(iceServers, sc, relayOpts(hideIP)...)
@@ -631,7 +729,9 @@ func (a *App) runSend(paths []string, hideIP bool) {
 		return
 	}
 	defer conn.Close()
-	a.setConn(conn)
+	if !a.setConn(g, conn) {
+		return // cancelled or superseded; the defer closes conn
+	}
 
 	dc, err := conn.SetupAsSender()
 	if err != nil {
@@ -641,10 +741,10 @@ func (a *App) runSend(paths []string, hideIP bool) {
 
 	if local, remote, fErr := conn.Fingerprints(); fErr == nil {
 		vc := verify.Code(local, remote)
-		go runtime.EventsEmit(a.ctx, "send:verify", vc) // off the transfer critical path
+		go emit("send:verify", vc) // off the transfer critical path
 	}
 	if ct, ctErr := conn.ConnectionType(); ctErr == nil {
-		runtime.EventsEmit(a.ctx, "send:route", ct) // "direct" or "relay", best-effort
+		emit("send:route", ct) // "direct" or "relay", best-effort
 	}
 
 	lastEmit := time.Now()
@@ -655,7 +755,7 @@ func (a *App) runSend(paths []string, hideIP bool) {
 			return
 		}
 		lastEmit = time.Now()
-		runtime.EventsEmit(a.ctx, "send:progress", p)
+		emit("send:progress", p)
 	}
 	if err := transfer.SendFilesWithProgress(dc, paths, version, onProgress); err != nil {
 		// The relay cap is a policy block, not a failure: skip the "transfer
@@ -671,8 +771,10 @@ func (a *App) runSend(paths []string, hideIP bool) {
 		fail(fmt.Errorf("transfer failed: %w", err))
 		return
 	}
-	runtime.EventsEmit(a.ctx, "send:done", "Files sent successfully.")
-	a.notify("Floe", "Files sent successfully.")
+	emit("send:done", "Files sent successfully.")
+	if a.transferActive(g) {
+		a.notify("Floe", "Files sent successfully.")
+	}
 }
 
 // ReceiveByCode connects to a peer using a Floe room code (or link) and receives
@@ -683,9 +785,34 @@ func (a *App) runSend(paths []string, hideIP bool) {
 //
 // Returns the absolute output directory on success.
 func (a *App) ReceiveByCode(codeOrLink string, outputDir string, hideIP bool, reportStats bool) (string, error) {
+	g := a.beginTransfer()
+	dir, err := a.receiveByCode(g, codeOrLink, outputDir, hideIP, reportStats)
+	if err != nil {
+		// Receive failures used to be completely silent behind a minimized
+		// window; mirror the send path's toast. Suppressed on user cancel and
+		// when a newer attempt has taken over.
+		a.notifyTransferFailed(g, "Floe - receive failed")
+		return "", err
+	}
+	return dir, nil
+}
+
+// receiveByCode is the body of ReceiveByCode, carrying the generation tag of
+// the attempt it belongs to.
+func (a *App) receiveByCode(g uint64, codeOrLink string, outputDir string, hideIP bool, reportStats bool) (string, error) {
 	// Release any sleep inhibitor on every exit (success, error, cancel, panic).
-	// Idempotent: a no-op if we return before acquiring it.
-	defer a.wake.release()
+	// Owner-tagged: a no-op if we never acquired it or a newer transfer holds it.
+	defer a.wake.release(g)
+	defer a.clearTransfer(g)
+
+	// emit forwards an event to the UI unless this attempt was cancelled or
+	// superseded (see runSend's twin for the rationale).
+	emit := func(event string, payload any) {
+		if !a.transferActive(g) {
+			return
+		}
+		runtime.EventsEmit(a.ctx, event, payload)
+	}
 
 	if outputDir == "" {
 		outputDir = defaultReceiveDir()
@@ -716,8 +843,9 @@ func (a *App) ReceiveByCode(codeOrLink string, outputDir string, hideIP bool, re
 		return "", fmt.Errorf("failed to connect to signaling server: %w", err)
 	}
 	defer sc.Close()
-	a.setSignaling(sc)
-	defer a.clearTransfer()
+	if !a.setSignaling(g, sc) {
+		return "", fmt.Errorf("transfer cancelled")
+	}
 
 	if err := sc.JoinRoom(roomID); err != nil {
 		return "", fmt.Errorf("failed to join room: %w", err)
@@ -744,14 +872,16 @@ func (a *App) ReceiveByCode(codeOrLink string, outputDir string, hideIP bool, re
 
 	// A receiver role means a sender is already present: keep the machine awake
 	// through WebRTC setup and the data transfer.
-	a.wake.acquire()
+	a.wake.acquire(g)
 
 	conn, err := peer.New(iceServers, sc, relayOpts(hideIP)...)
 	if err != nil {
 		return "", fmt.Errorf("failed to create peer connection: %w", err)
 	}
 	defer conn.Close()
-	a.setConn(conn)
+	if !a.setConn(g, conn) {
+		return "", fmt.Errorf("transfer cancelled")
+	}
 
 	dc, err := conn.SetupAsReceiver()
 	if err != nil {
@@ -760,10 +890,10 @@ func (a *App) ReceiveByCode(codeOrLink string, outputDir string, hideIP bool, re
 
 	if local, remote, fErr := conn.Fingerprints(); fErr == nil {
 		vc := verify.Code(local, remote)
-		go runtime.EventsEmit(a.ctx, "recv:verify", vc) // off the transfer critical path
+		go emit("recv:verify", vc) // off the transfer critical path
 	}
 	if ct, ctErr := conn.ConnectionType(); ctErr == nil {
-		runtime.EventsEmit(a.ctx, "recv:route", ct) // "direct" or "relay", best-effort
+		emit("recv:route", ct) // "direct" or "relay", best-effort
 	}
 
 	// autoAccept=true: a GUI cannot answer a terminal prompt. The receiver reports
@@ -779,12 +909,14 @@ func (a *App) ReceiveByCode(codeOrLink string, outputDir string, hideIP bool, re
 			return
 		}
 		lastEmit = time.Now()
-		runtime.EventsEmit(a.ctx, "recv:progress", p)
+		emit("recv:progress", p)
 	}
 	if err := transfer.ReceiveFilesWithProgress(dc, absOutput, true, version, statsURL, onProgress); err != nil {
 		return "", fmt.Errorf("transfer failed: %w", err)
 	}
 
-	a.notify("Floe", "Files received.")
+	if a.transferActive(g) {
+		a.notify("Floe", "Files received.")
+	}
 	return absOutput, nil
 }

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -185,6 +185,22 @@ func TestCancelledSetterRefuses(t *testing.T) {
 	}
 }
 
+// TestCancelThenBeginReArms pins the most common real flow (Cancel, then Start
+// over): beginTransfer after a cancel must fully re-arm the machinery, which
+// depends on it resetting the cancelled flag.
+func TestCancelThenBeginReArms(t *testing.T) {
+	a := &App{}
+	_ = a.beginTransfer()
+	a.CancelTransfer()
+	g2 := a.beginTransfer()
+	if !a.setSignaling(g2, &fakeCloser{}) || !a.setConn(g2, &fakeCloser{}) {
+		t.Fatal("setters refused the fresh generation after a cancel")
+	}
+	if !a.transferActive(g2) {
+		t.Fatal("fresh generation not active after a cancel")
+	}
+}
+
 // TestFailureToastsOnce: a live generation's failure produces exactly one
 // notification with the generic body (raw engine errors stay off toasts).
 func TestFailureToastsOnce(t *testing.T) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -97,3 +97,132 @@ func TestFilterFileArgs(t *testing.T) {
 func TestCancelTransferIdle(t *testing.T) {
 	(&App{}).CancelTransfer()
 }
+
+// fakeCloser records Close calls so the generation-tag tests can prove which
+// handles a cancel actually reached.
+type fakeCloser struct{ closed int }
+
+func (f *fakeCloser) Close() { f.closed++ }
+
+// TestCancelTransferClosesLiveHandles: a cancel must close exactly the live
+// generation's registered handles.
+func TestCancelTransferClosesLiveHandles(t *testing.T) {
+	a := &App{}
+	g := a.beginTransfer()
+	sc, conn := &fakeCloser{}, &fakeCloser{}
+	if !a.setSignaling(g, sc) || !a.setConn(g, conn) {
+		t.Fatal("setters refused the live generation")
+	}
+	a.CancelTransfer()
+	if sc.closed != 1 || conn.closed != 1 {
+		t.Fatalf("cancel closed sc=%d conn=%d times, want 1/1", sc.closed, conn.closed)
+	}
+	if a.transferActive(g) {
+		t.Fatal("generation still active after cancel")
+	}
+}
+
+// TestClearTransferOldGenerationNoOp pins the race fix: a superseded
+// goroutine's deferred clear must not wipe the live transfer's handles.
+func TestClearTransferOldGenerationNoOp(t *testing.T) {
+	a := &App{}
+	g1 := a.beginTransfer()
+	sc1, conn1 := &fakeCloser{}, &fakeCloser{}
+	a.setSignaling(g1, sc1)
+	a.setConn(g1, conn1)
+
+	g2 := a.beginTransfer()
+	sc2, conn2 := &fakeCloser{}, &fakeCloser{}
+	if !a.setSignaling(g2, sc2) || !a.setConn(g2, conn2) {
+		t.Fatal("setters refused the new live generation")
+	}
+
+	// The old goroutine exits up to 30 seconds later and runs its deferred
+	// clear. It must be a no-op against the new generation's slots.
+	a.clearTransfer(g1)
+
+	a.CancelTransfer()
+	if sc2.closed != 1 || conn2.closed != 1 {
+		t.Fatalf("cancel missed the live handles after an old clear: sc2=%d conn2=%d, want 1/1", sc2.closed, conn2.closed)
+	}
+	if sc1.closed != 0 || conn1.closed != 0 {
+		t.Fatalf("cancel closed the dead generation's handles: sc1=%d conn1=%d, want 0/0", sc1.closed, conn1.closed)
+	}
+}
+
+// TestSupersededSetterRefuses: a goroutine whose generation was superseded must
+// not be able to register handles into the live transfer's slots.
+func TestSupersededSetterRefuses(t *testing.T) {
+	a := &App{}
+	g1 := a.beginTransfer()
+	_ = a.beginTransfer() // g2 supersedes g1
+
+	stale := &fakeCloser{}
+	if a.setSignaling(g1, stale) {
+		t.Fatal("superseded setSignaling accepted a handle")
+	}
+	if a.setConn(g1, stale) {
+		t.Fatal("superseded setConn accepted a handle")
+	}
+	a.CancelTransfer()
+	if stale.closed != 0 {
+		t.Fatalf("cancel closed a handle that never entered the slots: %d, want 0", stale.closed)
+	}
+}
+
+// TestCancelledSetterRefuses: after a cancel, the cancelled generation's own
+// setters must refuse, so the goroutine bails instead of parking in WebRTC
+// setup with an orphaned connection.
+func TestCancelledSetterRefuses(t *testing.T) {
+	a := &App{}
+	g := a.beginTransfer()
+	a.CancelTransfer()
+	if a.setSignaling(g, &fakeCloser{}) {
+		t.Fatal("cancelled setSignaling accepted a handle")
+	}
+	if a.setConn(g, &fakeCloser{}) {
+		t.Fatal("cancelled setConn accepted a handle")
+	}
+}
+
+// TestFailureToastsOnce: a live generation's failure produces exactly one
+// notification with the generic body (raw engine errors stay off toasts).
+func TestFailureToastsOnce(t *testing.T) {
+	var got []string
+	a := &App{notifyFn: func(title, body string) { got = append(got, title+"|"+body) }}
+	g := a.beginTransfer()
+	a.notifyTransferFailed(g, "Floe - receive failed")
+	if len(got) != 1 {
+		t.Fatalf("notified %d times, want 1: %v", len(got), got)
+	}
+	want := "Floe - receive failed|The transfer did not complete. Open Floe to see what happened."
+	if got[0] != want {
+		t.Fatalf("notification = %q, want %q", got[0], want)
+	}
+}
+
+// TestCancelSuppressesFailureToast: a user cancel is not a failure and must
+// not toast.
+func TestCancelSuppressesFailureToast(t *testing.T) {
+	calls := 0
+	a := &App{notifyFn: func(string, string) { calls++ }}
+	g := a.beginTransfer()
+	a.CancelTransfer()
+	a.notifyTransferFailed(g, "Floe - receive failed")
+	if calls != 0 {
+		t.Fatalf("cancelled transfer toasted %d times, want 0", calls)
+	}
+}
+
+// TestSupersededTransferDoesNotToast: a dead attempt must not toast over the
+// live one.
+func TestSupersededTransferDoesNotToast(t *testing.T) {
+	calls := 0
+	a := &App{notifyFn: func(string, string) { calls++ }}
+	g1 := a.beginTransfer()
+	_ = a.beginTransfer()
+	a.notifyTransferFailed(g1, "Floe - send failed")
+	if calls != 0 {
+		t.Fatalf("superseded transfer toasted %d times, want 0", calls)
+	}
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1331,6 +1331,10 @@ function App() {
         setConfirmReset(false);
         sendCancel.current = true;
         recvCancel.current = true;
+        // Invalidate any in-flight receive attempt: its promise settles on a
+        // later tick, and without this bump its catch/finally would pass the
+        // attempt guard and overwrite the fresh state this reset installs.
+        recvAttempt.current++;
         CancelTransfer().catch(() => {});
 
         setSettingsOpen(false);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -48,6 +48,8 @@ import QRCode from 'react-qr-code';
 import {BoltMark, Button, Eyebrow, Input, StatusDot, cn} from './components/ui';
 import {advancedSummary, hostOf} from './settings';
 import {resetWarning} from './reset';
+import {friendlyError} from './errors';
+import {fmtBytes, formatIncoming, type IncomingPreview} from './incoming';
 import TitleBar from './components/TitleBar';
 import FileIcon from './components/FileIcon';
 import {Tooltip} from './components/Tooltip';
@@ -111,13 +113,6 @@ interface Prog {
 }
 
 type Marker = {t: number; bytes: number} | null;
-
-function fmtBytes(n: number): string {
-    if (!n || n < 0) return '0 B';
-    const u = ['B', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.min(u.length - 1, Math.floor(Math.log(n) / Math.log(1024)));
-    return (n / Math.pow(1024, i)).toFixed(i ? 1 : 0) + ' ' + u[i];
-}
 
 function fmtSpeed(bps: number): string {
     if (!isFinite(bps) || bps <= 0) return '';
@@ -647,8 +642,16 @@ function App() {
     const [recvProg, setRecvProg] = useState<{pct: number; label: string} | null>(null);
     const [recvDir, setRecvDir] = useState('');
     const [recvDone, setRecvDone] = useState(false);
+    // The pre-transfer preview line ("Incoming: 3 files · 812 MB"), set by the
+    // recv:incoming event before the first byte lands.
+    const [incoming, setIncoming] = useState('');
     const recvStart = useRef<Marker>(null);
     const recvCancel = useRef(false);
+    // Monotonic id of the latest receive attempt: the frontend twin of the Go
+    // generation tag. A cancelled attempt's promise settles AFTER an instant
+    // restart has re-armed the UI, so its catch/finally must go quiet instead
+    // of stomping the live attempt's state.
+    const recvAttempt = useRef(0);
     // Receive file names harvested from progress events (the Go throttle always
     // emits each file's final update, so every name is captured).
     const recvNamesRef = useRef<string[]>([]);
@@ -889,7 +892,7 @@ function App() {
         });
         EventsOn('send:error', (msg: string) => {
             if (sendCancel.current) return;
-            setSendStatus('Error: ' + msg + serverNote());
+            setSendStatus(friendlyError(msg) + serverNote());
             setSending(false);
             // The progress row goes with the transfer. Left behind it froze
             // on screen at whatever percent it died at, and worse, kept Start
@@ -901,6 +904,10 @@ function App() {
             setSendCode('');
             setSendLink('');
             setPeerConnected(false);
+        });
+        EventsOn('recv:incoming', (p: IncomingPreview) => {
+            if (recvCancel.current) return;
+            setIncoming(formatIncoming(p));
         });
         EventsOn('recv:progress', (p: Prog) => {
             if (recvCancel.current) return;
@@ -965,6 +972,7 @@ function App() {
             EventsOff('send:progress');
             EventsOff('send:done');
             EventsOff('send:error');
+            EventsOff('recv:incoming');
             EventsOff('recv:progress');
             EventsOff('send:route');
             EventsOff('recv:route');
@@ -1241,7 +1249,7 @@ function App() {
             if (sendKind === 'text') await StartSendText(sendText, hideIP);
             else await StartSend(files, hideIP);
         } catch (e: any) {
-            setSendStatus('Error: ' + e);
+            setSendStatus(friendlyError(e));
             setSending(false);
         }
     }
@@ -1251,10 +1259,12 @@ function App() {
             setRecvStatus('Please enter a code or link.');
             return;
         }
+        const attempt = ++recvAttempt.current;
         setReceiving(true);
         setRecvProg(null);
         setRecvDir('');
         setRecvDone(false);
+        setIncoming('');
         setRoute('');
         recvCancel.current = false;
         recvStart.current = null;
@@ -1263,14 +1273,17 @@ function App() {
         setRecvStatus('Connecting... keep this window open.');
         try {
             const dir = await ReceiveByCode(code.trim(), output.trim(), hideIP, reportStats);
+            if (recvAttempt.current !== attempt) return;
             setRecvDir(dir);
             setRecvDone(true);
             setRecvStatus('');
             const names = recvNamesRef.current;
             setHistory((prev) => [{kind: 'recv' as const, names, count: names.length, dir, bytes: recvBytesRef.current || undefined, at: Date.now()}, ...prev].slice(0, HISTORY_CAP));
         } catch (e: any) {
-            setRecvStatus(recvCancel.current ? 'Cancelled.' : 'Error: ' + e + serverNote());
+            if (recvAttempt.current !== attempt) return;
+            setRecvStatus(recvCancel.current ? 'Cancelled.' : friendlyError(e) + serverNote());
         } finally {
+            if (recvAttempt.current !== attempt) return;
             setReceiving(false);
             // Every exit clears the progress row, not just the successful one.
             // On failure it used to stay frozen on screen and keep Start over
@@ -1303,6 +1316,7 @@ function App() {
             setReceiving(false);
             setRecvProg(null);
             setRecvDone(false);
+            setIncoming('');
             setRecvStatus('Cancelled.');
         }
         CancelTransfer().catch(() => {});
@@ -1354,6 +1368,7 @@ function App() {
         setRecvProg(null);
         setRecvDir('');
         setRecvDone(false);
+        setIncoming('');
         recvStart.current = null;
         recvNamesRef.current = [];
 
@@ -2000,6 +2015,9 @@ function App() {
                                             </Button>
                                         )}
 
+                                        {receiving && incoming && (
+                                            <p className="animate-floe-in text-center text-xs text-zinc-400">{incoming}</p>
+                                        )}
                                         {recvProg && <ProgressRow prog={recvProg}/>}
                                         {recvDone && !receiving && (
                                             <div className="animate-floe-in flex items-center gap-2 text-sm text-zinc-300">

--- a/desktop/frontend/src/errors.test.ts
+++ b/desktop/frontend/src/errors.test.ts
@@ -31,6 +31,30 @@ describe('friendlyError', () => {
         ).toBe('Error: The sender cancelled, or the transfer was blocked before it started.');
     });
 
+    it('keeps the receiver-left diagnosis out of the generic bucket', () => {
+        expect(
+            friendlyError('transfer failed: connection closed while waiting for the receiver (transfer declined or receiver exited)'),
+        ).toBe('Error: The receiver left or declined before the transfer started.');
+    });
+
+    it('routes a wrapped network failure to the server bucket, not the typo bucket', () => {
+        expect(friendlyError('could not resolve "olive-tiger": could not reach signaling server: dial tcp: refused')).toBe(
+            'Error: Could not reach the server. Check your internet connection.',
+        );
+    });
+
+    it('maps a malformed room id in a pasted link to the incomplete-link sentence', () => {
+        expect(friendlyError('server error: Invalid room ID')).toBe(
+            'Error: That link looks incomplete. Copy the whole share link and try again.',
+        );
+    });
+
+    it('treats a server rejection as a rejection, not a connectivity problem', () => {
+        expect(friendlyError('server error: too many requests')).toBe(
+            'Error: The server rejected the request. Try again in a minute.',
+        );
+    });
+
     it('maps stall, timeout, server, and write-error buckets', () => {
         expect(friendlyError('transfer stalled: no data for 1m0s (5 of 10 bytes of "a")')).toBe(
             'Error: The transfer stalled and gave up. Start it again.',

--- a/desktop/frontend/src/errors.test.ts
+++ b/desktop/frontend/src/errors.test.ts
@@ -1,0 +1,66 @@
+import {describe, expect, it} from 'vitest';
+import {friendlyError} from './errors';
+
+describe('friendlyError', () => {
+    it('always starts with the Error prefix StatusLine keys its styling off', () => {
+        const samples = [
+            'transfer failed: connection closed mid-transfer: a.bin (10 of 20 bytes)',
+            'anything unknown at all',
+            'relay connections are capped at 2 GB (selected relay)',
+        ];
+        for (const s of samples) {
+            expect(friendlyError(s).startsWith('Error: ')).toBe(true);
+        }
+    });
+
+    it('maps a wrapped engine error through the backend prefixes', () => {
+        expect(friendlyError('transfer failed: error sending a.bin: failed to send chunk: x')).toBe(
+            'Error: The connection was lost before the transfer finished. Start it again.',
+        );
+    });
+
+    it('maps the backpressure stall to the connection-lost sentence', () => {
+        expect(friendlyError('backpressure stall: peer not draining (8388608 bytes buffered)')).toBe(
+            'Error: The connection was lost before the transfer finished. Start it again.',
+        );
+    });
+
+    it('keeps the specific closed-before-any-file diagnosis out of the generic bucket', () => {
+        expect(
+            friendlyError('connection closed before any file arrived (the sender cancelled, or the transfer was blocked)'),
+        ).toBe('Error: The sender cancelled, or the transfer was blocked before it started.');
+    });
+
+    it('maps stall, timeout, server, and write-error buckets', () => {
+        expect(friendlyError('transfer stalled: no data for 1m0s (5 of 10 bytes of "a")')).toBe(
+            'Error: The transfer stalled and gave up. Start it again.',
+        );
+        expect(friendlyError('timed out establishing a connection')).toBe(
+            'Error: A connection could not be established. Check that both devices are online and try again.',
+        );
+        expect(friendlyError('failed to connect to signaling server: dial tcp: refused')).toBe(
+            'Error: Could not reach the server. Check your internet connection.',
+        );
+        expect(friendlyError('write error: disk full')).toBe(
+            'Error: Could not write to the save folder. Check that it exists and has free space.',
+        );
+        expect(friendlyError('could not resolve "olive-tiger": 404')).toBe(
+            'Error: That code was not recognized. Check it for typos, or ask the sender for a new one.',
+        );
+    });
+
+    it('passes hand-written actionable messages through verbatim', () => {
+        const relay = 'transfer blocked: relay connections are capped at 2 GB (selected relay). Turn off Hide my IP to send larger files';
+        expect(friendlyError(relay)).toBe('Error: ' + relay);
+        const code = 'this code is no longer active; ask for a new one';
+        expect(friendlyError(code)).toBe('Error: ' + code);
+    });
+
+    it('passes unknown errors through unchanged for bug reports', () => {
+        expect(friendlyError('some novel failure nobody mapped')).toBe('Error: some novel failure nobody mapped');
+    });
+
+    it('does not double the prefix when the input already carries one', () => {
+        expect(friendlyError('Error: some novel failure')).toBe('Error: some novel failure');
+    });
+});

--- a/desktop/frontend/src/errors.ts
+++ b/desktop/frontend/src/errors.ts
@@ -22,7 +22,12 @@ const PASSTHROUGH = [
 // 'connection closed' bucket must stay last of the connection family so the
 // more precise closed-variants above it win.
 const RULES: Array<[pattern: string, friendly: string]> = [
+    // Before 'could not resolve': the resolve step wraps network failures too
+    // ('could not resolve %q: could not reach signaling server: ...'), and a
+    // dead server must not read as a typo in the code.
+    ['could not reach signaling server', 'Could not reach the server. Check your internet connection.'],
     ['could not resolve', 'That code was not recognized. Check it for typos, or ask the sender for a new one.'],
+    ['Invalid room ID', 'That link looks incomplete. Copy the whole share link and try again.'],
     ['connection closed before any file', 'The sender cancelled, or the transfer was blocked before it started.'],
     ['connection closed while waiting for the receiver', 'The receiver left or declined before the transfer started.'],
     ['no data arrived from the sender', 'Connected, but the sender never started sending. Ask them to try again.'],
@@ -35,7 +40,11 @@ const RULES: Array<[pattern: string, friendly: string]> = [
     ['failed to connect to signaling server', 'Could not reach the server. Check your internet connection.'],
     ['failed to fetch ICE credentials', 'Could not reach the server. Check your internet connection.'],
     ['timed out waiting for the server', 'Could not reach the server. Check your internet connection.'],
-    ['server error:', 'Could not reach the server. Check your internet connection.'],
+    // 'server error:' means the server WAS reached and rejected the request
+    // (e.g. rate limiting), so connectivity advice would mislead.
+    ['server error:', 'The server rejected the request. Try again in a minute.'],
+    ['timed out waiting for delivery', 'The connection was lost before the transfer finished. Start it again.'],
+    ['peer disconnected before connecting', 'The receiver left before the transfer started.'],
     ['cannot create', 'Could not write to the save folder. Check that it exists and has free space.'],
     ['write error', 'Could not write to the save folder. Check that it exists and has free space.'],
     ['connection failed (state', 'The connection was lost before the transfer finished. Start it again.'],

--- a/desktop/frontend/src/errors.ts
+++ b/desktop/frontend/src/errors.ts
@@ -1,0 +1,56 @@
+// friendlyError turns a raw engine/backend error into StatusLine text. It
+// lives outside App.tsx so it can be tested without a DOM or the Wails
+// runtime bindings.
+//
+// The returned string always starts with 'Error: ': StatusLine keys its red
+// styling and icon off that prefix, so the prefix is part of the contract.
+// Known patterns map to a sentence a person can act on, in the register of
+// serverprobe.go's describeDialError; anything unknown passes through
+// unchanged so a novel failure still reaches a bug report intact. Substring
+// matching, first match wins, because the backend wraps errors ("transfer
+// failed: error sending x: ...").
+
+// Messages that are already hand-written for humans (and may carry an
+// actionable hint, like the relay cap's Hide my IP note) pass through as-is.
+const PASSTHROUGH = [
+    'relay connections are capped',
+    'this code is no longer active',
+    'room is full',
+];
+
+// Ordered mapping table: specific patterns before generic ones. The final
+// 'connection closed' bucket must stay last of the connection family so the
+// more precise closed-variants above it win.
+const RULES: Array<[pattern: string, friendly: string]> = [
+    ['could not resolve', 'That code was not recognized. Check it for typos, or ask the sender for a new one.'],
+    ['connection closed before any file', 'The sender cancelled, or the transfer was blocked before it started.'],
+    ['connection closed while waiting for the receiver', 'The receiver left or declined before the transfer started.'],
+    ['no data arrived from the sender', 'Connected, but the sender never started sending. Ask them to try again.'],
+    ['transfer stalled', 'The transfer stalled and gave up. Start it again.'],
+    ['incomplete file', 'A file arrived incomplete, so it was not kept. Start the transfer again.'],
+    ['timed out waiting for the peer', 'The other side never connected. Both people need Floe open at the same time.'],
+    ['timed out waiting for ack', 'The other side never connected. Both people need Floe open at the same time.'],
+    ['timed out establishing a connection', 'A connection could not be established. Check that both devices are online and try again.'],
+    ['data channel did not open', 'A connection could not be established. Check that both devices are online and try again.'],
+    ['failed to connect to signaling server', 'Could not reach the server. Check your internet connection.'],
+    ['failed to fetch ICE credentials', 'Could not reach the server. Check your internet connection.'],
+    ['timed out waiting for the server', 'Could not reach the server. Check your internet connection.'],
+    ['server error:', 'Could not reach the server. Check your internet connection.'],
+    ['cannot create', 'Could not write to the save folder. Check that it exists and has free space.'],
+    ['write error', 'Could not write to the save folder. Check that it exists and has free space.'],
+    ['connection failed (state', 'The connection was lost before the transfer finished. Start it again.'],
+    ['failed to send chunk', 'The connection was lost before the transfer finished. Start it again.'],
+    ['backpressure stall', 'The connection was lost before the transfer finished. Start it again.'],
+    ['connection closed', 'The connection was lost before the transfer finished. Start it again.'],
+];
+
+export function friendlyError(raw: unknown): string {
+    const text = String(raw).replace(/^Error:\s*/, '');
+    for (const p of PASSTHROUGH) {
+        if (text.includes(p)) return 'Error: ' + text;
+    }
+    for (const [pattern, friendly] of RULES) {
+        if (text.includes(pattern)) return 'Error: ' + friendly;
+    }
+    return 'Error: ' + text;
+}

--- a/desktop/frontend/src/incoming.test.ts
+++ b/desktop/frontend/src/incoming.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from 'vitest';
+import {fmtBytes, formatIncoming} from './incoming';
+
+describe('formatIncoming', () => {
+    it('single file shows its name and size', () => {
+        expect(formatIncoming({files: 1, totalBytes: 31457280, firstName: 'video.mp4'})).toBe(
+            'Incoming: video.mp4 · 30.0 MB',
+        );
+    });
+
+    it('single file from a legacy sender (no size) shows the name only', () => {
+        expect(formatIncoming({files: 1, totalBytes: 0, firstName: 'old.bin'})).toBe('Incoming: old.bin');
+    });
+
+    it('batch shows the count and total', () => {
+        expect(formatIncoming({files: 3, totalBytes: 851443712, firstName: 'a.jpg'})).toBe(
+            'Incoming: 3 files · 812.0 MB',
+        );
+    });
+
+    it('batch without a total shows the count only', () => {
+        expect(formatIncoming({files: 5, totalBytes: 0, firstName: 'a.jpg'})).toBe('Incoming: 5 files');
+    });
+
+    it('an empty first name falls back to a generic word', () => {
+        expect(formatIncoming({files: 1, totalBytes: 4, firstName: ''})).toBe('Incoming: file · 4 B');
+    });
+});
+
+describe('fmtBytes', () => {
+    it('matches the app-wide rendering', () => {
+        expect(fmtBytes(0)).toBe('0 B');
+        expect(fmtBytes(1023)).toBe('1023 B');
+        expect(fmtBytes(1536)).toBe('1.5 KB');
+        expect(fmtBytes(1048576)).toBe('1.0 MB');
+    });
+});

--- a/desktop/frontend/src/incoming.test.ts
+++ b/desktop/frontend/src/incoming.test.ts
@@ -8,8 +8,8 @@ describe('formatIncoming', () => {
         );
     });
 
-    it('single file from a legacy sender (no size) shows the name only', () => {
-        expect(formatIncoming({files: 1, totalBytes: 0, firstName: 'old.bin'})).toBe('Incoming: old.bin');
+    it('a single zero-byte file shows 0 B, matching the CLI box', () => {
+        expect(formatIncoming({files: 1, totalBytes: 0, firstName: 'empty.bin'})).toBe('Incoming: empty.bin · 0 B');
     });
 
     it('batch shows the count and total', () => {

--- a/desktop/frontend/src/incoming.ts
+++ b/desktop/frontend/src/incoming.ts
@@ -25,8 +25,11 @@ export function fmtBytes(n: number): string {
 // and total. Sizes are omitted when a legacy sender did not announce one.
 export function formatIncoming(p: IncomingPreview): string {
     if (p.files === 1) {
+        // The engine falls back to the file's own size for single-file legacy
+        // senders, so a zero here is a genuine 0-byte file: show it, matching
+        // the CLI's Incoming box.
         const name = p.firstName || 'file';
-        return p.totalBytes > 0 ? `Incoming: ${name} · ${fmtBytes(p.totalBytes)}` : `Incoming: ${name}`;
+        return `Incoming: ${name} · ${fmtBytes(p.totalBytes)}`;
     }
     return p.totalBytes > 0
         ? `Incoming: ${p.files} files · ${fmtBytes(p.totalBytes)}`

--- a/desktop/frontend/src/incoming.ts
+++ b/desktop/frontend/src/incoming.ts
@@ -1,0 +1,34 @@
+// Pure helpers for the incoming-transfer preview. They live outside App.tsx so
+// they can be tested without a DOM or the Wails runtime bindings, which do not
+// exist outside the WebView.
+
+// IncomingPreview mirrors the engine's IncomingInfo payload on the
+// "recv:incoming" event: what the sender announced in its first metadata,
+// before any byte lands on disk.
+export interface IncomingPreview {
+    files: number;
+    totalBytes: number;
+    firstName: string;
+}
+
+// fmtBytes renders a byte count the way the rest of the app does (also used by
+// the progress label and history rows in App.tsx).
+export function fmtBytes(n: number): string {
+    if (!n || n < 0) return '0 B';
+    const u = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(u.length - 1, Math.floor(Math.log(n) / Math.log(1024)));
+    return (n / Math.pow(1024, i)).toFixed(i ? 1 : 0) + ' ' + u[i];
+}
+
+// formatIncoming renders the pre-transfer preview line, mirroring the CLI's
+// Incoming box: a single file shows its name and size, a batch shows the count
+// and total. Sizes are omitted when a legacy sender did not announce one.
+export function formatIncoming(p: IncomingPreview): string {
+    if (p.files === 1) {
+        const name = p.firstName || 'file';
+        return p.totalBytes > 0 ? `Incoming: ${name} · ${fmtBytes(p.totalBytes)}` : `Incoming: ${name}`;
+    }
+    return p.totalBytes > 0
+        ? `Incoming: ${p.files} files · ${fmtBytes(p.totalBytes)}`
+        : `Incoming: ${p.files} files`;
+}

--- a/desktop/wake.go
+++ b/desktop/wake.go
@@ -2,11 +2,15 @@ package main
 
 import "sync"
 
-// wakeGuard is an idempotent, concurrency-safe on/off switch for a system sleep
-// inhibitor. acquire() turns it on once, release() turns it off once, and repeat
-// calls in either direction are no-ops. The platform effect is delegated to
-// onBlock/onAllow (wired to blockSleep/allowSleep by newWakeGuard); tests inject
-// recorder funcs instead of touching the OS.
+// wakeGuard is a concurrency-safe on/off switch for a system sleep inhibitor,
+// owned by a transfer generation. acquire(g) takes (or keeps) the inhibitor
+// for generation g; release(g) turns it off only when g still owns it. The
+// ownership tag is what stops a superseded transfer goroutine's unconditional
+// deferred release from dropping the inhibitor under the live transfer that
+// acquired it moments earlier (releases may have no matching acquire, so a
+// refcount would break the same way). The platform effect is delegated to
+// onBlock/onAllow (wired to blockSleep/allowSleep by newWakeGuard); tests
+// inject recorder funcs instead of touching the OS.
 //
 // The platform hook is invoked INSIDE the mu-protected state transition. That is
 // what makes wake_windows.go's package-level stop channel safe: it is only ever
@@ -14,7 +18,7 @@ import "sync"
 // serializes. Do not move the hook calls outside the lock.
 type wakeGuard struct {
 	mu      sync.Mutex
-	held    bool
+	owner   uint64 // generation currently holding the inhibitor; 0 = not held (generations start at 1)
 	onBlock func()
 	onAllow func()
 }
@@ -24,26 +28,30 @@ func newWakeGuard() *wakeGuard {
 	return &wakeGuard{onBlock: blockSleep, onAllow: allowSleep}
 }
 
-// acquire asks the system to stay awake. Safe to call repeatedly; only the first
-// call while released has any effect.
-func (w *wakeGuard) acquire() {
+// acquire asks the system to stay awake on behalf of generation g. The platform
+// hook fires only on the not-held -> held transition; a newer generation
+// acquiring over an older one just transfers ownership.
+func (w *wakeGuard) acquire(g uint64) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if w.held {
+	if w.owner == g {
 		return
 	}
-	w.held = true
-	w.onBlock()
+	wasHeld := w.owner != 0
+	w.owner = g
+	if !wasHeld {
+		w.onBlock()
+	}
 }
 
-// release lets the system sleep again. Safe to call repeatedly, including without
-// a matching acquire; only the first call while held has any effect.
-func (w *wakeGuard) release() {
+// release lets the system sleep again, but only when generation g still owns
+// the inhibitor. Safe to call repeatedly and without a matching acquire.
+func (w *wakeGuard) release(g uint64) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	if !w.held {
+	if w.owner != g || w.owner == 0 {
 		return
 	}
-	w.held = false
+	w.owner = 0
 	w.onAllow()
 }

--- a/desktop/wake.go
+++ b/desktop/wake.go
@@ -37,6 +37,15 @@ func (w *wakeGuard) acquire(g uint64) {
 	if w.owner == g {
 		return
 	}
+	// Generations only grow, so an acquire from below the current owner is a
+	// dead goroutine that lost a race (e.g. its success-branch select already
+	// had a buffered message when the user cancelled). Refusing here keeps the
+	// documented invariant that a superseded attempt can never touch the
+	// inhibitor: accepting would hand ownership to the corpse, whose deferred
+	// release would then drop the wake lock under the live transfer.
+	if g < w.owner {
+		return
+	}
 	wasHeld := w.owner != 0
 	w.owner = g
 	if !wasHeld {

--- a/desktop/wake_test.go
+++ b/desktop/wake_test.go
@@ -78,6 +78,14 @@ func TestWakeGuardStolenReleaseIgnored(t *testing.T) {
 	if *allows != 0 || g.owner != 2 {
 		t.Fatalf("stranger release dropped the inhibitor: allows=%d owner=%d, want 0/2", *allows, g.owner)
 	}
+	g.acquire(1) // a DEAD generation acquiring late must not steal ownership back
+	if g.owner != 2 || *blocks != 1 {
+		t.Fatalf("stale acquire stole ownership: owner=%d blocks=%d, want 2/1", g.owner, *blocks)
+	}
+	g.release(1) // and its deferred release stays a no-op
+	if *allows != 0 || g.owner != 2 {
+		t.Fatalf("stale acquire+release dropped the inhibitor: allows=%d owner=%d, want 0/2", *allows, g.owner)
+	}
 	g.release(2) // the true owner releases
 	if *allows != 1 || g.owner != 0 {
 		t.Fatalf("owner release: allows=%d owner=%d, want 1/0", *allows, g.owner)

--- a/desktop/wake_test.go
+++ b/desktop/wake_test.go
@@ -20,20 +20,20 @@ func newTestGuard() (g *wakeGuard, blocks, allows *int) {
 func TestWakeGuardAcquireReleaseIdempotent(t *testing.T) {
 	g, blocks, allows := newTestGuard()
 
-	g.acquire()
-	if *blocks != 1 || *allows != 0 || !g.held {
-		t.Fatalf("after acquire: blocks=%d allows=%d held=%v, want 1/0/true", *blocks, *allows, g.held)
+	g.acquire(1)
+	if *blocks != 1 || *allows != 0 || g.owner == 0 {
+		t.Fatalf("after acquire: blocks=%d allows=%d owner=%d, want 1/0/held", *blocks, *allows, g.owner)
 	}
-	g.acquire() // idempotent: must not block twice
+	g.acquire(1) // idempotent: must not block twice
 	if *blocks != 1 {
 		t.Fatalf("re-acquire called onBlock again: blocks=%d, want 1", *blocks)
 	}
 
-	g.release()
-	if *allows != 1 || g.held {
-		t.Fatalf("after release: allows=%d held=%v, want 1/false", *allows, g.held)
+	g.release(1)
+	if *allows != 1 || g.owner != 0 {
+		t.Fatalf("after release: allows=%d owner=%d, want 1/0", *allows, g.owner)
 	}
-	g.release() // idempotent: must not allow twice
+	g.release(1) // idempotent: must not allow twice
 	if *allows != 1 {
 		t.Fatalf("re-release called onAllow again: allows=%d, want 1", *allows)
 	}
@@ -41,31 +41,58 @@ func TestWakeGuardAcquireReleaseIdempotent(t *testing.T) {
 
 func TestWakeGuardReleaseWithoutAcquire(t *testing.T) {
 	g, blocks, allows := newTestGuard()
-	g.release() // no matching acquire: must be a no-op
-	if *blocks != 0 || *allows != 0 || g.held {
-		t.Fatalf("release without acquire: blocks=%d allows=%d held=%v, want 0/0/false", *blocks, *allows, g.held)
+	g.release(1) // no matching acquire: must be a no-op
+	if *blocks != 0 || *allows != 0 || g.owner != 0 {
+		t.Fatalf("release without acquire: blocks=%d allows=%d owner=%d, want 0/0/0", *blocks, *allows, g.owner)
 	}
 }
 
 func TestWakeGuardReuse(t *testing.T) {
 	g, blocks, allows := newTestGuard()
-	for i := 0; i < 3; i++ {
-		g.acquire()
-		g.release()
+	for i := uint64(1); i <= 3; i++ {
+		g.acquire(i)
+		g.release(i)
 	}
 	if *blocks != 3 || *allows != 3 {
 		t.Fatalf("reuse: blocks=%d allows=%d, want 3/3", *blocks, *allows)
 	}
 }
 
-// TestWakeGuardConcurrent hammers acquire/release from many goroutines to prove
-// the mutex keeps held/onBlock/onAllow consistent (meaningful under -race). The
-// hooks run under the guard's lock, so plain counters would suffice, but atomics
-// keep the post-join read unambiguous. Every not-held->held transition (onBlock)
-// must be balanced by a held->not-held one (onAllow), and the guard must end
-// released, because the globally last operation is always a release().
+// TestWakeGuardStolenReleaseIgnored pins the ownership contract: a superseded
+// generation's deferred release must not drop the inhibitor a newer transfer
+// holds (the old boolean guard's exact bug), and ownership transfer must not
+// re-fire the platform hook.
+func TestWakeGuardStolenReleaseIgnored(t *testing.T) {
+	g, blocks, allows := newTestGuard()
+
+	g.acquire(1)
+	g.acquire(2) // newer transfer takes ownership; still one block
+	if *blocks != 1 || g.owner != 2 {
+		t.Fatalf("after ownership transfer: blocks=%d owner=%d, want 1/2", *blocks, g.owner)
+	}
+	g.release(1) // the dead generation's deferred release: must be ignored
+	if *allows != 0 || g.owner != 2 {
+		t.Fatalf("stolen release dropped the inhibitor: allows=%d owner=%d, want 0/2", *allows, g.owner)
+	}
+	g.release(3) // a generation that never held it: no-op
+	if *allows != 0 || g.owner != 2 {
+		t.Fatalf("stranger release dropped the inhibitor: allows=%d owner=%d, want 0/2", *allows, g.owner)
+	}
+	g.release(2) // the true owner releases
+	if *allows != 1 || g.owner != 0 {
+		t.Fatalf("owner release: allows=%d owner=%d, want 1/0", *allows, g.owner)
+	}
+}
+
+// TestWakeGuardConcurrent hammers acquire/release from many goroutines with
+// unique generations to prove the mutex keeps owner/onBlock/onAllow consistent
+// (meaningful under -race). Ownership transfers fire no hooks, so every
+// not-held->held transition (onBlock) is balanced by a held->not-held one
+// (onAllow), and the guard must end released: each generation acquires before
+// it releases, so the final owner's release can never have run early.
 func TestWakeGuardConcurrent(t *testing.T) {
 	var blocks, allows int64
+	var genCounter uint64
 	g := &wakeGuard{
 		onBlock: func() { atomic.AddInt64(&blocks, 1) },
 		onAllow: func() { atomic.AddInt64(&allows, 1) },
@@ -76,15 +103,16 @@ func TestWakeGuardConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < 200; j++ {
-				g.acquire()
-				g.release()
+				gen := atomic.AddUint64(&genCounter, 1)
+				g.acquire(gen)
+				g.release(gen)
 			}
 		}()
 	}
 	wg.Wait()
 
-	if g.held {
-		t.Fatal("guard still held after all goroutines finished")
+	if g.owner != 0 {
+		t.Fatalf("guard still held by generation %d after all goroutines finished", g.owner)
 	}
 	if b, a := atomic.LoadInt64(&blocks), atomic.LoadInt64(&allows); b != a || b == 0 {
 		t.Fatalf("unbalanced transitions: blocks=%d allows=%d", b, a)

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -40,9 +40,14 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
-<Update label="Unreleased" tags={["Desktop"]}>
-  **Start over stops losing notes it never sent, and stops claiming a dead transfer is running**
+<Update label="Unreleased" tags={["Desktop", "CLI"]}>
+  **Failed transfers clean up after themselves and speak plainly, and Start over stops losing notes**
 
+  - A receive that fails or is cancelled partway no longer leaves a half-written file behind under its final name. The partial is deleted, files that completed earlier in the batch are kept, and a retried transfer gets its original name back instead of a numbered one. The `floe` CLI receiver gets the same fix.
+  - The Receive card now shows what is incoming (the file name and size, or the file count and total) the moment the sender is known, before the first byte arrives.
+  - A failed receive now raises a Windows notification like a failed send always did, and cancelling a transfer no longer raises a false "send failed" one.
+  - Transfer errors are now written for people ("The connection was lost before the transfer finished. Start it again.") instead of surfacing the engine's internal wording. Genuinely unknown failures still show the raw text so bug reports stay useful.
+  - Cancelling a transfer and immediately starting another no longer lets the dead attempt interfere: its late events are ignored, it can no longer release the keep-awake lock the new transfer holds, and Cancel always reaches the transfer that is actually running.
   - Fixed **Start over** still discarding a typed note without asking, in the two cases the 0.2.2 fix missed. Typing a new note after a send completed, and typing a note then switching to Files and sending those instead, both left text in the box that had never gone anywhere, and both were cleared with no prompt. Floe now compares the box against what the last completed send actually put on the wire, so a note only counts as sent while it is still exactly the note that went out. Tidying up after a send with the sent note still in the box is unchanged and still silent, as is starting over while a connection is being set up.
   - Fixed a failed transfer leaving its progress bar frozen on screen underneath the error, on both the sending and the receiving side.
   - Fixed **Start over** offering to cancel a transfer that had already failed. The stale progress bar above was also what the confirmation read, so after a failure it warned about cancelling a transfer that was already over, and that warning hid the one about the unsent note behind it.

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -43,7 +43,7 @@ Each entry lists the parts it changed. Filter on the right to see only the ones 
 <Update label="Unreleased" tags={["Desktop", "CLI"]}>
   **Failed transfers clean up after themselves and speak plainly, and Start over stops losing notes**
 
-  - A receive that fails or is cancelled partway no longer leaves a half-written file behind under its final name. The partial is deleted, files that completed earlier in the batch are kept, and a retried transfer gets its original name back instead of a numbered one. The `floe` CLI receiver gets the same fix.
+  - A receive that fails or is cancelled partway no longer leaves a half-written file behind under its final name. The partial is deleted, files that completed earlier in the batch are kept, and a retried transfer gets its original name back instead of a numbered one. The `floe` CLI receiver gets the same cleanup when a transfer fails or stalls.
   - The Receive card now shows what is incoming (the file name and size, or the file count and total) the moment the sender is known, before the first byte arrives.
   - A failed receive now raises a Windows notification like a failed send always did, and cancelling a transfer no longer raises a false "send failed" one.
   - Transfer errors are now written for people ("The connection was lost before the transfer finished. Start it again.") instead of surfacing the engine's internal wording. Genuinely unknown failures still show the raw text so bug reports stay useful.

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -91,6 +91,7 @@ See [Flags Reference](/cli/flags) for the global flags that matter here (`--serv
 ## Notes
 
 - Received files are saved to the output directory. Existing files are never overwritten: if a name is already taken, the incoming file is saved with a numbered suffix before the extension (`report.pdf`, then `report (1).pdf`), the same way browsers de-duplicate downloads. The progress line shows the name actually written.
+- A transfer that fails or stalls partway deletes the file it was writing, so nothing half-written is left behind under a finished-looking name. Files that completed earlier in the batch are kept, and retrying reuses the original name instead of a numbered one.
 - Directory structure is preserved when the sender sends a folder. Files land at the same relative paths inside your output directory.
 - On Windows, received files are tagged with the mark of the web (a `Zone.Identifier` stream), so SmartScreen and Office Protected View treat them like browser downloads when opened.
 - Press `Ctrl+C` to cancel the transfer at any time.

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -116,13 +116,13 @@ If you point Floe at your own server, the report goes to that server rather than
 
 | Message | What it means |
 |---|---|
-| Could not resolve ... | The code was mistyped, has passed its 10 minutes, or belongs to a different server from the one you are on. |
+| That code was not recognized ... | The code was mistyped, has passed its 10 minutes, or belongs to a different server from the one you are on. |
 | This code is no longer active; ask for a new one | The code is still valid but nobody is sharing with it. The transfer already finished, or the sender closed Floe. |
 | Room is full (someone else may already be receiving) | Someone already joined with this code. A room takes one receiver, so ask for a new code. |
 
-If Floe connects but nothing arrives, it gives up after 30 seconds with "connected, but no data
-arrived from the sender". Ask the sender to start again. If it never connects at all, check that
-both of you are on the same signaling server. See [Troubleshooting](/troubleshooting).
+If Floe connects but nothing arrives, it gives up after 30 seconds and says the sender never
+started sending; ask them to try again. If it never connects at all, check that both of you are
+on the same signaling server. See [Troubleshooting](/troubleshooting).
 
 A transfer that fails or is cancelled partway deletes the file it was writing, so nothing
 half-written is left behind under a finished-looking name. Files that completed before the

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -34,12 +34,15 @@ Whatever you choose here is remembered for next time. You can also set it once i
 
 Click **Receive**. Floe joins the room, connects to the sender, and starts writing files
 straight to disk. There is nothing to accept: unlike `floe receive` on the command line, the
-desktop app starts as soon as it connects.
+desktop app starts as soon as it connects. The moment the sender is known, the card shows what
+is incoming (the file name and size, or the file count and total) before the first byte lands.
 
 The badge at the top right shows **DIRECT** or **RELAY** once the route is known, and a progress
 bar shows the current file with speed and time remaining. **Cancel** stops it.
 
-When it finishes you get a Windows notification, and the card shows where the files went:
+When it finishes you get a Windows notification, and a transfer that fails raises one too, so
+a failure behind a minimized window is never silent. Cancelling does not notify. On success the
+card shows where the files went:
 
 - For a single file, **Open** launches it in its usual app and **Show in folder** reveals it in
   File Explorer with the file selected.
@@ -120,3 +123,7 @@ If you point Floe at your own server, the report goes to that server rather than
 If Floe connects but nothing arrives, it gives up after 30 seconds with "connected, but no data
 arrived from the sender". Ask the sender to start again. If it never connects at all, check that
 both of you are on the same signaling server. See [Troubleshooting](/troubleshooting).
+
+A transfer that fails or is cancelled partway deletes the file it was writing, so nothing
+half-written is left behind under a finished-looking name. Files that completed before the
+failure are kept, and a retry can use the original name rather than a numbered one.


### PR DESCRIPTION
## Summary

Hardens transfers around failure, cancel, and restart, on the desktop app and the shared engine. Four shipped defects fixed and two upgrades: a receive that fails or is cancelled no longer leaves a half-written file behind under its final name; cancelling and instantly restarting can no longer let the dead attempt wipe the live transfer's cancel handles, steal its keep-awake lock, or talk over its UI; receive failures now raise a Windows notification (and cancelling a send no longer raises a false "send failed" one); the Receive card previews what is incoming before the first byte; and transfer errors are written for people instead of surfacing engine internals.

## Changes

- **cli/engine/transfer/receiver.go** - the interrupt path now deletes the in-flight partial (close before remove for Windows), the short-end-marker path removes its truncated file explicitly, and a second metadata with a file still open closes and deletes the abandoned one instead of leaking the handle. Completed files are always kept, success paths never remove anything, and a retry gets its original name back instead of `name (1).ext`. Ten new tests in `cleanup_test.go` cover stall, cut, short-end, success, mid-batch, abandoned-file, de-collided, and nested-folder cases plus the new hook.
- **cli/engine/transfer** - additive `ReceiveFilesWithOptions` with an `OnIncoming` hook that fires once, after the compat check and before the accept prompt, file creation, and ack. `ReceiveFiles` and `ReceiveFilesWithProgress` delegate unchanged; zero wire impact; CLI behavior identical.
- **desktop/app.go, desktop/wake.go** - transfers are generation-tagged: setters refuse once superseded or cancelled (also closing the cancel-between-setters leak and the 30-second zombie park), a dead attempt's deferred clear is a no-op against the live slots, every event emit and toast is gated by the live generation, and the wake guard is owner-tagged with a staleness check so no dead goroutine can drop the sleep inhibitor under a live transfer. `CancelTransfer` documents its ordering contract.
- **desktop notifications** - `notifyFn` seam; "Floe - receive failed" toast with a generic body (raw engine errors stay off toasts, matching the serverprobe wording register); cancelled and superseded attempts never toast.
- **desktop/frontend** - `recv:incoming` preview (pure `incoming.ts` + tests), `friendlyError` mapping layer (pure `errors.ts` + tests, ordered rules with passthrough for hand-written and unknown messages) wired at the three raw-error sites, and a receive-attempt guard so a settled old promise cannot stomp a restarted attempt's UI (including via Start over).
- **docs** - receiving and CLI receive pages cover the cleanup, preview, and failure notification; the changelog's Unreleased entry gains the hardening bullets with tags `Desktop, CLI`.

## Test plan

- Unit: 10 new engine tests (real in-process pion pairs, watchdog raw-sender pattern), 8 new desktop Go tests (generation and toast semantics, zero App + fakes), wake tests rewritten for ownership incl. the stolen-release and stale-acquire regressions, 40 frontend vitest tests total. All green locally; CI runs the same suites on 3 OSes.
- **Live simulation (9 scenarios, real transfers over a local server, hard mid-stream kills, `wails dev` + Playwright driving the real desktop app)**: a pre-change control run on the old build **reproduced the bug (146 MB partial left at its final name)**; the fixed build leaves an **empty directory** in the same scenario. Mid-batch kills keep completed files and remove only the in-flight partial. The desktop received and sent real files against the CLI with hash verification, `recv:incoming` arrived before the first progress event, five cancel-then-instant-restart rounds all completed cleanly with a mid-stream round proving the cancelled receive cleans up, a live cancel rejected in 313 ms with progress stopped, and the UI showed the mapped friendly error with no raw engine fragment. Every receiver ran with `--no-report` and `FLOE_NO_STATS=1` against localhost only.
- Six-agent adversarial QA on the final diff (race soundness, cleanup exit paths, API compatibility, frontend rule ordering, independent evidence audit, docs accuracy): all findings fixed in the final commit, including a wake-acquire staleness hole the review caught.
- Known limits stated plainly: receiver-side SIGKILL runs no defers (cleanup covers failure, stall, and cancel paths); toast rendering is unit-tested through the seam, not visually; `-race` unavailable locally and in CI (no cgo).
