### PR TITLE
docs: changelog and version pins for desktop-v0.2.5 and v1.10.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Version
       description: "Desktop app: Settings > About. CLI: `floe --version`. Skip for the web app."
-      placeholder: e.g., desktop-v0.2.4 or v1.10.1
+      placeholder: e.g., desktop-v0.2.5 or v1.10.2
     validations:
       required: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ go build ./cmd/floe    # local binary
 go test ./...          # run all tests
 ```
 
-The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version={{ .Version }}"`, which carries NO leading `v` (a v1.10.1 tag produces a binary that prints `floe 1.10.1`). The desktop app differs: desktop-release.yml injects the tag verbatim (`desktop-v0.2.4`).
+The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version={{ .Version }}"`, which carries NO leading `v` (a v1.10.2 tag produces a binary that prints `floe 1.10.2`). The desktop app differs: desktop-release.yml injects the tag verbatim (`desktop-v0.2.5`).
 
 ### Desktop (Wails)
 ```bash

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -182,8 +182,10 @@ receiver, which is deliberate (share a link and wait) and cancellable.
 
 ## Release history
 
-Current release: `desktop-v0.2.4` (Microsoft Store 9NBQ8ZQ1065L + GitHub
-pre-release), shipped 2026-08-14.
+Current release: `desktop-v0.2.5` (Microsoft Store 9NBQ8ZQ1065L + GitHub
+pre-release), shipped 2026-08-16. Paired with CLI `v1.10.2`, because the data
+channel fix they both carry is receiver-side and only protects a transfer once
+the RECEIVING peer has it.
 
 The list below is the verified order the first public release (0.1.0 beta)
 actually followed. Steps 1-3 shipped the GitHub beta; the plan then pivoted

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -5,7 +5,7 @@
   "info": {
     "companyName": "Jan Carlo Paredes",
     "productName": "Floe",
-    "productVersion": "0.2.4",
+    "productVersion": "0.2.5",
     "copyright": "(c) 2026 Jan Carlo Paredes",
     "comments": "Peer-to-peer file transfer"
   },

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -43,25 +43,26 @@ Each entry lists the parts it changed. Filter on the right to see only the ones 
 <Update label="desktop-v0.2.5" description="2026-08-16" tags={["Desktop"]}>
   **Empty a staged selection in one click, and a fix for transfers that connected but never started**
 
-  - A **Clear** button now sits beside **Send** on the send card. It empties whatever the tab you are on is holding, the file list on **Files** or the box on **Text**, and leaves your settings, the Receive tab, your history and anything already sent alone. It appears only when there is something to clear, and steps aside for **Cancel** while a send is running.
+  - A **Clear** button now sits beside **Send** on the send card. It empties whatever the tab you are on is holding, the file list on **Files** or the box on **Text**, and leaves your settings, the Receive tab, your history and the files themselves alone. It appears only when there is something to clear, and steps aside for **Cancel** while a send is running.
   - Clear does not ask first. It offers **Undo** instead, in a bar at the bottom of the window that puts back exactly what you had staged, whitespace and all. The bar shows for about ten seconds, longer while you point at it or reach it with the keyboard.
-  - The undo outlasts the bar. `Ctrl` `Z` still takes it once the bar has gone, and it stands until you put something new on that same tab, clear something else, or start over. Switching tabs, opening Settings or checking History only puts the bar away, and it comes back when you do.
+  - The undo outlasts the bar. `Ctrl` `Z` still takes it once the bar has gone, and it stands until you put something new on that same tab, clear something else, or start over. Switching tabs, opening Settings or checking History only puts the bar away, and it comes back when you do. Like the app's other shortcuts, `Ctrl` `Z` waits while the cursor is in a text box.
   - **Start over** now asks before discarding a note you have cleared, the same way it already asks about a note you typed but never sent.
-  - Fixed transfers that connected and then moved nothing: both ends showed a healthy connection, then sat silent until a timeout blamed the other side. The very first message of a transfer could be dropped before the receiving app was listening for it, which is likeliest when both peers are on the same machine or the same fast network. The fix is on the receiving side, so a transfer is protected once the **receiving** end is running Floe Desktop 0.2.5 or `floe` 1.10.2. Sending from this build to a peer that has not updated is unchanged.
-  - Every row in **History** is now a single button that opens and closes the row, with one chevron in the same place on every row. The opened row carries the file names, where a received transfer was saved, and quiet **Show in folder** and **Remove** actions along the bottom. Removing an entry can no longer shift which row is open.
+  - Fixed transfers that connected and then moved nothing: both ends showed a healthy connection, then sat silent until a timeout blamed the other side. The very first message of a transfer could be dropped before the receiving app was listening for it. The odds turn on the round trip between the two peers, so it was rare across a network and common between two Floe apps on one machine. The fix is on the receiving side, so a transfer is protected once the **receiving** end is running Floe Desktop 0.2.5 or `floe` 1.10.2. Sending from this build to a peer that has not updated is unchanged.
+  - Every row in **History** is now a single button that opens and closes the row, with one chevron in the same place on every row. The opened row carries the file names, and for a received transfer where it was saved plus a **Show in folder** action; every row carries **Remove**. Finishing a transfer no longer shifts which row is open, because a new entry goes on top and the open row used to be tracked by position.
   - The dashed borders on the drop area read as soft white now and brighten when you point at them. The blue is kept for the highlight that appears while you are actually dragging files over the window.
-  - Turning off animations in Windows now stops the app's own animations. The setting was being ignored, so the drop area, the update notice and the new undo bar all animated anyway.
+  - Turning off animations in Windows now stops the app's own animations. The setting was being ignored, so the update notice, the Settings panel, tooltips, the connection dot and the new undo bar all moved anyway.
   - The focus outline on buttons is brighter, so it is easier to see where the keyboard is.
   - No transfer-protocol change, so Floe Desktop 0.2.5 transfers with browser and CLI peers in every direction.
 </Update>
 
-<Update label="v1.10.2" description="2026-08-16" tags={["CLI"]}>
+<Update label="v1.10.2" description="2026-08-16" tags={["CLI", "Self-hosting"]}>
   **Fixed transfers that connected and then moved nothing**
 
   - A transfer could reach the point where both ends reported a healthy connection and then never start, ending 30 seconds later with `connected, but no data arrived from the sender` on one side and a message blaming the receiver on the other. The very first message of a transfer could be dropped before the receiving side was listening for it, and because the network layer had already accepted that message, nothing ever resent it.
   - The window is microseconds wide and closes as the round trip between peers grows, so it was rare between two machines and common between two Floe processes on one machine. It has been there since the first release.
   - The fix is on the receiving side. A transfer is protected once the **receiving** end is running `floe` 1.10.2 or Floe Desktop 0.2.5; sending from an updated build to a peer that has not updated is unchanged. Both surfaces ship the fix in this pair of releases.
-  - No transfer-protocol change, so v1.10.2 interoperates with older CLI and browser peers in every direction.
+  - Self-hosting: the published images are rebuilt as `1.10.2` with nothing of their own changed, since this release only touches the transfer engine the CLI and the desktop app share. There is nothing you need to do; pull when convenient.
+  - The wire protocol is unchanged, so v1.10.2 still speaks to older CLI and browser peers in both directions. That is a statement about compatibility, not about the bug above, which is fixed for whichever end is running the new build.
 </Update>
 
 <Update label="desktop-v0.2.4" description="2026-08-14" tags={["Desktop"]}>

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -40,6 +40,30 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
+<Update label="desktop-v0.2.5" description="2026-08-16" tags={["Desktop"]}>
+  **Empty a staged selection in one click, and a fix for transfers that connected but never started**
+
+  - A **Clear** button now sits beside **Send** on the send card. It empties whatever the tab you are on is holding, the file list on **Files** or the box on **Text**, and leaves your settings, the Receive tab, your history and anything already sent alone. It appears only when there is something to clear, and steps aside for **Cancel** while a send is running.
+  - Clear does not ask first. It offers **Undo** instead, in a bar at the bottom of the window that puts back exactly what you had staged, whitespace and all. The bar shows for about ten seconds, longer while you point at it or reach it with the keyboard.
+  - The undo outlasts the bar. `Ctrl` `Z` still takes it once the bar has gone, and it stands until you put something new on that same tab, clear something else, or start over. Switching tabs, opening Settings or checking History only puts the bar away, and it comes back when you do.
+  - **Start over** now asks before discarding a note you have cleared, the same way it already asks about a note you typed but never sent.
+  - Fixed transfers that connected and then moved nothing: both ends showed a healthy connection, then sat silent until a timeout blamed the other side. The very first message of a transfer could be dropped before the receiving app was listening for it, which is likeliest when both peers are on the same machine or the same fast network. The fix is on the receiving side, so a transfer is protected once the **receiving** end is running Floe Desktop 0.2.5 or `floe` 1.10.2. Sending from this build to a peer that has not updated is unchanged.
+  - Every row in **History** is now a single button that opens and closes the row, with one chevron in the same place on every row. The opened row carries the file names, where a received transfer was saved, and quiet **Show in folder** and **Remove** actions along the bottom. Removing an entry can no longer shift which row is open.
+  - The dashed borders on the drop area read as soft white now and brighten when you point at them. The blue is kept for the highlight that appears while you are actually dragging files over the window.
+  - Turning off animations in Windows now stops the app's own animations. The setting was being ignored, so the drop area, the update notice and the new undo bar all animated anyway.
+  - The focus outline on buttons is brighter, so it is easier to see where the keyboard is.
+  - No transfer-protocol change, so Floe Desktop 0.2.5 transfers with browser and CLI peers in every direction.
+</Update>
+
+<Update label="v1.10.2" description="2026-08-16" tags={["CLI"]}>
+  **Fixed transfers that connected and then moved nothing**
+
+  - A transfer could reach the point where both ends reported a healthy connection and then never start, ending 30 seconds later with `connected, but no data arrived from the sender` on one side and a message blaming the receiver on the other. The very first message of a transfer could be dropped before the receiving side was listening for it, and because the network layer had already accepted that message, nothing ever resent it.
+  - The window is microseconds wide and closes as the round trip between peers grows, so it was rare between two machines and common between two Floe processes on one machine. It has been there since the first release.
+  - The fix is on the receiving side. A transfer is protected once the **receiving** end is running `floe` 1.10.2 or Floe Desktop 0.2.5; sending from an updated build to a peer that has not updated is unchanged. Both surfaces ship the fix in this pair of releases.
+  - No transfer-protocol change, so v1.10.2 interoperates with older CLI and browser peers in every direction.
+</Update>
+
 <Update label="desktop-v0.2.4" description="2026-08-14" tags={["Desktop"]}>
   **A cleaner update notice, and the main screen says precisely what happens to your files**
 

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -63,7 +63,7 @@ Specific to the `update` command.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (1.10.1)` and stops either way (the installed version carries no leading `v`). On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
+| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (1.10.2)` and stops either way (the installed version carries no leading `v`). On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
 
 ## Opting out of the global counter
 

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -95,7 +95,7 @@ receives from browser peers and CLI peers without any extra setup.
 Every GitHub release ships `SHA256SUMS.txt`. To check a file you downloaded:
 
 ```powershell PowerShell
-Get-FileHash floe-desktop-setup-0.2.4.exe -Algorithm SHA256
+Get-FileHash floe-desktop-setup-0.2.5.exe -Algorithm SHA256
 ```
 
 Compare the result with the matching line in `SHA256SUMS.txt`. Store installs need no check:
@@ -104,7 +104,7 @@ the Store verifies the package signature itself.
 ## Check the version
 
 Open **Settings** (the gear in the title bar, or `Ctrl` `,`) and look at the **About** section.
-**App version** reads the release tag, for example `desktop-v0.2.4`. A build you compiled
+**App version** reads the release tag, for example `desktop-v0.2.5`. A build you compiled
 yourself reads `dev`.
 
 That section also shows the transfer protocol version and which signaling server the app is

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -12,7 +12,7 @@ description: "Every keyboard shortcut in Floe Desktop for Windows: adding files,
 | `Ctrl` `H` | Show or hide **History**. |
 | `Ctrl` `,` | Open or close **Settings**. |
 | `Ctrl` `R` | Start over. Clears the current selection and result. |
-| `Ctrl` `Z` | Undo a **Clear**, including after its bar has gone. Does nothing when there is nothing to undo. |
+| `Ctrl` `Z` | Undo a **Clear**, including after its bar has gone. Works on the Send tab the clear came from; does nothing anywhere else. |
 | `Esc` | Close whatever is on top. In Settings, goes back. |
 | `Enter` | In the **Code or link** field, starts receiving. In the **Text** box, use `Ctrl` `Enter`. |
 
@@ -25,6 +25,12 @@ the text box keeps its own undo.
 
 **One fires from anywhere.** `Ctrl` `,` opens Settings, the way a preferences shortcut normally
 does.
+
+**`Ctrl` `Z` is the narrowest of them.** It undoes a **Clear**, and only from the send tab that
+clear came from: on the other send tab, on **Receive**, in **History**, in **Settings**, or with
+a dialog open, it does nothing at all. The offer itself survives all of those, so going back to
+the tab you cleared brings it within reach again. `Ctrl` `Shift` `Z` is deliberately not an undo,
+because it is redo on every platform that has it.
 
 <Warning>
   `Ctrl` `R` asks for confirmation in three cases: when a transfer is actually moving data, when

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -93,12 +93,15 @@ have sent and received.
 </Frame>
 
 Each row shows the file name (or the count, for a batch), the direction, the size, and when it
-happened. Click a multi-file row to see the individual names. For a received transfer, hover
-the row for a button that opens its folder.
+happened. Click any row to open it. The panel underneath lists the individual file names, says
+where a received transfer was saved, and carries **Show in folder** and **Remove** along the
+bottom. Click the row again to close it.
 
 History holds the last 50 transfers. It is stored on your device only and is never sent
-anywhere. Remove a single entry with the `X` on its row, or **Clear** for all of them. Clearing
-history does not touch the files themselves.
+anywhere. Remove one entry with **Remove** inside its open row, or **Clear** in the History
+header to remove all of them. Clearing history does not touch the files themselves, and it is
+a different control from the **Clear** on the send card, which empties what you have staged and
+offers an undo.
 
 ## Contribute to global stats
 

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -93,9 +93,10 @@ have sent and received.
 </Frame>
 
 Each row shows the file name (or the count, for a batch), the direction, the size, and when it
-happened. Click any row to open it. The panel underneath lists the individual file names, says
-where a received transfer was saved, and carries **Show in folder** and **Remove** along the
-bottom. Click the row again to close it.
+happened. Click any row to open it. The panel underneath lists the individual file names and
+carries **Remove** along the bottom. A received transfer also says where it was saved and adds
+**Show in folder**; a sent transfer has no folder to open, so it shows neither. Click the row
+again to close it.
 
 History holds the last 50 transfers. It is stored on your device only and is never sent
 anywhere. Remove one entry with **Remove** inside its open row, or **Clear** in the History

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -23,9 +23,11 @@ There are four ways to stage files, and you can mix them:
 | `Ctrl` `V` | Pastes files you copied in File Explorer, or an image from the clipboard. |
 
 Everything you add appears in a list under **Files**. Remove a single entry with the `X` on its
-row, or empty the whole list with **Clear**, beside the Send button. Clear takes only what the
-tab you are on is holding (the file list on **Files**, the box on **Text**) and leaves your
-settings, the Receive tab, your history and anything already sent alone. It does not ask first.
+row, or empty the whole list with **Clear**, beside the Send button. Clear appears only when
+that tab is holding something, and while a transfer is sending its place belongs to **Cancel**,
+so on an empty tab or mid-send there is no Clear to find. It takes only what the tab you are on
+is holding (the file list on **Files**, the box on **Text**) and leaves your settings, the
+Receive tab, your history and the files themselves alone. It does not ask first.
 It offers **Undo** instead, in a bar at the bottom of the window, which puts back exactly what you
 had staged, whitespace and all.
 

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -197,7 +197,7 @@ This mirrors the CLI's `--web` flag. See
 
 ### App version
 
-The release you are running, for example `desktop-v0.2.4`. A build you compiled yourself reads
+The release you are running, for example `desktop-v0.2.5`. A build you compiled yourself reads
 `dev`.
 
 When the daily check has found a newer release, an **Update** row appears under it with a


### PR DESCRIPTION
Release prep for **two** tags, cut together.

## Why two

The data channel fix in #302 is receiver-side. An updated sender does not rescue a peer that has not updated, measured across a 2x2 of 61 transfers: 0 of 33 passed through an unfixed receiver, 25 of 25 through a fixed one, regardless of what the sender was running. Shipping only the desktop would leave desktop-to-CLI transfers exactly as broken as they are today, so both surfaces go out together and both changelog entries say so rather than implying an update protects you in both directions.

| Tag | Carries |
|---|---|
| `desktop-v0.2.5` | Clear with undo, the History row redesign, the drop-area borders, working reduced motion, a brighter focus ring, and the data channel fix |
| `v1.10.2` | the data channel fix, alone. Nothing else has landed on `cli/` since v1.10.1 except a docs commit |

## Pins

`desktop/wails.json` productVersion, the concrete version examples in `docs/desktop/installation.mdx` (x2) and `docs/desktop/settings.mdx`, the `DESKTOP.md` current-release line, the bug report template placeholder, and the two tag examples in `CLAUDE.md`.

`client/lib/desktopRelease.ts` is deliberately **not** bumped here. It goes in a follow-up once the assets exist, because `/download` derives its links from it and bumping early points the page at files that do not yet exist. `DESKTOP.md` is explicit about that, and 0.2.2 and 0.2.3 both shipped this way.

## Also fixed

`docs/desktop/receiving.mdx` still described the History rows as they were before #299: hover a row to reveal a folder button, an `X` on each row, and only multi-file rows opening. Every row is a disclosure now and Remove lives inside the opened row. That page has been wrong on `main` since #299 merged; it is corrected here because it ships with 0.2.5.

It now also states outright that History's **Clear** is a different control from the send card's **Clear**, which this release introduces under the same name with very different manners: one asks first and has no undo, the other does not ask and does.

## Known stale, not in this PR

`docs/images/desktop/history.png` and `send-files.png`, and `client/public/screenshots/desktop-{idle,staged}-2x.png`, all predate #299 and #301. Re-capturing them needs a new filename per the contract in `AppWindow.tsx`, and it wants the released build in front of the camera, so it follows the tags.

## Test plan

- Changelog contract checked against the comment at the top of the file: labels are the tags verbatim, dates are the tag dates, tags come from the fixed set with the primary surface first, each body opens with a bold one-sentence headline, no markdown headings inside an `<Update>`, and each entry closes with the house no-protocol-change bullet.
- Zero em dashes and zero en dashes anywhere in `docs/`, which is what Vale enforces.
- Every version string in the tree audited; the remaining `1.10.1` and `0.2.4` occurrences are either history (past changelog entries, `DESKTOP.md` release history) or deliberately generic examples (self-hosting image tags, `floe update` sample output).
