### PR TITLE
docs: changelog and version pins for v1.10.4 and desktop-v0.2.7

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -54,7 +54,7 @@ body:
     attributes:
       label: Version
       description: "Desktop app: Settings > About. CLI: `floe --version`. Skip for the web app."
-      placeholder: e.g., desktop-v0.2.6 or v1.10.3
+      placeholder: e.g., desktop-v0.2.7 or v1.10.4
     validations:
       required: false
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ go build ./cmd/floe    # local binary
 go test ./...          # run all tests
 ```
 
-The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version={{ .Version }}"`, which carries NO leading `v` (a v1.10.3 tag produces a binary that prints `floe 1.10.3`). The desktop app differs: desktop-release.yml injects the tag verbatim (`desktop-v0.2.6`).
+The CLI uses GoReleaser for cross-platform distribution; version is injected via `-ldflags "-X main.version={{ .Version }}"`, which carries NO leading `v` (a v1.10.4 tag produces a binary that prints `floe 1.10.4`). The desktop app differs: desktop-release.yml injects the tag verbatim (`desktop-v0.2.7`).
 
 ### Desktop (Wails)
 ```bash

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -204,8 +204,8 @@ receiver, which is deliberate (share a link and wait) and cancellable.
 
 ## Release history
 
-Current release: `desktop-v0.2.6` (Microsoft Store 9NBQ8ZQ1065L + GitHub
-pre-release), shipped 2026-08-19. Paired with CLI `v1.10.3`, because the data
+Current release: `desktop-v0.2.7` (Microsoft Store 9NBQ8ZQ1065L + GitHub
+pre-release), shipped 2026-08-20. Paired with CLI `v1.10.4`, because the data
 channel fix they both carry is receiver-side and only protects a transfer once
 the RECEIVING peer has it.
 

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -5,7 +5,7 @@
   "info": {
     "companyName": "Jan Carlo Paredes",
     "productName": "Floe",
-    "productVersion": "0.2.6",
+    "productVersion": "0.2.7",
     "copyright": "(c) 2026 Jan Carlo Paredes",
     "comments": "Peer-to-peer file transfer"
   },

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -40,6 +40,26 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
+<Update label="desktop-v0.2.7" description="2026-08-20" tags={["Desktop", "CLI"]}>
+  **A killed transfer never leaves a half-written file looking finished, closing mid-transfer asks first, and Send with Floe keeps every file**
+
+  - A received file is now written under a temporary name ending in `.part` and takes its real name only once every byte has arrived. Before this, closing the window, ending the app from Task Manager, or losing power partway through left the unfinished file in your folder under its final name, looking complete. Now the worst that can remain is a `.part` file, which is safe to delete.
+  - Closing the window during a transfer asks first. A new prompt offers **Keep going** or **Close anyway**, so one stray click on the close button no longer cuts a transfer off for both sides with nothing on screen.
+  - **Send with Floe** on several files at once now sends all of them. Windows starts Floe once for each file you select, and files that arrived before the window finished loading used to be silently dropped, so a five-file selection could send only one. Every selected file now lands in the same window.
+  - The file name that is shown and the one that is saved stay in step even when a name collision is only discovered as the file finishes, so **Open** and **Show in folder** always act on the file you actually received.
+  - No transfer-protocol change, so Floe Desktop 0.2.7 transfers with browser and CLI peers in every direction.
+</Update>
+
+<Update label="v1.10.4" description="2026-08-20" tags={["CLI", "Self-hosting"]}>
+  **Received files are written under a temporary name and only renamed when complete, so a killed transfer never leaves one looking finished**
+
+  - `floe receive` now writes each file under a temporary name ending in `.part` and renames it to its final name only after every byte has arrived and been verified. A transfer killed outright, or a machine that loses power partway through, can no longer leave a half-written file under a finished-looking name; the worst that remains is a `.part` file, safe to delete. On Windows the final rename is atomic; on macOS and Linux a crash at the exact instant of completion can leave an empty placeholder beside the intact `.part`.
+  - `Ctrl+C` removes the in-flight `.part` file on the way out, so a canceled receive leaves the output directory clean.
+  - The fix is on the receiving side. A transfer is protected once the **receiving** end is running `floe` 1.10.4 or Floe Desktop 0.2.7; sending from an updated build to a peer that has not updated is unchanged.
+  - Self-hosting: the published images are rebuilt as `1.10.4`. This release only touches the receive path the CLI and desktop app share, so there is nothing you need to do; pull when convenient. If you pinned `FLOE_IMAGE_TAG=1.10.3`, move to `1.10.4`.
+  - The wire protocol is unchanged, so v1.10.4 still speaks to older CLI and browser peers in both directions.
+</Update>
+
 <Update label="desktop-v0.2.6" description="2026-08-19" tags={["Desktop"]}>
   **Files whose names Windows cannot hold now arrive intact instead of arriving empty**
 

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -24,7 +24,7 @@ These come from the CLI framework rather than from Floe itself.
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--help` | `-h` | `false` | Print usage and exit. Works on every command, so `floe send --help` and `floe receive --help` each print that command's own flags. |
-| `--version` | `-v` | `false` | Print the installed version and exit, for example `floe 1.10.3`. Root only: `floe --version` works, `floe send --version` does not. See [Alternatives](/cli/version#alternatives). |
+| `--version` | `-v` | `false` | Print the installed version and exit, for example `floe 1.10.4`. Root only: `floe --version` works, `floe send --version` does not. See [Alternatives](/cli/version#alternatives). |
 
 `floe completion` and `floe help` come from the same place and are not part of Floe's own interface. Run `floe completion --help` if you want shell completion.
 
@@ -74,7 +74,7 @@ Specific to the `update` command.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (1.10.3)` and stops either way (the installed version carries no leading `v`). On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
+| `--check` | `false` | Report whether a newer release exists and exit without installing it. On an up-to-date binary the flag changes nothing: `floe update` prints `Already up to date (1.10.4)` and stops either way (the installed version carries no leading `v`). On a package-managed install the update guard runs first, so `--check` stops with the upgrade command for your package manager instead of a version report. See [Update the CLI](/cli/update). |
 
 ## Opting out of the global counter
 

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -95,7 +95,7 @@ receives from browser peers and CLI peers without any extra setup.
 Every GitHub release ships `SHA256SUMS.txt`. To check a file you downloaded:
 
 ```powershell PowerShell
-Get-FileHash floe-desktop-setup-0.2.6.exe -Algorithm SHA256
+Get-FileHash floe-desktop-setup-0.2.7.exe -Algorithm SHA256
 ```
 
 Compare the result with the matching line in `SHA256SUMS.txt`. Store installs need no check:
@@ -104,7 +104,7 @@ the Store verifies the package signature itself.
 ## Check the version
 
 Open **Settings** (the gear in the title bar, or `Ctrl` `,`) and look at the **About** section.
-**App version** reads the release tag, for example `desktop-v0.2.6`. A build you compiled
+**App version** reads the release tag, for example `desktop-v0.2.7`. A build you compiled
 yourself reads `dev`.
 
 That section also shows the transfer protocol version and which signaling server the app is

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -197,7 +197,7 @@ This mirrors the CLI's `--web` flag. See
 
 ### App version
 
-The release you are running, for example `desktop-v0.2.6`. A build you compiled yourself reads
+The release you are running, for example `desktop-v0.2.7`. A build you compiled yourself reads
 `dev`.
 
 When the daily check has found a newer release, an **Update** row appears under it with a


### PR DESCRIPTION
## Summary

Release prep for `v1.10.4` + `desktop-v0.2.7`, covering #319 (staged writes), #320 (Send with Floe buffering), #321 (close guard), #322 (bindings regen).

A paired release: the staged-write receive fix is in the shared engine and only takes effect on the receiving end, so both surfaces ship it together. The `desktop-v0.2.7` entry also carries the close-guard prompt and the multi-select fix (desktop-only). Changelog follows the authoring contract; version pins updated in `bug_report.yml`, `CLAUDE.md`, `DESKTOP.md`, `desktop/wails.json`, `docs/cli/flags.mdx`, `docs/desktop/{installation,settings}.mdx`.

**`client/lib/desktopRelease.ts` is deliberately not bumped here** (the `470a98d` precedent): it points the download page at a release asset, floe.one deploys on merge, so bumping it before the tag would 404. It follows in its own commit once assets exist.

## Test plan

Docs and pins only. `desktop/wails.json` re-parses with `info.productVersion` at `0.2.7`; new changelog entries checked for em dashes and non-American spelling (clean). No `ProtocolVersion` bump — neither fix touches the wire.