### PR TITLE
docs: neutralize the Add to assistant selection bubble

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -450,6 +450,14 @@ html:not(.dark) #content-area a.link {
    already neutral; they are listed anyway so anything Mintlify adds inside
    them later inherits the override instead of arriving ice.
 
+   `#text-selection-tooltip` is the Add to assistant bubble that appears when
+   you select text in the page, and its sparkle is `text-primary
+   dark:text-primary-light` like the sheet's. It was missed on the first pass
+   because it does not exist in the resting DOM: Mintlify portals it straight
+   to `body` on selection, so it is outside every other root listed here and a
+   sweep of an untouched page never sees it. Reproduce it by drag-selecting a
+   paragraph, not by querying the page as loaded.
+
    That list was taken on an IDLE sheet, and it is not the whole set. Three
    more primary consumers only mount once a conversation has content: the
    Retry button, the starter-question buttons, and the feedback chip. Hence
@@ -491,6 +499,7 @@ html:not(.dark) #content-area a.link {
 #assistant-entry,
 #assistant-entry-mobile,
 #ask-assistant-code-block-button,
+#text-selection-tooltip,
 .chat-assistant-floating-input,
 #chat-assistant-sheet {
   --primary: 17 17 17;
@@ -504,6 +513,7 @@ html:not(.dark) #content-area a.link {
 .dark #assistant-entry,
 .dark #assistant-entry-mobile,
 .dark #ask-assistant-code-block-button,
+.dark #text-selection-tooltip,
 .dark .chat-assistant-floating-input,
 .dark #chat-assistant-sheet {
   --primary: 255 255 255;


### PR DESCRIPTION
﻿## Summary

#278 neutralized the AI Assistant, but this surface slipped through, and the reason is worth recording: **the bubble does not exist in the resting DOM.**

Mintlify portals `div#text-selection-tooltip` straight to `body` the moment you select text in a page. It is therefore outside all five roots #278 scoped, and the sweep that produced that list was run against an untouched page, so it was never visible to it. Its sparkle carries `text-primary dark:text-primary-light`, the same shape as the sheet header glyph, so it kept rendering ice while everything around it went neutral.

Measured on production before the fix, dark mode:

```
button#text-selection-tooltip-button  ->  div#text-selection-tooltip  ->  body
svg.size-3.5.text-primary.dark:text-primary-light  ->  rgb(177, 221, 235)   // ice
```

Adding the root to the existing pair of rules is the whole fix. The values are already correct for it: near-black on the light page, white on the dark one, every primary variable resolving to its own mode's foreground so the unprefixed hover variants cannot paint white on white.

## Why there is no local verification

The hosted assistant does not run under `mint dev`. Confirmed on the local server with this branch applied:

| Surface | Local |
|---|---|
| `#assistant-entry` | absent |
| `#chat-assistant-sheet` | absent |
| `#text-selection-tooltip` | absent (drag-select yields a selection, no bubble) |
| `.chat-assistant-floating-input` | present |
| the new selector, loaded in the page's CSS | **yes** |

So the rule parses and applies locally, but the element it targets only exists in production. Colours verified there after deploy, exactly as #278 was.

Reproducing this by hand: drag-select a paragraph. Querying the page as loaded will not find it.

## Test plan

- `csstree-validator` clean, `git diff --check` clean, file pure ASCII (no em or en dash).
- Additive only: two selector lines and a comment. No existing rule or value changed, so nothing else in the stylesheet can regress.
- Post-merge verification on production, both themes: the sparkle must read near-black in light and white in dark, and the rest of the bubble (already neutral via `text-gray-900 dark:text-white`) must be unchanged.
