### PR TITLE
fix(desktop): use an app-specific update hint

### DIFF
--- a/cli/engine/transfer/protocol.go
+++ b/cli/engine/transfer/protocol.go
@@ -54,10 +54,16 @@ func CheckCompat(localMin, localMax, remoteMin, remoteMax int) (ok bool, localTo
 	return false, remoteMin > localMax
 }
 
-// CompatErrorMessage returns a user-facing error string for an incompatible
-// peer. localVer and remoteVer are human release strings (e.g. "v1.5.5");
-// either may be empty for legacy peers.
+// CompatErrorMessage returns the CLI's user-facing error string for an
+// incompatible peer. localVer and remoteVer are human release strings (e.g.
+// "v1.5.5"); either may be empty for legacy peers.
 func CompatErrorMessage(localTooOld bool, localVer, remoteVer string, localMin, localMax, remoteMin, remoteMax int) string {
+	return compatErrorMessage(localTooOld, localVer, remoteVer, localMin, localMax, remoteMin, remoteMax, "")
+}
+
+// compatErrorMessage lets GUI callers replace the CLI-only local update
+// instruction. An empty updateHint preserves the CLI wording exactly.
+func compatErrorMessage(localTooOld bool, localVer, remoteVer string, localMin, localMax, remoteMin, remoteMax int, updateHint string) string {
 	localRange := fmt.Sprintf("protocol %d", localMin)
 	if localMax != localMin {
 		localRange = fmt.Sprintf("protocol %d-%d", localMin, localMax)
@@ -73,8 +79,17 @@ func CompatErrorMessage(localTooOld bool, localVer, remoteVer string, localMin, 
 		remoteRange += " (" + remoteVer + ")"
 	}
 	if localTooOld {
+		if updateHint == "" {
+			updateHint = "Run `floe update` to upgrade."
+		}
 		return fmt.Sprintf(
-			"Cannot transfer: your floe is too old for this peer.\n  You: %s  Peer: %s\n  Run `floe update` to upgrade.",
+			"Cannot transfer: your floe is too old for this peer.\n  You: %s  Peer: %s\n  %s",
+			localRange, remoteRange, updateHint,
+		)
+	}
+	if updateHint != "" {
+		return fmt.Sprintf(
+			"Cannot transfer: peer's floe is too old.\n  You: %s  Peer: %s\n  Ask the other side to update Floe.",
 			localRange, remoteRange,
 		)
 	}
@@ -82,4 +97,26 @@ func CompatErrorMessage(localTooOld bool, localVer, remoteVer string, localMin, 
 		"Cannot transfer: peer's floe is too old.\n  You: %s  Peer: %s\n  Ask the other side to run `floe update`.",
 		localRange, remoteRange,
 	)
+}
+
+// peerCompatErrorMessage describes the same mismatch from the remote peer's
+// perspective. It is sent on the wire as a surface-neutral fallback for peers
+// that display Reason verbatim instead of rebuilding it from pv/pvMin.
+func peerCompatErrorMessage(localTooOld bool, localVer, remoteVer string, localMin, localMax, remoteMin, remoteMax int) string {
+	return compatErrorMessage(!localTooOld, remoteVer, localVer,
+		remoteMin, remoteMax, localMin, localMax, "Update Floe to continue.")
+}
+
+// compatErrorFromIncompatible rebuilds current peers' error messages from the
+// local caller's perspective. Older peers only supplied Reason, so retain it as
+// the compatibility fallback.
+func compatErrorFromIncompatible(localVer, updateHint string, incompat incompatibleMsg) string {
+	if ok, localTooOld := CheckCompat(MinProtocolVersion, ProtocolVersion, incompat.PvMin, incompat.Pv); !ok {
+		return compatErrorMessage(localTooOld, localVer, incompat.Ver,
+			MinProtocolVersion, ProtocolVersion, incompat.PvMin, incompat.Pv, updateHint)
+	}
+	if incompat.Reason != "" {
+		return incompat.Reason
+	}
+	return "peer rejected transfer: protocol incompatible"
 }

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -73,6 +73,9 @@ type IncomingInfo struct {
 type ReceiveOptions struct {
 	OnProgress ProgressFunc
 	OnIncoming func(IncomingInfo)
+	// UpdateHint replaces the CLI-only local update instruction in protocol
+	// compatibility errors. Leave empty for the default CLI wording.
+	UpdateHint string
 }
 
 // ReceiveFiles handles the full receiving side of the Floe protocol.
@@ -264,11 +267,13 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 					// fast with a clear message rather than waiting for an ack.
 					ok, localTooOld := CheckCompat(MinProtocolVersion, ProtocolVersion, info.PvMin, info.Pv)
 					if !ok {
-						errMsg := CompatErrorMessage(localTooOld, localVer, info.Ver,
+						errMsg := compatErrorMessage(localTooOld, localVer, info.Ver,
+							MinProtocolVersion, ProtocolVersion, info.PvMin, info.Pv, opts.UpdateHint)
+						peerErrMsg := peerCompatErrorMessage(localTooOld, localVer, info.Ver,
 							MinProtocolVersion, ProtocolVersion, info.PvMin, info.Pv)
 						incompat := incompatibleMsg{
 							Type:   "incompatible",
-							Reason: errMsg,
+							Reason: peerErrMsg,
 							Pv:     ProtocolVersion,
 							PvMin:  MinProtocolVersion,
 							Ver:    localVer,

--- a/cli/engine/transfer/sender.go
+++ b/cli/engine/transfer/sender.go
@@ -102,17 +102,33 @@ type endMsg struct {
 	Type string `json:"type"`
 }
 
+// SendOptions carries optional behavior for GUI clients. The zero value is
+// the CLI behavior: terminal progress and the CLI update instruction.
+type SendOptions struct {
+	OnProgress ProgressFunc
+	// UpdateHint replaces the CLI-only local update instruction in protocol
+	// compatibility errors. Leave empty for the default CLI wording.
+	UpdateHint string
+}
+
 // SendFiles sends all given file paths over the open data channel, rendering a
 // terminal progress bar. Folders are walked recursively. localVer is the human
 // release string (e.g. "v1.5.5") embedded in metadata; pass "" for dev/tests.
 func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
-	return SendFilesWithProgress(dc, paths, localVer, nil)
+	return SendFilesWithOptions(dc, paths, localVer, SendOptions{})
 }
 
 // SendFilesWithProgress is SendFiles with a progress callback for GUI clients.
 // When onProgress is non-nil, per-chunk progress is reported through it and the
 // terminal progress bar is suppressed.
 func SendFilesWithProgress(dc *webrtc.DataChannel, paths []string, localVer string, onProgress ProgressFunc) error {
+	return SendFilesWithOptions(dc, paths, localVer, SendOptions{OnProgress: onProgress})
+}
+
+// SendFilesWithOptions is the full-featured send entry point; the other two
+// delegate here.
+func SendFilesWithOptions(dc *webrtc.DataChannel, paths []string, localVer string, opts SendOptions) error {
+	onProgress := opts.OnProgress
 	// Expand paths: collect all files (walk directories)
 	files, err := collectFiles(paths)
 	if err != nil {
@@ -185,7 +201,7 @@ func SendFilesWithProgress(dc *webrtc.DataChannel, paths []string, localVer stri
 
 	var sentSoFar int64
 	for i, entry := range files {
-		if err := sendFile(dc, ackCh, sendMore, done, entry, i+1, len(files), totalBytes, localVer, onProgress, sentSoFar, chunk); err != nil {
+		if err := sendFile(dc, ackCh, sendMore, done, entry, i+1, len(files), totalBytes, localVer, onProgress, opts.UpdateHint, sentSoFar, chunk); err != nil {
 			return fmt.Errorf("error sending %s: %w", entry.displayName, err)
 		}
 		sentSoFar += entry.size
@@ -309,7 +325,7 @@ func collectFiles(paths []string) ([]fileEntry, error) {
 }
 
 // sendFile handles the full send sequence for a single file.
-func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, done <-chan struct{}, entry fileEntry, index, total int, totalBytes int64, localVer string, onProgress ProgressFunc, baseTotal int64, chunk int) error {
+func sendFile(dc *webrtc.DataChannel, ackCh <-chan []byte, sendMore <-chan struct{}, done <-chan struct{}, entry fileEntry, index, total int, totalBytes int64, localVer string, onProgress ProgressFunc, updateHint string, baseTotal int64, chunk int) error {
 	f, err := os.Open(entry.absPath)
 	if err != nil {
 		return err
@@ -363,14 +379,12 @@ ackLoop:
 			// If the receiver found the protocol ranges incompatible it sends
 			// an "incompatible" message instead of an ack.
 			if base.Type == "incompatible" {
-				var incompat struct {
-					Reason string `json:"reason"`
-				}
+				var incompat incompatibleMsg
 				json.Unmarshal(raw, &incompat) //nolint:errcheck
-				if incompat.Reason != "" {
-					return fmt.Errorf("%s", incompat.Reason)
-				}
-				return fmt.Errorf("peer rejected transfer: protocol incompatible")
+				// Current peers include their protocol range, so rebuild the
+				// message from this sender's perspective and surface-specific
+				// update hint. Reason remains the fallback for legacy peers.
+				return fmt.Errorf("%s", compatErrorFromIncompatible(localVer, updateHint, incompat))
 			}
 			if base.Type == "ack" {
 				var ack ackMsg
@@ -383,8 +397,8 @@ ackLoop:
 					if index == 1 {
 						ok, localTooOld := CheckCompat(MinProtocolVersion, ProtocolVersion, ack.PvMin, ack.Pv)
 						if !ok {
-							return fmt.Errorf("%s", CompatErrorMessage(localTooOld, localVer, ack.Ver,
-								MinProtocolVersion, ProtocolVersion, ack.PvMin, ack.Pv))
+							return fmt.Errorf("%s", compatErrorMessage(localTooOld, localVer, ack.Ver,
+								MinProtocolVersion, ProtocolVersion, ack.PvMin, ack.Pv, updateHint))
 						}
 						if ack.Ver != "" && localVer != "" && ack.Ver != localVer {
 							fmt.Printf("  Peer version: %s\n", ack.Ver)

--- a/cli/engine/transfer/transfer_test.go
+++ b/cli/engine/transfer/transfer_test.go
@@ -256,6 +256,56 @@ func TestCompatErrorMessage(t *testing.T) {
 	if strings.Contains(msg3, "()") {
 		t.Errorf("empty ver should not produce '()' in message, got: %s", msg3)
 	}
+
+	// GUI callers can replace the CLI-only local remedy.
+	const appHint = "Update Floe from your app store or floe.one/download."
+	msg4 := compatErrorMessage(true, "v1.5.5", "v2.0.0", 1, 1, 2, 2, appHint)
+	if !strings.Contains(msg4, appHint) || strings.Contains(msg4, "floe update") {
+		t.Errorf("custom local update hint not applied, got: %s", msg4)
+	}
+
+	// The local app cannot know which surface the peer uses, so the remote
+	// remedy stays surface-neutral when a custom local hint is configured.
+	msg5 := compatErrorMessage(false, "v2.0.0", "v1.5.5", 2, 2, 1, 1, appHint)
+	if !strings.Contains(msg5, "Ask the other side to update Floe.") || strings.Contains(msg5, "app store") {
+		t.Errorf("custom peer update hint should be surface-neutral, got: %s", msg5)
+	}
+
+	// A current receiver's reason is written from the receiver's perspective.
+	// The sender must reconstruct it from its own protocol range and hint.
+	msg6 := compatErrorFromIncompatible("v1.5.5", appHint, incompatibleMsg{
+		Reason: "receiver-perspective message",
+		Pv:     2,
+		PvMin:  2,
+		Ver:    "v2.0.0",
+	})
+	if !strings.Contains(msg6, appHint) || strings.Contains(msg6, "receiver-perspective") {
+		t.Errorf("sender did not rebuild incompatibility message, got: %s", msg6)
+	}
+
+	// Legacy peers supplied only a prebuilt reason.
+	const legacyReason = "legacy incompatibility reason"
+	if got := compatErrorFromIncompatible("v1.5.5", appHint, incompatibleMsg{Reason: legacyReason}); got != legacyReason {
+		t.Errorf("legacy reason = %q, want %q", got, legacyReason)
+	}
+
+	// When this receiver is newer, the sender-facing fallback must say that the
+	// sender itself is old and must not leak this receiver's app-store hint.
+	peerMsg := peerCompatErrorMessage(false, "v2.0.0", "v1.5.5", 2, 2, 1, 1)
+	if !strings.Contains(peerMsg, "your floe is too old") ||
+		!strings.Contains(peerMsg, "You: protocol 1 (v1.5.5)  Peer: protocol 2 (v2.0.0)") ||
+		!strings.Contains(peerMsg, "Update Floe to continue.") {
+		t.Errorf("newer receiver produced wrong sender-facing message: %s", peerMsg)
+	}
+
+	// When this receiver is older, the newer sender should be told neutrally
+	// that the peer needs an update.
+	peerMsg2 := peerCompatErrorMessage(true, "v1.5.5", "v2.0.0", 1, 1, 2, 2)
+	if !strings.Contains(peerMsg2, "peer's floe is too old") ||
+		!strings.Contains(peerMsg2, "You: protocol 2 (v2.0.0)  Peer: protocol 1 (v1.5.5)") ||
+		!strings.Contains(peerMsg2, "Ask the other side to update Floe.") {
+		t.Errorf("older receiver produced wrong sender-facing message: %s", peerMsg2)
+	}
 }
 
 // TestParseMetadataProtocolFields verifies that pv/pvMin/ver are parsed from

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -30,6 +30,8 @@ import (
 // a self-hosted server and it interoperates with peers on that server instead.
 const defaultServer = "https://api.floe.one"
 
+const desktopUpdateHint = "Update Floe from the Microsoft Store or floe.one/download."
+
 // The share-link origin is no longer a constant here. It is derived from the
 // signaling origin by engine/serverurl, which the CLI uses too, so both surfaces
 // emit identical links. See App.endpoints.
@@ -765,7 +767,10 @@ func (a *App) runSend(g uint64, paths []string, hideIP bool) {
 		lastEmit = time.Now()
 		emit("send:progress", p)
 	}
-	if err := transfer.SendFilesWithProgress(dc, paths, version, onProgress); err != nil {
+	if err := transfer.SendFilesWithOptions(dc, paths, version, transfer.SendOptions{
+		OnProgress: onProgress,
+		UpdateHint: desktopUpdateHint,
+	}); err != nil {
 		// The relay cap is a policy block, not a failure: skip the "transfer
 		// failed" wrapper, and when Hide my IP forced the relay, name the
 		// toggle that lifts the cap.
@@ -921,6 +926,7 @@ func (a *App) receiveByCode(g uint64, codeOrLink string, outputDir string, hideI
 	}
 	opts := transfer.ReceiveOptions{
 		OnProgress: onProgress,
+		UpdateHint: desktopUpdateHint,
 		// Fires once as the sender's first metadata arrives, before any byte
 		// lands: the UI shows what is incoming while the transfer starts.
 		OnIncoming: func(inc transfer.IncomingInfo) { emit("recv:incoming", inc) },


### PR DESCRIPTION
## Summary

- let Go transfer callers provide a surface-specific local update hint while preserving the existing CLI wording
- use the Microsoft Store/download guidance for both Desktop send and receive paths
- keep incompatible messages correct across Go, browser, and legacy peers by rebuilding current messages locally and sending a neutral peer-perspective fallback

Fixes #280.

## Test plan

- cd cli && go vet ./...
- cd cli && go test -count=1 ./...
- cd desktop/frontend && npm ci && npm test && npm run build (40 tests)
- cd desktop && go vet ./... && go test -count=1 ./...
- git diff --check