### PR TITLE
docs: true up the update example and navbar bullet to reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ go build ./cmd/floe    # local binary
 go test ./...          # run all tests
 ```
 
-The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version=v..."`.
+The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version={{ .Version }}"`, which carries NO leading `v` (a v1.10.1 tag produces a binary that prints `floe 1.10.1`). The desktop app differs: desktop-release.yml injects the tag verbatim (`desktop-v0.2.4`).
 
 ### Desktop (Wails)
 ```bash

--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -30,7 +30,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Build-time version — set by goreleaser: -ldflags "-X main.version=v1.0.0"
+// Build-time version — set by goreleaser: -ldflags "-X main.version=1.0.0"
+// (GoReleaser's {{ .Version }} strips the tag's leading v.)
 var version = "dev"
 
 // Shared flags

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -53,7 +53,7 @@ Each entry lists the parts it changed. Filter on the right to see only the ones 
 
   - `floe receive` no longer leaves a half-written file behind under its final name when a transfer fails or stalls. The partial is deleted, files that completed earlier in the batch are kept, and a retried transfer gets its original name back instead of a numbered one.
   - The protocol-incompatibility message the CLI sends across the wire is now worded from the reader's perspective, so older versions that display it word-for-word name the correct side. No release can trigger this today (every peer speaks the same protocol).
-  - Web app: the navbar now adapts to window width in three steps instead of two, and the Download link is visible at every size; it previously appeared only on wider windows, so a phone had no way to reach the desktop app's download page.
+  - Web app: the navbar now adapts to window width in three steps instead of two, and the Download link is visible at every size; it previously appeared only on wider windows, so the header offered no way to reach the desktop app's download page on a phone.
   - Web app: floe.one and the docs now share the same four-column footer (Product, Documentation, Project, Legal), and it appears on every page of the site rather than only the homepage and the download page.
   - Web app: fixed the docs pages showing outdated content that a reload could not refresh; an offline cache was keeping old copies forever, and they now clear automatically on your next visit.
   - Self-hosting: the published images carry every web-app change above plus updated dependencies (Next.js 16.3.0 and `ws` 8.21.2). To pick them up: `docker compose pull` then `docker compose up -d`; if you pinned `FLOE_IMAGE_TAG=1.10.0`, move to `1.10.1`.

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -63,7 +63,7 @@ Specific to the `update` command.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (v1.10.1)` and stops either way. On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
+| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (1.10.1)` and stops either way (the installed version carries no leading `v`). On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
 
 ## Opting out of the global counter
 


### PR DESCRIPTION
An adversarial docs audit ran the released v1.10.1 binary and caught two inaccuracies. First: floe update prints Already up to date (1.10.1) with no leading v (GoReleaser {{ .Version }} strips the tag prefix); the flags.mdx example, the main.go build-version comment, and CLAUDE.md all described a v-prefixed version, an error inherited from before v1.10.0. All three now match the real binary output. Second: the v1.10.1 changelog bullet overclaimed that a phone had no way to reach the download page before the navbar rework; the homepage desktop CTA, FAQ link, and footer were always phone-visible routes, so the bullet now says the header offered no way, which is what the code comment always said. Body-only accuracy edit on the shipped entry; label and anchor untouched. Test plan: comment-and-docs-only diff (one Go comment, no code change; go build passes); full CI runs since cli/ and CLAUDE.md are touched.