### PR TITLE
fix(desktop): keep every file from a multi-select Send with Floe

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -98,7 +98,14 @@ type App struct {
 
 	// pendingFiles holds file paths passed on the command line (Explorer's
 	// "Send with Floe", drag-onto-exe) until the frontend pulls them.
-	pendingFiles []string
+	// frontendReady flips true, once and forever, the moment the frontend
+	// pulls: from then on second-instance files are emitted as events instead
+	// of staged, because the pull proves the 'files:open' listener exists (the
+	// frontend registers it in the same synchronous effect, just before the
+	// pull). Before that flip the JS event bus silently discards emits, which
+	// is how a multi-select "Send with Floe" used to deliver one file of five.
+	pendingFiles  []string
+	frontendReady bool
 
 	// cfg is every persisted setting: the server override plus the preference
 	// toggles. Written from the UI goroutine when the user saves Settings and read
@@ -210,7 +217,12 @@ func (a *App) SetCheckUpdates(enabled bool) error {
 // startup is called when the app starts. The context is saved so we can call the
 // runtime methods (events, dialogs).
 func (a *App) startup(ctx context.Context) {
+	// Under mu: onSecondInstanceLaunch runs on its own goroutine and reads
+	// a.ctx, so an unguarded write here is a race exactly during the
+	// multi-select cold-start burst this code exists to survive.
+	a.mu.Lock()
 	a.ctx = ctx
+	a.mu.Unlock()
 	// Best-effort: register the app for OS notifications (sets up the toast
 	// AppUserModelID on Windows). Errors are non-fatal.
 	_ = runtime.InitializeNotifications(ctx)
@@ -218,11 +230,14 @@ func (a *App) startup(ctx context.Context) {
 	// Reclaim any pasted-image staging dirs left by a previous run.
 	sweepPasteTemps()
 
-	// Files passed on the command line are staged for the frontend to pull once
-	// it mounts (pull, not an event: startup runs before listeners exist).
-	a.mu.Lock()
-	a.pendingFiles = filterFileArgs(os.Args[1:])
-	a.mu.Unlock()
+	// Files passed on the command line go through the same stage-or-emit seam
+	// as second-instance forwards. Staging must MERGE, not assign: a second
+	// instance can land before this goroutine runs, and an assignment would
+	// silently discard what it staged. The emit branch covers the reverse
+	// interleave, where the frontend somehow pulled first.
+	if files := filterFileArgs(os.Args[1:]); a.stageOrEmit(files) {
+		runtime.EventsEmit(ctx, "files:open", files)
+	}
 
 	// Best-effort self-heal: if the user enabled the context menu and the exe
 	// has moved since, rewrite the entry to point here. Skipped when packaged:
@@ -242,18 +257,55 @@ func (a *App) startup(ctx context.Context) {
 // forward any file arguments (the Explorer context menu launches one process
 // per selected file; each lands here).
 func (a *App) onSecondInstanceLaunch(data options.SecondInstanceData) {
-	runtime.WindowUnminimise(a.ctx)
-	runtime.WindowShow(a.ctx)
-	if files := filterFileArgs(data.Args); len(files) > 0 {
-		runtime.EventsEmit(a.ctx, "files:open", files)
+	files := filterFileArgs(data.Args)
+	a.mu.Lock()
+	ctx := a.ctx
+	if ctx == nil {
+		// startup has not stored the context yet: its goroutine races this
+		// callback during a multi-select cold-start burst. Every runtime call
+		// below log.Fatals on a nil context, which used to kill the first
+		// instance outright and lose every file. Stage and return; the window
+		// being raised is still being created anyway.
+		a.pendingFiles = append(a.pendingFiles, files...)
+		a.mu.Unlock()
+		return
+	}
+	a.mu.Unlock()
+	runtime.WindowUnminimise(ctx)
+	runtime.WindowShow(ctx)
+	if a.stageOrEmit(files) {
+		runtime.EventsEmit(ctx, "files:open", files)
 	}
 }
 
+// stageOrEmit decides delivery for command-line files: before the frontend's
+// one pull, stage them (append: a burst of Explorer launches lands one file
+// per call, and cold-start args merge in whatever order they arrive); after
+// it, tell the caller to emit. State only, no runtime calls, so tests can
+// drive it on a bare &App{}.
+func (a *App) stageOrEmit(files []string) (emit bool) {
+	if len(files) == 0 {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if !a.frontendReady {
+		a.pendingFiles = append(a.pendingFiles, files...)
+		return false
+	}
+	return true
+}
+
 // GetPendingFiles returns files passed on the command line and clears them.
-// The frontend calls this once on mount.
+// The frontend calls this once on mount. Draining and flipping frontendReady
+// in one critical section is what makes delivery lossless: anything staged
+// before this instant is in the returned slice, and anything after it sees
+// frontendReady and is emitted into a listener the frontend provably
+// registered before making this call.
 func (a *App) GetPendingFiles() []string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.frontendReady = true
 	p := a.pendingFiles
 	a.pendingFiles = nil
 	return p

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -242,3 +242,80 @@ func TestSupersededTransferDoesNotToast(t *testing.T) {
 		t.Fatalf("superseded transfer toasted %d times, want 0", calls)
 	}
 }
+
+// TestSecondInstanceFilesStageUntilFirstPull pins the multi-select "Send with
+// Floe" fix. Explorer launches one process per selected file; before the
+// frontend's first pull every forward must be staged (an emit would be
+// silently discarded by the JS event bus, which is how five selected files
+// used to arrive as one), and after the pull forwards are emitted.
+func TestSecondInstanceFilesStageUntilFirstPull(t *testing.T) {
+	a := &App{}
+
+	if a.stageOrEmit([]string{"a"}) {
+		t.Fatal("first forward before the pull should stage, not emit")
+	}
+	if a.stageOrEmit([]string{"b", "c"}) {
+		t.Fatal("burst forward before the pull should stage, not emit")
+	}
+
+	got := a.GetPendingFiles()
+	if len(got) != 3 || got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Fatalf("pull = %v, want [a b c]", got)
+	}
+
+	if !a.stageOrEmit([]string{"d"}) {
+		t.Fatal("forward after the pull should emit")
+	}
+	if late := a.GetPendingFiles(); late != nil {
+		t.Fatalf("emit path must stage nothing, second pull = %v", late)
+	}
+}
+
+// TestStageOrEmitEmptyNoOp preserves the existing gate: launches with no file
+// arguments neither stage nor emit.
+func TestStageOrEmitEmptyNoOp(t *testing.T) {
+	a := &App{}
+	if a.stageOrEmit(nil) {
+		t.Fatal("empty forward emitted before ready")
+	}
+	a.GetPendingFiles()
+	if a.stageOrEmit(nil) {
+		t.Fatal("empty forward emitted after ready")
+	}
+	if got := a.GetPendingFiles(); got != nil {
+		t.Fatalf("empty forwards staged something: %v", got)
+	}
+}
+
+// TestColdStartArgsMergeWithStagedFiles pins the startup interleave: a second
+// instance can stage files BEFORE the startup goroutine stages the cold-start
+// arguments, and startup must merge rather than assign, or the earlier files
+// are silently discarded.
+func TestColdStartArgsMergeWithStagedFiles(t *testing.T) {
+	a := &App{}
+
+	// A second instance lands first (the nil-ctx path appends directly).
+	if a.stageOrEmit([]string{"second-instance.txt"}) {
+		t.Fatal("should stage")
+	}
+	// Then startup stages the cold-start args through the same seam.
+	if a.stageOrEmit([]string{"cold-start.txt"}) {
+		t.Fatal("should stage")
+	}
+
+	got := a.GetPendingFiles()
+	if len(got) != 2 || got[0] != "second-instance.txt" || got[1] != "cold-start.txt" {
+		t.Fatalf("pull = %v, want both files in arrival order", got)
+	}
+}
+
+// TestGetPendingFilesDrains: the pull clears the staging area.
+func TestGetPendingFilesDrains(t *testing.T) {
+	a := &App{pendingFiles: []string{"x"}}
+	if got := a.GetPendingFiles(); len(got) != 1 {
+		t.Fatalf("first pull = %v", got)
+	}
+	if got := a.GetPendingFiles(); got != nil {
+		t.Fatalf("second pull = %v, want nil", got)
+	}
+}

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -137,9 +137,11 @@ When it finishes you get a Windows notification and the card reads **Sent 1 item
 ## Send from File Explorer
 
 If you turned on [**Show in right-click menu**](/desktop/settings#show-in-right-click-menu),
-right-click any file in File Explorer and choose **Send with Floe**. On Windows 11 it sits
-under **Show more options**. Floe opens with that file already staged, or, if Floe is already
-running, brings the existing window forward and adds the file to it.
+right-click one file or a selection of files in File Explorer and choose **Send with Floe**. On
+Windows 11 it sits under **Show more options**. Floe opens with those files already staged, or,
+if Floe is already running, brings the existing window forward and adds them to it. A selection
+of several files works: Windows launches Floe once per selected file, and every one of them
+lands in the same window.
 
 This entry is only available in the build from GitHub. See
 [Installation](/desktop/installation#choose-a-channel).


### PR DESCRIPTION
## Summary

Explorer launches one Floe process per selected file. The extra instances forward their file to the running app, which emitted `files:open` immediately — but Wails runs that callback the moment the frontend OBJECT exists, long before the page loads, and the JS event bus silently discards events with no registered listener. Right-click five files: one arrived, four vanished with no error.

The second-instance path now uses the same pull model the cold-start path has always used. `stageOrEmit` stages while the frontend has not pulled and emits after it has; `GetPendingFiles` flips that switch inside the same critical section that drains the staging area, making delivery lossless (the frontend registers the listener in the same synchronous effect, before the pull, so post-pull emits provably land).

Two interleavings the old code lost are covered: `startup` used to ASSIGN `pendingFiles`, clobbering anything a fast second instance staged first (now merges through the same seam); and a forward arriving before `startup` stores the Wails context used to hit `runtime.WindowUnminimise(nil)`, which `log.Fatal`s — killing the first instance outright during exactly the multi-select cold-start burst this feature serves (now stages and returns; the ctx store moved under the mutex).

## Test plan

`go test ./...` in desktop/ passes. New tests on a bare `&App{}` (the decision seam never touches the runtime): the five-files-one-arrives bug pinned directly, the startup interleave, the empty-args gate, and the drain. Real-machine burst verification happens on the built app before release, alongside the PR #319 checklist.

Docs: `docs/desktop/sending.mdx` now says a multi-file selection works, which becomes true with this change.