### PR TITLE
docs: changelog and version pins for v1.10.3 and desktop-v0.2.6

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Version
       description: "Desktop app: Settings > About. CLI: `floe --version`. Skip for the web app."
-      placeholder: e.g., desktop-v0.2.5 or v1.10.2
+      placeholder: e.g., desktop-v0.2.6 or v1.10.3
     validations:
       required: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ go build ./cmd/floe    # local binary
 go test ./...          # run all tests
 ```
 
-The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version={{ .Version }}"`, which carries NO leading `v` (a v1.10.2 tag produces a binary that prints `floe 1.10.2`). The desktop app differs: desktop-release.yml injects the tag verbatim (`desktop-v0.2.5`).
+The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version={{ .Version }}"`, which carries NO leading `v` (a v1.10.3 tag produces a binary that prints `floe 1.10.3`). The desktop app differs: desktop-release.yml injects the tag verbatim (`desktop-v0.2.6`).
 
 ### Desktop (Wails)
 ```bash

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -204,8 +204,8 @@ receiver, which is deliberate (share a link and wait) and cancellable.
 
 ## Release history
 
-Current release: `desktop-v0.2.5` (Microsoft Store 9NBQ8ZQ1065L + GitHub
-pre-release), shipped 2026-08-16. Paired with CLI `v1.10.2`, because the data
+Current release: `desktop-v0.2.6` (Microsoft Store 9NBQ8ZQ1065L + GitHub
+pre-release), shipped 2026-08-19. Paired with CLI `v1.10.3`, because the data
 channel fix they both carry is receiver-side and only protects a transfer once
 the RECEIVING peer has it.
 

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -5,7 +5,7 @@
   "info": {
     "companyName": "Jan Carlo Paredes",
     "productName": "Floe",
-    "productVersion": "0.2.5",
+    "productVersion": "0.2.6",
     "copyright": "(c) 2026 Jan Carlo Paredes",
     "comments": "Peer-to-peer file transfer"
   },

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -40,6 +40,32 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
+<Update label="desktop-v0.2.6" description="2026-08-19" tags={["Desktop"]}>
+  **Files whose names Windows cannot hold now arrive intact instead of arriving empty**
+
+  - A file sent from a Mac or a Linux machine can carry a name Windows has no way to store. A timestamp like `backup:2026-08-19.log` is the everyday case, because Windows gives the colon a special meaning. Floe used to write that file, report success, and leave you an empty file called `backup`, with the contents routed somewhere you would never find them. Names like `what?.txt` were worse still: the file could not be created at all, and the error ended the rest of the batch, so files queued behind it never arrived.
+  - Incoming names are now adjusted before the file is written. The characters `< > : " | ? *` become underscores, trailing dots and spaces are removed, and a name that is a reserved device name such as `NUL` gets an underscore in front. The progress line and **Show in folder** both use the adjusted name, and two files that end up with the same adjusted name are numbered the way colliding names always have been.
+  - A file named with a trailing space used to lose its mark of the web, the tag that makes Windows treat a received file as downloaded from the internet. The tag attached to the wrong name and the saved file kept none, so SmartScreen and Office Protected View stayed out of the way on a file a stranger sent you. Received files are now tagged correctly whatever they are called.
+  - Control characters and text-direction marks are removed from incoming names on every platform. A text-direction mark can make `photo` followed by a reversed `exe.png` read as an image in the file list while the file on disk is a program.
+  - Folder sends keep their structure. Each part of the path is adjusted on its own, so a folder that needed adjusting stays a folder.
+  - No transfer-protocol change, so Floe Desktop 0.2.6 transfers with browser and CLI peers in every direction.
+</Update>
+
+<Update label="v1.10.3" description="2026-08-19" tags={["CLI", "Web", "Self-hosting"]}>
+  **Received files that a system cannot store, and browser downloads that were never complete, no longer pass as finished**
+
+  - `floe receive` adjusts an incoming file name that the receiving system cannot represent, instead of writing it and reporting success. On Windows a name like `backup:2026-08-19.log` used to leave an empty file called `backup`, a file called `NUL` left nothing at all, and a name containing `?` could not be created and ended the rest of the batch. macOS and Linux keep names exactly as sent, since all of those are valid there.
+  - On Windows, a received file named with a trailing space used to lose its mark of the web, so SmartScreen and Office Protected View did not apply to it. That tag now attaches correctly whatever the file is called.
+  - Control characters and text-direction marks are removed from incoming names on every platform, and the receiver refuses to write onto a device rather than discarding the contents silently.
+  - The fix is on the receiving side. A transfer is protected once the **receiving** end is running `floe` 1.10.3 or Floe Desktop 0.2.6; sending from an updated build to a peer that has not updated is unchanged. Both surfaces ship the fix in this pair of releases.
+  - Web app: a file that arrived incomplete is no longer offered as a finished download. The browser labeled each file with however many bytes turned up rather than the number the sender announced, so the two could never disagree and a file cut short still showed a checkmark and a working download button. It is now checked against the announced size and refused if it does not match, and a short count is no longer added to the public transfer counter.
+  - Web app: sending a file that becomes unreadable partway through, because it was moved, renamed, or sat on a drive or cloud folder that went away, now reports the failure instead of telling both sides the file finished.
+  - Web app: file names chosen by the sender are cleaned before they are used to name a download or an entry in a ZIP, so a name cannot describe a path or quietly drop a file from the archive.
+  - Web app: a transfer blocked by the 2 GB relay cap now closes the connection and explains itself, instead of leaving the other side waiting with nothing on screen.
+  - Self-hosting: the published images are rebuilt as `1.10.3` and carry the web app changes above. To pick them up: `docker compose pull` then `docker compose up -d`; if you pinned `FLOE_IMAGE_TAG=1.10.2`, move to `1.10.3`.
+  - The wire protocol is unchanged, so v1.10.3 still speaks to older CLI and browser peers in both directions.
+</Update>
+
 <Update label="desktop-v0.2.5" description="2026-08-16" tags={["Desktop"]}>
   **Empty a staged selection in one click, and a fix for transfers that connected but never started**
 

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -24,7 +24,7 @@ These come from the CLI framework rather than from Floe itself.
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--help` | `-h` | `false` | Print usage and exit. Works on every command, so `floe send --help` and `floe receive --help` each print that command's own flags. |
-| `--version` | `-v` | `false` | Print the installed version and exit, for example `floe 1.10.2`. Root only: `floe --version` works, `floe send --version` does not. See [Alternatives](/cli/version#alternatives). |
+| `--version` | `-v` | `false` | Print the installed version and exit, for example `floe 1.10.3`. Root only: `floe --version` works, `floe send --version` does not. See [Alternatives](/cli/version#alternatives). |
 
 `floe completion` and `floe help` come from the same place and are not part of Floe's own interface. Run `floe completion --help` if you want shell completion.
 
@@ -74,7 +74,7 @@ Specific to the `update` command.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (1.10.2)` and stops either way (the installed version carries no leading `v`). On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
+| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (1.10.3)` and stops either way (the installed version carries no leading `v`). On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
 
 ## Opting out of the global counter
 

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -95,7 +95,7 @@ receives from browser peers and CLI peers without any extra setup.
 Every GitHub release ships `SHA256SUMS.txt`. To check a file you downloaded:
 
 ```powershell PowerShell
-Get-FileHash floe-desktop-setup-0.2.5.exe -Algorithm SHA256
+Get-FileHash floe-desktop-setup-0.2.6.exe -Algorithm SHA256
 ```
 
 Compare the result with the matching line in `SHA256SUMS.txt`. Store installs need no check:
@@ -104,7 +104,7 @@ the Store verifies the package signature itself.
 ## Check the version
 
 Open **Settings** (the gear in the title bar, or `Ctrl` `,`) and look at the **About** section.
-**App version** reads the release tag, for example `desktop-v0.2.5`. A build you compiled
+**App version** reads the release tag, for example `desktop-v0.2.6`. A build you compiled
 yourself reads `dev`.
 
 That section also shows the transfer protocol version and which signaling server the app is

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -197,7 +197,7 @@ This mirrors the CLI's `--web` flag. See
 
 ### App version
 
-The release you are running, for example `desktop-v0.2.5`. A build you compiled yourself reads
+The release you are running, for example `desktop-v0.2.6`. A build you compiled yourself reads
 `dev`.
 
 When the daily check has found a newer release, an **Update** row appears under it with a


### PR DESCRIPTION
## Summary

Release prep for `v1.10.3` and `desktop-v0.2.6`, covering #310 and #311.

A paired release, because the file name fix in #310 lives in the transfer engine that the CLI and the desktop app share, and it only takes effect on the receiving end. Same shape as the `v1.10.2` / `desktop-v0.2.5` pair.

- `docs/changelog.mdx`: one entry per version line, following the authoring contract at the top of that file. The `desktop-v0.2.6` entry is Desktop-only; `v1.10.3` is tagged `CLI`, `Web`, `Self-hosting` because it also carries the browser truncation fix and the rebuilt images.
- Version pins: `.github/ISSUE_TEMPLATE/bug_report.yml`, `CLAUDE.md`, `DESKTOP.md`, `desktop/wails.json`, `docs/cli/flags.mdx`, `docs/desktop/installation.mdx`, `docs/desktop/settings.mdx`.

**`client/lib/desktopRelease.ts` is deliberately not bumped here**, matching the `470a98d` precedent. It points the download page at a release asset, and floe.one deploys on merge, so moving it before the tag exists would send visitors to a 404. It follows in its own commit once the assets are published.

`desktop/updatecheck_test.go` also keeps its `desktop-v0.2.5` strings: those are test fixtures for the update-check cache, not a version pin.

## Test plan

Docs and pins only, no code. `desktop/wails.json` re-parses as valid JSON with `info.productVersion` at `0.2.6`. Checked the new changelog entries for em dashes and non-American spelling, both clean; the one `cancelled` remaining in the file is inside the shipped `v1.10.1` entry, which the Vale config exempts on purpose.

Verified against the release workflows: `v1.10.3` publishes the CLI binaries plus the Homebrew, Scoop and winget manifests and rebuilds the self-hosting images, and `desktop-v0.2.6` publishes the Windows desktop installer and MSIX. No `ProtocolVersion` bump, since neither fix touches the wire format.
