### PR TITLE
chore(desktop): regenerate wails bindings for ConfirmClose

### DIFF
--- a/desktop/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop/frontend/wailsjs/go/main/App.d.ts
@@ -4,9 +4,9 @@ import {main} from '../models';
 
 export function CancelTransfer():Promise<void>;
 
-export function ConfirmClose():Promise<void>;
-
 export function CheckForUpdate():Promise<main.UpdateInfo>;
+
+export function ConfirmClose():Promise<void>;
 
 export function ContextMenuEnabled():Promise<boolean>;
 

--- a/desktop/frontend/wailsjs/go/main/App.js
+++ b/desktop/frontend/wailsjs/go/main/App.js
@@ -6,12 +6,12 @@ export function CancelTransfer() {
   return window['go']['main']['App']['CancelTransfer']();
 }
 
-export function ConfirmClose() {
-  return window['go']['main']['App']['ConfirmClose']();
-}
-
 export function CheckForUpdate() {
   return window['go']['main']['App']['CheckForUpdate']();
+}
+
+export function ConfirmClose() {
+  return window['go']['main']['App']['ConfirmClose']();
 }
 
 export function ContextMenuEnabled() {


### PR DESCRIPTION
## Summary

PR #321 hand-added the `ConfirmClose` binding right after `CancelTransfer`; the wails generator places it alphabetically (between `CheckForUpdate` and `ContextMenuEnabled`). Regenerated from a real `wails build` so the checked-in bindings match what CI produces and the next build leaves no diff. An independent reviewer flagged the ordering as expected regen noise.

## Test plan

Generated output only, no behavior change. `desktop/` Go tests and the frontend build/tests already pass on main.