### PR TITLE
fix(engine): install the data channel handler before pion can read

### DIFF
--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -234,8 +234,13 @@ func runSend(cmd *cobra.Command, args []string) error {
 	fmt.Println("  Connected")
 	fmt.Println()
 
-	// 9. Send files
-	return transfer.SendFiles(dc, args, version)
+	// 9. Send files. The pump comes from the connection, not from SendFiles: see
+	// peer.Early for why registering it later can silently lose a message.
+	early := conn.Early()
+	return transfer.SendFilesWithOptions(dc, args, version, transfer.SendOptions{
+		Messages: early.Msgs,
+		Closed:   early.Closed,
+	})
 }
 
 // ── floe receive ─────────────────────────────────────────────────────────────
@@ -352,7 +357,13 @@ func runReceive(cmd *cobra.Command, args []string) error {
 	if flagNoReport || os.Getenv("FLOE_NO_STATS") == "1" {
 		statsURL = "" // reportBytesToServer no-ops on empty URL
 	}
-	return transfer.ReceiveFiles(dc, absOutput, flagAutoAccept, version, statsURL)
+	// The pump comes from the connection, not from ReceiveFiles: see peer.Early.
+	// This is the side that was actually losing the sender's first message.
+	early := conn.Early()
+	return transfer.ReceiveFilesWithOptions(dc, absOutput, flagAutoAccept, version, statsURL, transfer.ReceiveOptions{
+		Messages: early.Msgs,
+		Closed:   early.Closed,
+	})
 }
 
 // ── floe version ─────────────────────────────────────────────────────────────

--- a/cli/engine/peer/connection.go
+++ b/cli/engine/peer/connection.go
@@ -94,6 +94,81 @@ type Connection struct {
 
 	// connected is sent once when the PeerConnection reaches "connected" state
 	connected chan error
+
+	// early is the data channel's message pump, wired the instant the channel
+	// exists rather than when the transfer layer gets around to it. See attach.
+	early *Early
+}
+
+// Early carries a data channel's incoming messages and its close signal.
+//
+// It exists because pion acknowledges a data channel and starts reading from it
+// before the application has been told anything. datachannel.Server writes the
+// DCEP ACK as soon as it reads the peer's OPEN, and webrtc's handleOpen then
+// starts readLoop. A message that readLoop delivers while DataChannel.onMessage
+// still holds a nil handler is DISCARDED, silently and permanently: SCTP has
+// already acknowledged it, so it is never retransmitted and the sender has no
+// idea it went nowhere.
+//
+// That window is microseconds wide and it is wide enough to lose a transfer.
+// Measured on one machine with both peers local, the desktop app as sender
+// completed 1 send in 25; adding a few hundred microseconds of delay anywhere in
+// the receiver's SCTP path took it to 19 in 19. The symptom is both ends
+// reporting a healthy connection and then nothing, which is exactly what the
+// watchdog comment at the top of transfer/receiver.go describes as a captured CI
+// failure. The margin scales with round-trip time, so two machines on a LAN or
+// the internet almost always win it, which is why this shipped and mostly works.
+//
+// The fix is not to make the transfer layer faster. It is to have a handler
+// installed before pion can possibly deliver, and to hand the resulting stream
+// to whoever wants it.
+type Early struct {
+	// Msgs carries every message the data channel receives, in order.
+	Msgs <-chan webrtc.DataChannelMessage
+	// Closed is closed when the data channel closes. pion fires OnClose on
+	// graceful closes only; see the note in transfer/sender.go.
+	Closed <-chan struct{}
+}
+
+// earlyBuffer matches the buffer the transfer layer used when it owned this
+// pump. It is backpressure, not a drop policy: a full buffer parks pion's read
+// loop until the transfer layer catches up.
+const earlyBuffer = 256
+
+// attach installs the ONLY OnMessage and OnClose handlers this data channel will
+// ever have, and must be called synchronously at the moment the channel appears:
+// immediately after CreateDataChannel for the sender, and inside OnDataChannel
+// before OnOpen for the receiver. Both are before pion can start reading.
+//
+// Whoever consumes the channel must use conn.Early() rather than registering
+// their own callbacks, because pion keeps one handler per event and a later
+// registration silently replaces this one, reopening the window it closes.
+func (conn *Connection) attach(dc *webrtc.DataChannel) {
+	msgs := make(chan webrtc.DataChannelMessage, earlyBuffer)
+	closed := make(chan struct{})
+	var once sync.Once
+	dc.OnClose(func() { once.Do(func() { close(closed) }) })
+	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+		// Selecting on closed means this can never block forever, and never
+		// panics: nothing closes msgs.
+		select {
+		case msgs <- msg:
+		case <-closed:
+		}
+	})
+	conn.mu.Lock()
+	conn.early = &Early{Msgs: msgs, Closed: closed}
+	conn.mu.Unlock()
+}
+
+// Early returns the message pump for the data channel returned by SetupAsSender
+// or SetupAsReceiver. Pass it into transfer.SendOptions or transfer.ReceiveOptions;
+// a transfer that registers its own OnMessage instead can lose the peer's first
+// message. Nil before either Setup call has returned.
+func (conn *Connection) Early() *Early {
+	conn.mu.Lock()
+	defer conn.mu.Unlock()
+	return conn.early
 }
 
 // Option configures a Connection created by New.
@@ -211,6 +286,9 @@ func (conn *Connection) SetupAsSender() (*webrtc.DataChannel, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create data channel: %w", err)
 	}
+	// Before the offer even leaves, so the receiver's first ack cannot land in a
+	// channel with no handler on it. See Early.
+	conn.attach(dc)
 
 	// Create the SDP offer describing our capabilities
 	offer, err := conn.pc.CreateOffer(nil)
@@ -277,6 +355,13 @@ func (conn *Connection) SetupAsReceiver() (*webrtc.DataChannel, error) {
 	// The receiver waits for a data channel from the sender.
 	dcChan := make(chan *webrtc.DataChannel, 1)
 	conn.pc.OnDataChannel(func(dc *webrtc.DataChannel) {
+		// attach FIRST, and in this callback rather than in OnOpen. pion runs
+		// OnDataChannel synchronously before it starts the channel's read loop,
+		// and it has already ACKed the channel by this point, so the sender may
+		// be writing its first message right now. Registering in OnOpen, or
+		// later in the transfer layer, is a race this loses on a fast path. See
+		// Early for what losing it costs.
+		conn.attach(dc)
 		dc.OnOpen(func() {
 			dcChan <- dc
 		})

--- a/cli/engine/transfer/early_test.go
+++ b/cli/engine/transfer/early_test.go
@@ -1,0 +1,212 @@
+package transfer
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// newPumpedPair is newConnectedPair with the receiver wired the way
+// peer.Connection now wires it: the message handler is installed inside
+// OnDataChannel, before OnOpen and before pion can start reading, and it feeds a
+// channel instead of the transfer layer registering its own handler later.
+//
+// It is deliberately a separate harness rather than a change to
+// newConnectedPair. The other loopback tests rely on nothing being delivered
+// before ReceiveFiles installs its handler, which is the very assumption this
+// file exists to attack, and giving them a pump would make them flaky for
+// reasons that have nothing to do with what they test.
+func newPumpedPair(t *testing.T) (sender *webrtc.DataChannel, recvCh <-chan *webrtc.DataChannel, msgs <-chan webrtc.DataChannelMessage, closed <-chan struct{}, closeFn func()) {
+	t.Helper()
+
+	se := webrtc.SettingEngine{}
+	se.SetIncludeLoopbackCandidate(true)
+	api := webrtc.NewAPI(webrtc.WithSettingEngine(se))
+
+	pcSender, err := api.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("create sender PC: %v", err)
+	}
+	pcReceiver, err := api.NewPeerConnection(webrtc.Configuration{})
+	if err != nil {
+		t.Fatalf("create receiver PC: %v", err)
+	}
+
+	got := make(chan *webrtc.DataChannel, 1)
+	pump := make(chan webrtc.DataChannelMessage, 256)
+	shut := make(chan struct{})
+	var once sync.Once
+	pcReceiver.OnDataChannel(func(dc *webrtc.DataChannel) {
+		dc.OnClose(func() { once.Do(func() { close(shut) }) })
+		dc.OnMessage(func(m webrtc.DataChannelMessage) {
+			select {
+			case pump <- m:
+			case <-shut:
+			}
+		})
+		dc.OnOpen(func() { got <- dc })
+	})
+
+	dc, err := pcSender.CreateDataChannel("floe", nil)
+	if err != nil {
+		t.Fatalf("create data channel: %v", err)
+	}
+	senderOpen := make(chan struct{})
+	dc.OnOpen(func() { close(senderOpen) })
+
+	offer, err := pcSender.CreateOffer(nil)
+	if err != nil {
+		t.Fatalf("create offer: %v", err)
+	}
+	gatherSender := webrtc.GatheringCompletePromise(pcSender)
+	if err := pcSender.SetLocalDescription(offer); err != nil {
+		t.Fatalf("sender SetLocalDescription: %v", err)
+	}
+	<-gatherSender
+	if err := pcReceiver.SetRemoteDescription(*pcSender.LocalDescription()); err != nil {
+		t.Fatalf("receiver SetRemoteDescription: %v", err)
+	}
+
+	answer, err := pcReceiver.CreateAnswer(nil)
+	if err != nil {
+		t.Fatalf("create answer: %v", err)
+	}
+	gatherReceiver := webrtc.GatheringCompletePromise(pcReceiver)
+	if err := pcReceiver.SetLocalDescription(answer); err != nil {
+		t.Fatalf("receiver SetLocalDescription: %v", err)
+	}
+	<-gatherReceiver
+	if err := pcSender.SetRemoteDescription(*pcReceiver.LocalDescription()); err != nil {
+		t.Fatalf("sender SetRemoteDescription: %v", err)
+	}
+
+	select {
+	case <-senderOpen:
+	case <-time.After(20 * time.Second):
+		pcSender.Close()
+		pcReceiver.Close()
+		t.Fatal("sender data channel never opened")
+	}
+
+	return dc, got, pump, shut, func() {
+		pcSender.Close()
+		pcReceiver.Close()
+	}
+}
+
+// TestReceiveDrainsMessagesThatArrivedFirst is the regression test for a bug
+// that silently ate roughly four out of five same-machine transfers.
+//
+// pion acknowledges a data channel and starts reading from it before the
+// application is told anything, and a message it reads while DataChannel's
+// handler is still nil is discarded permanently: SCTP has already acked it, so
+// it is never retransmitted and the sender believes it was delivered. The
+// transfer layer used to register that handler at the top of the receive, one
+// goroutine hop and a couple of prints too late, so on a fast path the sender's
+// metadata could be gone before anyone was listening. Both ends then sat on a
+// healthy connection with nothing happening until a watchdog fired.
+//
+// The test is deterministic rather than timing-based: it waits for the message
+// to be sitting in the pump BEFORE the receive starts, which is precisely the
+// state that used to be unrecoverable. Nothing here sleeps hoping to win a race.
+func TestReceiveDrainsMessagesThatArrivedFirst(t *testing.T) {
+	sender, recvCh, msgs, closed, closeFn := newPumpedPair(t)
+	defer closeFn()
+
+	src := filepath.Join(t.TempDir(), "early.bin")
+	payload := make([]byte, 64*1024)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatalf("seed payload: %v", err)
+	}
+	if err := os.WriteFile(src, payload, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	var dc *webrtc.DataChannel
+	select {
+	case dc = <-recvCh:
+	case <-time.After(20 * time.Second):
+		t.Fatal("receiver data channel never opened")
+	}
+
+	// Send with nobody in the transfer layer listening yet.
+	sendErr := make(chan error, 1)
+	go func() { sendErr <- SendFiles(sender, []string{src}, "") }()
+
+	// Block until the sender's first message is provably buffered. This is the
+	// whole point: at this instant the metadata has been delivered and acked at
+	// the SCTP layer, and the receive has not started.
+	deadline := time.After(20 * time.Second)
+	for len(msgs) == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("sender's first message never reached the pump")
+		default:
+			time.Sleep(2 * time.Millisecond)
+		}
+	}
+
+	outDir := t.TempDir()
+	recvErr := make(chan error, 1)
+	go func() {
+		recvErr <- ReceiveFilesWithOptions(dc, outDir, true, "", "", ReceiveOptions{
+			Messages: msgs,
+			Closed:   closed,
+		})
+	}()
+
+	select {
+	case err := <-recvErr:
+		if err != nil {
+			t.Fatalf("receive failed on a message that arrived before it started: %v", err)
+		}
+	case <-time.After(60 * time.Second):
+		t.Fatal("receive hung: the early message was dropped, which is the bug this guards")
+	}
+
+	select {
+	case err := <-sendErr:
+		if err != nil {
+			t.Fatalf("send failed: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("send did not return")
+	}
+
+	out, err := os.ReadFile(filepath.Join(outDir, "early.bin"))
+	if err != nil {
+		t.Fatalf("read received file: %v", err)
+	}
+	if sha256.Sum256(out) != sha256.Sum256(payload) {
+		t.Fatal("received bytes differ from the source")
+	}
+}
+
+// TestReceiveWithoutPumpStillWorks keeps the fallback honest: a caller that owns
+// its data channel and registered nothing must still get the old behaviour,
+// because that is what every other test in this package relies on.
+func TestReceiveWithoutPumpStillWorks(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "plain.bin")
+	payload := make([]byte, 32*1024)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatalf("seed payload: %v", err)
+	}
+	if err := os.WriteFile(src, payload, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	outDir := runTransfer(t, []string{src})
+	out, err := os.ReadFile(filepath.Join(outDir, "plain.bin"))
+	if err != nil {
+		t.Fatalf("read received file: %v", err)
+	}
+	if sha256.Sum256(out) != sha256.Sum256(payload) {
+		t.Fatal("received bytes differ from the source")
+	}
+}

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -76,6 +76,14 @@ type ReceiveOptions struct {
 	// UpdateHint replaces the CLI-only local update instruction in protocol
 	// compatibility errors. Leave empty for the default CLI wording.
 	UpdateHint string
+	// Messages and Closed come from peer.Connection.Early(), which wires the data
+	// channel the instant it exists. Pass BOTH whenever the channel came from
+	// peer.SetupAsReceiver: registering handlers here instead is a race against
+	// pion's read loop, and the message it loses is the sender's first, so the
+	// transfer hangs with both ends reporting a healthy connection. Leave both
+	// nil only for a channel you created and left unhandled.
+	Messages <-chan webrtc.DataChannelMessage
+	Closed   <-chan struct{}
 }
 
 // ReceiveFiles handles the full receiving side of the Floe protocol.
@@ -102,25 +110,41 @@ func ReceiveFilesWithProgress(dc *webrtc.DataChannel, outputDir string, autoAcce
 // any file is created or acked.
 func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccept bool, localVer string, serverURL string, opts ReceiveOptions) error {
 	onProgress := opts.OnProgress
-	// msgCh collects ALL incoming data channel messages.
-	// We use a channel so the OnMessage callback (goroutine) feeds a sequential loop.
-	msgCh := make(chan webrtc.DataChannelMessage, 256)
-
-	// done is closed when the data channel closes. We signal via a separate
-	// channel instead of closing msgCh from OnClose: closing msgCh while the
-	// OnMessage callback might still push would panic ("send on closed channel").
-	// The OnMessage send selects on done so it can never block or panic after close.
-	done := make(chan struct{})
-	var closeOnce sync.Once
-	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
-		select {
-		case msgCh <- msg:
-		case <-done:
-		}
-	})
-	dc.OnClose(func() {
-		closeOnce.Do(func() { close(done) })
-	})
+	// msgCh collects ALL incoming data channel messages, so the callback that
+	// pion runs on its own goroutine feeds a sequential loop here.
+	//
+	// It comes from peer.Connection.Early() when the caller has one, and that is
+	// the only correct source for a channel obtained from SetupAsReceiver: pion
+	// ACKs the data channel and starts reading before the application is told
+	// anything, so a handler registered here, at the top of the receive, can miss
+	// the sender's first message. It is not late by much. It is late by enough.
+	//
+	// The fallback below is for callers that own the data channel themselves and
+	// registered nothing, which in practice means the loopback tests.
+	var msgCh <-chan webrtc.DataChannelMessage
+	var done <-chan struct{}
+	if opts.Messages != nil && opts.Closed != nil {
+		msgCh, done = opts.Messages, opts.Closed
+	} else {
+		// done is closed when the data channel closes. We signal via a separate
+		// channel instead of closing msgCh from OnClose: closing msgCh while the
+		// OnMessage callback might still push would panic ("send on closed
+		// channel"). The OnMessage send selects on done so it can never block or
+		// panic after close.
+		ch := make(chan webrtc.DataChannelMessage, 256)
+		d := make(chan struct{})
+		var closeOnce sync.Once
+		dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+			select {
+			case ch <- msg:
+			case <-d:
+			}
+		})
+		dc.OnClose(func() {
+			closeOnce.Do(func() { close(d) })
+		})
+		msgCh, done = ch, d
+	}
 
 	// Process messages sequentially
 	var currentFile *os.File

--- a/cli/engine/transfer/sender.go
+++ b/cli/engine/transfer/sender.go
@@ -109,6 +109,14 @@ type SendOptions struct {
 	// UpdateHint replaces the CLI-only local update instruction in protocol
 	// compatibility errors. Leave empty for the default CLI wording.
 	UpdateHint string
+	// Messages and Closed come from peer.Connection.Early(), which wires the data
+	// channel the instant it exists. Pass BOTH whenever the channel came from
+	// peer.SetupAsSender. The sender has never been observed losing this race,
+	// because the receiver does more work before it acks than the sender does
+	// before it listens, but the window is the same one and it is the same
+	// silent, permanent drop. See peer.Early.
+	Messages <-chan webrtc.DataChannelMessage
+	Closed   <-chan struct{}
 }
 
 // SendFiles sends all given file paths over the open data channel, rendering a
@@ -152,18 +160,41 @@ func SendFilesWithOptions(dc *webrtc.DataChannel, paths []string, localVer strin
 
 	start := time.Now()
 
-	// ackCh receives JSON ack messages from the receiver
+	// ackCh receives JSON ack messages from the receiver.
+	// Accept ack as either string or binary: the CLI receiver sends binary for
+	// browser compatibility, CLI-to-CLI also works.
+	// Non-blocking: a full buffer means a stray/duplicate message arrived;
+	// dropping it is safe because the ack loop already matched its ID.
 	ackCh := make(chan []byte, 4)
-	dc.OnMessage(func(msg webrtc.DataChannelMessage) {
-		// Accept ack as either string or binary — the CLI receiver sends
-		// binary for browser compatibility, CLI-to-CLI also works.
-		// Non-blocking: a full buffer means a stray/duplicate message arrived;
-		// dropping it is safe because the ack loop already matched its ID.
-		select {
-		case ackCh <- msg.Data:
-		default:
-		}
-	})
+	if opts.Messages != nil && opts.Closed != nil {
+		// The pump was installed with the data channel, so the receiver's first
+		// ack cannot have arrived before anyone was listening. Forwarding into
+		// ackCh rather than reading opts.Messages directly leaves every deadline
+		// below exactly as it was.
+		go func() {
+			for {
+				select {
+				case msg, ok := <-opts.Messages:
+					if !ok {
+						return
+					}
+					select {
+					case ackCh <- msg.Data:
+					default:
+					}
+				case <-opts.Closed:
+					return
+				}
+			}
+		}()
+	} else {
+		dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+			select {
+			case ackCh <- msg.Data:
+			default:
+			}
+		})
+	}
 
 	// done is closed when the data channel closes, letting every wait below
 	// fail fast instead of burning its full deadline. pion fires OnClose on
@@ -172,11 +203,21 @@ func SendFilesWithOptions(dc *webrtc.DataChannel, paths []string, localVer strin
 	// chain (sctp retransmits forever by design and an ICE failure does not
 	// unblock reads), so the 120 s ack and 60 s backpressure deadlines remain
 	// the backstop for ungraceful death.
-	done := make(chan struct{})
-	var closeOnce sync.Once
-	dc.OnClose(func() {
-		closeOnce.Do(func() { close(done) })
-	})
+	//
+	// Taken from the pump when there is one. Registering our own OnClose would
+	// REPLACE the pump's, since pion keeps a single handler per event, and the
+	// pump needs its own close signal to be sure its send can never block.
+	var done <-chan struct{}
+	if opts.Closed != nil {
+		done = opts.Closed
+	} else {
+		d := make(chan struct{})
+		var closeOnce sync.Once
+		dc.OnClose(func() {
+			closeOnce.Do(func() { close(d) })
+		})
+		done = d
+	}
 
 	// Backpressure: pion calls OnBufferedAmountLow once the send buffer drains
 	// to bufferedAmountLowWater. The send loop blocks on sendMore whenever the

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -798,9 +798,15 @@ func (a *App) runSend(g uint64, paths []string, hideIP bool) {
 		lastEmit = time.Now()
 		emit("send:progress", p)
 	}
+	// The pump comes from the connection: see peer.Early for why registering the
+	// handler down in the transfer layer can silently lose the peer's first
+	// message on a fast path.
+	sendEarly := conn.Early()
 	if err := transfer.SendFilesWithOptions(dc, paths, version, transfer.SendOptions{
 		OnProgress: onProgress,
 		UpdateHint: desktopUpdateHint,
+		Messages:   sendEarly.Msgs,
+		Closed:     sendEarly.Closed,
 	}); err != nil {
 		// The relay cap is a policy block, not a failure: skip the "transfer
 		// failed" wrapper, and when Hide my IP forced the relay, name the
@@ -955,12 +961,17 @@ func (a *App) receiveByCode(g uint64, codeOrLink string, outputDir string, hideI
 		lastEmit = time.Now()
 		emit("recv:progress", p)
 	}
+	// The pump comes from the connection: see peer.Early. This is the side the
+	// race was actually being lost on.
+	recvEarly := conn.Early()
 	opts := transfer.ReceiveOptions{
 		OnProgress: onProgress,
 		UpdateHint: desktopUpdateHint,
 		// Fires once as the sender's first metadata arrives, before any byte
 		// lands: the UI shows what is incoming while the transfer starts.
 		OnIncoming: func(inc transfer.IncomingInfo) { emit("recv:incoming", inc) },
+		Messages:   recvEarly.Msgs,
+		Closed:     recvEarly.Closed,
 	}
 	if err := transfer.ReceiveFilesWithOptions(dc, absOutput, true, version, statsURL, opts); err != nil {
 		return "", fmt.Errorf("transfer failed: %w", err)


### PR DESCRIPTION
A transfer could connect and then move nothing. Both ends showed a healthy connection, DIRECT, the data channel open, and then silence until the receiver's 30 second watchdog fired with a message blaming the other side. On one machine with both peers local, the desktop app as sender completed **5 sends in 26**. The released 0.2.4 build and a current build were equally bad, so this is not a recent regression.

## Cause

pion acknowledges a data channel and starts reading from it before the application is told anything. `datachannel.Server` writes the DCEP ACK as soon as it reads the peer's OPEN, and webrtc's `handleOpen` then starts `readLoop`. A message `readLoop` delivers while `DataChannel.onMessage` still holds a nil handler is **discarded, silently and permanently**: SCTP has already acknowledged it, so it is never retransmitted and the sender has no idea it went nowhere.

The engine registered that handler at the top of `ReceiveFilesWithOptions`, one goroutine hop and two prints after the channel opened. Late by microseconds, and microseconds is the entire margin: the window closes when the metadata's round trip exceeds the receiver's registration time, so LAN and internet peers nearly always win it and two peers in the same OS instance nearly always lose. That is why this shipped and mostly works.

Two things in the tree already knew. `transfer/receiver.go` describes the exact symptom as "the captured CI failure mode: both sides log Connected, then nothing", and `loopback_test.go` says its harness delays the send so the handler "must be set before the first byte is sent". The suite was working around this rather than catching it.

## Fix

The `peer` package now installs the only `OnMessage` and `OnClose` this channel will ever have, at the instant the channel exists: immediately after `CreateDataChannel` for the sender, and inside `OnDataChannel` before `OnOpen` for the receiver. Both run before pion can deliver anything. It feeds a 256-buffered channel, and the transfer layer consumes that through `ReceiveOptions.Messages`/`Closed` instead of registering its own callbacks. pion keeps one handler per event, so a later registration would silently replace this one and reopen the window.

The sender side had the identical latent window on the receiver's ack. It has never been observed losing it, because the receiver does more work before acking than the sender does before listening, but it is the same defect and is closed the same way.

Callers that own their data channel and registered nothing keep the old path, which is what the existing loopback tests use.

## Measured

A 2x2 of fixed and unfixed builds, 61 transfers, interleaved, binary provenance verified by symbol scan and sha256 on every run:

| Sender | Receiver | Runs | Pass |
|---|---|---|---|
| fixed desktop | released CLI | 20 | 0 |
| released 0.2.4 desktop | released CLI | 13 | 0 |
| fixed desktop | fixed CLI | 10 | 10 |
| released 0.2.4 desktop | fixed CLI | 8 | 8 |
| fixed CLI | fixed CLI | 5 | 5 |
| released CLI | released CLI | 3 | 3 |

**The receiver's build decides the outcome and the sender's is irrelevant.** 0 of 33 through an unfixed receiver, 25 of 25 through a fixed one, every failure the same signature. 28 of 28 successes hash-identical end to end. 200 MB legs run at 56 MB/s, so the pump costs no throughput.

On confidence: zero failures in 25 is enough to exclude the old near-total failure rate, but by the rule of three the 95% upper bound on any residual is about 12%. Demonstrating under 5% would need roughly 60 consecutive passes.

## Test plan

- New `cli/engine/transfer/early_test.go`. It is deterministic rather than timing-based: it blocks until the sender's first message is provably buffered **before** the receive starts, which is exactly the state that used to be unrecoverable.
- Verified it can fail: with the fix disabled it fails with the production error, `connected, but no data arrived from the sender within 30s`. With the fix it passes.
- `go test ./...` green for both `cli` and `desktop`; build and vet clean.

## Release note

A fixed sender does **not** rescue an unfixed receiver, so this has to ship on both surfaces, and peers already running today's builds stay affected as receivers until they update. Making new senders work with already-shipped receivers would need a sender-side mitigation, for example keying a metadata resend off the existing ack. That is a separate change with its own backward-compatibility questions and is deliberately not in this PR.
