### PR TITLE
docs(client): point the download page at desktop-v0.2.3

### DIFF
--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -217,10 +217,12 @@ is reserved, so `pack.ps1` derives it mechanically as (major+1).minor.patch.0
 (0.2.0 -> 1.2.0.0, 1.0.0 -> 2.0.0.0). The product's own 0.x string stays in
 wails.json, the exe version resource, and all marketing. At tag time, bump
 wails.json's `productVersion` and the concrete version examples in
-docs/desktop/installation.mdx and docs/desktop/settings.mdx alongside
-`DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE` in client/lib/desktopRelease.ts; the release workflow
+docs/desktop/installation.mdx and docs/desktop/settings.mdx; the release workflow
 rewrites wails.json only in the runner's working tree, so the committed value
-goes stale otherwise.
+goes stale otherwise. Bump `DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE` in
+client/lib/desktopRelease.ts in a follow-up only AFTER the release assets are
+published: /download derives its links from them, and bumping early points the
+page at assets that do not exist yet (0.2.2 and 0.2.3 both shipped this way).
 
 Packaged-build behavior (verified empirically 2026-08-02 on a loose-layout
 package of this app): the app's HKCU registry writes are virtualized into the

--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.2';
-export const DESKTOP_RELEASE_DATE = 'Aug 8, 2026';
+export const DESKTOP_VERSION = '0.2.3';
+export const DESKTOP_RELEASE_DATE = 'Aug 13, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
## Summary

Post-release pin bump: DESKTOP_VERSION 0.2.3 + DESKTOP_RELEASE_DATE Aug 13, 2026 in client/lib/desktopRelease.ts, now that the desktop-v0.2.3 release and all three assets are published and hash-verified. Also rewords the DESKTOP.md versioning note to record the two-step (tag-time bumps vs post-publish pin) the last two releases actually practiced.

## Test plan

- [x] Release assets exist and hashes verified against SHA256SUMS.txt before this bump, so /download flips to working 0.2.3 links the moment this deploys.
- [x] desktopRelease.test.ts constraints hold: strict X.Y.Z, derived tag/URLs, non-future date.