### PR TITLE
docs(client): point the download page at desktop-v0.2.4

### DIFF
--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.3';
-export const DESKTOP_RELEASE_DATE = 'Aug 13, 2026';
+export const DESKTOP_VERSION = '0.2.4';
+export const DESKTOP_RELEASE_DATE = 'Aug 14, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
The desktop-v0.2.4 GitHub release is published with checksum-verified assets, and the Store submission is in certification. This moves the /download pin per the bump-after-assets rule in DESKTOP.md. Test plan: the desktopRelease vitest suite passes (7 tests, including the no-future-date guard and exact asset URL derivations); CI runs the full suite.