### PR TITLE
feat(desktop): calm dropzone borders and one-control history rows

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -49,6 +49,7 @@ import {
 import QRCode from 'react-qr-code';
 import {BoltMark, Button, Eyebrow, Input, StatusDot, cn} from './components/ui';
 import {advancedSummary, hostOf} from './settings';
+import {histKey} from './history';
 import {resetWarning} from './reset';
 import {friendlyError} from './errors';
 import {fmtBytes, formatIncoming, type IncomingPreview} from './incoming';
@@ -417,7 +418,7 @@ function Dropzone({expanded, onPickFiles, onPickFolder}: {
 }) {
     if (!expanded) {
         return (
-            <div style={dropVar} className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-white/15 bg-white/[0.02] py-1.5 pl-3 pr-1.5 transition-colors hover:border-ice/40">
+            <div style={dropVar} className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-white/40 bg-white/[0.02] py-1.5 pl-3 pr-1.5 transition-colors hover:border-white/70">
                 <span className="flex min-w-0 items-baseline gap-2.5">
                     <span className="text-sm font-medium text-zinc-200">Add files</span>
                     <span className="truncate font-mono text-[10px] uppercase tracking-[0.15em] text-zinc-600">or drop anywhere</span>
@@ -434,9 +435,9 @@ function Dropzone({expanded, onPickFiles, onPickFolder}: {
         );
     }
     return (
-        <div style={dropVar} className="group rounded-xl border border-dashed border-white/15 bg-white/[0.02] p-5 text-center transition-colors hover:border-ice/40 hover:bg-white/[0.03]">
-            <span className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.03] transition group-hover:border-ice/30">
-                <UploadCloud className="h-5 w-5 text-zinc-400 transition group-hover:text-ice"/>
+        <div style={dropVar} className="group rounded-xl border border-dashed border-white/40 bg-white/[0.02] p-5 text-center transition-colors hover:border-white/70 hover:bg-white/[0.03]">
+            <span className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/[0.03] transition group-hover:border-white/25">
+                <UploadCloud className="h-5 w-5 text-white/70 transition group-hover:text-white"/>
             </span>
             <p className="text-sm font-medium text-zinc-200">Select files to send</p>
             <p className="mt-1 font-mono text-[11px] text-zinc-500">or drag them onto the window</p>
@@ -725,7 +726,7 @@ function App() {
     const [history, setHistory] = useState<HistEntry[]>(loadHistory);
     // Whether the destructive Clear action is awaiting its inline confirm.
     const [confirmClear, setConfirmClear] = useState(false);
-    // Which history row (keyed `${at}-${i}`) has its file list expanded.
+    // Which history row (keyed by histKey, position-independent) is expanded.
     const [expandedRow, setExpandedRow] = useState<string | null>(null);
 
     // Selected ICE path of the in-flight transfer ('' until known). One transfer
@@ -2245,14 +2246,22 @@ function App() {
                                         ) : (
                                             <ul className="custom-scrollbar max-h-80 divide-y divide-white/[0.04] overflow-y-auto rounded-lg border border-white/[0.06] bg-white/[0.02]">
                                                 {history.map((h, i) => {
-                                                    const key = `${h.at}-${i}`;
+                                                    const key = histKey(h);
                                                     const multi = h.count > 1;
                                                     const expanded = expandedRow === key;
+                                                    const panelId = `floe-hist-panel-${i}`;
                                                     return (
-                                                        <li key={key} className="group px-3.5 py-2.5 transition-colors hover:bg-white/[0.03]">
-                                                            <div
-                                                                className={cn('flex items-center gap-3', multi && 'cursor-pointer')}
-                                                                onClick={multi ? () => setExpandedRow(expanded ? null : key) : undefined}
+                                                        <li key={key} className="transition-colors hover:bg-white/[0.03]">
+                                                            {/* The whole row is one disclosure button, the same idiom as the
+                                                                Advanced section. Every entry expands, single-file rows included,
+                                                                because collapsed titles truncate. Nothing else is clickable on
+                                                                the row; the actions live inside the panel as labeled text. */}
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => setExpandedRow(expanded ? null : key)}
+                                                                aria-expanded={expanded}
+                                                                aria-controls={expanded ? panelId : undefined}
+                                                                className="group flex w-full items-center gap-3 px-3.5 py-2.5 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ice/60"
                                                             >
                                                                 {h.kind === 'send'
                                                                     ? <ArrowUpRight className="size-4 shrink-0 text-zinc-500"/>
@@ -2267,39 +2276,52 @@ function App() {
                                                                         <span>{fmtWhen(h.at)}</span>
                                                                     </span>
                                                                 </span>
-                                                                {multi && (
-                                                                    <button
-                                                                        onClick={(e) => { e.stopPropagation(); setExpandedRow(expanded ? null : key); }}
-                                                                        aria-label={expanded ? 'Hide files' : 'Show files'}
-                                                                        aria-expanded={expanded}
-                                                                        className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-zinc-600 transition-colors hover:bg-white/10 hover:text-zinc-200"
-                                                                    >
-                                                                        <ChevronDown className={cn('size-3.5 transition-transform', expanded && 'rotate-180')}/>
-                                                                    </button>
-                                                                )}
-                                                                {h.kind === 'recv' && h.dir && (
-                                                                    <button
-                                                                        onClick={(e) => { e.stopPropagation(); (h.count === 1 ? RevealFile(h.dir!, h.names[0] || '') : OpenFolder(h.dir!)).catch(() => {}); }}
-                                                                        aria-label="Show in folder"
-                                                                        className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-zinc-500 opacity-0 transition-[color,background-color,opacity] hover:bg-white/10 hover:text-zinc-200 focus-visible:opacity-100 group-hover:opacity-100"
-                                                                    >
-                                                                        <FolderOpen className="size-3.5"/>
-                                                                    </button>
-                                                                )}
-                                                                <button
-                                                                    onClick={(e) => { e.stopPropagation(); setHistory((prev) => prev.filter((_, idx) => idx !== i)); }}
-                                                                    aria-label="Remove entry"
-                                                                    className="grid h-7 w-7 shrink-0 place-items-center rounded-md text-zinc-500 opacity-0 transition-[color,background-color,opacity] hover:bg-white/10 hover:text-zinc-200 focus-visible:opacity-100 group-hover:opacity-100"
-                                                                >
-                                                                    <X className="size-3.5"/>
-                                                                </button>
-                                                            </div>
+                                                                <ChevronDown className={cn('size-3.5 shrink-0 text-zinc-600 transition-[color,transform] duration-200 group-hover:text-zinc-400 motion-reduce:transition-none', expanded && 'rotate-180')}/>
+                                                            </button>
                                                             {expanded && (
-                                                                <ul className="custom-scrollbar mt-2 max-h-32 space-y-1 overflow-y-auto pl-7">
-                                                                    {h.names.map((n, j) => (
-                                                                        <li key={`${key}-${j}`} className="truncate text-xs text-zinc-500">{n}</li>
-                                                                    ))}
-                                                                </ul>
+                                                                <div id={panelId} className="animate-floe-in space-y-2 px-3.5 pb-2.5 motion-reduce:animate-none">
+                                                                    {multi ? (
+                                                                        <ul className="custom-scrollbar max-h-32 space-y-1 overflow-y-auto pl-7">
+                                                                            {h.names.map((n, j) => (
+                                                                                <li key={`${key}-${j}`} className="truncate text-xs text-zinc-500">{n}</li>
+                                                                            ))}
+                                                                        </ul>
+                                                                    ) : h.names[0] ? (
+                                                                        <p className="break-all pl-7 text-xs text-zinc-500">{h.names[0]}</p>
+                                                                    ) : null}
+                                                                    {h.kind === 'recv' && h.dir && (
+                                                                        <p className="truncate pl-7 font-mono text-xs text-zinc-500" title={h.dir}>{h.dir}</p>
+                                                                    )}
+                                                                    {/* Footer actions behind an inset hairline. The border-t is the
+                                                                        row dividers' white/[0.04] but stops at the px-3.5 content
+                                                                        edges, so it reads as this panel's footer, not the next row's
+                                                                        edge. Both actions group to the right rail, dialog-footer
+                                                                        style with the destructive action outermost: Show in folder,
+                                                                        then Remove. Remove's -mr-2 cancels its own px-2 so its label
+                                                                        right-aligns to the px-3.5 rail under the chevron (hover pill
+                                                                        mirroring into the gutter) - the same right-rail grammar as
+                                                                        the header Clear and Settings' Reset. gap-4 keeps the safe
+                                                                        action a deliberate reach away from the destructive one, and
+                                                                        DOM order keeps Show in folder before Remove for Tab. */}
+                                                                    <div className="flex items-center justify-end gap-4 border-t border-white/[0.04] pt-2">
+                                                                        {h.kind === 'recv' && h.dir && (
+                                                                            <button
+                                                                                type="button"
+                                                                                onClick={() => { (h.count === 1 ? RevealFile(h.dir!, h.names[0] || '') : OpenFolder(h.dir!)).catch(() => {}); }}
+                                                                                className="rounded-md px-2 py-1 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
+                                                                            >
+                                                                                Show in folder
+                                                                            </button>
+                                                                        )}
+                                                                        <button
+                                                                            type="button"
+                                                                            onClick={() => { setHistory((prev) => prev.filter((_, idx) => idx !== i)); setExpandedRow(null); }}
+                                                                            className="-mr-2 rounded-md px-2 py-1 text-xs text-zinc-400 transition-colors hover:bg-red-400/10 hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
+                                                                        >
+                                                                            Remove
+                                                                        </button>
+                                                                    </div>
+                                                                </div>
                                                             )}
                                                         </li>
                                                     );

--- a/desktop/frontend/src/history.test.ts
+++ b/desktop/frontend/src/history.test.ts
@@ -1,0 +1,22 @@
+import {describe, expect, it} from 'vitest';
+import {histKey} from './history';
+
+describe('histKey', () => {
+    // The whole point of the key: it must not encode list position, so a
+    // removal above an expanded row cannot change which row reads as open.
+    it('is position-independent and stable for the same entry', () => {
+        const h = {at: 1755200000000, names: ['a.txt', 'b.txt'], count: 2};
+        expect(histKey(h)).toBe(histKey({...h}));
+        expect(histKey(h)).toBe('1755200000000-a.txt-2');
+    });
+    it('separates same-timestamp entries by name and count', () => {
+        const at = 1755200000000;
+        expect(histKey({at, names: ['a.txt'], count: 1}))
+            .not.toBe(histKey({at, names: ['b.txt'], count: 1}));
+        expect(histKey({at, names: ['a.txt'], count: 1}))
+            .not.toBe(histKey({at, names: ['a.txt', 'c'], count: 2}));
+    });
+    it('tolerates entries with no names', () => {
+        expect(histKey({at: 5, names: [], count: 0})).toBe('5--0');
+    });
+});

--- a/desktop/frontend/src/history.ts
+++ b/desktop/frontend/src/history.ts
@@ -1,0 +1,13 @@
+// Pure helpers for the History view. They live outside App.tsx so they can be
+// tested without a DOM or the Wails runtime bindings, which do not exist
+// outside the WebView (the same arrangement as settings.ts).
+
+/** histKey identifies a history entry independently of its list position, so
+ *  removing an entry above an expanded row cannot shift which row is open.
+ *  `at` alone is near-unique (transfers are busy-gated, one at a time), but
+ *  localStorage['floe:history'] is loaded verbatim and user-editable, so the
+ *  first name and the count are folded in as free tiebreakers. Byte-identical
+ *  entries still collide; that is accepted for a 50-entry local list. */
+export function histKey(h: {at: number; names: string[]; count: number}): string {
+    return `${h.at}-${h.names[0] ?? ''}-${h.count}`;
+}


### PR DESCRIPTION
## Summary

Two visual/interaction refinements to the desktop app, both iterated live with pixel-level QA:

**Dropzone** - the dashed drop borders move from barely-there `white/15` to a soft `white/40`, brightening to `white/70` on hover; the upload icon follows (`white/70` resting, white on hover). The ice accent is now reserved for the OS drag-over highlight, which is unchanged.

**History rows** - replaces the ad-hoc per-row icon buttons (expand chevron that shifted position, folder button only on received rows, hover-revealed X) with one uniform idiom: the whole row is a single disclosure button with an always-visible chevron on the right rail of every row. The expanded panel shows the file names (full, untruncated for single files), the destination folder on received entries, and a hairline footer with quiet labeled actions - "Show in folder" and "Remove" (red-tinted hover) - grouped on the right rail, destructive action outermost, safe action first in tab order.

Under the hood: accordion state is now keyed by content (`histKey`, new tested pure module) instead of list index, so removing an entry can no longer shift which row reads as open, and the row is a real focusable button (`aria-expanded`/`aria-controls`) instead of an unfocusable clickable div.

## Test plan

- `desktop/frontend`: vitest 53/53 (3 new `histKey` tests), `tsc --noEmit` clean; `desktop`: `go test ./...` ok.
- Pixel-measured QA on a live build seeded with real history: chevron column zero-drift across all row types, action labels aligned to the content/rail columns (0px error), measured colors for every state including the red Remove hover, zero layout shift on hover, accordion + removal key-fix verified with a pixel-identical post-removal diff, keyboard Tab/Enter path with visible focus rings.
- Independent design-conformance review passed with no required follow-ups.
