### PR TITLE
docs: take Mintlify's default page background and theme menu

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -13,12 +13,6 @@
     "light": "#B1DDEB",
     "dark": "#00A3C9"
   },
-  "background": {
-    "color": {
-      "light": "#FFFFFF",
-      "dark": "#09090b"
-    }
-  },
   "styling": {
     "codeblocks": "system"
   },

--- a/docs/style.css
+++ b/docs/style.css
@@ -85,9 +85,13 @@
 
    Mintlify paints footer links at 50% alpha: gray-950/50 in light, white/50 in
    dark. Composited over the real footer ground (rgb(255,255,255) light,
-   rgb(14,14,16) dark) that lands on rgb(132,132,132) either way, which is
+   rgb(12,13,15) dark) that lands on rgb(132,132,132) either way, which is
    3.74:1 in light. AA wants 4.5:1 for body text, so every footer link on every
    docs page was failing. Dark was already fine at 5.37:1.
+
+   The dark ground quoted above is Mintlify's default. It was #09090b while
+   docs.json set background.color, and the ratios here shifted by hundredths
+   when that block was removed; none of them crossed a threshold.
 
    Measured, 0.56 alpha is the exact break-even in light. This uses 0.62 so a
    future tweak to the background does not silently drop it back under. Both
@@ -209,7 +213,9 @@
 
    The colours are not floe.one's zinc-600 verbatim because that fails WCAG
    at 11px (2.57:1 on zinc-950). These sit at 5.76:1 light (#65656F on
-   #FFFFFF) and 5.44:1 dark (#85858E on #09090b). */
+   #FFFFFF) and 5.32:1 dark (#85858E on rgb(12,13,15)). docs.json sets no
+   background.color, so both grounds are Mintlify's defaults and the dark one
+   can move under us; re-measure if it does. */
 #sidebar .sidebar-group-header .sidebar-title {
   font-family: "Geist Mono", ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas, monospace;
   font-size: 11px;
@@ -309,7 +315,8 @@
 
 /* The Tabs component (Install pages, reverse proxy) marks its selected tab
    with text-primary and a primary underline on the tablist border. Same
-   selected-state doctrine, same variable mechanism as the theme menu: the
+   selected-state doctrine, same variable mechanism as the copy button and the
+   card hover below: the
    active tab goes near-black on light and white on dark, inactive tabs keep
    their own gray classes. tabs-list is the observed data-component-part on
    the tablist (2026-08-09 DOM). */
@@ -320,21 +327,28 @@
   --color-primary-light: rgb(255 255 255);
 }
 
-/* The theme-switcher menu marks its selected row with text-primary ice, and
-   hides the other rows' check marks with text-primary/0, the SAME utility at
-   alpha zero. Overriding color directly would therefore reveal a check on
-   every row (tried, shipped for a minute, looked broken), so this redefines
-   the variables the utilities read instead: the selected check and label go
-   neutral, the /0 variants stay invisible, and each mode's utility reads its
-   own variable so no .dark split is needed. The role guard matters: the html
-   root also carries data-theme-preference (it stores the setting), and the
-   bare attribute selector would restyle the whole document. */
-[role='menuitem'][data-theme-preference] {
-  --primary: 17 17 17;
-  --primary-light: 255 255 255;
-  --color-primary: rgb(17 17 17);
-  --color-primary-light: rgb(255 255 255);
-}
+/* The theme-switcher menu is deliberately NOT overridden here (user call,
+   2026-08-12). Its selected row keeps Mintlify's stock `text-primary
+   dark:text-primary-light`, so the check mark and label render in the ice
+   accent from docs.json colors rather than the neutral used by the other
+   selected states in this file.
+
+   That makes it the one place where two controls doing the same job disagree:
+   the footer's own theme switch is still neutral, through the
+   #footer button[class*='bg-gray'] pair above. Ice in the navbar menu, neutral
+   in the footer, on purpose. In light mode the selected row resolves --primary
+   #00A3C9 on the white popover, which is 2.97:1, the same recorded
+   accessibility exception already booked for the eyebrow above.
+
+   If that is ever revisited, do NOT set `color` on the row: the unselected
+   rows hide their check marks with text-primary/0, the SAME utility at alpha
+   zero, so a colour override reveals a check on every row (tried, shipped for
+   a minute, looked broken). Redefine --primary / --primary-light, plus their
+   --color-* aliases as everywhere else in this file, on
+   [role='menuitem'][data-theme-preference] instead, which preserves the alpha.
+   The role guard matters too: the html root also carries data-theme-preference
+   to store the setting, so the bare attribute selector would restyle the whole
+   document. */
 
 /* Navbar links hover neutral, like floe.one's navbar (zinc at rest, plain
    black or white on hover), instead of the hover:text-primary ice Mintlify
@@ -513,7 +527,7 @@ html:not(.dark) #content-area a.link {
 }
 
 /* The copied-state check inside the copy button is text-primary, so it
-   flashed ice after every copy. Same variable trick as the theme menu and
+   flashed ice after every copy. Same variable trick as the tabs list and
    the card hover: within the button, primary resolves to neutral, so the
    check goes black on light and white on dark while the idle icon's own
    gray classes are untouched. */


### PR DESCRIPTION
## Summary

Two deliberate steps back toward the stock Mintlify theme.

**Page background.** `docs.json` set `background.color` to `#FFFFFF` light and `#09090b` dark, the zinc-950 floe.one uses as its own ground, so the marketing site and the docs met with no seam at the `/docs` boundary. Removing the block hands both grounds back to the theme.

| Theme | Was | Now (default) | Change |
|---|---|---|---|
| Light | `#FFFFFF` | `#FFFFFF` (`--background-light: 255 255 255`) | none, byte-identical |
| Dark | `#09090b` | `#0C0D0F` (`--background-dark: 12 13 15`) | 3 points lighter per channel |

Measured on a local `mint dev` server, not assumed. The default dark is not primary-hue derived, so the page does not pick up an ice cast.

**Theme-switcher menu.** The custom `[role='menuitem'][data-theme-preference]` override forced the selected row's check and label to neutral black/white. Removed, so the menu renders the stock ice accent again: `#00A3C9` in light, `#B1DDEB` in dark. The unselected rows still hide their checks at alpha 0, verified.

The rule is replaced by a comment rather than nothing, because the mechanism is the part worth keeping. Anyone tempted to set `color` on those rows reveals a check on *every* row, since the unselected ones hide theirs with `text-primary/0`, the same utility at alpha zero.

## Known, accepted consequences

- **The two theme controls now disagree.** The navbar menu is ice; the footer's own theme switch stays neutral through the `#footer button[class*='bg-gray']` rules. That is the point of the change, not an oversight, and it is now written into the comment.
- **Light-mode contrast on the selected row is 2.97:1** (`#00A3C9` on the white popover), under AA for a 14px label. This is the identical figure already booked in this file as a deliberate exception for `.eyebrow`, so it is recorded rather than fixed.

## Comment corrections carried in this PR

Removing the custom background falsified one comment and orphaned two cross-references:

- `style.css` sidebar-header note claimed `5.44:1 dark (#85858E on #09090b)`. The ground moved, so it is now **5.32:1 on rgb(12,13,15)**. Still well over the 4.5:1 the paragraph argues for, so only the number was wrong.
- The footer-WCAG note cited the dark footer ground as `rgb(14,14,16)`. Measured: `#footer` has **no background of its own** (`rgba(0,0,0,0)`), so it composites on the page ground, which is `rgb(12,13,15)`. Corrected, with a line recording that both grounds are now Mintlify defaults and can move.
- Two comments cited the deleted theme-menu rule as a live exemplar (`tabs-list` and `copy-code-button`). Repointed at rules that still exist.
- The recovery recipe in the new comment now also names the `--color-*` aliases, which the deleted rule set and which every other variable-trick rule in the file sets.

## Test plan

Verified by two independent agents against a local `mint dev` server, in **both themes**.

**Regression sweep** — every sampled custom rule still matches and still produces its intended value: update-tag separators (44 tags, 16 separators), footer logo crop (44 x 94.59, cover), sidebar group headers (11px, uppercase, 0.2em), `.eyebrow`, sidebar active pill (neutral, not ice), TOC active entry (neutral, not ice), assistant composer vars (neutral both modes), changelog filter chips (both selected and unselected states toggled), card icons, version pills, tabs-list, copy-code button, body-link underlines.

**Contrast on the new ground:**

| Theme | Prose | Ground | Ratio | AA |
|---|---|---|---|---|
| Light | `rgb(62,67,68)` | `rgb(255,255,255)` | 10.04:1 | pass |
| Dark | `rgb(158,163,164)` | `rgb(12,13,15)` | 7.62:1 | pass (was 7.80:1) |

Every other tuned dark value moved by hundredths and none crossed a threshold: H1 15.36 to 15.01, footer links 7.75 to 7.71, credit and social icon 5.92 to 5.78, filter-chip text 13.46 to 13.15, sidebar header 5.44 to 5.32.

**Menu behaviour:** exactly one visible check, in the ice accent, in both themes. The "check on every row" failure mode did not occur.

**Static:** `docs.json` still valid JSON and schema-legal (`background` is optional; top-level `required` is theme/name/colors/navigation). `csstree-validator` clean. `git diff --check` clean. `docs/style.css` is pure ASCII, so no em or en dash.
