### PR TITLE
chore(deps): move nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   esbuild: ^0.28.1
   ws: ^8.21.0
   postcss: ^8.5.23
+  nanoid: ^3.3.18
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   minimatch@3: ^3.1.3
@@ -2777,8 +2778,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6141,7 +6142,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -6296,13 +6297,13 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -10,6 +10,13 @@ overrides:
   esbuild: ^0.28.1
   ws: ^8.21.0
   postcss: ^8.5.23
+  # GHSA-2v37-7h3g-55p8 (CVE-2026-67213): a custom generator loops forever when
+  # size is zero. nanoid is here only as postcss ID source, and postcss 8.5.25
+  # and 8.5.26 declare ^3.3.16 and ^3.3.17, both of which 3.3.18 already
+  # satisfies, so only the frozen lockfile was holding it back. Keep this on the
+  # 3.x line: 3.3.18 is the last 3.x release, and 4.x and later are ESM-only,
+  # which postcss 8 will not accept. Build-time only, never in the bundle.
+  nanoid: ^3.3.18
   picomatch@2: ^2.3.2
   picomatch@4: ^4.0.4
   minimatch@3: ^3.1.3

--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -2384,9 +2384,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Closes Dependabot alert **#113**: `nanoid < 3.3.18` (GHSA-2v37-7h3g-55p8 / CVE-2026-67213, an infinite loop when `customAlphabet` or `customRandom` is called with size zero).

The alert names `client/pnpm-lock.yaml` only. It is not the only affected lockfile, so this fixes both.

## What changed

| File | Change |
|---|---|
| `client/pnpm-workspace.yaml` | new `nanoid: ^3.3.18` override next to the existing `postcss` pin |
| `client/pnpm-lock.yaml` | nanoid 3.3.17 to 3.3.18 |
| `desktop/frontend/package-lock.json` | nanoid 3.3.16 to 3.3.18 |

## Why an override rather than just a lockfile refresh

Semver did not require one: postcss 8.5.25 declares `^3.3.16` and 8.5.26 declares `^3.3.17`, and 3.3.18 satisfies both. But `pnpm install` is conservative and keeps an existing resolution while it still satisfies the range, so a plain reinstall leaves 3.3.17 in place. Pinning the floor is what actually moves it, and it stops a future refresh dropping back. Same reasoning as #259 for js-yaml.

The pin stays on the 3.x line deliberately: **3.3.18 is the last 3.x release**, and 4.x and later are ESM-only, which postcss 8 will not accept. That is written into the comment so nobody widens it later.

## Why desktop/frontend is here too

Dependabot never raised an alert for it, but it carried nanoid **3.3.16**, and it is the more meaningful half of this fix. The `size <= 0` guard landed in **3.3.17**, so the client copy was already effectively patched and the desktop copy genuinely was not. The entire 3.3.17 to 3.3.18 delta upstream is `async/index.native.js`, a React Native entry point nothing here resolves. Fixed with `npm audit fix`, no override needed since npm has no equivalent blocker.

## Reachability: none, in either lockfile

Stating this plainly so the change is not mistaken for incident response.

- The advisory affects `customAlphabet` and `customRandom`. The default `nanoid(size)` export is not affected.
- postcss's only call site is `postcss/lib/input.js:80`, `nanoid(6)`: the default export, a hardcoded size, imported from `nanoid/non-secure`, an entry point that does not even export `customRandom`.
- Floe's own code has zero nanoid call sites. It uses `uuid` for IDs.
- postcss runs at build time. It is absent from `.next/standalone`, and production browser chunks contain no nanoid. Dependabot's `scope: runtime` label comes from postcss sitting in Next's own `dependencies`, not from how it executes here.

This clears a real alert and keeps the tree clean. It does not close an exposure.

## Test plan

- `pnpm audit` (client) and `npm audit` (desktop/frontend): both **1 high to 0**.
- `pnpm install --frozen-lockfile` in `client/` passes, which is the exact command three CI jobs run and the one that fails if the override and lockfile disagree.
- `client/`: lint (0 errors, 2 pre-existing warnings), 191 tests, `next build`.
- `desktop/frontend/`: build and 91 tests. The emitted CSS is **byte-identical** (`index-CmKysXaK.css`, 48411 bytes), which is the real check that the postcss chain is unaffected.
- `desktop/`: `go build ./...` passes, so the `frontend/dist` embed still resolves.
