### PR TITLE
feat(desktop): redraw the update notice and true up the panel copy

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -215,37 +215,41 @@ function StatusLine({text, busy, live}: {text: string; busy: boolean; live?: boo
 function UpdateNotice({version, onDismiss}: {version: string; onDismiss: () => void}) {
     return (
         <div
+            role="group"
             aria-label="Update available"
             onKeyDown={(e) => { if (e.key === 'Escape') { e.stopPropagation(); onDismiss(); } }}
             className={cn(
-                'fixed right-4 top-[52px] z-30 flex w-[340px] items-start gap-3 rounded-xl border border-white/10',
-                'bg-zinc-900/90 p-4 shadow-2xl ring-1 ring-white/5 backdrop-blur-xl',
-                'animate-floe-in motion-reduce:animate-none',
+                'floe-notice-edge fixed right-4 top-[52px] z-30 isolate flex h-12 items-center gap-3 rounded-xl pl-4 pr-1.5',
+                'bg-zinc-900/80 ring-1 ring-inset ring-white/10 backdrop-blur-xl backdrop-saturate-150',
+                'shadow-[0_1px_1px_rgba(0,0,0,0.06),0_4px_8px_-4px_rgba(0,0,0,0.28),0_16px_32px_-12px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.07)]',
+                'animate-floe-notice-in motion-reduce:animate-none',
             )}
         >
-            <span className="grid size-9 shrink-0 place-items-center rounded-lg border border-white/10 bg-white/[0.04]" aria-hidden>
-                <Download className="size-4 text-ice"/>
-            </span>
-            <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                    <h2 className="text-sm font-semibold leading-5 text-white">Update available</h2>
-                    <button
-                        aria-label="Dismiss update notice"
-                        onClick={onDismiss}
-                        className="-m-1 grid size-7 shrink-0 place-items-center rounded-md text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-100 focus-visible:outline-2 focus-visible:outline-ice"
-                    >
-                        <X className="size-4"/>
-                    </button>
-                </div>
-                {/* Non-breaking space: a two-line body must not orphan "page." */}
-                <p className="mt-0.5 text-xs leading-4 text-zinc-400">
-                    Floe <span className="font-mono text-zinc-300">{bareVersion(version)}</span> is out on the download{'\u00a0'}page.
-                </p>
-                <div className="mt-3 flex justify-end">
-                    <Button className="h-8 text-xs" onClick={() => { BrowserOpenURL(DOWNLOAD_URL); onDismiss(); }}>
-                        Get update
-                    </Button>
-                </div>
+            {/* strokeWidth 3 on a 16px lucide renders a whole 2.0 device px, so
+                the glyph is true white and crisp; the default 2 draws 1.33px
+                straddling pixel boundaries, which antialiases to fuzzy grey. */}
+            <Download className="size-4 shrink-0 text-white" strokeWidth={3} aria-hidden/>
+            <div className="flex min-w-0 items-center gap-2">
+                <h2 className="whitespace-nowrap text-[13px] font-semibold leading-none tracking-[-0.01em] text-zinc-50">Update available</h2>
+                {/* top-px: an 11px mono centered against 13px text lands a hair
+                    high; this drops the digits onto the title's baseline. */}
+                <span className="relative top-px whitespace-nowrap font-mono text-[11px] leading-none text-zinc-400">{bareVersion(version)}</span>
+            </div>
+            <div className="flex shrink-0 items-center gap-1.5">
+                <Button className="h-7 px-2.5 text-xs" onClick={() => { BrowserOpenURL(DOWNLOAD_URL); onDismiss(); }}>
+                    Get update
+                </Button>
+                {/* ml-[5px] centers the divider optically: the X's ink sits
+                    ~10px inside its hit box while the button's edge is flush,
+                    so equal flex gaps read lopsided. */}
+                <span className="ml-[5px] h-5 w-px bg-white/[0.14]" aria-hidden/>
+                <button
+                    aria-label="Dismiss update notice"
+                    onClick={onDismiss}
+                    className="grid size-7 shrink-0 place-items-center rounded-md text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-100 focus-visible:outline-2 focus-visible:outline-ice"
+                >
+                    <X className="size-3.5"/>
+                </button>
             </div>
         </div>
     );

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -237,7 +237,10 @@ function UpdateNotice({version, onDismiss}: {version: string; onDismiss: () => v
                 <span className="whitespace-nowrap rounded bg-white/[0.07] px-1.5 py-1 font-mono text-[11px] leading-none text-zinc-300">{bareVersion(version)}</span>
             </div>
             <div className="flex shrink-0 items-center gap-1.5">
-                <Button className="h-7 px-2.5 text-xs" onClick={() => { BrowserOpenURL(DOWNLOAD_URL); onDismiss(); }}>
+                {/* No px override: cn is a plain join, so the base px-3 wins
+                    over any px-* here anyway (equal specificity, later in the
+                    sheet). h-7 and text-xs do apply. */}
+                <Button className="h-7 text-xs" onClick={() => { BrowserOpenURL(DOWNLOAD_URL); onDismiss(); }}>
                     Get update
                 </Button>
                 {/* ml-[5px] centers the divider optically: the X's ink sits

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -231,9 +231,10 @@ function UpdateNotice({version, onDismiss}: {version: string; onDismiss: () => v
             <Download className="size-4 shrink-0 text-white" strokeWidth={3} aria-hidden/>
             <div className="flex min-w-0 items-center gap-2">
                 <h2 className="whitespace-nowrap text-[13px] font-semibold leading-none tracking-[-0.01em] text-zinc-50">Update available</h2>
-                {/* top-px: an 11px mono centered against 13px text lands a hair
-                    high; this drops the digits onto the title's baseline. */}
-                <span className="relative top-px whitespace-nowrap font-mono text-[11px] leading-none text-zinc-400">{bareVersion(version)}</span>
+                {/* A chip, not bare text, by the owner's choice: the boxed
+                    version reads as a badge. Center-aligned like any badge, so
+                    no baseline nudge. */}
+                <span className="whitespace-nowrap rounded bg-white/[0.07] px-1.5 py-1 font-mono text-[11px] leading-none text-zinc-300">{bareVersion(version)}</span>
             </div>
             <div className="flex shrink-0 items-center gap-1.5">
                 <Button className="h-7 px-2.5 text-xs" onClick={() => { BrowserOpenURL(DOWNLOAD_URL); onDismiss(); }}>

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1958,7 +1958,11 @@ function App() {
                             Send anything,<br/>peer to peer.
                         </h1>
                         <p className="mt-3.5 text-sm leading-relaxed text-zinc-400">
-                            End-to-end encrypted. No accounts,<br/>no storage, no middleman.
+                            {/* "no uploads", not "no middleman": a relayed
+                                transfer does pass through a TURN relay (bullet
+                                01 admits as much), while nothing is uploaded
+                                on any path. Matches docs/introduction.mdx. */}
+                            End-to-end encrypted. No accounts,<br/>no storage, no uploads.
                         </p>
 
                         <div className="mt-10 space-y-6">

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -236,17 +236,18 @@ function UpdateNotice({version, onDismiss}: {version: string; onDismiss: () => v
                     no baseline nudge. */}
                 <span className="whitespace-nowrap rounded bg-white/[0.07] px-1.5 py-1 font-mono text-[11px] leading-none text-zinc-300">{bareVersion(version)}</span>
             </div>
-            <div className="flex shrink-0 items-center gap-1.5">
+            <div className="flex shrink-0 items-center">
                 {/* No px override: cn is a plain join, so the base px-3 wins
                     over any px-* here anyway (equal specificity, later in the
                     sheet). h-7 and text-xs do apply. */}
                 <Button className="h-7 text-xs" onClick={() => { BrowserOpenURL(DOWNLOAD_URL); onDismiss(); }}>
                     Get update
                 </Button>
-                {/* ml-[5px] centers the divider optically: the X's ink sits
-                    ~10px inside its hit box while the button's edge is flush,
-                    so equal flex gaps read lopsided. */}
-                <span className="ml-[5px] h-5 w-px bg-white/[0.14]" aria-hidden/>
+                {/* Ink-symmetric margins, not flex gaps: the button's edge is
+                    flush while the X's ink sits ~10px inside its hit box, so
+                    14px of margin on the button side and 4px on the X side
+                    give the divider equal ~14px optical gaps to both. */}
+                <span className="ml-3.5 mr-1 h-5 w-px bg-white/[0.14]" aria-hidden/>
                 <button
                     aria-label="Dismiss update notice"
                     onClick={onDismiss}

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -61,6 +61,46 @@
     animation: floe-in 0.2s ease-out both;
   }
 
+  /* The update notice's entrance: drops in from the edge it lives on and
+     settles fast (fast arrival, gentle landing), unlike the generic floe-in
+     rise. Entrance only - dismissal also unmounts via the busy/dialog paths,
+     which cannot animate a conditional render. */
+  @keyframes floe-notice-in {
+    from {
+      opacity: 0;
+      transform: translate3d(0, -10px, 0) scale(0.97);
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+  }
+
+  .animate-floe-notice-in {
+    animation: floe-notice-in 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  /* The notice's one accent: a 1px ice strip along the top edge only, fading
+     out left to right. A full-perimeter gradient rim was tried first and read
+     as a bright bracket wrapping the whole left side, the only saturated
+     pixels in the app. Inset past the corner radius so the strip never
+     overhangs the curve. No position on the class itself: the notice is
+     already position:fixed, and a same-layer `position: relative` here would
+     override Tailwind's `fixed` utility and drop the card into document flow. */
+  .floe-notice-edge::before {
+    content: "";
+    position: absolute;
+    inset: 0 12px auto 12px;
+    height: 1px;
+    border-radius: 9999px;
+    background: linear-gradient(
+      90deg,
+      color-mix(in oklab, var(--color-ice) 35%, transparent),
+      transparent 55%
+    );
+    pointer-events: none;
+  }
+
   /* Wails adds this class to the element carrying `--wails-drop-target: drop`
      while an OS file drag hovers it (WebView2 does not emit HTML drag events). */
   .wails-drop-target-active {

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -95,9 +95,9 @@
     padding: 1px;
     background: linear-gradient(
       155deg,
-      color-mix(in oklab, var(--color-ice) 50%, transparent) 0%,
-      rgb(255 255 255 / 0.12) 40%,
-      transparent 75%
+      color-mix(in oklab, var(--color-ice) 32%, transparent) 0%,
+      rgb(255 255 255 / 0.09) 38%,
+      transparent 62%
     );
     -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
     mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -80,24 +80,29 @@
     animation: floe-notice-in 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
   }
 
-  /* The notice's one accent: a 1px ice strip along the top edge only, fading
-     out left to right. A full-perimeter gradient rim was tried first and read
-     as a bright bracket wrapping the whole left side, the only saturated
-     pixels in the app. Inset past the corner radius so the strip never
-     overhangs the curve. No position on the class itself: the notice is
+  /* The notice's one accent: a 1px ice rim in the bar's border, catching
+     light at the top left and dissolving toward the bottom right, drawn with
+     the double-mask trick so it stays transparent-safe under backdrop-blur.
+     A top-edge-only strip was tried and rejected: the wrapped rim is the
+     look the owner chose. No position on the class itself: the notice is
      already position:fixed, and a same-layer `position: relative` here would
      override Tailwind's `fixed` utility and drop the card into document flow. */
   .floe-notice-edge::before {
     content: "";
     position: absolute;
-    inset: 0 12px auto 12px;
-    height: 1px;
-    border-radius: 9999px;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
     background: linear-gradient(
-      90deg,
-      color-mix(in oklab, var(--color-ice) 35%, transparent),
-      transparent 55%
+      155deg,
+      color-mix(in oklab, var(--color-ice) 50%, transparent) 0%,
+      rgb(255 255 255 / 0.12) 40%,
+      transparent 75%
     );
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
     pointer-events: none;
   }
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -46,6 +46,7 @@ Each entry lists the parts it changed. Filter on the right to see only the ones 
   - `floe receive` no longer leaves a half-written file behind under its final name when a transfer fails or stalls. The partial is deleted, files that completed earlier in the batch are kept, and a retried transfer gets its original name back instead of a numbered one.
   - The protocol-incompatibility message the CLI sends across the wire is now worded from the reader's perspective, so older versions that display it word-for-word name the correct side. No release can trigger this today (every peer speaks the same protocol).
   - Desktop: the update notice is redrawn as a slim one-row frosted bar with a whisper of ice in its border. What it does is unchanged.
+  - Desktop: the main screen's subline now promises "no uploads" instead of "no middleman". A relayed transfer does pass through a relay, so the old word claimed too much; nothing is uploaded on any path.
   - No transfer-protocol change.
 </Update>
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -40,11 +40,12 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
-<Update label="Unreleased" tags={["CLI"]}>
+<Update label="Unreleased" tags={["CLI", "Desktop"]}>
   **Failed or stalled receives clean up their partial file**
 
   - `floe receive` no longer leaves a half-written file behind under its final name when a transfer fails or stalls. The partial is deleted, files that completed earlier in the batch are kept, and a retried transfer gets its original name back instead of a numbered one.
   - The protocol-incompatibility message the CLI sends across the wire is now worded from the reader's perspective, so older versions that display it word-for-word name the correct side. No release can trigger this today (every peer speaks the same protocol).
+  - Desktop: the update notice is redrawn as a slim one-row frosted bar with a hairline of ice along its top edge. What it does is unchanged.
   - No transfer-protocol change.
 </Update>
 

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -45,7 +45,7 @@ Each entry lists the parts it changed. Filter on the right to see only the ones 
 
   - `floe receive` no longer leaves a half-written file behind under its final name when a transfer fails or stalls. The partial is deleted, files that completed earlier in the batch are kept, and a retried transfer gets its original name back instead of a numbered one.
   - The protocol-incompatibility message the CLI sends across the wire is now worded from the reader's perspective, so older versions that display it word-for-word name the correct side. No release can trigger this today (every peer speaks the same protocol).
-  - Desktop: the update notice is redrawn as a slim one-row frosted bar with a hairline of ice along its top edge. What it does is unchanged.
+  - Desktop: the update notice is redrawn as a slim one-row frosted bar with a whisper of ice in its border. What it does is unchanged.
   - No transfer-protocol change.
 </Update>
 


### PR DESCRIPTION
## Summary  - Redraws the desktop update notice from a two-line toast card into a single 48px glass bar at the top right: white Download glyph, **Update available**, the version in a mono chip, the primary **Get update** button, a hairline divider, and the dismiss X. - The bar is quieter glass (`zinc-900/80` + backdrop blur and saturation, inset hairline ring, layered shadow with an inset top sheen) and carries exactly one accent: a 1px ice gradient rim in the border, brightest at the top left and dissolving toward the bottom right, drawn by a masked pseudo-element so it composes with the backdrop blur. - Pixel-level polish from an adversarial design review: the Download glyph draws at `strokeWidth 3` so its strokes land on whole device pixels and render true white instead of antialiased grey, and the divider sits at the optical midpoint between the button edge and the X's ink. - A notice-specific entrance (10px drop, fast-settling `cubic-bezier(0.16, 1, 0.3, 1)`, 320ms) replaces the generic `floe-in` rise, still `motion-reduce`-guarded. No idle animation. - The root gains `role="group"` so the existing `aria-label` stops being inert on a bare div. - Changelog: two Desktop-prefixed bullets in the Unreleased entry, whose tags gain `Desktop`.
- Panel accuracy fix from a four-agent claims audit: the main screen's subline now promises "no uploads" instead of "no middleman" (a relayed transfer does pass through a TURN relay; nothing is uploaded on any path). Every other panel claim verified accurate against the engine, server, and docs.  Everything contractual is untouched: the "Update available" / "Get update" strings, `aria-label="Dismiss update notice"`, `DOWNLOAD_URL`, `z-30` under tooltips and dialogs, local Escape handling with `stopPropagation`, no focus steal on appear, the sr-only announcer, and the Settings About row.  ## Test plan  - `npm test` in `desktop/frontend`: 50/50 green (the suites are pure logic and untouched). - Built a synthetic `desktop-v0.2.2` exe and ran it against the live release list: the bar renders at the top right below the titlebar; X dismisses and the notice returns on relaunch; screen captures were sampled at the pixel level to confirm the glyph's true-white core (255/255/255), the ice tint confined to the top edge, and a neutral left edge. - Caught and fixed in review: the accent utility originally declared `position: relative`, which out-cascaded Tailwind's `fixed` (same layer, later declaration) and dropped the card into document flow. 