### PR TITLE
feat(desktop): clear the staged selection in one click, with undo

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2235,21 +2235,37 @@ function App() {
                                             sending, where the slot belongs to Cancel. A receive running on
                                             the other tab does not take Clear away: the send stage is
                                             separate state, and clearing it is both harmless and undoable.
-                                            Send does narrow when
-                                            Clear arrives; on Files that lands with the list and the label
-                                            gaining its count, on Text it is the one visible shift, and it
-                                            marks the moment there is something to send either way.
-                                            Clear sits left of Send like the safe choice in this app's
-                                            dialogs (Cancel before Reset all settings, Keep going before
-                                            Start over), which also puts it first in the tab order. That is
-                                            the opposite of the history row, where Remove is outermost, and
-                                            deliberately so: that row has no primary action to defer to. */}
+                                            Send does narrow when Clear arrives; on Files that lands with
+                                            the list and the label gaining its count, on Text it is the one
+                                            visible shift, and it marks the moment there is something to
+                                            send either way.
+                                            Send leads and Clear sits on the right, which is where this app
+                                            puts every quiet or undoing control: the history header's Clear,
+                                            Settings' Reset, the update notice's dismiss, and Remove on a
+                                            history row. Reading order therefore reaches the thing you came
+                                            to do first, and DOM order matches it, so the tab order needs no
+                                            correction. */}
                                         {sending ? (
                                             <Button variant="outline" size="lg" className="w-full" onClick={cancel}>
                                                 <X/> Cancel
                                             </Button>
                                         ) : (
                                             <div className="flex gap-3">
+                                                {/* The gradient paints over the primary variant's flat white,
+                                                    because a background-image sits above a background-color.
+                                                    That is also why the hover moves the stops instead of the
+                                                    colour: the variant's own hover:bg-zinc-200 is underneath
+                                                    the gradient and would never be seen. */}
+                                                <Button
+                                                    size="lg"
+                                                    className="flex-1 bg-gradient-to-b from-white to-zinc-100 shadow-sm hover:from-zinc-100 hover:to-zinc-200"
+                                                    onClick={send}
+                                                    disabled={busy || !staged}
+                                                >
+                                                    <Send/> {sendKind === 'text'
+                                                        ? 'Send text'
+                                                        : `Send${files.length ? ` ${files.length} ${files.length === 1 ? 'item' : 'items'}` : ''}`}
+                                                </Button>
                                                 {/* The visible word stays "Clear" because its object is
                                                     right there in the Send label beside it; the accessible
                                                     name carries that object for anyone who cannot see the
@@ -2271,21 +2287,6 @@ function App() {
                                                         Clear
                                                     </Button>
                                                 )}
-                                                {/* The gradient paints over the primary variant's flat white,
-                                                    because a background-image sits above a background-color.
-                                                    That is also why the hover moves the stops instead of the
-                                                    colour: the variant's own hover:bg-zinc-200 is underneath
-                                                    the gradient and would never be seen. */}
-                                                <Button
-                                                    size="lg"
-                                                    className="flex-1 bg-gradient-to-b from-white to-zinc-100 shadow-sm hover:from-zinc-100 hover:to-zinc-200"
-                                                    onClick={send}
-                                                    disabled={busy || !staged}
-                                                >
-                                                    <Send/> {sendKind === 'text'
-                                                        ? 'Send text'
-                                                        : `Send${files.length ? ` ${files.length} ${files.length === 1 ? 'item' : 'items'}` : ''}`}
-                                                </Button>
                                             </div>
                                         )}
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -325,25 +325,26 @@ function UndoToast({label, action, onUndo, onHold, onArm, onFocus}: {
                 onMouseEnter={onHold}
                 onMouseLeave={onArm}
                 className={cn(
-                    'pointer-events-auto isolate flex h-12 items-center gap-3 rounded-full pl-4 pr-1.5',
-                    'bg-zinc-900/80 ring-1 ring-inset ring-white/10 backdrop-blur-xl backdrop-saturate-150',
-                    'shadow-[0_1px_1px_rgba(0,0,0,0.06),0_4px_8px_-4px_rgba(0,0,0,0.28),0_16px_32px_-12px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.07)]',
+                    // The card's own corner and material, one step more opaque so
+                    // a floating strip stays legible over whatever is behind it.
+                    'pointer-events-auto isolate flex items-center gap-3 rounded-xl border border-white/10 bg-zinc-900/85 p-2.5',
+                    'shadow-2xl ring-1 ring-white/5 backdrop-blur-xl backdrop-saturate-150',
                     'animate-floe-toast-in motion-reduce:animate-none',
                 )}
             >
-                {/* strokeWidth 3 for the same reason the notice's icon carries it:
-                    at 16px the default 2 draws 1.33 device px and antialiases to
-                    fuzzy grey. */}
-                <Undo2 className="size-4 shrink-0 text-zinc-400" strokeWidth={3} aria-hidden/>
-                <span className="whitespace-nowrap text-[13px] leading-none tracking-[-0.01em] text-zinc-200">{label}</span>
-                <span className="ml-1 h-5 w-px bg-white/[0.14]" aria-hidden/>
+                {/* The same icon tile the file rows use, which is what makes this
+                    read as part of the app rather than a browser notification. */}
+                <span className="grid size-8 shrink-0 place-items-center rounded-md bg-white/[0.04] ring-1 ring-inset ring-white/10">
+                    <Undo2 className="size-4 text-zinc-300" strokeWidth={2.5} aria-hidden/>
+                </span>
+                <span className="whitespace-nowrap pr-1 text-[13px] leading-none tracking-[-0.005em] text-zinc-200">{label}</span>
                 <button
                     id="floe-undo-clear"
                     aria-label={action}
                     onClick={onUndo}
                     onFocus={onFocus}
                     onBlur={onArm}
-                    className="h-9 shrink-0 rounded-full px-3.5 text-[13px] font-semibold leading-none text-zinc-50 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ice/60"
+                    className="h-8 shrink-0 rounded-md border border-white/10 bg-white/[0.06] px-3 text-[13px] font-medium leading-none text-zinc-100 transition-colors hover:border-white/20 hover:bg-white/[0.12] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
                 >
                     Undo
                 </button>

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -51,7 +51,7 @@ import QRCode from 'react-qr-code';
 import {BoltMark, Button, Eyebrow, Input, StatusDot, cn} from './components/ui';
 import {advancedSummary, hostOf} from './settings';
 import {histKey} from './history';
-import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, isExpired, stagedSnapshot, undoLabel, type Cleared} from './clear';
+import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, stagedSnapshot, undoLabel, type Cleared} from './clear';
 import {resetWarning} from './reset';
 import {friendlyError} from './errors';
 import {fmtBytes, formatIncoming, type IncomingPreview} from './incoming';
@@ -753,15 +753,19 @@ function App() {
     const [sentText, setSentText] = useState('');
     const [peerConnected, setPeerConnected] = useState(false);
     const [filesOpen, setFilesOpen] = useState(false);
-    // What Clear last took away, and the timer that retires the offer to put it
-    // back. The snapshot is state because the offer renders from it; the timer
-    // id is a ref because nothing renders from it and because the
+    // What Clear last took away, and whether its bar is still on screen. These
+    // are two lifetimes, not one, and keeping them apart is the whole point:
+    // the BAR is a passing message and goes on a timer, while the OFFER behind
+    // it stands until something retires it. So the clock decides how long the
+    // message is visible, never whether the undo is still available, and Ctrl+Z
+    // reaches it either way. A timed control whose only route expires with it
+    // would be a WCAG 2.2.1 failure, and it would also make the Start over
+    // prompt about a cleared note stop being true while the user was reading it.
+    // The timer id is a ref because nothing renders from it and because the
     // once-registered handlers have to be able to cancel it.
     const [cleared, setCleared] = useState<Cleared | null>(null);
+    const [offerUp, setOfferUp] = useState(false);
     const clearedTimer = useRef<number | null>(null);
-    // When the standing offer runs out. Checked again on the click, because a
-    // background window can have its timers clamped; Infinity while held.
-    const clearedUntil = useRef(0);
     const sendStart = useRef<Marker>(null);
     const sendCancel = useRef(false);
     // Snapshot of the sent file names, readable from the once-registered
@@ -1254,6 +1258,17 @@ function App() {
     // bring a ghost offer back with a partly spent timer.
     useEffect(() => { if (mode !== 'send' || settingsOpen) forgetCleared(); }, [mode, settingsOpen]);
 
+    // A dialog puts the bar away and stops its clock; dismissing one gives it
+    // back with its full few seconds. Time spent behind a scrim was never time
+    // the user could act in. armUndo is a no-op while a timer is already
+    // running, so the `cleared` dependency costs nothing on the render where
+    // clearStaged has just armed it.
+    useEffect(() => {
+        if (!cleared) return;
+        if (confirmReset || confirmDefaults) holdUndo();
+        else armUndo();
+    }, [confirmReset, confirmDefaults, cleared]);
+
     // The undo timer is the one thing here that outlives a render, so it needs an
     // explicit teardown. (Started in the click handler, never in an effect: this
     // app renders under StrictMode, which double-invokes effects in dev.)
@@ -1369,10 +1384,12 @@ function App() {
                     e.preventDefault();
                     openHistory();
                     break;
-                // Undo the clear, while its offer stands. The offer is on a
-                // timer, and a timed control with no other way to reach it is a
-                // WCAG 2.2.1 failure; this is the way that does not depend on
-                // the clock, and it is what every desktop user tries first.
+                // Undo the clear. This is the route that genuinely does not
+                // depend on the clock: the bar goes after a few seconds, the
+                // offer behind it stands until something stages or changes the
+                // send view, and this reaches it either way. A timed control
+                // whose only route expires with it would be a WCAG 2.2.1
+                // failure, and this is also what every desktop user tries first.
                 // Skipped while typing so the textarea keeps its own undo, and
                 // silent when nothing is pending so Ctrl+Z stays free for the
                 // field the user is actually in.
@@ -1424,38 +1441,42 @@ function App() {
         setSendDone(false);
     }
 
-    // forgetCleared retires a pending undo offer and its timer. Every path that
-    // stages something new or moves the send view on calls it, so Undo can never
-    // put a payload back into a screen that changed underneath it. Safe from the
-    // once-registered closures: a ref and a stable setter, nothing else.
+    // forgetCleared retires a pending undo offer, takes its bar down and stops
+    // the timer. Every path that stages something new or moves the send view on
+    // calls it, so Undo can never put a payload back into a screen that changed
+    // underneath it. This is the ONLY thing that ends an offer: the clock ends
+    // the bar, never the offer. Safe from the once-registered closures: a ref
+    // and stable setters, nothing else.
     function forgetCleared() {
         holdUndo();
+        setOfferUp(false);
         setCleared(null);
     }
 
-    // holdUndo stops the countdown without retiring the offer, and armUndo
-    // starts a fresh one. Pointing at the offer holds it, so it cannot expire
-    // out from under the pointer travelling towards it.
+    // holdUndo stops the bar's countdown without taking the bar down, and
+    // armUndo starts a fresh one. Pointing at the bar holds it, so it cannot go
+    // out from under a pointer travelling towards it, and so does a dialog
+    // opening over it: time a message spends behind a scrim is not time the user
+    // had to read it.
     function holdUndo() {
         if (clearedTimer.current !== null) {
             clearTimeout(clearedTimer.current);
             clearedTimer.current = null;
         }
-        clearedUntil.current = Infinity;
     }
 
     function armUndo() {
         if (clearedTimer.current !== null) return;
-        clearedUntil.current = Date.now() + UNDO_WINDOW_MS;
         clearedTimer.current = window.setTimeout(() => {
             clearedTimer.current = null;
             // Never unmount the element the keyboard is sitting on. If Undo has
-            // focus when its time runs out, hand focus back the way the settings
-            // dialog hands it to the trigger that opened it. The target is the
-            // active tab button, not Send: Send is disabled the moment a clear
-            // empties the tab, and focus() on a disabled button goes nowhere.
+            // focus when the bar's time runs out, hand focus back the way the
+            // settings dialog hands it to the trigger that opened it. The target
+            // is the active tab button, not Send: Send is disabled the moment a
+            // clear empties the tab, and focus() on a disabled button goes
+            // nowhere.
             const onUndo = document.activeElement?.id === 'floe-undo-clear';
-            setCleared(null);
+            setOfferUp(false);
             if (onUndo) requestAnimationFrame(() => document.getElementById('floe-send-kind')?.focus());
         }, UNDO_WINDOW_MS);
     }
@@ -1477,6 +1498,7 @@ function App() {
         // "Cancelled." from an earlier send would reappear when the offer went.
         setSendStatus('');
         setCleared(snap);
+        setOfferUp(true);
         armUndo();
         // Clear unmounts with the last thing it cleared, so focus would fall to
         // the body. Moving it to Undo keeps the keyboard where the user was, and
@@ -1491,14 +1513,25 @@ function App() {
     // Undo replaces rather than merges, because it cannot collide: anything that
     // could have staged something in the meantime has already retired the offer.
     // Returns whether it actually put something back, so the Ctrl+Z handler can
-    // stay silent (and leave the keystroke alone) when there is no offer.
+    // stay silent (and leave the keystroke alone) when there is no offer. No
+    // clock here: the bar may be long gone, and the offer is still good.
     function undoClear(): boolean {
         if (!cleared) return false;
-        if (isExpired(clearedUntil.current, Date.now())) { forgetCleared(); return false; }
+        // An offer belongs to the tab it was taken from, and to no other. Every
+        // path that changes the tab retires it, so this guard should be dead
+        // code; it is here because the cost of one path forgetting is a note
+        // restored into a box nobody is looking at, or destroyed by the next
+        // Clear on the other tab. Ctrl+O was exactly that path once.
+        if (!restorable(cleared, sendKind)) { forgetCleared(); return false; }
         const snap = cleared;
+        const onUndo = document.activeElement?.id === 'floe-undo-clear';
         forgetCleared();
         if (snap.kind === 'files') setFiles(snap.files);
         else setSendText(snap.text);
+        // The same handoff the bar's own expiry makes, for the same reason:
+        // pressing Undo destroys the button being pressed, and without this the
+        // keyboard lands on the body and Tab restarts at the title bar.
+        if (onUndo) requestAnimationFrame(() => document.getElementById('floe-send-kind')?.focus());
         return true;
     }
 
@@ -1753,8 +1786,13 @@ function App() {
     toggleHistoryRef.current = toggleHistory;
 
     // Ctrl+O: leave Settings, land on Send > Files, open the native picker.
+    // It retires the offer up front rather than leaving that to pickFiles, which
+    // only does it once a pick succeeds: cancelling the dialog still leaves the
+    // user on a tab they did not start on, and an offer taken from the other tab
+    // has no business surviving that.
     function openPicker() {
         if (busy) return;
+        forgetCleared();
         setSettingsOpen(false);
         setMode('send');
         setSendKind('files');
@@ -1823,12 +1861,16 @@ function App() {
             <span className="sr-only" role="status" aria-live="polite">
                 {cleared ? clearedAnnouncement(cleared) : ''}
             </span>
-            {/* No key needed to replay the entrance: two offers can never be
-                adjacent renders, because reaching a second clear means staging
-                something first, and every staging path retires the first offer,
-                so the toast always unmounts in between. */}
-            {cleared && (
+            {/* The bar, which is not the offer: it comes down on its own after a
+                few seconds while the undo behind it stays good, and it steps
+                aside entirely for a dialog rather than sitting dimmed under the
+                scrim where it cannot be clicked. showUpdate guards on the same
+                two for the same reason. Keyed on what it says so a second offer
+                always replays the entrance, rather than relying on an argument
+                about which renders can be adjacent. */}
+            {cleared && offerUp && !confirmReset && !confirmDefaults && (
                 <UndoToast
+                    key={clearedLabel(cleared)}
                     label={clearedLabel(cleared)}
                     action={undoLabel(cleared)}
                     onUndo={undoClear}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -318,9 +318,9 @@ function UndoToast({label, action, onUndo, onHold, onArm}: {
     // the card it is talking about at every window width. Fixed rather than
     // absolute inside main, because that column scrolls and would carry the
     // toast away with it.
+    // The px-8 on the positioner matches the console's own gutter, so a long
+    // line can never run to the edges of the column.
     return (
-        {/* px-8 matches the console's own gutter, so a long line can never run
-            to the edges of the column. */}
         <div className="pointer-events-none fixed bottom-8 left-[min(42%,460px)] right-0 z-30 flex justify-center px-8">
             <div
                 onMouseEnter={onHold}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1517,9 +1517,13 @@ function App() {
 
     // discardCleared throws the standing offer away, whatever it is and whichever
     // tab it belongs to. It is TAB-BLIND, which is why it is named for what it
-    // costs rather than for tidying up, and why it has exactly three callers:
-    // Start over (which prompts first), another Clear (which replaces it), and an
-    // undo (which has just spent it).
+    // costs rather than for tidying up, and why its call sites are counted.
+    //
+    // There are exactly four, and only one of them is safe to copy. Three are
+    // deliberate endings: Start over (which prompts first), another Clear (which
+    // replaces it), and an undo (which has just spent it). The fourth is
+    // supersede below, which is the guarded wrapper and the only caller that
+    // checks whose offer it is about to end.
     //
     // Do not add a fourth without proving the offer is genuinely dead. Three
     // separate audit rounds failed on exactly that mistake: a call added to a
@@ -1765,6 +1769,13 @@ function App() {
     // swallowed; the next real transfer re-arms them.
     function doReset() {
         setConfirmReset(false);
+        // Also pre-existing housekeeping: this closes the settings screen below,
+        // and the defaults dialog renders OUTSIDE that branch, so without this it
+        // could outlive the screen it belongs to. Its Escape is gated on
+        // settingsOpen, and its Cancel focuses a button that is no longer
+        // mounted, so the survivor is both unclosable by keyboard and a focus
+        // orphan. Symmetric with the two dismissals either side of it.
+        setConfirmDefaults(false);
         sendCancel.current = true;
         recvCancel.current = true;
         // Invalidate any in-flight receive attempt: its promise settles on a
@@ -1833,7 +1844,21 @@ function App() {
             setConfirmReset(true);
             return;
         }
+        // The dialog's FOURTH exit, and the one that is easy to miss because it
+        // does not look like an exit at all. Ctrl+R or the lockup while the
+        // dialog is already up re-enters here, and if resetLoss has since gone
+        // empty (the transfer it was warning about finished, the note it was
+        // warning about got sent) this branch runs doReset, which sets
+        // setConfirmReset(false) and so DISMISSES a dialog it did not raise.
+        // With autoFocus on "Keep going", focus is sitting inside that dialog
+        // when it goes, and without this it lands on the body.
+        //
+        // The handoff is here rather than inside doReset because doReset also
+        // runs from Ctrl+R and the lockup with no dialog in the way, where
+        // moving focus would be an unasked-for jump.
+        const dismissing = confirmReset;
         doReset();
+        if (dismissing) focusLockup();
     }
 
     // Keep a stable reference to the latest startOver so the once-registered
@@ -1911,9 +1936,13 @@ function App() {
     openPickerRef.current = openPicker;
 
     // Ctrl+Enter: the current tab's primary action, mirroring the action button's
-    // enabled rules. No-op in Settings, while busy, or in History (no action there).
+    // enabled rules. No-op in Settings, while busy, in History (no action there),
+    // or behind a modal. That last guard is pre-existing housekeeping rather than
+    // anything to do with Clear: without it Ctrl+Enter starts a transfer BEHIND
+    // the Start over scrim, which is how an audit reached this dialog's unwired
+    // exit in the first place. showUpdate has guarded on the same two all along.
     function primaryAction() {
-        if (busy || settingsOpen) return;
+        if (busy || settingsOpen || confirmReset || confirmDefaults) return;
         if (mode === 'send') {
             if (sendKind === 'text' ? sendText.trim() : files.length) send();
         } else if (mode === 'receive') {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -319,43 +319,39 @@ function UndoToast({label, action, onUndo, onHold, onArm}: {
     // absolute inside main, because that column scrolls and would carry the
     // toast away with it.
     return (
-        <div className="pointer-events-none fixed bottom-8 left-[min(42%,460px)] right-0 z-30 flex justify-center">
-            {/* The console's own measure, repeated verbatim from the card's
-                wrapper, so the bar is the card's width and sits on the card's
-                left and right edges at every window size rather than being a
-                pill that happens to be near it. */}
-            <div className="w-full max-w-lg px-8">
-                <div
-                    onMouseEnter={onHold}
-                    onMouseLeave={onArm}
-                    className={cn(
-                        // The card's surface verbatim, fill included: this is the
-                        // card's bar, not a floating thing above it. px-5 is the
-                        // card's own content inset, so the sentence starts on the
-                        // same left edge as everything stacked above it.
-                        'pointer-events-auto flex h-12 w-full items-center gap-3 rounded-xl border border-white/10 bg-zinc-900/60 px-5',
-                        'shadow-2xl ring-1 ring-white/5 backdrop-blur-xl backdrop-saturate-150',
-                        'animate-floe-toast-in motion-reduce:animate-none',
-                    )}
+        {/* px-8 matches the console's own gutter, so a long line can never run
+            to the edges of the column. */}
+        <div className="pointer-events-none fixed bottom-8 left-[min(42%,460px)] right-0 z-30 flex justify-center px-8">
+            <div
+                onMouseEnter={onHold}
+                onMouseLeave={onArm}
+                className={cn(
+                    // The card's surface, corner and fill, but only as wide as
+                    // what it has to say: at these labels that is about half the
+                    // card, which is the size a passing message should be. A bar
+                    // the full width of the card read as a second card.
+                    'pointer-events-auto flex h-12 max-w-full items-center gap-3 rounded-xl border border-white/10 bg-zinc-900/60 pl-4 pr-2.5',
+                    'shadow-2xl ring-1 ring-white/5 backdrop-blur-xl backdrop-saturate-150',
+                    'animate-floe-toast-in motion-reduce:animate-none',
+                )}
+            >
+                <Undo2 className="size-4 shrink-0 text-zinc-400" strokeWidth={2.5} aria-hidden/>
+                <span className="truncate text-[13px] leading-none tracking-[-0.005em] text-zinc-200">{label}</span>
+                <button
+                    id="floe-undo-clear"
+                    aria-label={action}
+                    onClick={onUndo}
+                    // Hold the countdown only for a keyboard landing. The focus
+                    // move that brings the user here happens after a mouse click
+                    // too, and holding then would pin the offer open until they
+                    // clicked something else. :focus-visible is exactly that
+                    // distinction, and Tooltip.tsx already leans on it.
+                    onFocus={(e) => { if (e.currentTarget.matches(':focus-visible')) onHold(); }}
+                    onBlur={onArm}
+                    className="ml-1 h-8 shrink-0 rounded-md border border-white/10 bg-white/[0.06] px-3 text-[13px] font-medium leading-none text-zinc-100 transition-colors hover:border-white/20 hover:bg-white/[0.12] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
                 >
-                    <Undo2 className="size-4 shrink-0 text-zinc-400" strokeWidth={2.5} aria-hidden/>
-                    <span className="whitespace-nowrap text-[13px] leading-none tracking-[-0.005em] text-zinc-200">{label}</span>
-                    <button
-                        id="floe-undo-clear"
-                        aria-label={action}
-                        onClick={onUndo}
-                        // Hold the countdown only for a keyboard landing. The focus
-                        // move that brings the user here happens after a mouse click
-                        // too, and holding then would pin the offer open until they
-                        // clicked something else. :focus-visible is exactly that
-                        // distinction, and Tooltip.tsx already leans on it.
-                        onFocus={(e) => { if (e.currentTarget.matches(':focus-visible')) onHold(); }}
-                        onBlur={onArm}
-                        className="ml-auto h-8 shrink-0 rounded-md border border-white/10 bg-white/[0.06] px-3 text-[13px] font-medium leading-none text-zinc-100 transition-colors hover:border-white/20 hover:bg-white/[0.12] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
-                    >
-                        Undo
-                    </button>
-                </div>
+                    Undo
+                </button>
             </div>
         </div>
     );

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1819,6 +1819,10 @@ function App() {
             <span className="sr-only" role="status" aria-live="polite">
                 {cleared ? clearedAnnouncement(cleared) : ''}
             </span>
+            {/* No key needed to replay the entrance: two offers can never be
+                adjacent renders, because reaching a second clear means staging
+                something first, and every staging path retires the first offer,
+                so the toast always unmounts in between. */}
             {cleared && (
                 <UndoToast
                     label={clearedLabel(cleared)}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1525,7 +1525,7 @@ function App() {
     // supersede below, which is the guarded wrapper and the only caller that
     // checks whose offer it is about to end.
     //
-    // Do not add a fourth without proving the offer is genuinely dead. Three
+    // Do not add a fifth without proving the offer is genuinely dead. Three
     // separate audit rounds failed on exactly that mistake: a call added to a
     // transition that felt like an ending (a tab switch, opening Settings,
     // Ctrl+O, a send, a cancel) but was not, each one silently destroying a
@@ -1769,13 +1769,6 @@ function App() {
     // swallowed; the next real transfer re-arms them.
     function doReset() {
         setConfirmReset(false);
-        // Also pre-existing housekeeping: this closes the settings screen below,
-        // and the defaults dialog renders OUTSIDE that branch, so without this it
-        // could outlive the screen it belongs to. Its Escape is gated on
-        // settingsOpen, and its Cancel focuses a button that is no longer
-        // mounted, so the survivor is both unclosable by keyboard and a focus
-        // orphan. Symmetric with the two dismissals either side of it.
-        setConfirmDefaults(false);
         sendCancel.current = true;
         recvCancel.current = true;
         // Invalidate any in-flight receive attempt: its promise settles on a
@@ -1937,10 +1930,12 @@ function App() {
 
     // Ctrl+Enter: the current tab's primary action, mirroring the action button's
     // enabled rules. No-op in Settings, while busy, in History (no action there),
-    // or behind a modal. That last guard is pre-existing housekeeping rather than
+    // or behind a modal. That last guard fixes a pre-existing bug rather than
     // anything to do with Clear: without it Ctrl+Enter starts a transfer BEHIND
     // the Start over scrim, which is how an audit reached this dialog's unwired
     // exit in the first place. showUpdate has guarded on the same two all along.
+    // (confirmDefaults is belt and braces: it implies settingsOpen, which is
+    // already here.)
     function primaryAction() {
         if (busy || settingsOpen || confirmReset || confirmDefaults) return;
         if (mode === 'send') {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -43,6 +43,7 @@ import {
     Send,
     Share2,
     SquareArrowOutUpRight,
+    Undo2,
     UploadCloud,
     X,
 } from 'lucide-react';
@@ -283,6 +284,72 @@ function mergePaths(prev: string[], add: string[]): string[] {
         }
     }
     return out;
+}
+
+/** UndoToast is the app's second toast, and the opposite kind to the first:
+ *  the update notice stands until it is acted on, while this one exists only
+ *  for as long as the undo behind it does. It sits bottom centre, in the empty
+ *  space under the card, so the two can never collide, and it is a pill rather
+ *  than a rounded rectangle because it carries a passing sentence rather than a
+ *  standing task.
+ *
+ *  Same material as the notice (blurred zinc, an inset hairline, the layered
+ *  shadow) so they read as one family, but deliberately WITHOUT the ice rim:
+ *  that is the notice's one accent, and ice otherwise belongs to focus rings
+ *  and the OS drag highlight.
+ *
+ *  The full-width positioner is pointer-events-none so this cannot swallow a
+ *  click meant for the card behind it; only the pill itself takes the pointer.
+ *  Hovering the pill holds the countdown, so the offer cannot expire out from
+ *  under a pointer travelling towards it.
+ *
+ *  Screen-reader announcement lives in the persistent sr-only region at the app
+ *  root, next to the update notice's, for the reason documented there: a live
+ *  region that mounts with its text already inside announces nothing. */
+function UndoToast({label, action, onUndo, onHold, onArm, onFocus}: {
+    label: string;
+    action: string;
+    onUndo: () => void;
+    onHold: () => void;
+    onArm: () => void;
+    onFocus: () => void;
+}) {
+    // Centred under the console, not under the window: the left edge mirrors
+    // the hero rail's own w-[42%] max-w-[460px] rule, so the pill lines up with
+    // the card it is talking about at every window width. Fixed rather than
+    // absolute inside main, because that column scrolls and would carry the
+    // toast away with it.
+    return (
+        <div className="pointer-events-none fixed bottom-6 left-[min(42%,460px)] right-0 z-30 flex justify-center px-4">
+            <div
+                onMouseEnter={onHold}
+                onMouseLeave={onArm}
+                className={cn(
+                    'pointer-events-auto isolate flex h-12 items-center gap-3 rounded-full pl-4 pr-1.5',
+                    'bg-zinc-900/80 ring-1 ring-inset ring-white/10 backdrop-blur-xl backdrop-saturate-150',
+                    'shadow-[0_1px_1px_rgba(0,0,0,0.06),0_4px_8px_-4px_rgba(0,0,0,0.28),0_16px_32px_-12px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.07)]',
+                    'animate-floe-toast-in motion-reduce:animate-none',
+                )}
+            >
+                {/* strokeWidth 3 for the same reason the notice's icon carries it:
+                    at 16px the default 2 draws 1.33 device px and antialiases to
+                    fuzzy grey. */}
+                <Undo2 className="size-4 shrink-0 text-zinc-400" strokeWidth={3} aria-hidden/>
+                <span className="whitespace-nowrap text-[13px] leading-none tracking-[-0.01em] text-zinc-200">{label}</span>
+                <span className="ml-1 h-5 w-px bg-white/[0.14]" aria-hidden/>
+                <button
+                    id="floe-undo-clear"
+                    aria-label={action}
+                    onClick={onUndo}
+                    onFocus={onFocus}
+                    onBlur={onArm}
+                    className="h-9 shrink-0 rounded-full px-3.5 text-[13px] font-semibold leading-none text-zinc-50 transition-colors hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ice/60"
+                >
+                    Undo
+                </button>
+            </div>
+        </div>
+    );
 }
 
 /** Switch is the settings toggle: a small track/thumb pair driven by an
@@ -1732,6 +1799,24 @@ function App() {
             </span>
             {showUpdate && <UpdateNotice version={updateVer} onDismiss={() => setUpdateDismissed(true)}/>}
 
+            {/* The undo offer's own announcement, a separate span from the
+                update one above rather than a shared channel: the two can stand
+                at the same time, and one ternary owning both would let either
+                erase the other's sentence. */}
+            <span className="sr-only" role="status" aria-live="polite">
+                {cleared ? clearedAnnouncement(cleared) : ''}
+            </span>
+            {cleared && (
+                <UndoToast
+                    label={clearedLabel(cleared)}
+                    action={undoLabel(cleared)}
+                    onUndo={undoClear}
+                    onHold={holdUndo}
+                    onArm={() => { if (cleared) armUndo(); }}
+                    onFocus={() => { if (undoAutoFocus.current) { undoAutoFocus.current = false; return; } holdUndo(); }}
+                />
+            )}
+
             {settingsOpen ? (
             /* ── SETTINGS SCREEN ─────────────────────────────────────────── */
                 <div className="flex flex-1 flex-col overflow-hidden">
@@ -2303,39 +2388,7 @@ function App() {
                                                 <span>Sent {sentCount} {sentCount === 1 ? 'item' : 'items'}</span>
                                             </div>
                                         )}
-                                        {/* While it stands, the undo offer speaks for the status line:
-                                            two rows of small print under the button would be one too many. */}
-                                        {cleared ? (
-                                            <p className="flex min-h-5 items-center justify-center gap-2 text-center text-xs">
-                                                <span className="text-zinc-500">{clearedLabel(cleared)}</span>
-                                                <button
-                                                    type="button"
-                                                    id="floe-undo-clear"
-                                                    aria-label={undoLabel(cleared)}
-                                                    onClick={undoClear}
-                                                    onMouseEnter={holdUndo}
-                                                    onMouseLeave={() => { if (cleared) armUndo(); }}
-                                                    onFocus={() => { if (undoAutoFocus.current) { undoAutoFocus.current = false; return; } holdUndo(); }}
-                                                    onBlur={() => { if (cleared) armUndo(); }}
-                                                    className="rounded-md px-2 py-1 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
-                                                >
-                                                    Undo
-                                                </button>
-                                            </p>
-                                        ) : (
-                                            <StatusLine text={sendStatus} busy={sending}/>
-                                        )}
-                                        {/* Zero height, and mounted whether or not there is anything to
-                                            say, because a live region only announces a CHANGE: one that
-                                            mounts with its text already inside stays silent, which this
-                                            file has learned twice (StatusLine's docblock, and the update
-                                            notice's sr-only twin). sr-only is absolutely positioned, so it
-                                            adds no row to the stack. Belt and braces with the focus move:
-                                            whichever of the two a screen reader honours, the user hears
-                                            both what went and that there is a way back. */}
-                                        <span className="sr-only" role="status" aria-live="polite">
-                                            {cleared ? clearedAnnouncement(cleared) : ''}
-                                        </span>
+                                        <StatusLine text={sendStatus} busy={sending}/>
                                     </div>
 
                                 ) : mode === 'receive' ? (

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -306,13 +306,12 @@ function mergePaths(prev: string[], add: string[]): string[] {
  *  Screen-reader announcement lives in the persistent sr-only region at the app
  *  root, next to the update notice's, for the reason documented there: a live
  *  region that mounts with its text already inside announces nothing. */
-function UndoToast({label, action, onUndo, onHold, onArm, onFocus}: {
+function UndoToast({label, action, onUndo, onHold, onArm}: {
     label: string;
     action: string;
     onUndo: () => void;
     onHold: () => void;
     onArm: () => void;
-    onFocus: () => void;
 }) {
     // Centred under the console, not under the window: the left edge mirrors
     // the hero rail's own w-[42%] max-w-[460px] rule, so the pill lines up with
@@ -320,7 +319,7 @@ function UndoToast({label, action, onUndo, onHold, onArm, onFocus}: {
     // absolute inside main, because that column scrolls and would carry the
     // toast away with it.
     return (
-        <div className="pointer-events-none fixed bottom-6 left-[min(42%,460px)] right-0 z-30 flex justify-center px-4">
+        <div className="pointer-events-none fixed bottom-8 left-[min(42%,460px)] right-0 z-30 flex justify-center px-4">
             <div
                 onMouseEnter={onHold}
                 onMouseLeave={onArm}
@@ -338,7 +337,12 @@ function UndoToast({label, action, onUndo, onHold, onArm, onFocus}: {
                     id="floe-undo-clear"
                     aria-label={action}
                     onClick={onUndo}
-                    onFocus={onFocus}
+                    // Hold the countdown only for a keyboard landing. The focus
+                    // move that brings the user here happens after a mouse click
+                    // too, and holding then would pin the offer open until they
+                    // clicked something else. :focus-visible is exactly that
+                    // distinction, and Tooltip.tsx already leans on it.
+                    onFocus={(e) => { if (e.currentTarget.matches(':focus-visible')) onHold(); }}
                     onBlur={onArm}
                     className="h-8 shrink-0 rounded-md border border-white/10 bg-white/[0.06] px-3 text-[13px] font-medium leading-none text-zinc-100 transition-colors hover:border-white/20 hover:bg-white/[0.12] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
                 >
@@ -754,9 +758,6 @@ function App() {
     // When the standing offer runs out. Checked again on the click, because a
     // background window can have its timers clamped; Infinity while held.
     const clearedUntil = useRef(0);
-    // Marks the one programmatic focus clearStaged performs, so that landing on
-    // Undo does not read as "the user reached for it" and stop the countdown.
-    const undoAutoFocus = useRef(false);
     const sendStart = useRef<Marker>(null);
     const sendCancel = useRef(false);
     // Snapshot of the sent file names, readable from the once-registered
@@ -1364,6 +1365,17 @@ function App() {
                     e.preventDefault();
                     openHistory();
                     break;
+                // Undo the clear, while its offer stands. The offer is on a
+                // timer, and a timed control with no other way to reach it is a
+                // WCAG 2.2.1 failure; this is the way that does not depend on
+                // the clock, and it is what every desktop user tries first.
+                // Skipped while typing so the textarea keeps its own undo, and
+                // silent when nothing is pending so Ctrl+Z stays free for the
+                // field the user is actually in.
+                case 'z':
+                    if (typing || !undoClearRef.current()) return;
+                    e.preventDefault();
+                    break;
             }
         };
         window.addEventListener('keydown', onKey);
@@ -1464,28 +1476,26 @@ function App() {
         armUndo();
         // Clear unmounts with the last thing it cleared, so focus would fall to
         // the body. Moving it to Undo keeps the keyboard where the user was, and
-        // is what tells a screen reader the offer exists: an aria-live region
-        // that mounts with its own text already inside announces nothing, which
-        // this file has learned twice already. The button describes itself with
-        // the sentence beside it, so the landing reads "Undo, Cleared 12 items."
-        // Same id lookup as focusResetTrigger, for the same reason.
-        undoAutoFocus.current = true;
-        requestAnimationFrame(() => {
-            const el = document.getElementById('floe-undo-clear');
-            if (el) el.focus();
-            else undoAutoFocus.current = false;
-        });
+        // tells a screen reader the offer exists. The guidance against toasts
+        // taking focus is about ones that arrive unbidden; this one is the
+        // synchronous product of a click on a button that destroyed itself, so
+        // the choice is a destination or nowhere. Same id lookup as
+        // focusResetTrigger, for the same reason.
+        requestAnimationFrame(() => document.getElementById('floe-undo-clear')?.focus());
     }
 
     // Undo replaces rather than merges, because it cannot collide: anything that
     // could have staged something in the meantime has already retired the offer.
-    function undoClear() {
-        if (!cleared) return;
-        if (isExpired(clearedUntil.current, Date.now())) { forgetCleared(); return; }
+    // Returns whether it actually put something back, so the Ctrl+Z handler can
+    // stay silent (and leave the keystroke alone) when there is no offer.
+    function undoClear(): boolean {
+        if (!cleared) return false;
+        if (isExpired(clearedUntil.current, Date.now())) { forgetCleared(); return false; }
         const snap = cleared;
         forgetCleared();
         if (snap.kind === 'files') setFiles(snap.files);
         else setSendText(snap.text);
+        return true;
     }
 
     async function pickSaveFolder() {
@@ -1685,6 +1695,12 @@ function App() {
     const startOverRef = useRef(startOver);
     startOverRef.current = startOver;
 
+    // Same once-registered-closure idiom as the refs above: the Ctrl+Z listener
+    // is bound at mount and would otherwise only ever see the first render's
+    // empty offer.
+    const undoClearRef = useRef(undoClear);
+    undoClearRef.current = undoClear;
+
     const busy = sending || receiving;
 
     // What the send tab is holding, or null when it is empty. One rule, read by
@@ -1810,7 +1826,6 @@ function App() {
                     onUndo={undoClear}
                     onHold={holdUndo}
                     onArm={() => { if (cleared) armUndo(); }}
-                    onFocus={() => { if (undoAutoFocus.current) { undoAutoFocus.current = false; return; } holdUndo(); }}
                 />
             )}
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -319,35 +319,43 @@ function UndoToast({label, action, onUndo, onHold, onArm}: {
     // absolute inside main, because that column scrolls and would carry the
     // toast away with it.
     return (
-        <div className="pointer-events-none fixed bottom-8 left-[min(42%,460px)] right-0 z-30 flex justify-center px-4">
-            <div
-                onMouseEnter={onHold}
-                onMouseLeave={onArm}
-                className={cn(
-                    // The card's own corner and material, one step more opaque so
-                    // a floating strip stays legible over whatever is behind it.
-                    'pointer-events-auto isolate flex items-center gap-3 rounded-xl border border-white/10 bg-zinc-900/85 p-2.5',
-                    'shadow-2xl ring-1 ring-white/5 backdrop-blur-xl backdrop-saturate-150',
-                    'animate-floe-toast-in motion-reduce:animate-none',
-                )}
-            >
-                <Undo2 className="ml-1.5 size-4 shrink-0 text-zinc-400" strokeWidth={2.5} aria-hidden/>
-                <span className="whitespace-nowrap pr-1 text-[13px] leading-none tracking-[-0.005em] text-zinc-200">{label}</span>
-                <button
-                    id="floe-undo-clear"
-                    aria-label={action}
-                    onClick={onUndo}
-                    // Hold the countdown only for a keyboard landing. The focus
-                    // move that brings the user here happens after a mouse click
-                    // too, and holding then would pin the offer open until they
-                    // clicked something else. :focus-visible is exactly that
-                    // distinction, and Tooltip.tsx already leans on it.
-                    onFocus={(e) => { if (e.currentTarget.matches(':focus-visible')) onHold(); }}
-                    onBlur={onArm}
-                    className="h-8 shrink-0 rounded-md border border-white/10 bg-white/[0.06] px-3 text-[13px] font-medium leading-none text-zinc-100 transition-colors hover:border-white/20 hover:bg-white/[0.12] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
+        <div className="pointer-events-none fixed bottom-8 left-[min(42%,460px)] right-0 z-30 flex justify-center">
+            {/* The console's own measure, repeated verbatim from the card's
+                wrapper, so the bar is the card's width and sits on the card's
+                left and right edges at every window size rather than being a
+                pill that happens to be near it. */}
+            <div className="w-full max-w-lg px-8">
+                <div
+                    onMouseEnter={onHold}
+                    onMouseLeave={onArm}
+                    className={cn(
+                        // The card's surface verbatim, fill included: this is the
+                        // card's bar, not a floating thing above it. px-5 is the
+                        // card's own content inset, so the sentence starts on the
+                        // same left edge as everything stacked above it.
+                        'pointer-events-auto flex h-12 w-full items-center gap-3 rounded-xl border border-white/10 bg-zinc-900/60 px-5',
+                        'shadow-2xl ring-1 ring-white/5 backdrop-blur-xl backdrop-saturate-150',
+                        'animate-floe-toast-in motion-reduce:animate-none',
+                    )}
                 >
-                    Undo
-                </button>
+                    <Undo2 className="size-4 shrink-0 text-zinc-400" strokeWidth={2.5} aria-hidden/>
+                    <span className="whitespace-nowrap text-[13px] leading-none tracking-[-0.005em] text-zinc-200">{label}</span>
+                    <button
+                        id="floe-undo-clear"
+                        aria-label={action}
+                        onClick={onUndo}
+                        // Hold the countdown only for a keyboard landing. The focus
+                        // move that brings the user here happens after a mouse click
+                        // too, and holding then would pin the offer open until they
+                        // clicked something else. :focus-visible is exactly that
+                        // distinction, and Tooltip.tsx already leans on it.
+                        onFocus={(e) => { if (e.currentTarget.matches(':focus-visible')) onHold(); }}
+                        onBlur={onArm}
+                        className="ml-auto h-8 shrink-0 rounded-md border border-white/10 bg-white/[0.06] px-3 text-[13px] font-medium leading-none text-zinc-100 transition-colors hover:border-white/20 hover:bg-white/[0.12] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
+                    >
+                        Undo
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -51,7 +51,7 @@ import QRCode from 'react-qr-code';
 import {BoltMark, Button, Eyebrow, Input, StatusDot, cn} from './components/ui';
 import {advancedSummary, hostOf} from './settings';
 import {histKey} from './history';
-import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, stagedSnapshot, undoLabel, type Cleared} from './clear';
+import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, restoredAnnouncement, stagedSnapshot, supersededBy, undoLabel, type Cleared} from './clear';
 import {resetWarning} from './reset';
 import {friendlyError} from './errors';
 import {fmtBytes, formatIncoming, type IncomingPreview} from './incoming';
@@ -690,6 +690,9 @@ function App() {
     // Whether the "start over?" confirm overlay is showing. Not only about a live
     // transfer: see resetWarning in reset.ts for every state that raises it.
     const [confirmReset, setConfirmReset] = useState(false);
+    // The sentence the Start over dialog is showing, captured when it opens. See
+    // startOver for why this is not read live.
+    const [resetMsg, setResetMsg] = useState('');
     // Whether the "reset all settings?" confirm overlay is showing. Deliberately
     // NOT named confirmReset: that one guards Start over, which clears the
     // transfer UI and keeps every preference. This one is the opposite.
@@ -766,6 +769,14 @@ function App() {
     const [cleared, setCleared] = useState<Cleared | null>(null);
     const [offerUp, setOfferUp] = useState(false);
     const clearedTimer = useRef<number | null>(null);
+    // Readable from the once-registered file-drop and paste closures, which see
+    // only the first render's state. Same idiom as busyRef above.
+    const clearedRef = useRef<Cleared | null>(null);
+    clearedRef.current = cleared;
+    // What the live region says. A piece of state rather than a render of
+    // `cleared`, because an undo has to ANNOUNCE something: emptying the region
+    // is a removal, and removals are not spoken.
+    const [announce, setAnnounce] = useState('');
     const sendStart = useRef<Marker>(null);
     const sendCancel = useRef(false);
     // Snapshot of the sent file names, readable from the once-registered
@@ -849,7 +860,7 @@ function App() {
     // once-registered closures (functional updates + stable setters only).
     function addFiles(paths: string[]) {
         if (!paths || !paths.length || busyRef.current) return;
-        forgetCleared();
+        supersede('files');
         setSettingsOpen(false);
         setMode('send');
         setSendKind('files');
@@ -1251,23 +1262,49 @@ function App() {
     // Leaving the history view abandons a pending Clear confirmation.
     useEffect(() => { if (mode !== 'history') setConfirmClear(false); }, [mode]);
 
-    // Leaving the send view abandons a pending undo offer: it belongs to a screen
-    // the user is no longer looking at, and its timer would otherwise fire there.
-    // Settings is not a mode but it covers the send view all the same, so it
-    // counts as leaving: without this, closing Settings inside the window would
-    // bring a ghost offer back with a partly spent timer.
-    useEffect(() => { if (mode !== 'send' || settingsOpen) forgetCleared(); }, [mode, settingsOpen]);
+    // Whether the undo bar is on screen. Note what this is NOT: it is not
+    // whether the undo is available. Hiding the bar and forgetting the offer
+    // were the same act until the audit pointed out what that cost, which was
+    // that a note became LESS safe the moment you cleared it. Sitting in the
+    // textarea it survived a tab switch, a look at Settings and a glance at
+    // History; held in an offer, each of those destroyed it silently. So the bar
+    // is a view concern (right screen, right tab, nothing covering it) and the
+    // offer is not: only supersededBy, a send, a Start over or another clear
+    // ends one. Coming back brings the bar back with it.
+    const barUp = !!cleared && offerUp && mode === 'send' && !settingsOpen
+        && !confirmReset && !confirmDefaults && restorable(cleared, sendKind);
 
-    // A dialog puts the bar away and stops its clock; dismissing one gives it
-    // back with its full few seconds. Time spent behind a scrim was never time
-    // the user could act in. armUndo is a no-op while a timer is already
-    // running, so the `cleared` dependency costs nothing on the render where
-    // clearStaged has just armed it.
+    // The bar's clock runs only while the bar is actually on screen and
+    // reachable. Look somewhere else, open Settings, raise a dialog, and it
+    // stops; come back and it starts again with its full few seconds. Time spent
+    // behind a scrim or on another screen was never time the user could act in.
+    // armUndo is a no-op while a timer is already running, so the `cleared`
+    // dependency costs nothing on the render where a clear has just happened.
     useEffect(() => {
         if (!cleared) return;
-        if (confirmReset || confirmDefaults) holdUndo();
-        else armUndo();
-    }, [confirmReset, confirmDefaults, cleared]);
+        if (barUp) armUndo();
+        else holdUndo();
+    }, [barUp, cleared]);
+
+    // One focus handoff for every way the bar can leave: its own expiry, an undo,
+    // a dialog opening over it, leaving the send view, switching tab. A clear
+    // deliberately puts focus ON the bar's button, so each of those would
+    // otherwise destroy the element the keyboard is sitting on and drop focus to
+    // the body, where the next Tab restarts at the title bar (WCAG 2.4.3,
+    // technique F85). Handling it here rather than at each call site is the
+    // point: two of them were handled and four were not.
+    //
+    // The rescue fires only when focus is genuinely orphaned, so it can never
+    // steal focus from something that legitimately took it, which is also how
+    // the Start over dialog is left alone to focus its own safe button.
+    const barWasUp = useRef(false);
+    useEffect(() => {
+        const leaving = barWasUp.current && !barUp;
+        barWasUp.current = barUp;
+        if (!leaving) return;
+        if (document.activeElement && document.activeElement !== document.body) return;
+        requestAnimationFrame(() => document.getElementById('floe-send-kind')?.focus());
+    }, [barUp]);
 
     // The undo timer is the one thing here that outlives a render, so it needs an
     // explicit teardown. (Started in the click handler, never in an effect: this
@@ -1394,7 +1431,10 @@ function App() {
                 // silent when nothing is pending so Ctrl+Z stays free for the
                 // field the user is actually in.
                 case 'z':
-                    if (typing || !undoClearRef.current()) return;
+                    // Shift excluded: Ctrl+Shift+Z is redo on every platform that
+                    // has it, and performing an undo there would be the opposite
+                    // of what was asked.
+                    if (typing || e.shiftKey || !undoClearRef.current()) return;
                     e.preventDefault();
                     break;
             }
@@ -1407,7 +1447,7 @@ function App() {
         try {
             const picked = await SelectFiles();
             if (picked && picked.length) {
-                forgetCleared();
+                supersede('files');
                 setFiles((prev) => mergePaths(prev, picked));
                 setSendDone(false);
                 setSendStatus('');
@@ -1423,7 +1463,7 @@ function App() {
         try {
             const dir = await SelectFolder();
             if (dir) {
-                forgetCleared();
+                supersede('files');
                 setFiles((prev) => mergePaths(prev, [dir]));
                 setSendDone(false);
                 setSendStatus('');
@@ -1451,6 +1491,17 @@ function App() {
         holdUndo();
         setOfferUp(false);
         setCleared(null);
+        setAnnounce('');
+    }
+
+    // supersede is the ONLY automatic way an offer ends. New content on the tab
+    // the offer came from overtakes it, because undo replaces rather than merges
+    // and putting the old payload back would destroy what was just staged.
+    // Content on the other tab overtakes nothing. Reads the ref, not the state,
+    // because the drop and paste paths call this from closures bound at mount.
+    function supersede(kind: 'files' | 'text') {
+        const c = clearedRef.current;
+        if (c && supersededBy(c, kind)) forgetCleared();
     }
 
     // holdUndo stops the bar's countdown without taking the bar down, and
@@ -1465,19 +1516,14 @@ function App() {
         }
     }
 
+    // Lowering the bar is all this does. The offer it was announcing is
+    // untouched, and the focus it may have been holding is caught by the single
+    // handoff effect above, which covers this route and the five others.
     function armUndo() {
         if (clearedTimer.current !== null) return;
         clearedTimer.current = window.setTimeout(() => {
             clearedTimer.current = null;
-            // Never unmount the element the keyboard is sitting on. If Undo has
-            // focus when the bar's time runs out, hand focus back the way the
-            // settings dialog hands it to the trigger that opened it. The target
-            // is the active tab button, not Send: Send is disabled the moment a
-            // clear empties the tab, and focus() on a disabled button goes
-            // nowhere.
-            const onUndo = document.activeElement?.id === 'floe-undo-clear';
             setOfferUp(false);
-            if (onUndo) requestAnimationFrame(() => document.getElementById('floe-send-kind')?.focus());
         }, UNDO_WINDOW_MS);
     }
 
@@ -1499,7 +1545,10 @@ function App() {
         setSendStatus('');
         setCleared(snap);
         setOfferUp(true);
-        armUndo();
+        setAnnounce(clearedAnnouncement(snap));
+        // The clock is armed by the effect that owns it, so it can never run
+        // while the bar is not actually on screen.
+        //
         // Clear unmounts with the last thing it cleared, so focus would fall to
         // the body. Moving it to Undo keeps the keyboard where the user was, and
         // tells a screen reader the offer exists. The guidance against toasts
@@ -1510,28 +1559,24 @@ function App() {
         requestAnimationFrame(() => document.getElementById('floe-undo-clear')?.focus());
     }
 
-    // Undo replaces rather than merges, because it cannot collide: anything that
-    // could have staged something in the meantime has already retired the offer.
-    // Returns whether it actually put something back, so the Ctrl+Z handler can
-    // stay silent (and leave the keystroke alone) when there is no offer. No
-    // clock here: the bar may be long gone, and the offer is still good.
+    // Undo replaces rather than merges, because it cannot collide: new content on
+    // the offer's own tab has already superseded it. Returns whether it actually
+    // put something back, so the Ctrl+Z handler can stay silent (and leave the
+    // keystroke alone) when there is nothing to undo. No clock here: the bar may
+    // be long gone and the offer is still good.
     function undoClear(): boolean {
         if (!cleared) return false;
-        // An offer belongs to the tab it was taken from, and to no other. Every
-        // path that changes the tab retires it, so this guard should be dead
-        // code; it is here because the cost of one path forgetting is a note
-        // restored into a box nobody is looking at, or destroyed by the next
-        // Clear on the other tab. Ctrl+O was exactly that path once.
-        if (!restorable(cleared, sendKind)) { forgetCleared(); return false; }
+        // Refuses rather than retires. An offer sitting out a visit to the other
+        // tab is still perfectly good, and Ctrl+Z pressed over there should do
+        // nothing at all rather than quietly spend it.
+        if (!restorable(cleared, sendKind)) return false;
         const snap = cleared;
-        const onUndo = document.activeElement?.id === 'floe-undo-clear';
         forgetCleared();
         if (snap.kind === 'files') setFiles(snap.files);
         else setSendText(snap.text);
-        // The same handoff the bar's own expiry makes, for the same reason:
-        // pressing Undo destroys the button being pressed, and without this the
-        // keyboard lands on the body and Tab restarts at the title bar.
-        if (onUndo) requestAnimationFrame(() => document.getElementById('floe-send-kind')?.focus());
+        // Emptying the region would be a removal, and removals are not spoken,
+        // so the one route added for keyboard users would confirm nothing.
+        setAnnounce(restoredAnnouncement(snap));
         return true;
     }
 
@@ -1721,6 +1766,12 @@ function App() {
     // supplies the sentence, so do not restate its rules here.
     function startOver() {
         if (resetLoss) {
+            // Frozen at the moment it is shown. resetLoss is derived from live
+            // state, and state moves while the dialog is up: a send completing,
+            // an offer being superseded. Read live, the paragraph the user is in
+            // the middle of can be rewritten to a different reason, or emptied
+            // altogether, leaving a titled dialog over nothing.
+            setResetMsg(resetLoss);
             setConfirmReset(true);
             return;
         }
@@ -1786,13 +1837,13 @@ function App() {
     toggleHistoryRef.current = toggleHistory;
 
     // Ctrl+O: leave Settings, land on Send > Files, open the native picker.
-    // It retires the offer up front rather than leaving that to pickFiles, which
-    // only does it once a pick succeeds: cancelling the dialog still leaves the
-    // user on a tab they did not start on, and an offer taken from the other tab
-    // has no business surviving that.
+    // Nothing is retired here. Landing on Files hides a note's bar (restorable
+    // says so) and pickFiles supersedes only if a pick actually lands, so
+    // cancelling the dialog costs nothing: the note is still there on the tab it
+    // came from. An earlier fix retired eagerly at this line, which closed one
+    // hole by destroying the thing the hole endangered.
     function openPicker() {
         if (busy) return;
-        forgetCleared();
         setSettingsOpen(false);
         setMode('send');
         setSendKind('files');
@@ -1859,7 +1910,7 @@ function App() {
                 at the same time, and one ternary owning both would let either
                 erase the other's sentence. */}
             <span className="sr-only" role="status" aria-live="polite">
-                {cleared ? clearedAnnouncement(cleared) : ''}
+                {announce}
             </span>
             {/* The bar, which is not the offer: it comes down on its own after a
                 few seconds while the undo behind it stays good, and it steps
@@ -1868,7 +1919,7 @@ function App() {
                 two for the same reason. Keyed on what it says so a second offer
                 always replays the entrance, rather than relying on an argument
                 about which renders can be adjacent. */}
-            {cleared && offerUp && !confirmReset && !confirmDefaults && (
+            {barUp && cleared && (
                 <UndoToast
                     key={clearedLabel(cleared)}
                     label={clearedLabel(cleared)}
@@ -2323,10 +2374,14 @@ function App() {
                                                     <button
                                                         key={k}
                                                         // The active tab is where focus lands if the undo
-                                                        // offer expires under the keyboard, so exactly one
-                                                        // of the two carries the id at a time.
+                                                        // bar goes while the keyboard is on it, so exactly
+                                                        // one of the two carries the id at a time.
                                                         id={sendKind === k ? 'floe-send-kind' : undefined}
-                                                        onClick={() => { forgetCleared(); setSendKind(k); }}
+                                                        // No retire: switching tabs only puts the bar away.
+                                                        // An unsent note survives a tab switch when it sits
+                                                        // in the box, and it has to survive one when it sits
+                                                        // in an offer, or Clear would be a trap.
+                                                        onClick={() => setSendKind(k)}
                                                         className={cn(
                                                             'border-b pb-0.5 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors',
                                                             sendKind === k ? 'border-white text-zinc-200' : 'border-transparent text-zinc-600 hover:text-zinc-400',
@@ -2348,7 +2403,7 @@ function App() {
                                         {!sending && sendKind === 'text' && (
                                             <textarea
                                                 value={sendText}
-                                                onChange={(e) => { if (cleared) forgetCleared(); setSendText(e.target.value); }}
+                                                onChange={(e) => { supersede('text'); setSendText(e.target.value); }}
                                                 onKeyDown={(e) => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && sendText.trim() && !busy) send(); }}
                                                 placeholder="Type or paste text to send"
                                                 rows={4}
@@ -2719,10 +2774,16 @@ function App() {
                         <h2 id="floe-startover-title" className="text-sm font-semibold text-white">Start over?</h2>
                         {/* resetWarning decided to open this dialog, so it also
                             supplies the sentence. One source, so the guard and
-                            the copy cannot disagree about why you were stopped. */}
-                        <p className="mt-1.5 text-xs leading-relaxed text-zinc-400">{resetLoss}</p>
+                            the copy cannot disagree about why you were stopped.
+                            Captured at open time, not read live: see startOver. */}
+                        <p className="mt-1.5 text-xs leading-relaxed text-zinc-400">{resetMsg}</p>
                         <div className="mt-4 flex justify-end gap-2">
-                            <Button variant="outline" onClick={() => setConfirmReset(false)}>Keep going</Button>
+                            {/* The safe choice takes focus. Without it the dialog
+                                opens with focus wherever it was, which after a
+                                Clear is a button this dialog just unmounted, so
+                                focus falls to the body and Tab walks the page
+                                behind the scrim. */}
+                            <Button variant="outline" autoFocus onClick={() => setConfirmReset(false)}>Keep going</Button>
                             <Button onClick={doReset}>Start over</Button>
                         </div>
                     </div>

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1262,17 +1262,23 @@ function App() {
     // Leaving the history view abandons a pending Clear confirmation.
     useEffect(() => { if (mode !== 'history') setConfirmClear(false); }, [mode]);
 
-    // Whether the undo bar is on screen. Note what this is NOT: it is not
-    // whether the undo is available. Hiding the bar and forgetting the offer
-    // were the same act until the audit pointed out what that cost, which was
-    // that a note became LESS safe the moment you cleared it. Sitting in the
-    // textarea it survived a tab switch, a look at Settings and a glance at
-    // History; held in an offer, each of those destroyed it silently. So the bar
-    // is a view concern (right screen, right tab, nothing covering it) and the
-    // offer is not: only supersededBy, a send, a Start over or another clear
-    // ends one. Coming back brings the bar back with it.
-    const barUp = !!cleared && offerUp && mode === 'send' && !settingsOpen
+    // Whether an undo can be taken right now: the offer exists, it belongs to the
+    // tab on screen, and that screen is actually in front of the user. Ctrl+Z
+    // reads this too, so the keystroke can never spend an offer from a screen
+    // that cannot show what happened, the way primaryAction bails on Settings.
+    //
+    // Note what it is NOT: it is not whether the offer still EXISTS. Being unable
+    // to undo from History does not end anything; walk back to Send and it is
+    // there. Only supersededBy, a Start over or another Clear ends an offer.
+    // Hiding and forgetting were the same act until the audit priced it: a note
+    // became LESS safe the moment you cleared it, because sitting in the textarea
+    // it survives a tab switch, Settings, History, a send and a cancel, while
+    // held in an offer each of those destroyed it silently.
+    const canUndo = !!cleared && mode === 'send' && !settingsOpen
         && !confirmReset && !confirmDefaults && restorable(cleared, sendKind);
+    // The bar is that, plus its own short life. The clock only ever lowers the
+    // bar; coming back to the view raises it again with a fresh window.
+    const barUp = canUndo && offerUp;
 
     // The bar's clock runs only while the bar is actually on screen and
     // reachable. Look somewhere else, open Settings, raise a dialog, and it
@@ -1292,7 +1298,13 @@ function App() {
     // otherwise destroy the element the keyboard is sitting on and drop focus to
     // the body, where the next Tab restarts at the title bar (WCAG 2.4.3,
     // technique F85). Handling it here rather than at each call site is the
-    // point: two of them were handled and four were not.
+    // point: previously two routes were handled and the rest were not.
+    //
+    // Two targets, because the first does not exist everywhere the bar can leave
+    // from: #floe-send-kind lives inside the send view, so Ctrl+, and Ctrl+H
+    // unmount it in the same commit and the lookup would find nothing. The
+    // titlebar lockup is mounted on every screen, and is where the settings
+    // dialogs already hand focus back to.
     //
     // The rescue fires only when focus is genuinely orphaned, so it can never
     // steal focus from something that legitimately took it, which is also how
@@ -1303,7 +1315,10 @@ function App() {
         barWasUp.current = barUp;
         if (!leaving) return;
         if (document.activeElement && document.activeElement !== document.body) return;
-        requestAnimationFrame(() => document.getElementById('floe-send-kind')?.focus());
+        requestAnimationFrame(() => {
+            const target = document.getElementById('floe-send-kind') ?? document.getElementById('floe-reset-trigger');
+            target?.focus();
+        });
     }, [barUp]);
 
     // The undo timer is the one thing here that outlives a render, so it needs an
@@ -1321,7 +1336,11 @@ function App() {
         if (!settingsOpen && !confirmReset) return;
         const onKey = (e: KeyboardEvent) => {
             if (e.key !== 'Escape') return;
-            if (confirmReset) setConfirmReset(false);
+            // Both dialogs hand focus back the same way now. Start over did not
+            // need to before, because focus never entered it; it does now that
+            // it autofocuses its safe button, and without this the dismissal
+            // drops the keyboard on the body.
+            if (confirmReset) { setConfirmReset(false); focusResetTrigger(); }
             else if (confirmDefaults) { setConfirmDefaults(false); focusResetTrigger(); }
             else setSettingsOpen(false);
         };
@@ -1473,7 +1492,7 @@ function App() {
         }
     }
 
-    // No forgetCleared here, and not by oversight: an offer only ever stands over
+    // No discard here, and not by oversight: an offer only ever stands over
     // an emptied tab, so there is no row left to remove from while one is up. If
     // Clear ever learns to clear a subset, this needs the call.
     function removeFile(path: string) {
@@ -1481,27 +1500,37 @@ function App() {
         setSendDone(false);
     }
 
-    // forgetCleared retires a pending undo offer, takes its bar down and stops
-    // the timer. Every path that stages something new or moves the send view on
-    // calls it, so Undo can never put a payload back into a screen that changed
-    // underneath it. This is the ONLY thing that ends an offer: the clock ends
-    // the bar, never the offer. Safe from the once-registered closures: a ref
-    // and stable setters, nothing else.
-    function forgetCleared() {
+    // discardCleared throws the standing offer away, whatever it is and whichever
+    // tab it belongs to. It is TAB-BLIND, which is why it is named for what it
+    // costs rather than for tidying up, and why it has exactly three callers:
+    // Start over (which prompts first), another Clear (which replaces it), and an
+    // undo (which has just spent it).
+    //
+    // Do not add a fourth without proving the offer is genuinely dead. Three
+    // separate audit rounds failed on exactly that mistake: a call added to a
+    // transition that felt like an ending (a tab switch, opening Settings,
+    // Ctrl+O, a send, a cancel) but was not, each one silently destroying a
+    // typed note whose only copy this offer was. If what you mean is "this tab
+    // has new content now", call supersede(kind) instead, which cannot touch an
+    // offer belonging to the other tab.
+    //
+    // Safe from the once-registered closures: a ref and stable setters, nothing
+    // else.
+    function discardCleared() {
         holdUndo();
         setOfferUp(false);
         setCleared(null);
         setAnnounce('');
     }
 
-    // supersede is the ONLY automatic way an offer ends. New content on the tab
+    // supersede is the only AUTOMATIC way an offer ends. New content on the tab
     // the offer came from overtakes it, because undo replaces rather than merges
     // and putting the old payload back would destroy what was just staged.
     // Content on the other tab overtakes nothing. Reads the ref, not the state,
     // because the drop and paste paths call this from closures bound at mount.
     function supersede(kind: 'files' | 'text') {
         const c = clearedRef.current;
-        if (c && supersededBy(c, kind)) forgetCleared();
+        if (c && supersededBy(c, kind)) discardCleared();
     }
 
     // holdUndo stops the bar's countdown without taking the bar down, and
@@ -1535,7 +1564,7 @@ function App() {
     function clearStaged() {
         const snap = stagedSnapshot(sendKind, files, sendText);
         if (!snap) return;
-        forgetCleared();
+        discardCleared();
         if (snap.kind === 'files') setFiles([]);
         else setSendText('');
         setSendDone(false);
@@ -1565,13 +1594,13 @@ function App() {
     // keystroke alone) when there is nothing to undo. No clock here: the bar may
     // be long gone and the offer is still good.
     function undoClear(): boolean {
-        if (!cleared) return false;
-        // Refuses rather than retires. An offer sitting out a visit to the other
-        // tab is still perfectly good, and Ctrl+Z pressed over there should do
-        // nothing at all rather than quietly spend it.
-        if (!restorable(cleared, sendKind)) return false;
+        // Refuses rather than discards. An offer sitting out a visit to the other
+        // tab, or to Settings, is still perfectly good, and Ctrl+Z pressed over
+        // there should do nothing at all rather than quietly spend it somewhere
+        // the user cannot see the result.
+        if (!cleared || !canUndo) return false;
         const snap = cleared;
-        forgetCleared();
+        discardCleared();
         if (snap.kind === 'files') setFiles(snap.files);
         else setSendText(snap.text);
         // Emptying the region would be a removal, and removals are not spoken,
@@ -1599,7 +1628,15 @@ function App() {
             setSendStatus('Select at least one file first.');
             return;
         }
-        forgetCleared();
+        // Nothing is discarded here, and the reason is worth stating because the
+        // opposite looks obvious. An offer of kind K only exists while tab K is
+        // empty (every path that puts content on a tab supersedes that tab's
+        // offer first), and the guards just above refuse to send an empty tab.
+        // So a live offer at this line ALWAYS belongs to the other tab, and
+        // ending it could only ever destroy a payload this send has nothing to
+        // do with. Sending files is not a reason to forget a note you cleared,
+        // any more than it is a reason to empty the box a note is still sitting
+        // in, which it also does not do.
         sendCancel.current = false;
         setSending(true);
         setSendDone(false);
@@ -1672,8 +1709,14 @@ function App() {
 
     // cancel aborts the in-flight transfer: flag it so late Go events are ignored,
     // reset the UI optimistically, then close the connections on the Go side.
+    //
+    // Nothing is discarded here either, and this one was actively wrong: the call
+    // used to be the first statement, before the function had even decided which
+    // transfer it was cancelling, so cancelling a RECEIVE destroyed a send-side
+    // offer that had nothing to do with it. The render comment on the action row
+    // promises that clearing during a receive is "harmless and undoable", and
+    // that promise is only true with this gone.
     function cancel() {
-        forgetCleared();
         if (sending) {
             sendCancel.current = true;
             setSending(false);
@@ -1722,7 +1765,7 @@ function App() {
         prevModeRef.current = fresh;
         setConfirmClear(false);
         setExpandedRow(null);
-        forgetCleared();
+        discardCleared();
         sendBytesRef.current = 0;
         recvBytesRef.current = 0;
 
@@ -2783,8 +2826,12 @@ function App() {
                                 Clear is a button this dialog just unmounted, so
                                 focus falls to the body and Tab walks the page
                                 behind the scrim. */}
-                            <Button variant="outline" autoFocus onClick={() => setConfirmReset(false)}>Keep going</Button>
-                            <Button onClick={doReset}>Start over</Button>
+                            <Button variant="outline" autoFocus onClick={() => { setConfirmReset(false); focusResetTrigger(); }}>Keep going</Button>
+                            {/* The handoff goes here rather than inside doReset,
+                                which also runs from Ctrl+R and the titlebar with
+                                no dialog in the way, where moving focus would be
+                                an unasked-for jump. */}
+                            <Button onClick={() => { doReset(); focusResetTrigger(); }}>Start over</Button>
                         </div>
                     </div>
                 </div>

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -332,11 +332,7 @@ function UndoToast({label, action, onUndo, onHold, onArm, onFocus}: {
                     'animate-floe-toast-in motion-reduce:animate-none',
                 )}
             >
-                {/* The same icon tile the file rows use, which is what makes this
-                    read as part of the app rather than a browser notification. */}
-                <span className="grid size-8 shrink-0 place-items-center rounded-md bg-white/[0.04] ring-1 ring-inset ring-white/10">
-                    <Undo2 className="size-4 text-zinc-300" strokeWidth={2.5} aria-hidden/>
-                </span>
+                <Undo2 className="ml-1.5 size-4 shrink-0 text-zinc-400" strokeWidth={2.5} aria-hidden/>
                 <span className="whitespace-nowrap pr-1 text-[13px] leading-none tracking-[-0.005em] text-zinc-200">{label}</span>
                 <button
                     id="floe-undo-clear"

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -50,6 +50,7 @@ import QRCode from 'react-qr-code';
 import {BoltMark, Button, Eyebrow, Input, StatusDot, cn} from './components/ui';
 import {advancedSummary, hostOf} from './settings';
 import {histKey} from './history';
+import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, isExpired, stagedSnapshot, undoLabel, type Cleared} from './clear';
 import {resetWarning} from './reset';
 import {friendlyError} from './errors';
 import {fmtBytes, formatIncoming, type IncomingPreview} from './incoming';
@@ -680,6 +681,18 @@ function App() {
     const [sentText, setSentText] = useState('');
     const [peerConnected, setPeerConnected] = useState(false);
     const [filesOpen, setFilesOpen] = useState(false);
+    // What Clear last took away, and the timer that retires the offer to put it
+    // back. The snapshot is state because the offer renders from it; the timer
+    // id is a ref because nothing renders from it and because the
+    // once-registered handlers have to be able to cancel it.
+    const [cleared, setCleared] = useState<Cleared | null>(null);
+    const clearedTimer = useRef<number | null>(null);
+    // When the standing offer runs out. Checked again on the click, because a
+    // background window can have its timers clamped; Infinity while held.
+    const clearedUntil = useRef(0);
+    // Marks the one programmatic focus clearStaged performs, so that landing on
+    // Undo does not read as "the user reached for it" and stop the countdown.
+    const undoAutoFocus = useRef(false);
     const sendStart = useRef<Marker>(null);
     const sendCancel = useRef(false);
     // Snapshot of the sent file names, readable from the once-registered
@@ -763,6 +776,7 @@ function App() {
     // once-registered closures (functional updates + stable setters only).
     function addFiles(paths: string[]) {
         if (!paths || !paths.length || busyRef.current) return;
+        forgetCleared();
         setSettingsOpen(false);
         setMode('send');
         setSendKind('files');
@@ -1164,6 +1178,18 @@ function App() {
     // Leaving the history view abandons a pending Clear confirmation.
     useEffect(() => { if (mode !== 'history') setConfirmClear(false); }, [mode]);
 
+    // Leaving the send view abandons a pending undo offer: it belongs to a screen
+    // the user is no longer looking at, and its timer would otherwise fire there.
+    // Settings is not a mode but it covers the send view all the same, so it
+    // counts as leaving: without this, closing Settings inside the window would
+    // bring a ghost offer back with a partly spent timer.
+    useEffect(() => { if (mode !== 'send' || settingsOpen) forgetCleared(); }, [mode, settingsOpen]);
+
+    // The undo timer is the one thing here that outlives a render, so it needs an
+    // explicit teardown. (Started in the click handler, never in an effect: this
+    // app renders under StrictMode, which double-invokes effects in dev.)
+    useEffect(() => () => { if (clearedTimer.current !== null) clearTimeout(clearedTimer.current); }, []);
+
     // Escape dismisses whichever overlay is on top, else the settings screen.
     //
     // The branch order matches the paint order below: Start over renders last and
@@ -1284,6 +1310,7 @@ function App() {
         try {
             const picked = await SelectFiles();
             if (picked && picked.length) {
+                forgetCleared();
                 setFiles((prev) => mergePaths(prev, picked));
                 setSendDone(false);
                 setSendStatus('');
@@ -1299,6 +1326,7 @@ function App() {
         try {
             const dir = await SelectFolder();
             if (dir) {
+                forgetCleared();
                 setFiles((prev) => mergePaths(prev, [dir]));
                 setSendDone(false);
                 setSendStatus('');
@@ -1308,9 +1336,92 @@ function App() {
         }
     }
 
+    // No forgetCleared here, and not by oversight: an offer only ever stands over
+    // an emptied tab, so there is no row left to remove from while one is up. If
+    // Clear ever learns to clear a subset, this needs the call.
     function removeFile(path: string) {
         setFiles((prev) => prev.filter((f) => normPath(f) !== normPath(path)));
         setSendDone(false);
+    }
+
+    // forgetCleared retires a pending undo offer and its timer. Every path that
+    // stages something new or moves the send view on calls it, so Undo can never
+    // put a payload back into a screen that changed underneath it. Safe from the
+    // once-registered closures: a ref and a stable setter, nothing else.
+    function forgetCleared() {
+        holdUndo();
+        setCleared(null);
+    }
+
+    // holdUndo stops the countdown without retiring the offer, and armUndo
+    // starts a fresh one. Pointing at the offer holds it, so it cannot expire
+    // out from under the pointer travelling towards it.
+    function holdUndo() {
+        if (clearedTimer.current !== null) {
+            clearTimeout(clearedTimer.current);
+            clearedTimer.current = null;
+        }
+        clearedUntil.current = Infinity;
+    }
+
+    function armUndo() {
+        if (clearedTimer.current !== null) return;
+        clearedUntil.current = Date.now() + UNDO_WINDOW_MS;
+        clearedTimer.current = window.setTimeout(() => {
+            clearedTimer.current = null;
+            // Never unmount the element the keyboard is sitting on. If Undo has
+            // focus when its time runs out, hand focus back the way the settings
+            // dialog hands it to the trigger that opened it. The target is the
+            // active tab button, not Send: Send is disabled the moment a clear
+            // empties the tab, and focus() on a disabled button goes nowhere.
+            const onUndo = document.activeElement?.id === 'floe-undo-clear';
+            setCleared(null);
+            if (onUndo) requestAnimationFrame(() => document.getElementById('floe-send-kind')?.focus());
+        }, UNDO_WINDOW_MS);
+    }
+
+    // clearStaged empties what the current tab is holding and offers it back for
+    // a few seconds. No confirm: re-picking files is tedious rather than
+    // destructive, the same judgement resetWarning makes about staged files, and
+    // an undo catches the slip a prompt would have caught without taxing every
+    // deliberate clear.
+    function clearStaged() {
+        const snap = stagedSnapshot(sendKind, files, sendText);
+        if (!snap) return;
+        forgetCleared();
+        if (snap.kind === 'files') setFiles([]);
+        else setSendText('');
+        setSendDone(false);
+        // Blanked for the same reason every staging path blanks it: whatever it
+        // said was about a payload that no longer exists. Without this, a
+        // "Cancelled." from an earlier send would reappear when the offer went.
+        setSendStatus('');
+        setCleared(snap);
+        armUndo();
+        // Clear unmounts with the last thing it cleared, so focus would fall to
+        // the body. Moving it to Undo keeps the keyboard where the user was, and
+        // is what tells a screen reader the offer exists: an aria-live region
+        // that mounts with its own text already inside announces nothing, which
+        // this file has learned twice already. The button describes itself with
+        // the sentence beside it, so the landing reads "Undo, Cleared 12 items."
+        // Same id lookup as focusResetTrigger, for the same reason.
+        undoAutoFocus.current = true;
+        requestAnimationFrame(() => {
+            const el = document.getElementById('floe-undo-clear');
+            if (el) el.focus();
+            else undoAutoFocus.current = false;
+        });
+    }
+
+    // Undo replaces rather than merges, because it cannot collide: anything that
+    // could have staged something in the meantime has already retired the offer.
+    function undoClear() {
+        if (!cleared) return;
+        if (isExpired(clearedUntil.current, Date.now())) { forgetCleared(); return; }
+        const snap = cleared;
+        forgetCleared();
+        if (snap.kind === 'files') setFiles(snap.files);
+        else setSendText(snap.text);
     }
 
     async function pickSaveFolder() {
@@ -1332,6 +1443,7 @@ function App() {
             setSendStatus('Select at least one file first.');
             return;
         }
+        forgetCleared();
         sendCancel.current = false;
         setSending(true);
         setSendDone(false);
@@ -1405,6 +1517,7 @@ function App() {
     // cancel aborts the in-flight transfer: flag it so late Go events are ignored,
     // reset the UI optimistically, then close the connections on the Go side.
     function cancel() {
+        forgetCleared();
         if (sending) {
             sendCancel.current = true;
             setSending(false);
@@ -1453,6 +1566,7 @@ function App() {
         prevModeRef.current = fresh;
         setConfirmClear(false);
         setExpandedRow(null);
+        forgetCleared();
         sendBytesRef.current = 0;
         recvBytesRef.current = 0;
 
@@ -1509,6 +1623,11 @@ function App() {
 
     const busy = sending || receiving;
 
+    // What the send tab is holding, or null when it is empty. One rule, read by
+    // three places: whether Send is enabled, whether Clear is offered at all, and
+    // what an undo would have to put back.
+    const staged = stagedSnapshot(sendKind, files, sendText);
+
     // Update-notice visibility. updateAvailable drives the quiet About row and
     // survives dismissal; showUpdate adds the popup's manners: never over a
     // live transfer, never behind a dialog's scrim, gone for the session once
@@ -1525,6 +1644,9 @@ function App() {
         busy,
         text: sendText,
         sentText,
+        // A cleared note lives in the undo offer and nowhere else, and Start
+        // over drops the offer, so it earns the same prompt the box does.
+        clearedText: cleared?.kind === 'text' ? cleared.text : '',
     });
     // Amber marks anything relay-flavored: a known relayed route, or (before
     // the route is known / while idle) the Hide-my-IP preference forcing one.
@@ -2053,7 +2175,11 @@ function App() {
                                                 {(['files', 'text'] as const).map((k) => (
                                                     <button
                                                         key={k}
-                                                        onClick={() => setSendKind(k)}
+                                                        // The active tab is where focus lands if the undo
+                                                        // offer expires under the keyboard, so exactly one
+                                                        // of the two carries the id at a time.
+                                                        id={sendKind === k ? 'floe-send-kind' : undefined}
+                                                        onClick={() => { forgetCleared(); setSendKind(k); }}
                                                         className={cn(
                                                             'border-b pb-0.5 font-mono text-[10px] uppercase tracking-[0.2em] transition-colors',
                                                             sendKind === k ? 'border-white text-zinc-200' : 'border-transparent text-zinc-600 hover:text-zinc-400',
@@ -2075,7 +2201,7 @@ function App() {
                                         {!sending && sendKind === 'text' && (
                                             <textarea
                                                 value={sendText}
-                                                onChange={(e) => setSendText(e.target.value)}
+                                                onChange={(e) => { if (cleared) forgetCleared(); setSendText(e.target.value); }}
                                                 onKeyDown={(e) => { if (e.key === 'Enter' && (e.ctrlKey || e.metaKey) && sendText.trim() && !busy) send(); }}
                                                 placeholder="Type or paste text to send"
                                                 rows={4}
@@ -2103,21 +2229,64 @@ function App() {
                                             />
                                         )}
 
-                                        {/* action: a stable slot across stages so the button never jumps */}
+                                        {/* action: one slot across every stage, so the primary button stays
+                                            put. Clear joins Send exactly when the tab is holding something,
+                                            which is the same rule that enables Send, and never while
+                                            sending, where the slot belongs to Cancel. A receive running on
+                                            the other tab does not take Clear away: the send stage is
+                                            separate state, and clearing it is both harmless and undoable.
+                                            Send does narrow when
+                                            Clear arrives; on Files that lands with the list and the label
+                                            gaining its count, on Text it is the one visible shift, and it
+                                            marks the moment there is something to send either way.
+                                            Clear sits left of Send like the safe choice in this app's
+                                            dialogs (Cancel before Reset all settings, Keep going before
+                                            Start over), which also puts it first in the tab order. That is
+                                            the opposite of the history row, where Remove is outermost, and
+                                            deliberately so: that row has no primary action to defer to. */}
                                         {sending ? (
-                                            <Button variant="outline" className="w-full" onClick={cancel}>
+                                            <Button variant="outline" size="lg" className="w-full" onClick={cancel}>
                                                 <X/> Cancel
                                             </Button>
                                         ) : (
-                                            <Button
-                                                className="w-full"
-                                                onClick={send}
-                                                disabled={busy || (sendKind === 'text' ? !sendText.trim() : !files.length)}
-                                            >
-                                                <Send/> {sendKind === 'text'
-                                                    ? 'Send text'
-                                                    : `Send${files.length ? ` ${files.length} ${files.length === 1 ? 'item' : 'items'}` : ''}`}
-                                            </Button>
+                                            <div className="flex gap-3">
+                                                {/* The visible word stays "Clear" because its object is
+                                                    right there in the Send label beside it; the accessible
+                                                    name carries that object for anyone who cannot see the
+                                                    pair. No tooltip: a labelled button next to the thing it
+                                                    acts on does not need one, and the wrapper would take
+                                                    the layout classes with it. */}
+                                                {staged && (
+                                                    <Button
+                                                        variant="secondary"
+                                                        size="lg"
+                                                        // A floor on the width so the short word cannot
+                                                        // collapse into a chip beside a stretched primary,
+                                                        // and font-medium so the pair differs by material
+                                                        // rather than by weight as well as everything else.
+                                                        className="min-w-24 font-medium"
+                                                        onClick={clearStaged}
+                                                        aria-label={clearLabel(staged)}
+                                                    >
+                                                        Clear
+                                                    </Button>
+                                                )}
+                                                {/* The gradient paints over the primary variant's flat white,
+                                                    because a background-image sits above a background-color.
+                                                    That is also why the hover moves the stops instead of the
+                                                    colour: the variant's own hover:bg-zinc-200 is underneath
+                                                    the gradient and would never be seen. */}
+                                                <Button
+                                                    size="lg"
+                                                    className="flex-1 bg-gradient-to-b from-white to-zinc-100 shadow-sm hover:from-zinc-100 hover:to-zinc-200"
+                                                    onClick={send}
+                                                    disabled={busy || !staged}
+                                                >
+                                                    <Send/> {sendKind === 'text'
+                                                        ? 'Send text'
+                                                        : `Send${files.length ? ` ${files.length} ${files.length === 1 ? 'item' : 'items'}` : ''}`}
+                                                </Button>
+                                            </div>
                                         )}
 
                                         {/* share surface: waiting stage only — the 1:1 room is consumed
@@ -2133,7 +2302,39 @@ function App() {
                                                 <span>Sent {sentCount} {sentCount === 1 ? 'item' : 'items'}</span>
                                             </div>
                                         )}
-                                        <StatusLine text={sendStatus} busy={sending}/>
+                                        {/* While it stands, the undo offer speaks for the status line:
+                                            two rows of small print under the button would be one too many. */}
+                                        {cleared ? (
+                                            <p className="flex min-h-5 items-center justify-center gap-2 text-center text-xs">
+                                                <span className="text-zinc-500">{clearedLabel(cleared)}</span>
+                                                <button
+                                                    type="button"
+                                                    id="floe-undo-clear"
+                                                    aria-label={undoLabel(cleared)}
+                                                    onClick={undoClear}
+                                                    onMouseEnter={holdUndo}
+                                                    onMouseLeave={() => { if (cleared) armUndo(); }}
+                                                    onFocus={() => { if (undoAutoFocus.current) { undoAutoFocus.current = false; return; } holdUndo(); }}
+                                                    onBlur={() => { if (cleared) armUndo(); }}
+                                                    className="rounded-md px-2 py-1 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ice/60"
+                                                >
+                                                    Undo
+                                                </button>
+                                            </p>
+                                        ) : (
+                                            <StatusLine text={sendStatus} busy={sending}/>
+                                        )}
+                                        {/* Zero height, and mounted whether or not there is anything to
+                                            say, because a live region only announces a CHANGE: one that
+                                            mounts with its text already inside stays silent, which this
+                                            file has learned twice (StatusLine's docblock, and the update
+                                            notice's sr-only twin). sr-only is absolutely positioned, so it
+                                            adds no row to the stack. Belt and braces with the focus move:
+                                            whichever of the two a screen reader honours, the user hears
+                                            both what went and that there is a way back. */}
+                                        <span className="sr-only" role="status" aria-live="polite">
+                                            {cleared ? clearedAnnouncement(cleared) : ''}
+                                        </span>
                                     </div>
 
                                 ) : mode === 'receive' ? (

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1038,9 +1038,13 @@ function App() {
         focusResetTrigger();
     }
 
-    // Returns focus to the trigger after the dialog closes, so a keyboard user is
-    // not dropped at the top of the document. The trigger is never unmounted, so
-    // this always has somewhere to land.
+    // Returns focus to the Settings "Reset" button after the defaults dialog
+    // closes, so a keyboard user is not dropped at the top of the document.
+    //
+    // #floe-reset-trigger lives INSIDE the settings screen, which is exactly
+    // right here (the defaults dialog can only be raised from there) and exactly
+    // wrong anywhere else. It was briefly used as a general fallback, which was a
+    // no-op on every screen but Settings.
     //
     // Looked up by id rather than by ref because Button is a plain React 18
     // function component shared with the transfer screen: accepting a ref would
@@ -1048,6 +1052,14 @@ function App() {
     // The rAF waits for the dialog to unmount before moving focus.
     function focusResetTrigger() {
         requestAnimationFrame(() => document.getElementById('floe-reset-trigger')?.focus());
+    }
+
+    // The app's last-resort focus home: the titlebar lockup, which is the only
+    // focusable element rendered on every screen, and which is itself the Start
+    // over control. Use this wherever focus would otherwise be orphaned on a
+    // screen you cannot predict.
+    function focusLockup() {
+        requestAnimationFrame(() => document.getElementById('floe-lockup')?.focus());
     }
 
     useEffect(() => {
@@ -1302,9 +1314,11 @@ function App() {
     //
     // Two targets, because the first does not exist everywhere the bar can leave
     // from: #floe-send-kind lives inside the send view, so Ctrl+, and Ctrl+H
-    // unmount it in the same commit and the lookup would find nothing. The
-    // titlebar lockup is mounted on every screen, and is where the settings
-    // dialogs already hand focus back to.
+    // unmount it in the same commit and the lookup finds nothing. #floe-lockup is
+    // the titlebar brand button, the only focusable element rendered on every
+    // screen. An earlier attempt used #floe-reset-trigger for this, which is
+    // inside the SETTINGS screen and therefore absent on exactly the routes that
+    // needed it.
     //
     // The rescue fires only when focus is genuinely orphaned, so it can never
     // steal focus from something that legitimately took it, which is also how
@@ -1316,7 +1330,7 @@ function App() {
         if (!leaving) return;
         if (document.activeElement && document.activeElement !== document.body) return;
         requestAnimationFrame(() => {
-            const target = document.getElementById('floe-send-kind') ?? document.getElementById('floe-reset-trigger');
+            const target = document.getElementById('floe-send-kind') ?? document.getElementById('floe-lockup');
             target?.focus();
         });
     }, [barUp]);
@@ -1336,11 +1350,12 @@ function App() {
         if (!settingsOpen && !confirmReset) return;
         const onKey = (e: KeyboardEvent) => {
             if (e.key !== 'Escape') return;
-            // Both dialogs hand focus back the same way now. Start over did not
-            // need to before, because focus never entered it; it does now that
-            // it autofocuses its safe button, and without this the dismissal
-            // drops the keyboard on the body.
-            if (confirmReset) { setConfirmReset(false); focusResetTrigger(); }
+            // Start over did not need a handoff before, because focus never
+            // entered it; it does now that it autofocuses its safe button. It
+            // goes to the lockup, NOT to the settings Reset button: this dialog
+            // is normally raised by Ctrl+R or by the lockup itself with Settings
+            // closed, where that button does not exist.
+            if (confirmReset) { setConfirmReset(false); focusLockup(); }
             else if (confirmDefaults) { setConfirmDefaults(false); focusResetTrigger(); }
             else setSettingsOpen(false);
         };
@@ -2826,12 +2841,12 @@ function App() {
                                 Clear is a button this dialog just unmounted, so
                                 focus falls to the body and Tab walks the page
                                 behind the scrim. */}
-                            <Button variant="outline" autoFocus onClick={() => { setConfirmReset(false); focusResetTrigger(); }}>Keep going</Button>
+                            <Button variant="outline" autoFocus onClick={() => { setConfirmReset(false); focusLockup(); }}>Keep going</Button>
                             {/* The handoff goes here rather than inside doReset,
                                 which also runs from Ctrl+R and the titlebar with
                                 no dialog in the way, where moving focus would be
                                 an unasked-for jump. */}
-                            <Button onClick={() => { doReset(); focusResetTrigger(); }}>Start over</Button>
+                            <Button onClick={() => { doReset(); focusLockup(); }}>Start over</Button>
                         </div>
                     </div>
                 </div>

--- a/desktop/frontend/src/clear.test.ts
+++ b/desktop/frontend/src/clear.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, stagedSnapshot, undoLabel} from './clear';
+import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, restoredAnnouncement, stagedSnapshot, supersededBy, undoLabel} from './clear';
 
 describe('stagedSnapshot', () => {
     it('is null when there is nothing to clear', () => {
@@ -35,10 +35,10 @@ describe('clearedLabel', () => {
     });
     // The bar pairs this line with a button, so it is a label rather than
     // prose. The period belongs only in the spoken version, where it is what
-    // makes a screen reader pause before "Undo is available".
+    // makes a screen reader pause before the second sentence.
     it('carries no full stop, while the announcement does', () => {
         expect(clearedLabel({kind: 'files', files: ['a.txt']})).not.toContain('.');
-        expect(clearedAnnouncement({kind: 'files', files: ['a.txt']})).toContain('item. Undo');
+        expect(clearedAnnouncement({kind: 'files', files: ['a.txt']})).toContain('item. Press');
     });
     // Folders stage into the same list as files, so the count has to be in
     // items. "Cleared 12 files." would be a lie about a folder pick.
@@ -81,7 +81,19 @@ describe('the accessible names', () => {
     it('carry the visible sentence into speech verbatim', () => {
         const c = {kind: 'files' as const, files: ['a', 'b']};
         expect(clearedAnnouncement(c)).toContain(clearedLabel(c));
-        expect(clearedAnnouncement(c)).toContain('Undo');
+    });
+    // The bar outlives nothing; the OFFER outlives the bar. So the announcement
+    // has to name the route that is still there once the button is gone, or it
+    // sends someone hunting the accessibility tree for a control that left.
+    it('name the key rather than the button', () => {
+        const c = {kind: 'files' as const, files: ['a', 'b']};
+        expect(clearedAnnouncement(c)).toContain('Control Z');
+        expect(clearedAnnouncement(c)).not.toContain('is available');
+    });
+    // "Ctrl+Z" is read out as punctuation by a screen reader.
+    it('spell the key out', () => {
+        expect(clearedAnnouncement({kind: 'text', text: 'x'})).not.toContain('Ctrl');
+        expect(clearedAnnouncement({kind: 'text', text: 'x'})).not.toContain('+');
     });
     // The window is a constant that should stay tunable without touching copy.
     it('promise no particular number of seconds', () => {
@@ -89,12 +101,27 @@ describe('the accessible names', () => {
     });
 });
 
-// The guard that makes a missed retire harmless. Ctrl+O was the path that
-// missed one: it switched to the Files tab without dropping a note's offer, so
-// Undo would have pushed the note into a box that was not on screen, and a Clear
-// on the new tab would have destroyed it silently. Every tab-changing path
-// retires the offer now, and this is the check that survives the next one that
-// forgets.
+// An undo has to say so. The live region simply emptying is a REMOVAL, and
+// removals are not announced, so without this the keyboard route added for
+// WCAG 2.2.1 confirmed nothing at all.
+describe('restoredAnnouncement', () => {
+    it('says what came back, in the same words that said what went', () => {
+        expect(restoredAnnouncement({kind: 'files', files: ['a']})).toBe('Restored 1 item');
+        expect(restoredAnnouncement({kind: 'files', files: ['a', 'b']})).toBe('Restored 2 items');
+        expect(restoredAnnouncement({kind: 'text', text: 'hello'})).toBe('Restored the text');
+    });
+    it('never repeats the text it restored', () => {
+        expect(restoredAnnouncement({kind: 'text', text: 'my bank code'})).not.toContain('bank');
+    });
+    it('offers no undo of its own, because there is none', () => {
+        expect(restoredAnnouncement({kind: 'files', files: ['a']})).not.toContain('Control Z');
+    });
+});
+
+// An offer waits out a visit to the other tab rather than dying at the door.
+// This is what lets the bar be a view concern while the offer is not: switching
+// tabs hides the bar, and restorable is what keeps the hidden offer honest if
+// Ctrl+Z is pressed over there.
 describe('restorable', () => {
     it('allows an undo only into the tab the offer came from', () => {
         expect(restorable({kind: 'files', files: ['a.txt']}, 'files')).toBe(true);
@@ -105,12 +132,43 @@ describe('restorable', () => {
         expect(restorable({kind: 'files', files: ['a.txt']}, 'text')).toBe(false);
     });
     // No clock anywhere in the offer's life: the bar is what expires. An offer
-    // taken an hour ago is still good if nothing has staged or switched since,
-    // which is what makes Ctrl+Z a route that does not depend on the clock.
+    // taken an hour ago is still good if nothing has superseded it, which is
+    // what makes Ctrl+Z a route that does not depend on the clock.
     it('does not depend on how long the offer has stood', () => {
         const c = {kind: 'files' as const, files: ['a.txt']};
         expect(restorable(c, 'files')).toBe(true);
         expect(Object.keys(c)).not.toContain('until');
+    });
+});
+
+// The one automatic way an offer ends, and the rule that decides it. The audit
+// that produced this found the opposite arrangement: EVERY view change retired
+// the offer, which made a typed note strictly LESS safe once you pressed Clear
+// than it had been sitting in the box, where a tab switch, Settings and History
+// all left it alone. Looking somewhere else must supersede nothing.
+describe('supersededBy', () => {
+    it('is overtaken by new content on its own tab', () => {
+        expect(supersededBy({kind: 'files', files: ['a.txt']}, 'files')).toBe(true);
+        expect(supersededBy({kind: 'text', text: 'hi'}, 'text')).toBe(true);
+    });
+    it('is untouched by content on the other tab', () => {
+        expect(supersededBy({kind: 'text', text: 'hi'}, 'files')).toBe(false);
+        expect(supersededBy({kind: 'files', files: ['a.txt']}, 'text')).toBe(false);
+    });
+    // The two rules are deliberately the same predicate read from opposite ends:
+    // the tab an offer can go back into is exactly the tab that can overtake it.
+    // If they ever diverge, an offer could become both unrestorable and
+    // unsupersedable, which is a leak that nothing would ever clean up.
+    it('agrees with restorable on every combination', () => {
+        const offers = [
+            {kind: 'files' as const, files: ['a.txt']},
+            {kind: 'text' as const, text: 'hi'},
+        ];
+        for (const c of offers) {
+            for (const kind of ['files', 'text'] as const) {
+                expect(supersededBy(c, kind)).toBe(restorable(c, kind));
+            }
+        }
     });
 });
 

--- a/desktop/frontend/src/clear.test.ts
+++ b/desktop/frontend/src/clear.test.ts
@@ -118,9 +118,12 @@ describe('the emptiness rule Send and Clear share', () => {
 
 describe('UNDO_WINDOW_MS', () => {
     // Guards against a stray edit: an offer that stands for a blink or for a
-    // minute is a different feature from the one that was designed.
-    it('stands for a few seconds', () => {
-        expect(UNDO_WINDOW_MS).toBeGreaterThanOrEqual(4000);
-        expect(UNDO_WINDOW_MS).toBeLessThanOrEqual(10000);
+    // minute is a different feature from the one that was designed. The floor
+    // is the one every design system with an ACTION in its toast converges on
+    // (Polaris warns below it, Material's Long is exactly it), so dropping back
+    // to the five or six seconds a plain notice gets would be a regression.
+    it('stands long enough for an offer that carries an action', () => {
+        expect(UNDO_WINDOW_MS).toBeGreaterThanOrEqual(10000);
+        expect(UNDO_WINDOW_MS).toBeLessThanOrEqual(20000);
     });
 });

--- a/desktop/frontend/src/clear.test.ts
+++ b/desktop/frontend/src/clear.test.ts
@@ -27,11 +27,18 @@ describe('stagedSnapshot', () => {
 
 describe('clearedLabel', () => {
     it('counts items the way the Send button does', () => {
-        expect(clearedLabel({kind: 'files', files: ['a.txt']})).toBe('Cleared 1 item.');
-        expect(clearedLabel({kind: 'files', files: ['a.txt', 'b.txt']})).toBe('Cleared 2 items.');
+        expect(clearedLabel({kind: 'files', files: ['a.txt']})).toBe('Cleared 1 item');
+        expect(clearedLabel({kind: 'files', files: ['a.txt', 'b.txt']})).toBe('Cleared 2 items');
     });
     it('names the note without counting it', () => {
-        expect(clearedLabel({kind: 'text', text: 'hello'})).toBe('Cleared the text.');
+        expect(clearedLabel({kind: 'text', text: 'hello'})).toBe('Cleared the text');
+    });
+    // The bar pairs this line with a button, so it is a label rather than
+    // prose. The period belongs only in the spoken version, where it is what
+    // makes a screen reader pause before "Undo is available".
+    it('carries no full stop, while the announcement does', () => {
+        expect(clearedLabel({kind: 'files', files: ['a.txt']})).not.toContain('.');
+        expect(clearedAnnouncement({kind: 'files', files: ['a.txt']})).toContain('item. Undo');
     });
     // Folders stage into the same list as files, so the count has to be in
     // items. "Cleared 12 files." would be a lie about a folder pick.

--- a/desktop/frontend/src/clear.test.ts
+++ b/desktop/frontend/src/clear.test.ts
@@ -1,0 +1,126 @@
+import {describe, expect, it} from 'vitest';
+import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, isExpired, stagedSnapshot, undoLabel} from './clear';
+
+describe('stagedSnapshot', () => {
+    it('is null when there is nothing to clear', () => {
+        expect(stagedSnapshot('files', [], 'ignored')).toBeNull();
+        expect(stagedSnapshot('text', ['ignored.txt'], '')).toBeNull();
+    });
+    // The same rule the Send button uses: a note of only whitespace is not a note.
+    it('treats a whitespace-only note as empty', () => {
+        expect(stagedSnapshot('text', [], '   \n\t ')).toBeNull();
+    });
+    it('reads only the tab it was asked about', () => {
+        expect(stagedSnapshot('files', ['a.txt'], '')).toEqual({kind: 'files', files: ['a.txt']});
+        expect(stagedSnapshot('text', [], 'hello')).toEqual({kind: 'text', text: 'hello'});
+    });
+    // Undo has to hand the box back exactly as it was, so the snapshot keeps
+    // the untrimmed string even though the emptiness test trims.
+    it('keeps the note untrimmed', () => {
+        expect(stagedSnapshot('text', [], '  hi  ')).toEqual({kind: 'text', text: '  hi  '});
+    });
+    it('keeps the file order it was given', () => {
+        const files = ['b.txt', 'a.txt', 'c.txt'];
+        expect(stagedSnapshot('files', files, '')).toEqual({kind: 'files', files});
+    });
+});
+
+describe('clearedLabel', () => {
+    it('counts items the way the Send button does', () => {
+        expect(clearedLabel({kind: 'files', files: ['a.txt']})).toBe('Cleared 1 item.');
+        expect(clearedLabel({kind: 'files', files: ['a.txt', 'b.txt']})).toBe('Cleared 2 items.');
+    });
+    it('names the note without counting it', () => {
+        expect(clearedLabel({kind: 'text', text: 'hello'})).toBe('Cleared the text.');
+    });
+    // Folders stage into the same list as files, so the count has to be in
+    // items. "Cleared 12 files." would be a lie about a folder pick.
+    it('never counts in files', () => {
+        expect(clearedLabel({kind: 'files', files: ['a.txt', 'b.txt']})).not.toContain('file');
+    });
+    it('uses no em dashes', () => {
+        const all = [
+            clearedLabel({kind: 'files', files: ['a.txt']}),
+            clearedLabel({kind: 'files', files: ['a.txt', 'b.txt']}),
+            clearedLabel({kind: 'text', text: 'hello'}),
+        ];
+        for (const s of all) {
+            expect(s).not.toContain('—');
+            expect(s).not.toContain('–');
+        }
+    });
+});
+
+// The two accessible names. Both have to contain their visible word, or speech
+// control ("click Clear", "click Undo") stops matching the button: WCAG 2.5.3.
+describe('the accessible names', () => {
+    it('name what would go, and what would come back', () => {
+        expect(clearLabel({kind: 'files', files: ['a', 'b']})).toBe('Clear 2 items');
+        expect(clearLabel({kind: 'files', files: ['a']})).toBe('Clear 1 item');
+        expect(clearLabel({kind: 'text', text: 'x'})).toBe('Clear the text');
+        expect(undoLabel({kind: 'files', files: ['a', 'b', 'c']})).toBe('Undo clearing 3 items');
+        expect(undoLabel({kind: 'text', text: 'x'})).toBe('Undo clearing the text');
+    });
+    it('contain their visible words', () => {
+        expect(clearLabel({kind: 'files', files: ['a']})).toContain('Clear');
+        expect(undoLabel({kind: 'files', files: ['a']})).toContain('Undo');
+    });
+    // The announcement is spoken, and a cleared note is exactly the thing the
+    // user just decided nobody should be looking at.
+    it('never repeat the text they cleared', () => {
+        expect(clearedAnnouncement({kind: 'text', text: 'my bank code'})).not.toContain('bank');
+        expect(undoLabel({kind: 'text', text: 'my bank code'})).not.toContain('bank');
+    });
+    it('carry the visible sentence into speech verbatim', () => {
+        const c = {kind: 'files' as const, files: ['a', 'b']};
+        expect(clearedAnnouncement(c)).toContain(clearedLabel(c));
+        expect(clearedAnnouncement(c)).toContain('Undo');
+    });
+    // The window is a constant that should stay tunable without touching copy.
+    it('promise no particular number of seconds', () => {
+        expect(clearedAnnouncement({kind: 'text', text: 'x'})).not.toMatch(/\d/);
+    });
+});
+
+describe('isExpired', () => {
+    it('is true at the deadline, not just past it', () => {
+        expect(isExpired(1000, 999)).toBe(false);
+        expect(isExpired(1000, 1000)).toBe(true);
+        expect(isExpired(1000, 5000)).toBe(true);
+    });
+    // holdUndo parks the deadline at Infinity while the pointer or the keyboard
+    // is on the offer, so a held offer must never read as expired.
+    it('never expires a held offer', () => {
+        expect(isExpired(Infinity, Number.MAX_SAFE_INTEGER)).toBe(false);
+    });
+});
+
+// Clear is offered exactly when Send is armed. Both read stagedSnapshot, and
+// this table is what keeps the two from drifting apart if one is ever rewritten.
+describe('the emptiness rule Send and Clear share', () => {
+    const cases: Array<{kind: 'files' | 'text'; files: string[]; text: string; staged: boolean}> = [
+        {kind: 'files', files: [], text: '', staged: false},
+        {kind: 'files', files: [], text: 'a note', staged: false},
+        {kind: 'files', files: ['a.txt'], text: '', staged: true},
+        {kind: 'text', files: [], text: '', staged: false},
+        {kind: 'text', files: [], text: '  ', staged: false},
+        {kind: 'text', files: ['a.txt'], text: '', staged: false},
+        {kind: 'text', files: [], text: 'a note', staged: true},
+    ];
+    for (const c of cases) {
+        it(`${c.kind} tab, ${c.files.length} file(s), note ${JSON.stringify(c.text)}`, () => {
+            const sendEnabled = c.kind === 'text' ? c.text.trim() !== '' : c.files.length > 0;
+            expect(stagedSnapshot(c.kind, c.files, c.text) !== null).toBe(c.staged);
+            expect(stagedSnapshot(c.kind, c.files, c.text) !== null).toBe(sendEnabled);
+        });
+    }
+});
+
+describe('UNDO_WINDOW_MS', () => {
+    // Guards against a stray edit: an offer that stands for a blink or for a
+    // minute is a different feature from the one that was designed.
+    it('stands for a few seconds', () => {
+        expect(UNDO_WINDOW_MS).toBeGreaterThanOrEqual(4000);
+        expect(UNDO_WINDOW_MS).toBeLessThanOrEqual(10000);
+    });
+});

--- a/desktop/frontend/src/clear.test.ts
+++ b/desktop/frontend/src/clear.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, isExpired, stagedSnapshot, undoLabel} from './clear';
+import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, stagedSnapshot, undoLabel} from './clear';
 
 describe('stagedSnapshot', () => {
     it('is null when there is nothing to clear', () => {
@@ -89,16 +89,28 @@ describe('the accessible names', () => {
     });
 });
 
-describe('isExpired', () => {
-    it('is true at the deadline, not just past it', () => {
-        expect(isExpired(1000, 999)).toBe(false);
-        expect(isExpired(1000, 1000)).toBe(true);
-        expect(isExpired(1000, 5000)).toBe(true);
+// The guard that makes a missed retire harmless. Ctrl+O was the path that
+// missed one: it switched to the Files tab without dropping a note's offer, so
+// Undo would have pushed the note into a box that was not on screen, and a Clear
+// on the new tab would have destroyed it silently. Every tab-changing path
+// retires the offer now, and this is the check that survives the next one that
+// forgets.
+describe('restorable', () => {
+    it('allows an undo only into the tab the offer came from', () => {
+        expect(restorable({kind: 'files', files: ['a.txt']}, 'files')).toBe(true);
+        expect(restorable({kind: 'text', text: 'hi'}, 'text')).toBe(true);
     });
-    // holdUndo parks the deadline at Infinity while the pointer or the keyboard
-    // is on the offer, so a held offer must never read as expired.
-    it('never expires a held offer', () => {
-        expect(isExpired(Infinity, Number.MAX_SAFE_INTEGER)).toBe(false);
+    it('refuses a note into the file list, and a file list into the note', () => {
+        expect(restorable({kind: 'text', text: 'hi'}, 'files')).toBe(false);
+        expect(restorable({kind: 'files', files: ['a.txt']}, 'text')).toBe(false);
+    });
+    // No clock anywhere in the offer's life: the bar is what expires. An offer
+    // taken an hour ago is still good if nothing has staged or switched since,
+    // which is what makes Ctrl+Z a route that does not depend on the clock.
+    it('does not depend on how long the offer has stood', () => {
+        const c = {kind: 'files' as const, files: ['a.txt']};
+        expect(restorable(c, 'files')).toBe(true);
+        expect(Object.keys(c)).not.toContain('until');
     });
 });
 
@@ -124,11 +136,12 @@ describe('the emptiness rule Send and Clear share', () => {
 });
 
 describe('UNDO_WINDOW_MS', () => {
-    // Guards against a stray edit: an offer that stands for a blink or for a
-    // minute is a different feature from the one that was designed. The floor
-    // is the one every design system with an ACTION in its toast converges on
-    // (Polaris warns below it, Material's Long is exactly it), so dropping back
-    // to the five or six seconds a plain notice gets would be a regression.
+    // Guards against a stray edit: a bar that shows for a blink or for a minute
+    // is a different feature from the one that was designed. The floor is the
+    // one every design system with an ACTION in its toast converges on (Polaris
+    // warns below it, Material's Long is exactly it), so dropping back to the
+    // five or six seconds a plain notice gets would be a regression. Note this
+    // bounds the BAR only; the undo behind it is not on a clock at all.
     it('stands long enough for an offer that carries an action', () => {
         expect(UNDO_WINDOW_MS).toBeGreaterThanOrEqual(10000);
         expect(UNDO_WINDOW_MS).toBeLessThanOrEqual(20000);

--- a/desktop/frontend/src/clear.ts
+++ b/desktop/frontend/src/clear.ts
@@ -11,12 +11,16 @@ export type Cleared =
     | {kind: 'files'; files: string[]}
     | {kind: 'text'; text: string};
 
-/** How long the undo offer stands. Ten seconds rather than the five or six a
- *  plain notification gets, because this one carries an action: Shopify's
+/** How long the undo BAR stays on screen. Ten seconds rather than the five or
+ *  six a plain notification gets, because this one carries an action: Shopify's
  *  Polaris warns in the console below 10s for exactly that reason, Material's
  *  own Long duration is 10s, and VS Code gives an actionable notice 10 to 15.
- *  Pointing at the offer or reaching it with the keyboard holds it open past
- *  this, and Ctrl+Z works whether it is on screen or not. */
+ *  Pointing at the bar or reaching it with the keyboard holds it open past this,
+ *  and a dialog opening over it stops the clock.
+ *
+ *  It does NOT govern the offer. The snapshot stands until something stages or
+ *  changes the send view, so Ctrl+Z works long after the bar has gone. Nothing
+ *  the user can lose is on a countdown; only the message about it is. */
 export const UNDO_WINDOW_MS = 10000;
 
 /**
@@ -32,13 +36,15 @@ export function stagedSnapshot(kind: 'files' | 'text', files: string[], text: st
     return files.length === 0 ? null : {kind: 'files', files};
 }
 
-/** isExpired says whether an offer that was armed to stand until `until` has
- *  run out. The countdown is a deadline, not only a timeout: a window in the
- *  background can have its timers clamped, so the moment Undo is pressed is the
- *  moment worth asking. Nothing is persisted anywhere, so an offer never
- *  outlives the process that made it. */
-export function isExpired(until: number, now: number): boolean {
-    return now >= until;
+/** restorable says whether an offer can be put back into the tab now on screen.
+ *  An offer belongs to the tab it was taken from: restoring a note into the file
+ *  list, or a file list into a note, would be worse than not restoring at all.
+ *  Every path that changes the tab retires the offer, so a mismatch means one of
+ *  them was missed; this is the check that makes the miss harmless. There is
+ *  deliberately no clock in here. Nothing is persisted anywhere, so an offer
+ *  never outlives the process that made it. */
+export function restorable(c: Cleared, kind: 'files' | 'text'): boolean {
+    return c.kind === kind;
 }
 
 const items = (n: number) => `${n} ${n === 1 ? 'item' : 'items'}`;

--- a/desktop/frontend/src/clear.ts
+++ b/desktop/frontend/src/clear.ts
@@ -36,15 +36,29 @@ export function stagedSnapshot(kind: 'files' | 'text', files: string[], text: st
     return files.length === 0 ? null : {kind: 'files', files};
 }
 
+// An offer belongs to the tab it was taken from, and both questions below are
+// really that one question asked from two directions.
+const sameTab = (c: Cleared, kind: 'files' | 'text') => c.kind === kind;
+
 /** restorable says whether an offer can be put back into the tab now on screen.
- *  An offer belongs to the tab it was taken from: restoring a note into the file
- *  list, or a file list into a note, would be worse than not restoring at all.
- *  Every path that changes the tab retires the offer, so a mismatch means one of
- *  them was missed; this is the check that makes the miss harmless. There is
- *  deliberately no clock in here. Nothing is persisted anywhere, so an offer
- *  never outlives the process that made it. */
+ *  Restoring a note into the file list, or a file list into a note, would be
+ *  worse than not restoring at all, so an offer taken on one tab simply waits
+ *  while the user is on the other. There is deliberately no clock in here.
+ *  Nothing is persisted anywhere, so an offer never outlives its process. */
 export function restorable(c: Cleared, kind: 'files' | 'text'): boolean {
-    return c.kind === kind;
+    return sameTab(c, kind);
+}
+
+/** supersededBy says whether new content on a given tab has overtaken the offer.
+ *  Undo replaces rather than merges, so once that tab holds something again,
+ *  putting the old payload back would destroy the new one, and the offer has to
+ *  go. Content on the OTHER tab overtakes nothing: it changes neither what the
+ *  offer holds nor the empty box it would go back into. This is the ONLY reason
+ *  an offer is dropped without the user asking, which is why it is a named rule
+ *  with tests rather than a call scattered through the view code. Merely LOOKING
+ *  somewhere else, a tab, Settings, History, a dialog, supersedes nothing. */
+export function supersededBy(c: Cleared, kind: 'files' | 'text'): boolean {
+    return sameTab(c, kind);
 }
 
 const items = (n: number) => `${n} ${n === 1 ? 'item' : 'items'}`;
@@ -74,14 +88,29 @@ export function undoLabel(c: Cleared): string {
     return c.kind === 'text' ? 'Undo clearing the text' : `Undo clearing ${items(c.files.length)}`;
 }
 
-/** clearedAnnouncement is what the always-mounted live region says: the visible
- *  sentence plus the one thing that row shows rather than states. Built FROM
+/** clearedAnnouncement is what the always-mounted live region says. Built FROM
  *  clearedLabel so the words on screen and the words in speech cannot drift.
- *  No number of seconds, because promising seconds in speech costs some of
- *  them to say, and the window is a constant that should stay tunable. */
+ *  No number of seconds, because promising seconds in speech costs some of them
+ *  to say, and the window is a constant that should stay tunable.
+ *
+ *  It names the KEY rather than saying "Undo is available", and that is the
+ *  point: the bar goes after a few seconds while the offer does not, so a
+ *  sentence about an available button outlives the button and sends someone
+ *  hunting the accessibility tree for a control that is no longer in it. The
+ *  key stays true for exactly as long as the offer does, and it is also the only
+ *  place in the app that names the shortcut, which the docs otherwise carry
+ *  alone. Spelled out, because "Ctrl+Z" is read aloud as punctuation. */
 export function clearedAnnouncement(c: Cleared): string {
     // The full stop the visible line drops goes back in here, at the seam:
     // punctuation is what makes a screen reader pause, and without it this is
     // one run-on breath.
-    return `${clearedLabel(c)}. Undo is available.`;
+    return `${clearedLabel(c)}. Press Control Z to undo.`;
+}
+
+/** restoredAnnouncement is the other half of that conversation. Without it an
+ *  undo is silent for a screen reader: the live region simply empties, and a
+ *  removal is not announced, so the one route added for keyboard users gave no
+ *  confirmation that anything came back. */
+export function restoredAnnouncement(c: Cleared): string {
+    return c.kind === 'text' ? 'Restored the text' : `Restored ${items(c.files.length)}`;
 }

--- a/desktop/frontend/src/clear.ts
+++ b/desktop/frontend/src/clear.ts
@@ -43,11 +43,14 @@ export function isExpired(until: number, now: number): boolean {
 
 const items = (n: number) => `${n} ${n === 1 ? 'item' : 'items'}`;
 
-/** clearedLabel is the sentence the undo offer shows. It says what went, in
- *  the same words the Send button and the history entries use ("items"), so
- *  the count reads as the one the user just saw. */
+/** clearedLabel is the line the undo bar shows. It says what went, in the same
+ *  words the Send button and the history entries use ("items"), so the count
+ *  reads as the one the user just saw. No full stop: the row is a label paired
+ *  with a control, not prose, and a period mid-row punctuates a thought the
+ *  button beside it has not finished. The app's text-only status lines keep
+ *  theirs. */
 export function clearedLabel(c: Cleared): string {
-    return c.kind === 'text' ? 'Cleared the text.' : `Cleared ${items(c.files.length)}.`;
+    return c.kind === 'text' ? 'Cleared the text' : `Cleared ${items(c.files.length)}`;
 }
 
 /** clearLabel is the Clear button's accessible name. The visible word stays
@@ -71,5 +74,8 @@ export function undoLabel(c: Cleared): string {
  *  No number of seconds, because promising seconds in speech costs some of
  *  them to say, and the window is a constant that should stay tunable. */
 export function clearedAnnouncement(c: Cleared): string {
-    return `${clearedLabel(c)} Undo is available.`;
+    // The full stop the visible line drops goes back in here, at the seam:
+    // punctuation is what makes a screen reader pause, and without it this is
+    // one run-on breath.
+    return `${clearedLabel(c)}. Undo is available.`;
 }

--- a/desktop/frontend/src/clear.ts
+++ b/desktop/frontend/src/clear.ts
@@ -1,0 +1,71 @@
+// Pure helpers for the Clear control on the send view. They live outside
+// App.tsx for the same reason settings.ts and reset.ts do: so they can be
+// tested without a DOM or the Wails runtime bindings, which do not exist
+// outside the WebView.
+
+/** What Clear took away, held only long enough to put it back. `kind` is the
+ *  send tab it came from, so an undo can never restore a note into the file
+ *  list or the other way round. Text is kept raw, not trimmed: undo has to
+ *  return the box exactly as it was, whitespace and all. */
+export type Cleared =
+    | {kind: 'files'; files: string[]}
+    | {kind: 'text'; text: string};
+
+/** How long the undo offer stands. Long enough to see the list go and reach
+ *  for it, short enough to be gone before the next thing you do. */
+export const UNDO_WINDOW_MS = 6000;
+
+/**
+ * stagedSnapshot describes what the send tab is currently holding, or null
+ * when there is nothing to clear.
+ *
+ * The emptiness test matches the Send button's own disabled rule, so Clear
+ * appears exactly when Send has something to act on: a file list is empty at
+ * zero entries, and a note is empty when it is only whitespace.
+ */
+export function stagedSnapshot(kind: 'files' | 'text', files: string[], text: string): Cleared | null {
+    if (kind === 'text') return text.trim() === '' ? null : {kind: 'text', text};
+    return files.length === 0 ? null : {kind: 'files', files};
+}
+
+/** isExpired says whether an offer that was armed to stand until `until` has
+ *  run out. The countdown is a deadline, not only a timeout: a window in the
+ *  background can have its timers clamped, so the moment Undo is pressed is the
+ *  moment worth asking. Nothing is persisted anywhere, so an offer never
+ *  outlives the process that made it. */
+export function isExpired(until: number, now: number): boolean {
+    return now >= until;
+}
+
+const items = (n: number) => `${n} ${n === 1 ? 'item' : 'items'}`;
+
+/** clearedLabel is the sentence the undo offer shows. It says what went, in
+ *  the same words the Send button and the history entries use ("items"), so
+ *  the count reads as the one the user just saw. */
+export function clearedLabel(c: Cleared): string {
+    return c.kind === 'text' ? 'Cleared the text.' : `Cleared ${items(c.files.length)}.`;
+}
+
+/** clearLabel is the Clear button's accessible name. The visible word stays
+ *  "Clear" because its object is right there in the Send label beside it, but a
+ *  name has to carry that object itself. It contains the visible word, so
+ *  speech control still matches "click Clear". */
+export function clearLabel(c: Cleared): string {
+    return c.kind === 'text' ? 'Clear the text' : `Clear ${items(c.files.length)}`;
+}
+
+/** undoLabel is the Undo button's accessible name. Focus lands here the moment
+ *  a clear happens, so this is the first thing a screen reader says about it,
+ *  and "Undo" alone would not say undo what. */
+export function undoLabel(c: Cleared): string {
+    return c.kind === 'text' ? 'Undo clearing the text' : `Undo clearing ${items(c.files.length)}`;
+}
+
+/** clearedAnnouncement is what the always-mounted live region says: the visible
+ *  sentence plus the one thing that row shows rather than states. Built FROM
+ *  clearedLabel so the words on screen and the words in speech cannot drift.
+ *  No number of seconds, because promising seconds in speech costs some of
+ *  them to say, and the window is a constant that should stay tunable. */
+export function clearedAnnouncement(c: Cleared): string {
+    return `${clearedLabel(c)} Undo is available.`;
+}

--- a/desktop/frontend/src/clear.ts
+++ b/desktop/frontend/src/clear.ts
@@ -11,9 +11,13 @@ export type Cleared =
     | {kind: 'files'; files: string[]}
     | {kind: 'text'; text: string};
 
-/** How long the undo offer stands. Long enough to see the list go and reach
- *  for it, short enough to be gone before the next thing you do. */
-export const UNDO_WINDOW_MS = 6000;
+/** How long the undo offer stands. Ten seconds rather than the five or six a
+ *  plain notification gets, because this one carries an action: Shopify's
+ *  Polaris warns in the console below 10s for exactly that reason, Material's
+ *  own Long duration is 10s, and VS Code gives an actionable notice 10 to 15.
+ *  Pointing at the offer or reaching it with the keyboard holds it open past
+ *  this, and Ctrl+Z works whether it is on screen or not. */
+export const UNDO_WINDOW_MS = 10000;
 
 /**
  * stagedSnapshot describes what the send tab is currently holding, or null

--- a/desktop/frontend/src/components/TitleBar.tsx
+++ b/desktop/frontend/src/components/TitleBar.tsx
@@ -27,6 +27,11 @@ export default function TitleBar({onSettings, settingsActive, onStartOver}: {
                 to a fresh app, mirroring the browser's click-the-logo reset */}
             <Tooltip label="Start over" keys="Ctrl+R" align="start">
                 <button
+                    // The one focusable element mounted on every screen, which is
+                    // what makes it the app's fallback when focus would otherwise
+                    // be orphaned. App.tsx looks it up by this id; do not remove
+                    // it without giving that lookup somewhere else to land.
+                    id="floe-lockup"
                     style={noDrag}
                     onClick={onStartOver}
                     onDoubleClick={(e) => e.stopPropagation()}

--- a/desktop/frontend/src/components/ui.tsx
+++ b/desktop/frontend/src/components/ui.tsx
@@ -65,17 +65,36 @@ const buttonVariants: Record<ButtonVariant, string> = {
     ghost:     'text-zinc-400 hover:bg-white/10 hover:text-zinc-100',
 };
 
+type ButtonSize = 'md' | 'lg';
+
+/** Size owns the padding and the corner, because cn is a plain join with no
+ *  tailwind-merge: a px-* or rounded-* passed through className cannot beat the
+ *  same property coming from the base string, so the only way to have two
+ *  sizes is to keep them out of the base. `md` is what every button in the app
+ *  rendered before this prop existed, character for character, so adding it
+ *  changed nothing on screen. `lg` is for the send card's committing row, where
+ *  the file rows' own radius and a little more room make the pair read as one
+ *  deliberate row rather than two leftovers. Its 9px is deliberate and sits
+ *  between the two steps of the spacing scale: 38px tall reads as a committing
+ *  control without the slab quality 40px gave it beside a 40px file row. */
+const buttonSizes: Record<ButtonSize, string> = {
+    md: 'rounded-md px-3 py-2',
+    lg: 'rounded-lg px-4 py-[9px]',
+};
+
 export function Button({
     variant = 'primary',
+    size = 'md',
     className,
     children,
     ...props
-}: ButtonHTMLAttributes<HTMLButtonElement> & {variant?: ButtonVariant}) {
+}: ButtonHTMLAttributes<HTMLButtonElement> & {variant?: ButtonVariant; size?: ButtonSize}) {
     return (
         <button
             {...props}
             className={cn(
-                'inline-flex items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors',
+                'inline-flex items-center justify-center gap-2 text-sm transition-colors',
+                buttonSizes[size],
                 'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ice/40',
                 'disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0',
                 buttonVariants[variant],

--- a/desktop/frontend/src/components/ui.tsx
+++ b/desktop/frontend/src/components/ui.tsx
@@ -102,7 +102,11 @@ export function Button({
             className={cn(
                 'inline-flex items-center justify-center gap-2 text-sm transition-colors',
                 buttonSizes[size],
-                'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ice/40',
+                // ice/60, not /40: measured from rendered pixels, /40 paints
+                // #516269 for 2.96:1 against the card and fails 1.4.11's 3:1,
+                // while /60 measures 5.23:1. Every hand-rolled focusable in the
+                // app already uses /60; this shared component was the outlier.
+                'focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ice/60',
                 'disabled:pointer-events-none disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0',
                 buttonVariants[variant],
                 className,

--- a/desktop/frontend/src/components/ui.tsx
+++ b/desktop/frontend/src/components/ui.tsx
@@ -74,12 +74,19 @@ type ButtonSize = 'md' | 'lg';
  *  rendered before this prop existed, character for character, so adding it
  *  changed nothing on screen. `lg` is for the send card's committing row, where
  *  the file rows' own radius and a little more room make the pair read as one
- *  deliberate row rather than two leftovers. Its 9px is deliberate and sits
- *  between the two steps of the spacing scale: 38px tall reads as a committing
- *  control without the slab quality 40px gave it beside a 40px file row. */
+ *  deliberate row rather than two leftovers. 38px tall reads as a committing
+ *  control without the slab quality 40px gave it beside a 40px file row.
+ *
+ *  That height is set outright rather than left to padding, and the reason is
+ *  worth keeping. Padding alone made the number depend on the variant:
+ *  `secondary` and `outline` carry a 1px border, which sits outside a padding
+ *  box and made them 40px, and flex's default align-items:stretch then dragged
+ *  the borderless `primary` up to match. The row was 40px with Clear beside
+ *  Send and 38px with Send alone. An explicit height is absorbed by border-box,
+ *  so every variant is the same 38px in every state. */
 const buttonSizes: Record<ButtonSize, string> = {
     md: 'rounded-md px-3 py-2',
-    lg: 'rounded-lg px-4 py-[9px]',
+    lg: 'h-[38px] rounded-lg px-4',
 };
 
 export function Button({

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -158,7 +158,10 @@
    Keep any new `animate-*` utility listed here. The pulse is included because a
    dot that breathes forever is exactly the ambient motion this setting is for,
    and stopping it costs nothing: the halo is decorative and aria-hidden, and the
-   solid core it sits behind never moves. */
+   solid core it sits behind never moves. `animate-spin` is deliberately absent:
+   it is the busy indicator, and a spinner frozen mid-transfer would say the app
+   had hung. That is the "essential" exception WCAG 2.2.2 names, and it is the
+   one animation here that carries information rather than polish. */
 @media (prefers-reduced-motion: reduce) {
   .animate-floe-in,
   .animate-floe-notice-in,

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -80,6 +80,25 @@
     animation: floe-notice-in 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
   }
 
+  /* The undo toast's entrance, mirroring the notice's: each arrives from the
+     edge it lives on, so the notice drops and this one rises. Same curve and
+     duration, so the two read as one family. Entrance only, for the same
+     reason: a conditional render cannot animate out. */
+  @keyframes floe-toast-in {
+    from {
+      opacity: 0;
+      transform: translate3d(0, 10px, 0) scale(0.97);
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(0, 0, 0) scale(1);
+    }
+  }
+
+  .animate-floe-toast-in {
+    animation: floe-toast-in 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
   /* The notice's one accent: a 1px ice rim in the bar's border, catching
      light at the top left and dissolving toward the bottom right, drawn with
      the double-mask trick so it stays transparent-safe under backdrop-blur.

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -145,3 +145,25 @@
     background-color: rgb(255 255 255 / 0.05) !important;
   }
 }
+
+/* Reduced motion, and deliberately OUTSIDE @layer utilities.
+   `motion-reduce:animate-none` in the markup does not work on the animations
+   above, and the reason is pure cascade: Tailwind emits that utility inside the
+   same `utilities` layer, earlier in the file than these custom classes, and at
+   the same specificity, so the later rule wins and the animation plays anyway.
+   Raising specificity or adding !important would both work and both invite the
+   next person to fight the same battle. Unlayered declarations beat layered ones
+   outright, whatever the source order, so this block is the one thing that
+   cannot lose.
+   Keep any new `animate-*` utility listed here. The pulse is included because a
+   dot that breathes forever is exactly the ambient motion this setting is for,
+   and stopping it costs nothing: the halo is decorative and aria-hidden, and the
+   solid core it sits behind never moves. */
+@media (prefers-reduced-motion: reduce) {
+  .animate-floe-in,
+  .animate-floe-notice-in,
+  .animate-floe-toast-in,
+  .animate-pulse {
+    animation: none;
+  }
+}

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -80,29 +80,36 @@
     animation: floe-notice-in 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
   }
 
-  /* The undo toast's entrance, mirroring the notice's: each arrives from the
-     edge it lives on, so the notice drops and this one rises. Same curve and
-     duration, so the two read as one family. Entrance only, for the same
-     reason: a conditional render cannot animate out. */
+  /* The undo toast's entrance. Same decelerate family as the notice, but its
+     own curve, travel and duration, because it is a different object: the
+     notice is peripheral and waits to be dealt with, while this bar is
+     bottom-centre, transient, and carries an action on a clock, so it has to
+     be seen and read fast without ever moving its own hit target.
+
+     24px of travel, half the bar's height. The notice's 10px is why a straight
+     copy of its entrance read as plain here: expo covers 90% of that distance
+     in the first 106ms and then sits still, so more than half the animation is
+     sub-pixel dead tail and most frames show no change at all.
+
+     No overshoot, deliberately, and this is the one place it is tempting. A
+     back-out curve on this geometry buys about 2px of bounce and costs 100ms
+     during which Undo has not settled where the user is already reaching. No
+     toast in any surveyed system overshoots, and Apple's own default spring is
+     critically damped. Entrance only, like everything else here: a conditional
+     render cannot animate out. */
   @keyframes floe-toast-in {
-    0% {
+    from {
       opacity: 0;
-      transform: translate3d(0, 18px, 0) scale(0.96);
+      transform: translate3d(0, 24px, 0) scale(0.97);
     }
-    55% {
-      opacity: 1;
-    }
-    70% {
-      transform: translate3d(0, -3px, 0) scale(1.008);
-    }
-    100% {
+    to {
       opacity: 1;
       transform: translate3d(0, 0, 0) scale(1);
     }
   }
 
   .animate-floe-toast-in {
-    animation: floe-toast-in 0.44s cubic-bezier(0.22, 1, 0.36, 1) both;
+    animation: floe-toast-in 0.4s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 
   /* The notice's one accent: a 1px ice rim in the bar's border, catching

--- a/desktop/frontend/src/globals.css
+++ b/desktop/frontend/src/globals.css
@@ -85,18 +85,24 @@
      duration, so the two read as one family. Entrance only, for the same
      reason: a conditional render cannot animate out. */
   @keyframes floe-toast-in {
-    from {
+    0% {
       opacity: 0;
-      transform: translate3d(0, 10px, 0) scale(0.97);
+      transform: translate3d(0, 18px, 0) scale(0.96);
     }
-    to {
+    55% {
+      opacity: 1;
+    }
+    70% {
+      transform: translate3d(0, -3px, 0) scale(1.008);
+    }
+    100% {
       opacity: 1;
       transform: translate3d(0, 0, 0) scale(1);
     }
   }
 
   .animate-floe-toast-in {
-    animation: floe-toast-in 0.32s cubic-bezier(0.16, 1, 0.3, 1) both;
+    animation: floe-toast-in 0.44s cubic-bezier(0.22, 1, 0.36, 1) both;
   }
 
   /* The notice's one accent: a 1px ice rim in the bar's border, catching

--- a/desktop/frontend/src/reset.test.ts
+++ b/desktop/frontend/src/reset.test.ts
@@ -93,11 +93,35 @@ describe('resetWarning', () => {
         expect(resetWarning(base)).toBe('');
     });
 
+    // Clear moves a note out of the box and into the undo offer, which is then
+    // the only copy in existence. Start over drops the offer, so it has to earn
+    // the same prompt the box does; before this, a note typed, cleared, and then
+    // abandoned to Ctrl+R vanished in silence inside the undo window.
+    it('prompts for a note that Clear is holding', () => {
+        const s = resetWarning({...base, text: '', clearedText: 'the note I just cleared'});
+        expect(s).toContain('brought back');
+    });
+    it('says nothing about a cleared note that was already sent', () => {
+        expect(resetWarning({...base, text: '', clearedText: 'sent note', sentText: 'sent note'})).toBe('');
+    });
+    // The staged-files rule survives the new input: a cleared FILE list is still
+    // just paths on disk, so it prompts for nothing.
+    it('does not prompt for a cleared file list', () => {
+        expect(resetWarning({...base, text: '', clearedText: ''})).toBe('');
+    });
+    // The note in the box outranks the one in the offer: they cannot both be
+    // live, but if they ever were, the visible one is the one to name.
+    it('names the note in the box before the cleared one', () => {
+        const s = resetWarning({...base, text: 'typed', clearedText: 'cleared'});
+        expect(s).toContain('has not been sent');
+    });
+
     // House style, enforced rather than trusted: no em dashes anywhere in UI copy.
     it('uses no em dashes', () => {
         for (const s of [
             resetWarning({...base, transferring: true}),
             resetWarning({...base, text: 'draft'}),
+            resetWarning({...base, text: '', clearedText: 'draft'}),
         ]) {
             expect(s).not.toContain('—');
         }

--- a/desktop/frontend/src/reset.ts
+++ b/desktop/frontend/src/reset.ts
@@ -36,6 +36,13 @@
  * from "attempted": a send that fails or is cancelled leaves the note unsent,
  * and it still earns its prompt.
  *
+ * clearedText is the same note one step later: Clear moves it out of the box
+ * and into the undo offer, where it is still the only copy in existence. Start
+ * over drops that offer, so without this input a note typed, cleared, and then
+ * abandoned to Ctrl+R would vanish exactly the way the one in the box used to.
+ * It is optional because callers that predate the Clear control mean "nothing
+ * is pending" by omitting it.
+ *
  * busy is the one gate that keeps the prompt off a path where it would be
  * noise, because a send that is connecting or waiting for a peer still holds
  * its text and file list, and a dialog in front of the escape hatch that exists
@@ -58,13 +65,17 @@ export function resetWarning(s: {
     busy: boolean;
     text: string;
     sentText: string;
+    clearedText?: string;
 }): string {
     if (s.transferring) return 'A transfer is in progress. Starting over will cancel it.';
     if (s.busy) return '';
-    const t = s.text.trim();
     // Trimmed on both sides, like the emptiness test it shares a line with: a
     // note that differs from the one that went out by trailing whitespace is
     // not lost work.
-    if (t === '' || t === s.sentText.trim()) return '';
-    return 'The text you typed has not been sent yet. Starting over will clear it.';
+    const sent = s.sentText.trim();
+    const t = s.text.trim();
+    if (t !== '' && t !== sent) return 'The text you typed has not been sent yet. Starting over will clear it.';
+    const c = (s.clearedText ?? '').trim();
+    if (c !== '' && c !== sent) return 'The text you cleared can still be brought back. Starting over will discard it.';
+    return '';
 }

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -12,7 +12,7 @@ description: "Every keyboard shortcut in Floe Desktop for Windows: adding files,
 | `Ctrl` `H` | Show or hide **History**. |
 | `Ctrl` `,` | Open or close **Settings**. |
 | `Ctrl` `R` | Start over. Clears the current selection and result. |
-| `Ctrl` `Z` | Undo a **Clear**. Works after its bar has gone, until you stage something else or start over. Does nothing otherwise, so the text box keeps its own undo. |
+| `Ctrl` `Z` | Undo a **Clear**, including after its bar has gone. Does nothing when there is nothing to undo. |
 | `Esc` | Close whatever is on top. In Settings, goes back. |
 | `Enter` | In the **Code or link** field, starts receiving. In the **Text** box, use `Ctrl` `Enter`. |
 
@@ -28,12 +28,12 @@ does.
 
 <Warning>
   `Ctrl` `R` asks for confirmation in three cases: when a transfer is actually moving data, when
-  the text box holds a note that has not been sent, and when you have cleared a note whose
-  **Undo** is still available, whether or not its bar is still up. The prompts cover both paths
-  to Start over, the shortcut itself and clicking the Floe lockup in the titlebar. The
-  unsent-note dialog reads "The text you typed has not been sent yet. Starting over will clear
-  it."; the cleared-note one reads "The text you cleared can still be brought back. Starting over
-  will discard it."
+  the text box holds a note that has not been sent, and when you cleared a note that had never
+  been sent and its **Undo** is still available, whether or not its bar is still up. The prompts
+  cover both paths to Start over, the shortcut itself and clicking the Floe lockup in the
+  titlebar. The unsent-note dialog reads "The text you typed has not been sent yet. Starting over
+  will clear it."; the cleared-note one reads "The text you cleared can still be brought back.
+  Starting over will discard it."
 
   A note counts as sent only while the box still holds exactly what went out, so typing a new
   one after a send prompts again, and so does a note you typed and then abandoned in favour of

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -25,10 +25,12 @@ never interrupted, nothing fires twice, and a half-typed note is never wiped mid
 does.
 
 <Warning>
-  `Ctrl` `R` asks for confirmation in two cases: when a transfer is actually moving data, and
-  when the text box holds a note that has not been sent. The unsent-note prompt covers both
-  paths to Start over, the shortcut itself and clicking the Floe lockup in the titlebar. The
-  dialog reads "The text you typed has not been sent yet. Starting over will clear it."
+  `Ctrl` `R` asks for confirmation in three cases: when a transfer is actually moving data, when
+  the text box holds a note that has not been sent, and when you have just cleared a note and
+  its **Undo** offer is still on screen. The prompts cover both paths to Start over, the
+  shortcut itself and clicking the Floe lockup in the titlebar. The unsent-note dialog reads
+  "The text you typed has not been sent yet. Starting over will clear it."; the cleared-note one
+  reads "The text you cleared can still be brought back. Starting over will discard it."
 
   A note counts as sent only while the box still holds exactly what went out, so typing a new
   one after a send prompts again, and so does a note you typed and then abandoned in favour of

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -12,6 +12,7 @@ description: "Every keyboard shortcut in Floe Desktop for Windows: adding files,
 | `Ctrl` `H` | Show or hide **History**. |
 | `Ctrl` `,` | Open or close **Settings**. |
 | `Ctrl` `R` | Start over. Clears the current selection and result. |
+| `Ctrl` `Z` | Undo a **Clear**, while its offer is still standing. Does nothing otherwise, so the text box keeps its own undo. |
 | `Esc` | Close whatever is on top. In Settings, goes back. |
 | `Enter` | In the **Code or link** field, starts receiving. In the **Text** box, use `Ctrl` `Enter`. |
 

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -12,26 +12,28 @@ description: "Every keyboard shortcut in Floe Desktop for Windows: adding files,
 | `Ctrl` `H` | Show or hide **History**. |
 | `Ctrl` `,` | Open or close **Settings**. |
 | `Ctrl` `R` | Start over. Clears the current selection and result. |
-| `Ctrl` `Z` | Undo a **Clear**, while its offer is still standing. Does nothing otherwise, so the text box keeps its own undo. |
+| `Ctrl` `Z` | Undo a **Clear**. Works after its bar has gone, until you stage something else or start over. Does nothing otherwise, so the text box keeps its own undo. |
 | `Esc` | Close whatever is on top. In Settings, goes back. |
 | `Enter` | In the **Code or link** field, starts receiving. In the **Text** box, use `Ctrl` `Enter`. |
 
 ## Behaviour worth knowing
 
-**Most shortcuts pause while you type.** `Ctrl` `O`, `Ctrl` `Enter`, `Ctrl` `V`, `Ctrl` `H` and
-`Ctrl` `R` do nothing while the cursor is in a text field, so typing a room code or a note is
-never interrupted, nothing fires twice, and a half-typed note is never wiped mid-word.
+**Most shortcuts pause while you type.** `Ctrl` `O`, `Ctrl` `Enter`, `Ctrl` `V`, `Ctrl` `H`,
+`Ctrl` `R` and `Ctrl` `Z` do nothing while the cursor is in a text field, so typing a room code or
+a note is never interrupted, nothing fires twice, a half-typed note is never wiped mid-word, and
+the text box keeps its own undo.
 
 **One fires from anywhere.** `Ctrl` `,` opens Settings, the way a preferences shortcut normally
 does.
 
 <Warning>
   `Ctrl` `R` asks for confirmation in three cases: when a transfer is actually moving data, when
-  the text box holds a note that has not been sent, and when you have just cleared a note and
-  its **Undo** offer is still on screen. The prompts cover both paths to Start over, the
-  shortcut itself and clicking the Floe lockup in the titlebar. The unsent-note dialog reads
-  "The text you typed has not been sent yet. Starting over will clear it."; the cleared-note one
-  reads "The text you cleared can still be brought back. Starting over will discard it."
+  the text box holds a note that has not been sent, and when you have cleared a note whose
+  **Undo** is still available, whether or not its bar is still up. The prompts cover both paths
+  to Start over, the shortcut itself and clicking the Floe lockup in the titlebar. The
+  unsent-note dialog reads "The text you typed has not been sent yet. Starting over will clear
+  it."; the cleared-note one reads "The text you cleared can still be brought back. Starting over
+  will discard it."
 
   A note counts as sent only while the box still holds exactly what went out, so typing a new
   one after a send prompts again, and so does a note you typed and then abandoned in favour of

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -23,10 +23,16 @@ There are four ways to stage files, and you can mix them:
 | `Ctrl` `V` | Pastes files you copied in File Explorer, or an image from the clipboard. |
 
 Everything you add appears in a list under **Files**. Remove a single entry with the `X` on its
-row. `Ctrl` `R` starts over, which clears the selection along with everything else on the card.
-It asks first if a transfer is already moving bytes, or if the text box holds a note that has
-not been sent (the dialog reads "The text you typed has not been sent yet. Starting over will
-clear it."). Clicking the Floe lockup in the titlebar starts over too, with the same
+row, or empty the whole list with **Clear**, beside the Send button. Clear takes only what the
+tab you are on is holding (the file list on **Files**, the box on **Text**) and leaves your
+settings, the Receive tab, your history and anything already sent alone. It does not ask first.
+It offers **Undo** for a few seconds instead, which puts back exactly what it took.
+
+`Ctrl` `R` starts over, which clears the selection along with everything else on the card.
+It asks first if a transfer is already moving bytes, if the text box holds a note that has not
+been sent (the dialog reads "The text you typed has not been sent yet. Starting over will clear
+it."), or if you have just cleared a note and its Undo offer is still standing, since starting
+over discards it. Clicking the Floe lockup in the titlebar starts over too, with the same
 confirmations, but only the shortcut is held back while you are typing.
 
 Adding the same path twice does nothing, so dragging a file you already staged is safe. One

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -26,17 +26,22 @@ Everything you add appears in a list under **Files**. Remove a single entry with
 row, or empty the whole list with **Clear**, beside the Send button. Clear takes only what the
 tab you are on is holding (the file list on **Files**, the box on **Text**) and leaves your
 settings, the Receive tab, your history and anything already sent alone. It does not ask first.
-It offers **Undo** instead, in a bar at the bottom of the window, which puts back exactly what it
-took. The bar shows for about ten seconds, longer while you point at it or hold it with the
-keyboard. The offer behind it lasts longer than the bar does: `Ctrl` `Z` still takes it after the
-bar has gone, up until you stage something else, switch tabs, send, or start over.
+It offers **Undo** instead, in a bar at the bottom of the window, which puts back exactly what you
+had staged, whitespace and all.
+
+The bar shows for about ten seconds, longer while you point at it or reach it with the keyboard.
+The offer behind it lasts longer than the bar does, and `Ctrl` `Z` takes it once the bar has gone.
+It stands until you put something new on that same tab, send, or start over. Looking somewhere
+else does not spend it: switch tabs, open Settings or check History and the bar simply steps out
+of the way, then comes back when you do. `Ctrl` `Z` is ignored while the cursor is in a text box,
+so click out of the box first.
 
 `Ctrl` `R` starts over, which clears the selection along with everything else on the card.
 It asks first if a transfer is already moving bytes, if the text box holds a note that has not
 been sent (the dialog reads "The text you typed has not been sent yet. Starting over will clear
-it."), or if you have just cleared a note and its Undo offer is still standing, since starting
-over discards it. Clicking the Floe lockup in the titlebar starts over too, with the same
-confirmations, but only the shortcut is held back while you are typing.
+it."), or if you cleared a note that had never been sent and its Undo is still standing, since
+starting over discards it. Clicking the Floe lockup in the titlebar starts over too, with the
+same confirmations, but only the shortcut is held back while you are typing.
 
 Adding the same path twice does nothing, so dragging a file you already staged is safe. One
 edge worth knowing: if you add a folder **and** a file that lives inside it, that file is sent

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -26,7 +26,9 @@ Everything you add appears in a list under **Files**. Remove a single entry with
 row, or empty the whole list with **Clear**, beside the Send button. Clear takes only what the
 tab you are on is holding (the file list on **Files**, the box on **Text**) and leaves your
 settings, the Receive tab, your history and anything already sent alone. It does not ask first.
-It offers **Undo** for a few seconds instead, which puts back exactly what it took.
+It offers **Undo** instead, in a bar at the bottom of the window, which puts back exactly what it
+took. The offer stands for about ten seconds, longer while you point at it or hold it with the
+keyboard, and `Ctrl` `Z` takes it whether the bar is still up or not.
 
 `Ctrl` `R` starts over, which clears the selection along with everything else on the card.
 It asks first if a transfer is already moving bytes, if the text box holds a note that has not

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -27,8 +27,9 @@ row, or empty the whole list with **Clear**, beside the Send button. Clear takes
 tab you are on is holding (the file list on **Files**, the box on **Text**) and leaves your
 settings, the Receive tab, your history and anything already sent alone. It does not ask first.
 It offers **Undo** instead, in a bar at the bottom of the window, which puts back exactly what it
-took. The offer stands for about ten seconds, longer while you point at it or hold it with the
-keyboard, and `Ctrl` `Z` takes it whether the bar is still up or not.
+took. The bar shows for about ten seconds, longer while you point at it or hold it with the
+keyboard. The offer behind it lasts longer than the bar does: `Ctrl` `Z` still takes it after the
+bar has gone, up until you stage something else, switch tabs, send, or start over.
 
 `Ctrl` `R` starts over, which clears the selection along with everything else on the card.
 It asks first if a transfer is already moving bytes, if the text box holds a note that has not
@@ -148,5 +149,5 @@ See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
 
 ## Keyboard
 
-`Ctrl` `O` adds files, `Ctrl` `Enter` sends, `Ctrl` `R` starts over. The full list is in
-[Keyboard shortcuts](/desktop/keyboard-shortcuts).
+`Ctrl` `O` adds files, `Ctrl` `Enter` sends, `Ctrl` `Z` undoes a **Clear**, `Ctrl` `R` starts
+over. The full list is in [Keyboard shortcuts](/desktop/keyboard-shortcuts).

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -31,10 +31,16 @@ had staged, whitespace and all.
 
 The bar shows for about ten seconds, longer while you point at it or reach it with the keyboard.
 The offer behind it lasts longer than the bar does, and `Ctrl` `Z` takes it once the bar has gone.
-It stands until you put something new on that same tab, send, or start over. Looking somewhere
-else does not spend it: switch tabs, open Settings or check History and the bar simply steps out
-of the way, then comes back when you do. `Ctrl` `Z` is ignored while the cursor is in a text box,
-so click out of the box first.
+It stands until you put something new on that same tab, clear something else, or start over.
+Looking somewhere else does not spend it: switch tabs, open Settings, check History, send from
+the other tab or cancel a transfer, and the bar simply steps out of the way, then comes back when
+you return. `Ctrl` `Z` works only on the Send tab it came from, and is ignored while the cursor is
+in a text box, so click out of the box first.
+
+<Note>
+  Floe holds one undo at a time. Clearing on one tab while an offer from the other is still
+  standing replaces it, so if you cleared a note, undo it before you clear a file list.
+</Note>
 
 `Ctrl` `R` starts over, which clears the selection along with everything else on the card.
 It asks first if a transfer is already moving bytes, if the text box holds a note that has not


### PR DESCRIPTION
Emptying a staged selection was one X click per file, and after a completed send the selection deliberately lingers, so starting a fresh send meant clearing by hand every time. The only bulk escape was Start over, which is heavier and also throws away a typed note, the room code and the status.

**Clear** now sits beside **Send**. It empties whatever the tab you are on is holding, the file list on Files or the box on Text, and leaves settings, the Receive tab, history and anything already sent alone. It appears only when there is something to clear.

It does not ask first. It offers **Undo** instead, in a bar at the bottom of the window. The bar shows for about ten seconds; the offer behind it is not on a clock at all, and `Ctrl` `Z` takes it after the bar has gone. Only new content on that same tab, another Clear, or Start over ends an offer. Looking somewhere else, a tab switch, Settings, History, a send from the other tab, a cancelled transfer, only puts the bar away and it returns when you do.

Start over now asks before discarding a cleared note, the same way it already asks about a note typed but never sent.

## What took six audit rounds

The feature's whole safety argument is that an undo beats a confirm. Five separate paths were found that broke it, all the same shape: a transition that felt like an ending called the tab-blind discard and silently destroyed a note whose only copy that offer was, in a situation where the same note left sitting in the text box would have survived. Ctrl+O, tab switches, Settings, History, `send()` and `cancel()` each did it in turn.

The rule now is structural rather than patched. Hiding the bar and forgetting the offer are separate acts: the bar is a view concern, the offer is not. `discardCleared` is named for what it costs and has four call sites, three deliberate endings plus the same-tab-gated `supersede`. `cleared` has two writers and `offerUp` three, so the set of things that can end an offer is closed by construction and was verified as such down to the shipped bundle.

## Also in here

- The action row is pinned at 38px. Padding alone made the height depend on the variant's border, so the row was 40px with Clear present and 38px without.
- Reduced motion now works. Tailwind's `motion-reduce:animate-none` was emitted earlier in the same cascade layer than the app's own animation classes and lost to them, so every animation played at full travel for anyone who had asked for less. The override is unlayered now.
- The shared Button focus ring moves from ice/40 to ice/60. Measured at 2.96:1 it failed 1.4.11's 3:1, and every hand-rolled focusable in the app was already at /60.
- Focus handoffs for every route that can unmount the undo bar or the Start over dialog, and a fix for a focus orphan that predates this branch.
- Two pre-existing bugs found along the way: Ctrl+Enter could start a transfer behind a modal scrim, and the Start over dialog had a fourth exit nobody had counted.

## Test plan

- 91 unit tests, `tsc --noEmit` clean, full CI green.
- Six audit rounds, each ending in an independent go/no-go that re-derived the load-bearing claims rather than trusting the lanes. Rounds 1 through 5 returned NO-GO and are the reason the list above exists; round 6 passed.
- Live interaction sweeps on the built binary covering undo across tab switches, Settings, History, a send from the other tab, a cancelled receive, supersede, all four dialog exits, keyboard-only focus paths, and reduced motion.
- Transfer smoke, hash verified: a restored selection sends bytes identical to one that was never cleared.
