### PR TITLE
fix(client): refuse a file that did not arrive whole

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -127,7 +127,13 @@ export function P2PTransfer() {
 
     const { relayEnabled, setRelayEnabled } = useRelayConfiguration();
 
+    const [relayBlocked, setRelayBlocked] = useState(false);
+    // Live check, used before the transfer is blocked. It derives from
+    // connectionType, which peer.destroy() resets to null, so the blocked state
+    // below is latched separately or tearing the connection down would also
+    // erase the banner that explains why.
     const isRelayOverLimit = connectionType === 'relay' && totalBytes > RELAY_SIZE_LIMIT;
+    const showRelayLimitNotice = isRelayOverLimit || relayBlocked;
 
     const peerRef = useRef<PeerInstance | null>(null);
     const hasJoinedRef = useRef(false);
@@ -623,12 +629,17 @@ export function P2PTransfer() {
 
                     if (verdict.action === 'block-over-limit') {
                         setStatus('Transfer blocked. Relay limit exceeded.');
+                        setRelayBlocked(true);
                         Sentry.addBreadcrumb({
                             category: 'transfer',
                             message: 'Transfer blocked: relay size limit exceeded',
                             level: 'warning',
                             data: { totalSize: verdict.totalSize, limitBytes: RELAY_SIZE_LIMIT },
                         });
+                        // Without this the connection stayed open and the person
+                        // on the other end waited forever with nothing on screen.
+                        // The sibling branch above has always done this.
+                        peer.destroy();
                         return;
                     }
 
@@ -820,7 +831,7 @@ export function P2PTransfer() {
                                     </button>
                                 </div>
                             )}
-                            {isSender && isRelayOverLimit && (
+                            {isSender && showRelayLimitNotice && (
                                 <div className="mt-2 bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 flex items-start gap-3">
                                     <AlertTriangle className="h-4 w-4 text-amber-400 flex-shrink-0 mt-0.5" />
                                     <div className="flex-1 text-xs text-amber-300 leading-relaxed">

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -206,3 +206,27 @@ export function classifyControl(data: ArrayBuffer | Uint8Array): ControlMessage 
     if (t === 'incompatible') return msg as unknown as Incompatible;
     return null;
 }
+
+/**
+ * Validates a peer-supplied `fileSize`.
+ *
+ * `classifyControl` above casts the parsed JSON straight to its interface, so
+ * every field on a `Metadata` is whatever the other side chose to send:
+ * `fileSize` may be absent, a string, negative, fractional, or beyond the range
+ * where JavaScript integers are exact.
+ *
+ * Returns the value when it is a real byte count, and `null` otherwise. `null`
+ * means "the peer announced no usable size", and every caller must fall back to
+ * whatever it did before validation existed rather than treat it as a failure:
+ * that is what keeps a peer which never announced a size working exactly as it
+ * used to.
+ *
+ * Zero is a valid size and must survive as `0`, not collapse to `null`, or every
+ * empty file would lose its (trivially satisfiable) integrity check.
+ */
+export function normalizeFileSize(value: unknown): number | null {
+    if (typeof value !== 'number') return null;
+    if (!Number.isInteger(value)) return null; // also rejects NaN and Infinity
+    if (value < 0 || value > Number.MAX_SAFE_INTEGER) return null;
+    return value;
+}

--- a/client/lib/transfer/receiver.ts
+++ b/client/lib/transfer/receiver.ts
@@ -8,6 +8,7 @@ import {
     compatErrorMessage,
     PROTOCOL_VERSION,
     MIN_PROTOCOL_VERSION,
+    normalizeFileSize,
     type Metadata,
 } from './protocol';
 
@@ -70,7 +71,12 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
     const partialDownloads = new Map<string, PartialDownload>();
     let currentMetadata: Metadata | null = null;
     let hasCheckedCompat = false;
-    let incompatibleDetected = false;
+    // Hard stop. Set by any unrecoverable failure (an incompatible peer, or a
+    // file that did not arrive whole); every later message is dropped.
+    let aborted = false;
+    // The announced size of the file being received, once validated, or null
+    // when the peer announced nothing we can compare against.
+    let expectedSize: number | null = null;
     let sessionBytes = 0; // accumulated across all files of the current transfer
 
     let receiveSpeedStart = performance.now();
@@ -78,7 +84,7 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
     let lastReceiveSpeedUpdate = 0;
 
     function handleMessage(data: Uint8Array | ArrayBuffer): void {
-        if (incompatibleDetected) return;
+        if (aborted) return;
 
         const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
         const msg = classifyControl(buf);
@@ -96,7 +102,7 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
                         remotePvMin, remotePv
                     );
                     if (!ok) {
-                        incompatibleDetected = true;
+                        aborted = true;
                         const errMsg = compatErrorMessage(
                             localTooOld, '', msg.ver ?? '',
                             MIN_PROTOCOL_VERSION, PROTOCOL_VERSION,
@@ -112,11 +118,16 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
                 }
 
                 currentMetadata = msg;
+                // classifyControl casts the metadata JSON straight to its
+                // interface, so fileSize is whatever the peer chose to send.
+                // Anything that is not a real byte count becomes null, which
+                // reads as "unknown" everywhere below.
+                expectedSize = normalizeFileSize(msg.fileSize);
                 receiveSpeedStart = performance.now();
                 receiveSpeedBytes = 0;
                 lastReceiveSpeedUpdate = 0;
                 cb.onSpeedReset?.();
-                cb.onFileStart?.(msg.index, msg.total, msg.fileName, msg.fileSize);
+                cb.onFileStart?.(msg.index, msg.total, msg.fileName, expectedSize ?? 0);
 
                 let offset = 0;
                 const existing = partialDownloads.get(msg.id);
@@ -133,6 +144,40 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
                 if (!currentMetadata) return;
                 const fileData = partialDownloads.get(currentMetadata.id);
                 if (!fileData) return;
+
+                // Integrity guard, matching cli/engine/transfer/receiver.go: a
+                // byte count that does not equal the announced size means the
+                // file is not what the sender described, so refuse it rather
+                // than hand over something that looks complete.
+                //
+                // Exact inequality on two numbers, never a threshold or a timer.
+                // Both directions fail: a short count is a truncation, and an
+                // over-count means a frame boundary was wrong, which corrupts
+                // the blob just as thoroughly.
+                //
+                // `expectedSize` is null when the peer announced no usable size,
+                // and that skips the guard entirely. That is the whole
+                // back-compat surface: a peer that sends nothing we can compare
+                // against behaves exactly as it did before.
+                if (expectedSize !== null && fileData.received !== expectedSize) {
+                    const name = currentMetadata.fileName;
+                    const got = fileData.received;
+                    const want = expectedSize;
+                    partialDownloads.delete(currentMetadata.id);
+                    currentMetadata = null;
+                    expectedSize = null;
+                    // Latch, like the incompatibility path: without this a
+                    // multi-file transfer reports the failure and then flips
+                    // straight back to "Receiving file 3 of 3".
+                    aborted = true;
+                    cb.onProgress?.(0, 0, 0);
+                    cb.onSpeedReset?.();
+                    cb.onError?.(
+                        `Incomplete file "${name}": received ${got} of ${want} bytes. ` +
+                        `The transfer was cut short, so the file was discarded. Ask the sender to try again.`
+                    );
+                    return;
+                }
 
                 const blob = new Blob(fileData.chunks);
                 const completed: ReceivedFile = {
@@ -153,6 +198,8 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
                     sessionBytes = 0; // reset for a possible subsequent transfer
                 }
 
+                currentMetadata = null;
+                expectedSize = null;
                 cb.onWaiting?.();
                 cb.onProgress?.(0, 0, 0);
                 cb.onSpeedReset?.();
@@ -178,9 +225,9 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
         const now = performance.now();
         if (now - lastReceiveSpeedUpdate > 1000) {
             const elapsed = (now - receiveSpeedStart) / 1000;
-            if (elapsed > 0 && currentMetadata.fileSize) {
+            if (elapsed > 0 && expectedSize) {
                 const bytesPerSec = receiveSpeedBytes / elapsed;
-                const remaining = currentMetadata.fileSize - fileData.received;
+                const remaining = expectedSize - fileData.received;
                 cb.onSpeed?.(bytesPerSec, remaining / bytesPerSec);
             }
             receiveSpeedStart = now;
@@ -189,15 +236,15 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
         }
 
         if (
-            currentMetadata.fileSize &&
+            expectedSize &&
             (fileData.received - fileData.lastReported >= PROGRESS_STEP ||
-                fileData.received === currentMetadata.fileSize)
+                fileData.received === expectedSize)
         ) {
             fileData.lastReported = fileData.received;
             cb.onProgress?.(
-                Math.round((fileData.received / currentMetadata.fileSize) * 100),
+                Math.round((fileData.received / expectedSize) * 100),
                 fileData.received,
-                currentMetadata.fileSize
+                expectedSize
             );
         }
     }

--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -289,7 +289,22 @@ async function sendSingleFile(
         try {
             slabBuffer = await file.slice(offset, slabEnd).arrayBuffer();
         } catch {
-            break;
+            // The file became unreadable after the user picked it: moved,
+            // renamed, on an unplugged drive, or a cloud placeholder whose
+            // local copy was evicted.
+            //
+            // This used to `break`, which fell through to the unconditional
+            // end marker below and returned true, so the sender announced a
+            // finished file after a short byte count and both sides showed
+            // success. Returning false skips the end marker and stops the
+            // transfer, which is what this function already documents itself
+            // as doing. No retry: a file that is genuinely gone will not come
+            // back on a second read.
+            cb.onError?.(
+                `Could not read "${file.name}". It may have been moved, renamed, ` +
+                `or on a drive or folder that is no longer available. Nothing further was sent.`
+            );
+            return false;
         }
 
         let slabOffset = 0;

--- a/client/lib/transfer/transfer.test.ts
+++ b/client/lib/transfer/transfer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { sendFiles, type SenderDeps, type FileEntry } from './sender';
 import { createReceiver } from './receiver';
-import { metadataMessage, endMessage } from './protocol';
+import { metadataMessage, endMessage, ackMessage } from './protocol';
 
 const enc = new TextEncoder();
 
@@ -245,5 +245,206 @@ describe('loopback: small binary framing guard', () => {
         expect(result).toHaveLength(1);
         expect(result[0].bytes.byteLength).toBe(SIZE);
         expect(result[0].bytes[0]).toBe(0x7b);
+    });
+});
+
+/**
+ * The receiver must refuse a file whose byte count does not match the size the
+ * sender announced, matching cli/engine/transfer/receiver.go. Before this it
+ * labelled the file with however many bytes arrived, so announced and actual
+ * could never disagree and a truncated file was handed over as complete.
+ */
+describe('receiver: truncation guard', () => {
+    // Feeds metadata announcing `announced` bytes but only delivers `actual`.
+    function feedTruncated(
+        rx: { handleMessage: (d: Uint8Array | ArrayBuffer) => void },
+        id: string,
+        announced: number,
+        actual: number,
+        index = 1,
+        total = 1,
+    ) {
+        rx.handleMessage(enc.encode(metadataMessage(id, `${id}.bin`, announced, index, total, 0)));
+        if (actual > 0) {
+            const chunk = new Uint8Array(actual);
+            for (let i = 0; i < actual; i++) chunk[i] = (i + 1) % 256; // never starts with '{'
+            rx.handleMessage(chunk);
+        }
+        rx.handleMessage(enc.encode(endMessage()));
+    }
+
+    function harness() {
+        const completed: string[] = [];
+        const errors: string[] = [];
+        const allComplete: number[] = [];
+        const rx = createReceiver({
+            send: () => {},
+            onFileComplete: (f) => completed.push(f.fileName),
+            onAllComplete: (bytes) => allComplete.push(bytes),
+            onError: (m) => errors.push(m),
+        });
+        return { rx, completed, errors, allComplete };
+    }
+
+    it('refuses a file that arrived short', () => {
+        const h = harness();
+        feedTruncated(h.rx, 'a', 100, 60);
+        expect(h.completed).toEqual([]);
+        expect(h.errors).toHaveLength(1);
+        expect(h.errors[0]).toContain('60');
+        expect(h.errors[0]).toContain('100');
+    });
+
+    it('refuses a file that arrived long, so the guard is equality not a floor', () => {
+        const h = harness();
+        feedTruncated(h.rx, 'a', 50, 80);
+        expect(h.completed).toEqual([]);
+        expect(h.errors).toHaveLength(1);
+    });
+
+    it('does not report truncated bytes to the global counter', () => {
+        const h = harness();
+        feedTruncated(h.rx, 'a', 100, 60, 1, 1);
+        expect(h.allComplete).toEqual([]);
+    });
+
+    it('stops the transfer instead of moving on to the next file', () => {
+        const h = harness();
+        feedTruncated(h.rx, 'a', 100, 60, 1, 3);
+        feedTruncated(h.rx, 'b', 10, 10, 2, 3);
+        feedTruncated(h.rx, 'c', 10, 10, 3, 3);
+        expect(h.completed).toEqual([]);
+        expect(h.errors).toHaveLength(1);
+        expect(h.allComplete).toEqual([]);
+    });
+
+    it('accepts a file whose count matches exactly', () => {
+        const h = harness();
+        feedTruncated(h.rx, 'a', 100, 100);
+        expect(h.completed).toEqual(['a.bin']);
+        expect(h.errors).toEqual([]);
+    });
+
+    it('accepts a zero byte file announced as zero', () => {
+        const h = harness();
+        feedTruncated(h.rx, 'a', 0, 0);
+        expect(h.completed).toEqual(['a.bin']);
+        expect(h.errors).toEqual([]);
+    });
+
+    it('accepts a peer that announces no size at all', () => {
+        // metadataMessage always writes a fileSize, so build the frame by hand.
+        const h = harness();
+        h.rx.handleMessage(
+            enc.encode(JSON.stringify({
+                type: 'metadata', id: 'a', fileName: 'a.bin', index: 1, total: 1, totalBytes: 0,
+            }))
+        );
+        const chunk = new Uint8Array(50);
+        for (let i = 0; i < 50; i++) chunk[i] = (i + 1) % 256;
+        h.rx.handleMessage(chunk);
+        h.rx.handleMessage(enc.encode(endMessage()));
+        expect(h.completed).toEqual(['a.bin']);
+        expect(h.errors).toEqual([]);
+    });
+
+    it('treats an unusable announced size as unknown rather than failing', () => {
+        for (const bad of ['100', -1, 1.5, null, Number.MAX_SAFE_INTEGER + 2]) {
+            const h = harness();
+            h.rx.handleMessage(
+                enc.encode(JSON.stringify({
+                    type: 'metadata', id: 'a', fileName: 'a.bin',
+                    fileSize: bad, index: 1, total: 1, totalBytes: 0,
+                }))
+            );
+            const chunk = new Uint8Array(10);
+            for (let i = 0; i < 10; i++) chunk[i] = (i + 1) % 256;
+            h.rx.handleMessage(chunk);
+            h.rx.handleMessage(enc.encode(endMessage()));
+            expect(h.completed).toEqual(['a.bin']);
+            expect(h.errors).toEqual([]);
+        }
+    });
+
+    it('accepts a resumed file that reaches the announced size', () => {
+        // Metadata for the same id arrives twice; the receiver acks the bytes it
+        // already has and the sender continues from there. The sum is against
+        // the full announced size, so equality still holds.
+        const h = harness();
+        const acks: string[] = [];
+        const rx = createReceiver({
+            send: (d) => acks.push(typeof d === 'string' ? d : new TextDecoder().decode(d)),
+            onFileComplete: (f) => h.completed.push(f.fileName),
+            onError: (m) => h.errors.push(m),
+        });
+        const part = (n: number) => {
+            const c = new Uint8Array(n);
+            for (let i = 0; i < n; i++) c[i] = (i + 1) % 256;
+            return c;
+        };
+        rx.handleMessage(enc.encode(metadataMessage('a', 'a.bin', 100, 1, 1, 0)));
+        rx.handleMessage(part(40));
+        rx.handleMessage(enc.encode(metadataMessage('a', 'a.bin', 100, 1, 1, 0)));
+        rx.handleMessage(part(60));
+        rx.handleMessage(enc.encode(endMessage()));
+
+        expect(JSON.parse(acks[1]).offset).toBe(40);
+        expect(h.completed).toEqual(['a.bin']);
+        expect(h.errors).toEqual([]);
+    });
+});
+
+/**
+ * A file that becomes unreadable mid-send used to `break` out of the read loop
+ * and fall through to the unconditional end marker, so the sender announced a
+ * finished file after a short byte count and both sides showed success.
+ */
+describe('sender: unreadable file', () => {
+    it('reports an error and never announces the file as done', async () => {
+        let sawEnd = false;
+        const errors: string[] = [];
+        let allSent = false;
+
+        // Rejects on the first slab read, the way a moved file, an unplugged
+        // drive, or an evicted cloud placeholder does.
+        const bad = {
+            name: 'gone.bin',
+            size: 4096,
+            slice: () => ({ arrayBuffer: () => Promise.reject(new Error('NotReadableError')) }),
+        } as unknown as File;
+
+        // The sender blocks on the ack before it reads anything, so the harness
+        // has to answer it or the test just waits out the ack timeout.
+        let senderDataHandler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+
+        const deps: SenderDeps = {
+            send: (d) => {
+                if (typeof d !== 'string') return;
+                if (d.includes('"end"')) sawEnd = true;
+                const parsed = JSON.parse(d) as { type: string; id?: string };
+                if (parsed.type === 'metadata' && parsed.id) {
+                    const ack = enc.encode(ackMessage(parsed.id, 0));
+                    queueMicrotask(() => senderDataHandler?.(ack));
+                }
+            },
+            onData: (handler) => {
+                senderDataHandler = handler;
+                return () => { senderDataHandler = null; };
+            },
+            channel: makeBufferChannel(),
+            sctpMaxMessageSize: null,
+        };
+
+        await sendFiles(deps, [{ file: bad, id: 'x' }], {
+            onError: (m) => errors.push(m),
+            onAllSent: () => { allSent = true; },
+        });
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('gone.bin');
+        // The bug: this used to be true, so the receiver was told the file was
+        // finished after a short byte count.
+        expect(sawEnd).toBe(false);
+        expect(allSent).toBe(false);
     });
 });

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -40,7 +40,7 @@ description: "Answers to common questions about Floe: how peer-to-peer file tran
   <Accordion title="How long does the sender have to stay connected?">
     For the full duration of the transfer. Files stream directly from the sender's device, so the browser tab, the CLI process, or the Floe Desktop window must stay open. The browser and the desktop app both ask the device to stay awake while a transfer is connected. The CLI does not, so check your machine's own sleep settings before a long headless transfer.
 
-    If the sender closes the tab or window, quits, or cancels mid-transfer, the session ends. A CLI or desktop receiver is left with a truncated file on disk. A browser receiver gets no download at all for the file that was in flight, because it only turns a file into a download once the whole file has arrived.
+    If the sender closes the tab or window, quits, or cancels mid-transfer, the session ends. Nothing half-written is left behind: a CLI or desktop receiver deletes the file it was writing, and a browser receiver offers no download for the file that was in flight. Files that finished earlier in the same batch are kept. Either way, a file that did not arrive whole is never handed to you looking complete.
   </Accordion>
 
   <Accordion title="Are my files stored anywhere?">


### PR DESCRIPTION
## Summary

The browser receiver built each file from whatever chunks arrived and then set `fileSize: fileData.received` — the arrived count overwrote the announced one. The two could never disagree, so a truncated file was handed over as complete: green checkmark, believable size, working download button. The Go engine has always done the opposite, deleting the partial and failing loudly rather than leaving something that looks finished.

**The trigger is reachable from Floe's own sender, not just a hostile peer.** The slab read was wrapped in `catch { break; }`, and that `break` fell through to the unconditional `send(endMessage())` and `return true`. A file that was moved, renamed, or on a drive or cloud folder that went away *after* the user picked it produced a well-formed "done" after a short byte count, and both sides showed success. `sendSingleFile` is already documented as "Returns false when the transfer must stop (error already reported via cb)" — the `break` was the only thing violating that contract.

### The guard

Exact inequality on two numbers, on receipt of the end marker. **Never a threshold and never a timer**: a wrong threshold on the surface every share link opens would reject transfers that work today. Both directions fail, because an over-count means a frame boundary was wrong and the blob is corrupt just as thoroughly.

On mismatch the partial is discarded, the error goes through the existing `onError` path, and neither `onFileComplete` nor the byte accumulation runs — so a short count never reaches the public global counter. The failure latches like the incompatibility path; without that, a multi-file transfer reports the error and then flips straight back to "Receiving file 3 of 3".

`fileSize` is peer-supplied and `classifyControl` casts the metadata JSON with no field checking, so `normalizeFileSize` validates it once when metadata arrives. Anything that is not a real byte count reads as unknown and skips the guard entirely. **That is the whole back-compat surface**: a peer that announces nothing comparable behaves exactly as before. Zero survives as zero rather than collapsing to unknown, so empty files keep their (trivially satisfiable) check.

### Relay cap branch

The `block-over-limit` branch set a status string and bare-returned, leaving the connection open and the recipient waiting forever with nothing on screen, while its `block-relay-disabled` sibling has always called `peer.destroy()`. It now tears down too.

One subtlety worth reviewing: the amber banner explaining the 2 GB cap rendered on `isRelayOverLimit`, which derives from the **live** `connectionType`, and `peer.destroy()` triggers `resetConnectionType()`. Destroying the peer would therefore have erased the explanation along with the connection, trading a detailed panel for a one-line error. The verdict is now latched in state so the banner survives teardown.

## Test plan

- `pnpm test` passes, 201 tests across 19 files.
- **Verified the tests fail without the fix.** With the guard bypassed and the sender's `break` restored, exactly 5 tests fail: short count, over-count, no stats report, no continuation to the next file, and the sender announcing done. Every "accepts" test passes both ways, which is what makes them real false-positive guards rather than noise.
- False-positive paths are covered explicitly, because this is the risk that matters: exact match, zero-byte announced as zero, a peer that announces no size at all, unusable sizes (`"100"`, `-1`, `1.5`, `null`, beyond `MAX_SAFE_INTEGER`), and **resume** — metadata for the same id arriving twice, asserting the second ack carries `offset: 40` and the file still completes at 100 bytes.
- `pnpm lint` clean apart from two pre-existing warnings. `pnpm build` succeeds.

## Notes

Client-only, no wire change and no `ProtocolVersion` bump — the announced size is already in the message the receiver reads. Ships to floe.one on merge; no tag needed.

`docs/faq.mdx` was stale before this PR: it claimed "A CLI or desktop receiver is left with a truncated file on disk", which `v1.10.1` fixed. Corrected here, since this PR makes the browser half of that same sentence true as well.

### Follow-up, deliberately not in this PR

If the truncated file is the last one and the sender is a peer without this fix (an older tab, or a CLI), that sender still shows success while the receiver shows failure. Closing that needs a generic error control message in both the Go and TypeScript implementations under a `ProtocolVersion` bump. Reusing the existing `incompatible` type would be wrong, since the Go sender turns that into "run `floe update`".
