### PR TITLE
docs(client): point the download page at desktop-v0.2.7

### DIFF
--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -205,7 +205,7 @@ receiver, which is deliberate (share a link and wait) and cancellable.
 ## Release history
 
 Current release: `desktop-v0.2.7` (Microsoft Store 9NBQ8ZQ1065L + GitHub
-pre-release), shipped 2026-08-20. Paired with CLI `v1.10.4`, because the data
+pre-release), shipped 2026-08-19. Paired with CLI `v1.10.4`, because the data
 channel fix they both carry is receiver-side and only protects a transfer once
 the RECEIVING peer has it.
 

--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.6';
-export const DESKTOP_RELEASE_DATE = 'Aug 19, 2026';
+export const DESKTOP_VERSION = '0.2.7';
+export const DESKTOP_RELEASE_DATE = 'Aug 20, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store

--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -15,7 +15,7 @@
 
 // Bump these two together on every desktop release.
 export const DESKTOP_VERSION = '0.2.7';
-export const DESKTOP_RELEASE_DATE = 'Aug 20, 2026';
+export const DESKTOP_RELEASE_DATE = 'Aug 19, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -40,7 +40,7 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
-<Update label="desktop-v0.2.7" description="2026-08-20" tags={["Desktop", "CLI"]}>
+<Update label="desktop-v0.2.7" description="2026-08-19" tags={["Desktop", "CLI"]}>
   **A killed transfer never leaves a half-written file looking finished, closing mid-transfer asks first, and Send with Floe keeps every file**
 
   - A received file is now written under a temporary name ending in `.part` and takes its real name only once every byte has arrived. Before this, closing the window, ending the app from Task Manager, or losing power partway through left the unfinished file in your folder under its final name, looking complete. Now the worst that can remain is a `.part` file, which is safe to delete.
@@ -50,7 +50,7 @@ Each entry lists the parts it changed. Filter on the right to see only the ones 
   - No transfer-protocol change, so Floe Desktop 0.2.7 transfers with browser and CLI peers in every direction.
 </Update>
 
-<Update label="v1.10.4" description="2026-08-20" tags={["CLI", "Self-hosting"]}>
+<Update label="v1.10.4" description="2026-08-19" tags={["CLI", "Self-hosting"]}>
   **Received files are written under a temporary name and only renamed when complete, so a killed transfer never leaves one looking finished**
 
   - `floe receive` now writes each file under a temporary name ending in `.part` and renames it to its final name only after every byte has arrived and been verified. A transfer killed outright, or a machine that loses power partway through, can no longer leave a half-written file under a finished-looking name; the worst that remains is a `.part` file, safe to delete. On Windows the final rename is atomic; on macOS and Linux a crash at the exact instant of completion can leave an empty placeholder beside the intact `.part`.


### PR DESCRIPTION
## Summary

Final step of the `v1.10.4` / `desktop-v0.2.7` release. Held back from #323 on purpose: floe.one deploys on merge and the asset URLs derive from this version, so bumping before the tag existed would 404 every download button. Both `desktop-v0.2.7` assets now report `state=uploaded`.

## Test plan

`pnpm test` passes (227 tests). Asset availability confirmed via the GitHub API.