### PR TITLE
docs: put the theme menu's selected row back to neutral

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -327,28 +327,33 @@
   --color-primary-light: rgb(255 255 255);
 }
 
-/* The theme-switcher menu is deliberately NOT overridden here (user call,
-   2026-08-12). Its selected row keeps Mintlify's stock `text-primary
-   dark:text-primary-light`, so the check mark and label render in the ice
-   accent from docs.json colors rather than the neutral used by the other
-   selected states in this file.
+/* The theme-switcher menu's selected row, neutral like every other selected
+   state in this file: near-black on the light page, white on the dark one.
 
-   That makes it the one place where two controls doing the same job disagree:
-   the footer's own theme switch is still neutral, through the
-   #footer button[class*='bg-gray'] pair above. Ice in the navbar menu, neutral
-   in the footer, on purpose. In light mode the selected row resolves --primary
-   #00A3C9 on the white popover, which is 2.97:1, the same recorded
-   accessibility exception already booked for the eyebrow above.
+   Left stock for one release and reverted on sight (user call, 2026-08-12).
+   Mintlify paints the selected row `text-primary dark:text-primary-light`,
+   which the ice colors config turns #00A3C9 on the white popover, and that is
+   both louder than the row deserves and 2.97:1, under AA for a 14px label. The
+   footer's own theme switch was neutral throughout, so leaving this one ice
+   also had two controls doing the same job disagreeing on screen. Do not take
+   it stock again without deciding both of those on purpose.
 
-   If that is ever revisited, do NOT set `color` on the row: the unselected
-   rows hide their check marks with text-primary/0, the SAME utility at alpha
-   zero, so a colour override reveals a check on every row (tried, shipped for
-   a minute, looked broken). Redefine --primary / --primary-light, plus their
-   --color-* aliases as everywhere else in this file, on
-   [role='menuitem'][data-theme-preference] instead, which preserves the alpha.
-   The role guard matters too: the html root also carries data-theme-preference
-   to store the setting, so the bare attribute selector would restyle the whole
+   Variables, not `color`. The unselected rows hide their check marks with
+   text-primary/0, the SAME utility at alpha zero, so setting `color` reveals a
+   check on every row (tried, shipped for a minute, looked broken). Redefining
+   the variables preserves the alpha, and each mode's utility reads its own
+   variable, so no .dark split is needed. The --color-* aliases cover the
+   Tailwind v4 form, as everywhere else in this file.
+
+   The role guard matters: the html root also carries data-theme-preference to
+   store the setting, so the bare attribute selector would restyle the whole
    document. */
+[role='menuitem'][data-theme-preference] {
+  --primary: 17 17 17;
+  --primary-light: 255 255 255;
+  --color-primary: rgb(17 17 17);
+  --color-primary-light: rgb(255 255 255);
+}
 
 /* Navbar links hover neutral, like floe.one's navbar (zinc at rest, plain
    black or white on hover), instead of the hover:text-primary ice Mintlify


### PR DESCRIPTION
﻿## Summary

#286 left the theme-switcher menu's selected row stock for one release. Reverting that half; the background half of #286 is untouched.

Mintlify paints the row `text-primary dark:text-primary-light`, which the ice `colors` config turns `#00A3C9` on the white popover. Two problems with that in practice:

- **Contrast.** `#00A3C9` on white is **2.97:1**, under AA for a 14px label. Neutral is ~17:1 in light and 13.3:1 in dark.
- **Consistency.** The footer's own theme switch stayed neutral throughout (`#footer button[class*='bg-gray']`), so leaving this one ice put two controls doing the same job in visible disagreement.

The restored rule brings it back in line with every other selected state in the file: near-black on the light page, white on the dark one.

## Why variables and not `color`

This is the part worth keeping, and the comment now spells it out. The unselected rows hide their check marks with `text-primary/0` - the **same utility at alpha zero**. Setting `color` on the row therefore reveals a check on *every* row, which was tried once and shipped broken for a minute. Redefining `--primary` / `--primary-light` (plus the `--color-*` aliases, as everywhere else in this file) preserves that alpha, and each mode's utility reads its own variable so no `.dark` split is needed.

The `[role='menuitem']` guard is also load-bearing: the `html` root carries `data-theme-preference` to store the setting, so the bare attribute selector would restyle the whole document.

## Test plan

Verified on a local `mint dev` server, measured in **both themes** with the menu open:

| Theme | Selected row check | Unselected rows | Visible checks |
|---|---|---|---|
| Dark | `rgb(255, 255, 255)` | `oklab(0 0 0 / 0)` | **1** |
| Light | `rgb(17, 17, 17)` | `oklab(0 0 0 / 0)` | **1** |

The alpha-zero failure mode did not trigger in either theme.

Static: `csstree-validator` clean, `git diff --check` clean, file is pure ASCII (no em or en dash), `docs.json` not touched.
