### PR TITLE
docs(client): point the download page at desktop-v0.2.6

### DIFF
--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.5';
-export const DESKTOP_RELEASE_DATE = 'Aug 16, 2026';
+export const DESKTOP_VERSION = '0.2.6';
+export const DESKTOP_RELEASE_DATE = 'Aug 19, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
## Summary

Final step of the `v1.10.3` / `desktop-v0.2.6` release. Held back from #312 on purpose: floe.one deploys on merge and the asset URLs derive from this version, so bumping it before the tag existed would have pointed every download button at a 404.

## Test plan

`pnpm test` passes, 220 tests across 19 files. Confirmed via the GitHub API that both `floe-desktop-setup-0.2.6.exe` and `floe-desktop-0.2.6-windows-amd64.zip` report `state=uploaded` on the release, so the links the page builds resolve.