### PR TITLE
chore: use American spelling in user-facing text across docs, desktop, and CLI

### DIFF
--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -450,7 +450,7 @@ func main() {
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-sigCh
-		fmt.Fprintln(os.Stderr, "\n  Cancelled.")
+		fmt.Fprintln(os.Stderr, "\n  Canceled.")
 		os.Exit(130)
 	}()
 

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -213,7 +213,7 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 						currentInfo.FileName, bytesReceived, currentInfo.FileSize)
 				}
 				if filesReceived == 0 {
-					return fmt.Errorf("connection closed before any file arrived (the sender cancelled, or the transfer was blocked)")
+					return fmt.Errorf("connection closed before any file arrived (the sender canceled, or the transfer was blocked)")
 				}
 				if currentInfo.Total > 0 && filesReceived < currentInfo.Total {
 					return fmt.Errorf("connection closed after %d of %d files", filesReceived, currentInfo.Total)
@@ -230,7 +230,7 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 							currentInfo.FileName, bytesReceived, currentInfo.FileSize)
 					}
 					if filesReceived == 0 {
-						return fmt.Errorf("connection closed before any file arrived (the sender cancelled, or the transfer was blocked)")
+						return fmt.Errorf("connection closed before any file arrived (the sender canceled, or the transfer was blocked)")
 					}
 					if currentInfo.Total > 0 && filesReceived < currentInfo.Total {
 						return fmt.Errorf("connection closed after %d of %d files", filesReceived, currentInfo.Total)

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -894,7 +894,7 @@ func (a *App) receiveByCode(g uint64, codeOrLink string, outputDir string, hideI
 	}
 	defer sc.Close()
 	if !a.setSignaling(g, sc) {
-		return "", fmt.Errorf("transfer cancelled")
+		return "", fmt.Errorf("transfer canceled")
 	}
 
 	if err := sc.JoinRoom(roomID); err != nil {
@@ -930,7 +930,7 @@ func (a *App) receiveByCode(g uint64, codeOrLink string, outputDir string, hideI
 	}
 	defer conn.Close()
 	if !a.setConn(g, conn) {
-		return "", fmt.Errorf("transfer cancelled")
+		return "", fmt.Errorf("transfer canceled")
 	}
 
 	dc, err := conn.SetupAsReceiver()

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1589,7 +1589,7 @@ function App() {
         setSendDone(false);
         // Blanked for the same reason every staging path blanks it: whatever it
         // said was about a payload that no longer exists. Without this, a
-        // "Cancelled." from an earlier send would reappear when the offer went.
+        // "Canceled." from an earlier send would reappear when the offer went.
         setSendStatus('');
         setCleared(snap);
         setOfferUp(true);
@@ -1714,7 +1714,7 @@ function App() {
             setHistory((prev) => [{kind: 'recv' as const, names, count: names.length, dir, bytes: recvBytesRef.current || undefined, at: Date.now()}, ...prev].slice(0, HISTORY_CAP));
         } catch (e: any) {
             if (recvAttempt.current !== attempt) return;
-            setRecvStatus(recvCancel.current ? 'Cancelled.' : friendlyError(e) + serverNote());
+            setRecvStatus(recvCancel.current ? 'Canceled.' : friendlyError(e) + serverNote());
         } finally {
             if (recvAttempt.current !== attempt) return;
             setReceiving(false);
@@ -1748,7 +1748,7 @@ function App() {
             setSendLink('');
             setPeerConnected(false);
             setFilesOpen(false);
-            setSendStatus('Cancelled.');
+            setSendStatus('Canceled.');
         }
         setRoute('');
         if (receiving) {
@@ -1757,7 +1757,7 @@ function App() {
             setRecvProg(null);
             setRecvDone(false);
             setIncoming('');
-            setRecvStatus('Cancelled.');
+            setRecvStatus('Canceled.');
         }
         CancelTransfer().catch(() => {});
     }

--- a/desktop/frontend/src/components/TitleBar.tsx
+++ b/desktop/frontend/src/components/TitleBar.tsx
@@ -59,18 +59,18 @@ export default function TitleBar({onSettings, settingsActive, onStartOver}: {
                     </button>
                 </Tooltip>
                 <span aria-hidden className="mx-1 h-3.5 w-px bg-white/10"/>
-                <Tooltip label="Minimise">
+                <Tooltip label="Minimize">
                     <button
-                        aria-label="Minimise"
+                        aria-label="Minimize"
                         onClick={() => WindowMinimise()}
                         className="grid h-9 w-11 place-items-center text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-100"
                     >
                         <Minus className="size-4"/>
                     </button>
                 </Tooltip>
-                <Tooltip label="Maximise">
+                <Tooltip label="Maximize">
                     <button
-                        aria-label="Maximise"
+                        aria-label="Maximize"
                         onClick={() => WindowToggleMaximise()}
                         className="grid h-9 w-11 place-items-center text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-100"
                     >

--- a/desktop/frontend/src/errors.test.ts
+++ b/desktop/frontend/src/errors.test.ts
@@ -27,8 +27,8 @@ describe('friendlyError', () => {
 
     it('keeps the specific closed-before-any-file diagnosis out of the generic bucket', () => {
         expect(
-            friendlyError('connection closed before any file arrived (the sender cancelled, or the transfer was blocked)'),
-        ).toBe('Error: The sender cancelled, or the transfer was blocked before it started.');
+            friendlyError('connection closed before any file arrived (the sender canceled, or the transfer was blocked)'),
+        ).toBe('Error: The sender canceled, or the transfer was blocked before it started.');
     });
 
     it('keeps the receiver-left diagnosis out of the generic bucket', () => {

--- a/desktop/frontend/src/errors.ts
+++ b/desktop/frontend/src/errors.ts
@@ -28,7 +28,7 @@ const RULES: Array<[pattern: string, friendly: string]> = [
     ['could not reach signaling server', 'Could not reach the server. Check your internet connection.'],
     ['could not resolve', 'That code was not recognized. Check it for typos, or ask the sender for a new one.'],
     ['Invalid room ID', 'That link looks incomplete. Copy the whole share link and try again.'],
-    ['connection closed before any file', 'The sender cancelled, or the transfer was blocked before it started.'],
+    ['connection closed before any file', 'The sender canceled, or the transfer was blocked before it started.'],
     ['connection closed while waiting for the receiver', 'The receiver left or declined before the transfer started.'],
     ['no data arrived from the sender', 'Connected, but the sender never started sending. Ask them to try again.'],
     ['transfer stalled', 'The transfer stalled and gave up. Start it again.'],

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -73,7 +73,7 @@ When the first file's metadata arrives, Floe shows a summary of what is incoming
   Accept? [Y/n]
 ```
 
-- Type `n` or `no`, in any capitalization, to decline. The transfer is cancelled and the connection closes.
+- Type `n` or `no`, in any capitalization, to decline. The transfer is canceled and the connection closes.
 - Press **Enter** or type anything else to accept and begin receiving. The prompt only looks for a decline, so a typo counts as yes.
 
 Pass `-y` to skip this prompt and accept automatically.

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -41,7 +41,7 @@ The badge at the top right shows **DIRECT** or **RELAY** once the route is known
 bar shows the current file with speed and time remaining. **Cancel** stops it.
 
 When it finishes you get a Windows notification, and a transfer that fails raises one too, so
-a failure behind a minimized window is never silent. Cancelling does not notify. On success the
+a failure behind a minimized window is never silent. Canceling does not notify. On success the
 card shows where the files went:
 
 - For a single file, **Open** launches it in its usual app and **Show in folder** reveals it in
@@ -128,6 +128,6 @@ If Floe connects but nothing arrives, it gives up after 30 seconds and says the 
 started sending; ask them to try again. If it never connects at all, check that both of you are
 on the same signaling server. See [Troubleshooting](/troubleshooting).
 
-A transfer that fails or is cancelled partway deletes the file it was writing, so nothing
+A transfer that fails or is canceled partway deletes the file it was writing, so nothing
 half-written is left behind under a finished-looking name. Files that completed before the
 failure are kept, and a retry can use the original name rather than a numbered one.

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -128,7 +128,7 @@ The badge at the top right of the card tells you what is happening:
 Below it, a progress bar shows the current file, the percentage, the speed, and the estimated
 time remaining. **Cancel** stops the transfer at any point.
 
-You can minimise the window and the transfer keeps running, because the transfer happens in
+You can minimize the window and the transfer keeps running, because the transfer happens in
 Floe's core rather than in the window. Windows is also asked not to sleep while a transfer is
 connected. Closing the window ends the transfer.
 

--- a/docs/self-hosting/images.mdx
+++ b/docs/self-hosting/images.mdx
@@ -64,7 +64,7 @@ It lists one entry per platform, so you can confirm your architecture is covered
 <Note>
   Each architecture is built and smoke-tested on its own hardware before any tag points at it, and a tag is only published once every architecture of both images has passed. A partly-built release is never visible.
 
-  That matters more than it sounds. The image optimiser fails at load time rather than at build time, and when it fails it does not error: it quietly serves the original file. So a broken ARM image would look perfectly healthy to anything that only checks whether the page loads. The smoke test asserts the optimiser actually returns WebP, on real ARM.
+  That matters more than it sounds. The image optimizer fails at load time rather than at build time, and when it fails it does not error: it quietly serves the original file. So a broken ARM image would look perfectly healthy to anything that only checks whether the page loads. The smoke test asserts the optimizer actually returns WebP, on real ARM.
 </Note>
 
 32-bit ARM (`linux/arm/v7`, older Raspberry Pi models) is not published. Node dropped support for it and no prebuilt image-processing binaries exist.


### PR DESCRIPTION
## Summary

The docs and the product disagreed on spelling. Docs prose ran 16 British tokens to 15 American, the desktop app shipped `Minimise`, `Maximise` and `Cancelled.` with no American counterpart anywhere, and the CLI printed `Cancelled.` on interrupt. Nothing in the repo pins a locale, so the weekly docs style automation kept proposing conversions (#157, closed; #293, merged).

This settles it on American English, and changes the product strings and the docs that describe them **in the same commit**, so the docs never document a spelling the app does not use. That is the difference from #157, which proposed the same `receive.mdx` edit on its own and was closed for creating exactly that divergence.

## Product strings

| File | Change |
|---|---|
| `desktop/frontend/src/components/TitleBar.tsx` | tooltip and aria-label, `Minimise` and `Maximise` |
| `desktop/frontend/src/App.tsx` | send and receive status, `'Cancelled.'` |
| `desktop/frontend/src/errors.ts` | friendly error for a sender-side abort |
| `desktop/app.go` | `transfer cancelled` errors that surface through the UI |
| `cli/cmd/floe/main.go` | interrupt handler, `Cancelled.` |
| `cli/engine/transfer/receiver.go` | connection closed before any file arrived |

`desktop/frontend/src/errors.test.ts` moves with `errors.ts`: it asserts the friendly sentence verbatim, so the two are a lockstep pair. Its input fixture is updated too, so it keeps mirroring what the engine actually produces.

## Docs

`docs/desktop/sending.mdx`, `docs/desktop/receiving.mdx`, `docs/cli/receive.mdx`, and `optimiser` on `docs/self-hosting/images.mdx`. That page's `receiving.mdx:44` already read "minimized" next to "Cancelling", so it was mixed mid-sentence.

## Deliberately unchanged

- **Wails runtime API names** (`WindowMinimise`, `WindowToggleMaximise`, `WindowUnminimise`). These are upstream identifiers, not our text. A blind find and replace here breaks `tsc` with TS2305 and `go vet`, which is why every edit was made by exact line rather than with `sed` across the tree.
- **`docs/changelog.mdx`** keeps its 8 British spellings. Those entries describe releases whose UI really did say "Cancelling", so re-spelling them would misdescribe what shipped.
- **Code comments and identifiers** (`a.cancelled`, `recvCancel`, `TestCancelledSetterRefuses`). One exception: the `App.tsx` comment that quotes the status string it documents, which would otherwise have become false.
- **Every `cancelled` under `.github/`**, which is Actions' own status vocabulary (`!cancelled()`, `contains(needs.*.result, 'cancelled')`).

## Test plan

- `cli`: `go build ./...` and `go test ./...` pass, including the transfer package, whose `loopback_test.go` asserts on `"before any file"` and is unaffected by the reworded tail.
- `desktop/frontend`: `npm run build` passes, which is what proves the Wails imports survived, and `npm test` passes 91 tests across 7 files.
- `desktop`: `go vet ./...` and `go test ./...` pass.
- Sweep: British tokens in `docs/**/*.mdx` go from 14 to 8, and the remaining 8 are all in `changelog.mdx` by design.

## Note on rollout

The desktop and CLI strings only reach users in the next `desktop-v*` and `v*` releases, so until then the docs will say "canceled" while an installed build still says "Cancelled." That gap is one letter and cosmetic. No wire-protocol impact: every string here is generated and displayed locally and none cross the data channel, so no `ProtocolVersion` bump.
