### PR TITLE
docs(client): point the download page at desktop-v0.2.5

### DIFF
--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.4';
-export const DESKTOP_RELEASE_DATE = 'Aug 14, 2026';
+export const DESKTOP_VERSION = '0.2.5';
+export const DESKTOP_RELEASE_DATE = 'Aug 16, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
﻿Follows the `desktop-v0.2.5` tag rather than shipping with it, which is what `DESKTOP.md` prescribes: `/download` derives every asset URL from `DESKTOP_VERSION`, so bumping before the release exists points the page at 404s. 0.2.2 and 0.2.3 both shipped this way.

Verified before committing, all HTTP 200:

- `floe-desktop-setup-0.2.5.exe`
- `floe-desktop-0.2.5-windows-amd64.zip`
- `SHA256SUMS.txt`
- the `desktop-v0.2.5` release page

## Test plan

- `desktopRelease.test.ts`: 7 passed. Every other constant and all four consumers derive from these two, and the tests assert shapes rather than literals, so nothing else needed changing.
