### PR TITLE
chore(docs): pin American spelling with a Vale rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,8 @@ Do not use em dashes in any markdown files or documentation. Use periods, commas
 
 What Vale actually covers is narrower than this rule: it matches the em dash and en dash characters only, in `docs/` only. An ASCII `--` used as a dash is a human-review matter, because a token for it fires on every CLI flag in the docs. Markdown outside `docs/` has no style linter (root Prettier can format it, but nothing checks dash usage there).
 
+Floe writes American English, in the docs and in user-facing product strings alike. In `docs/`, Vale enforces it (`docs/styles/Floe/Spelling.yml`), with `docs/changelog.mdx` exempted because its shipped entries describe releases whose UI really did say "Cancelling". The word list is short on purpose: it covers the pairs that have actually come up here rather than English generally, so extend it when a new one appears. The rule must stay at `level: error`, because `MinAlertLevel = error` makes Vale skip a lower-level rule entirely rather than merely hiding its output. Outside `docs/` this is a convention rather than a check, and it covers text a user can see (window titles, status lines, error messages, CLI output), not code comments or identifiers. Wails runtime names such as `WindowMinimise` are upstream API and stay as they are.
+
 ## Git Conventions
 
 Do not credit Claude or any AI assistant as an author. Specifically:

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -14,3 +14,15 @@ mdx = md
 
 [*.{md,mdx}]
 BasedOnStyles = Floe
+
+; changelog.mdx keeps the British spellings in its shipped entries, because they
+; describe releases whose UI really did say "Cancelling". Re-spelling them would
+; misdescribe what those versions did.
+;
+; This section must contain ONLY the rule toggle. Adding BasedOnStyles here would
+; silently switch EmDash off for the changelog: Vale registers a section in
+; StyleKeys only when it declares BasedOnStyles, and the resulting BaseStyles is
+; assigned rather than merged. The leading * matters too, because section globs
+; match the path as Vale was invoked with it and * crosses separators.
+[*changelog.mdx]
+Floe.Spelling = NO

--- a/docs/styles/Floe/Spelling.yml
+++ b/docs/styles/Floe/Spelling.yml
@@ -1,0 +1,40 @@
+# Floe writes American English. This rule exists because nothing else pinned a
+# locale, so the weekly docs style automation kept proposing conversions in both
+# directions (PR #157 was closed, PR #293 was merged).
+#
+# The list is deliberately short: it covers the words that have actually come up
+# in these docs and in the product's own UI strings, not English generally. Add
+# a pair when a new one appears rather than trying to be exhaustive.
+#
+# level must be error. docs/.vale.ini sets MinAlertLevel = error, and Vale skips
+# a rule whose level is below that minimum entirely, so a warning-level rule here
+# would never run at all.
+extends: substitution
+message: "Floe uses American spelling: '%s' rather than '%s'."
+level: error
+ignorecase: true
+capitalize: true
+swap:
+  behaviour: behavior
+  behaviours: behaviors
+  cancelled: canceled
+  cancelling: canceling
+  centre: center
+  centred: centered
+  centres: centers
+  colour: color
+  coloured: colored
+  colours: colors
+  favour: favor
+  favoured: favored
+  favours: favors
+  maximise: maximize
+  maximised: maximized
+  maximises: maximizes
+  minimise: minimize
+  minimised: minimized
+  minimises: minimizes
+  optimise: optimize
+  optimised: optimized
+  optimiser: optimizer
+  optimisers: optimizers


### PR DESCRIPTION
## Summary

Nothing in the repo stated a spelling convention, so the weekly docs style automation kept proposing conversions and getting different answers: #157 was closed for diverging from the product, #293 was merged. Now that the docs and the product agree (#307), this writes the convention down so the question stops recurring.

## Changes

- **`docs/styles/Floe/Spelling.yml`** (new): a `substitution` rule mapping British spellings to American ones, with `ignorecase: true` so `Cancelling` is caught alongside `cancelling`, and `capitalize: true` so the suggestion matches the observed case.
- **`docs/.vale.ini`**: a path-scoped `[*changelog.mdx]` section exempting that one file from that one rule.
- **`CLAUDE.md`**: the convention in prose, next to the existing em dash rule.

## Two things that are easy to get wrong here

**The level has to be `error`.** `.vale.ini` sets `MinAlertLevel = error`, and Vale skips a rule whose level is below the minimum *entirely*, rather than running it and hiding the output. A `level: warning` rule would have looked configured and done nothing.

**The exemption section must contain only the toggle.** Adding `BasedOnStyles` to it would silently switch `EmDash` off for the changelog, because Vale registers a section in `StyleKeys` only when it declares `BasedOnStyles`, and the resulting `BaseStyles` is assigned rather than merged. The leading `*` in the glob matters too, since section patterns match the path as Vale was invoked with it, which makes the pattern independent of Mintlify's working directory. Both points are written into the file as comments so a future edit does not undo them.

## Why changelog.mdx is exempt

Its 8 British spellings sit in shipped entries describing releases whose UI really did say "Cancelling". Re-spelling them would misdescribe what those versions actually did.

## Test plan

Verified against a real Vale 3.14.1 binary rather than reasoned about:

- Full run over `docs/`: **0 errors, 0 warnings, 0 suggestions in 37 files.**
- An ordinary page containing `behaviour`, `cancelled`, `favour`, `colour`, `Cancelling`, `minimise` and `optimiser`: all 7 reported, and `Cancelling` correctly suggests `Canceling` rather than `canceling`.
- The same words in `changelog.mdx`: silent, as intended.
- An em dash in `changelog.mdx`: still reported by `Floe.EmDash`, which is the check that proves the exemption is scoped to one rule and did not disable the file's other linting.
