### PR TITLE
docs: restructure the sidebar and add the four pages it was missing

### DIFF
--- a/docs/choosing-floe.mdx
+++ b/docs/choosing-floe.mdx
@@ -1,0 +1,99 @@
+---
+title: "Which Floe should I use?"
+sidebarTitle: "Which Floe to use"
+description: "Compare the Floe web app, Floe Desktop for Windows, and the floe CLI: what each one can send, where files land, and which features only one of them has."
+keywords: ["web vs desktop", "web vs cli", "compare", "which version", "difference"]
+---
+
+There are three Floes and they all talk to each other, so the one you pick is about
+convenience rather than compatibility. Any of them can send to any other, in any direction,
+across different networks.
+
+If you only want one sentence: **use the browser unless you need folders, a place on disk, or
+a script.**
+
+<Columns cols={3}>
+  <Card title="Web app" icon="globe" href="/web-app/sending">
+    Nothing to install. Best for a one-off, and the only one your recipient definitely already
+    has.
+  </Card>
+  <Card title="Floe Desktop" icon="monitor" href="/desktop/installation">
+    Windows only, in beta. Best for folders, large files, and sending the same way every day.
+  </Card>
+  <Card title="CLI" icon="terminal" href="/cli/installation">
+    macOS, Windows, Linux. Best for servers, scripts, and anything headless.
+  </Card>
+</Columns>
+
+## Pick by what you are doing
+
+**Sending one file to someone who has never heard of Floe.** Use the browser. You send them a
+link, they open it, and the transfer starts on its own. They install nothing and no part of the
+exchange needs explaining.
+
+**Sending a folder.** Use Floe Desktop or the CLI. The browser has no folder picker, and
+dropping a folder onto the page adds nothing. Both of the others walk the folder for you and
+rebuild the same structure on the other side.
+
+**Receiving something very large.** Use Floe Desktop or the CLI. A browser receiver keeps each
+file in memory until that file is complete, so a multi-gigabyte file can exhaust a phone or a
+laptop tab. The other two write straight to disk as bytes arrive and have no such ceiling.
+
+**Transferring from a machine with no screen.** Use the CLI. It is one self-contained binary
+with no runtime dependencies, and it runs anywhere Go runs.
+
+**Sending regularly from Windows.** Use Floe Desktop. It keeps a local history of the last 50
+transfers, remembers where you save things, and can put **Send with Floe** in the File Explorer
+right-click menu.
+
+## Feature by feature
+
+| | Web app | Floe Desktop | CLI |
+|---|---|---|---|
+| Platforms | Any modern browser | Windows 10 or later, x64, beta | macOS, Windows, Linux, on Intel and ARM |
+| Install | None | Microsoft Store or a download | Package manager, one-line script, or `go install` |
+| Send files | Yes | Yes | Yes |
+| Send a folder | No | Yes | Yes |
+| Send a typed note | No | Yes, as `message.txt` | No |
+| Paste files or a screenshot | No | Yes, with `Ctrl` `V` | No |
+| Share a link | Yes | Yes | Yes |
+| Share a short code | No | Yes | Yes |
+| Show a QR code | Yes | Yes | No |
+| Join with a link | Yes | Yes | Yes |
+| Join with a short code | No | Yes | Yes |
+| Where received files go | Your browser's downloads, after the whole file is in memory | Straight to disk, in a folder you choose | Straight to disk, in `-o` or the current directory |
+| Folder structure on arrival | Flattened to a list | Rebuilt | Rebuilt |
+| Confirm before receiving | No, it starts on its own | No, it starts on its own | Yes, unless you pass `-y` |
+| Refuse the relay | Yes, the **Network relay fallback** checkbox | No | Yes, `--no-relay` |
+| Force the relay to hide your IP | No | Yes, **Hide my IP address** | No |
+| Transfer history | No | The last 50, stored on your device | No |
+| File Explorer right-click entry | No | Yes, on the build from GitHub | No |
+| Point at a self-hosted server | Automatic, it is served by that instance | **Settings**, then **Server address** | `--server` or `FLOE_SERVER` |
+
+## What is the same everywhere
+
+These are properties of the transfer itself, so they do not change with the client you pick.
+
+- **Encryption.** Every transfer runs over an encrypted WebRTC data channel. See
+  [Encryption](/how-it-works/encryption).
+- **No size limit on a direct connection**, and a 2 GB cap when the connection has to fall back
+  to the relay. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+- **One receiver per transfer.** A room holds exactly two peers, so a link or code is spent once
+  someone joins.
+- **The sender stays connected** for the whole transfer. Closing the tab, quitting the app, or
+  stopping the process ends it.
+- **Versions do not need to match.** A browser sender and a two-year-old CLI receiver transfer
+  normally. See [Protocol versioning](/reference/transfer-protocol#protocol-versioning).
+
+## Mixing them
+
+Every combination works, and neither side needs to know what the other is using. The browser
+speaks to the signaling server over Socket.IO while the desktop app and the CLI use a WebSocket,
+but both land in the same room and the server routes between them.
+
+The one asymmetry worth remembering: **a browser recipient needs the link.** There is no place
+to type a short code in the web UI, and a browser sender never mints one. Short codes are a
+desktop and CLI feature in both directions. When you are not sure what the person on the other
+end will use, share the link, because every client accepts it.
+
+See the [cross-platform table](/quickstart#cross-platform-transfers) for how each pairing joins.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,40 +56,97 @@
       {
         "header": "Product",
         "items": [
-          { "label": "Floe", "href": "https://www.floe.one" },
-          { "label": "Download", "href": "https://www.floe.one/download" },
-          { "label": "How It Works", "href": "https://www.floe.one/how-it-works" }
+          {
+            "label": "Floe",
+            "href": "https://www.floe.one"
+          },
+          {
+            "label": "Download",
+            "href": "https://www.floe.one/download"
+          },
+          {
+            "label": "How It Works",
+            "href": "https://www.floe.one/how-it-works"
+          }
         ]
       },
       {
         "header": "Documentation",
         "items": [
-          { "label": "Quickstart", "href": "https://www.floe.one/docs/quickstart" },
-          { "label": "Web App", "href": "https://www.floe.one/docs/web-app/sending" },
-          { "label": "CLI", "href": "https://www.floe.one/docs/cli/installation" },
-          { "label": "Desktop App", "href": "https://www.floe.one/docs/desktop/installation" },
-          { "label": "Self-Hosting", "href": "https://www.floe.one/docs/self-hosting/overview" },
-          { "label": "FAQ", "href": "https://www.floe.one/docs/faq" },
-          { "label": "Changelog", "href": "https://www.floe.one/docs/changelog" }
+          {
+            "label": "Quickstart",
+            "href": "https://www.floe.one/docs/quickstart"
+          },
+          {
+            "label": "Web App",
+            "href": "https://www.floe.one/docs/web-app/sending"
+          },
+          {
+            "label": "CLI",
+            "href": "https://www.floe.one/docs/cli/installation"
+          },
+          {
+            "label": "Desktop App",
+            "href": "https://www.floe.one/docs/desktop/installation"
+          },
+          {
+            "label": "Self-Hosting",
+            "href": "https://www.floe.one/docs/self-hosting/overview"
+          },
+          {
+            "label": "FAQ",
+            "href": "https://www.floe.one/docs/faq"
+          },
+          {
+            "label": "Changelog",
+            "href": "https://www.floe.one/docs/changelog"
+          }
         ]
       },
       {
         "header": "Project",
         "items": [
-          { "label": "GitHub", "href": "https://github.com/jannskiee/floe" },
-          { "label": "Releases", "href": "https://github.com/jannskiee/floe/releases" },
-          { "label": "Report an Issue", "href": "https://github.com/jannskiee/floe/issues" },
-          { "label": "Contributing", "href": "https://github.com/jannskiee/floe/blob/main/CONTRIBUTING.md" },
-          { "label": "Sponsor", "href": "https://github.com/sponsors/jannskiee" }
+          {
+            "label": "GitHub",
+            "href": "https://github.com/jannskiee/floe"
+          },
+          {
+            "label": "Releases",
+            "href": "https://github.com/jannskiee/floe/releases"
+          },
+          {
+            "label": "Report an Issue",
+            "href": "https://github.com/jannskiee/floe/issues"
+          },
+          {
+            "label": "Contributing",
+            "href": "https://github.com/jannskiee/floe/blob/main/CONTRIBUTING.md"
+          },
+          {
+            "label": "Sponsor",
+            "href": "https://github.com/sponsors/jannskiee"
+          }
         ]
       },
       {
         "header": "Legal",
         "items": [
-          { "label": "Privacy Policy", "href": "https://www.floe.one/privacy" },
-          { "label": "Terms of Use", "href": "https://www.floe.one/terms" },
-          { "label": "Security Policy", "href": "https://github.com/jannskiee/floe/security/policy" },
-          { "label": "License (MIT)", "href": "https://github.com/jannskiee/floe/blob/main/LICENSE" }
+          {
+            "label": "Privacy Policy",
+            "href": "https://www.floe.one/privacy"
+          },
+          {
+            "label": "Terms of Use",
+            "href": "https://www.floe.one/terms"
+          },
+          {
+            "label": "Security Policy",
+            "href": "https://github.com/jannskiee/floe/security/policy"
+          },
+          {
+            "label": "License (MIT)",
+            "href": "https://github.com/jannskiee/floe/blob/main/LICENSE"
+          }
         ]
       }
     ]
@@ -98,17 +155,37 @@
     "groups": [
       {
         "group": "Getting started",
-        "pages": ["introduction", "quickstart"]
+        "icon": "rocket",
+        "pages": [
+          "introduction",
+          "quickstart",
+          "choosing-floe"
+        ]
       },
       {
-        "group": "Web",
+        "group": "Core concepts",
+        "icon": "lightbulb",
+        "pages": [
+          "how-it-works/signaling",
+          "how-it-works/direct-connection",
+          "how-it-works/relay-connection",
+          "how-it-works/2gb-limit",
+          "how-it-works/encryption",
+          "security-privacy",
+          "how-it-works/known-limitations"
+        ]
+      },
+      {
+        "group": "Web app",
+        "icon": "globe",
         "pages": [
           "web-app/sending",
           "web-app/receiving"
         ]
       },
       {
-        "group": "Desktop",
+        "group": "Desktop app",
+        "icon": "monitor",
         "pages": [
           "desktop/installation",
           "desktop/sending",
@@ -119,6 +196,7 @@
       },
       {
         "group": "CLI",
+        "icon": "terminal",
         "pages": [
           "cli/installation",
           "cli/send",
@@ -131,42 +209,101 @@
       },
       {
         "group": "Self-hosting",
+        "icon": "server",
         "pages": [
-          "self-hosting/overview",
-          "self-hosting/quickstart",
-          "self-hosting/without-docker",
-          "self-hosting/images",
-          "self-hosting/unraid",
-          "self-hosting/configuration",
-          "self-hosting/build-time-url",
-          "self-hosting/reverse-proxy",
-          "self-hosting/production",
-          "self-hosting/turn-relay",
-          "self-hosting/operations"
-        ]
-      },
-      {
-        "group": "How it works",
-        "pages": [
-          "how-it-works/signaling",
-          "how-it-works/direct-connection",
-          "how-it-works/relay-connection",
-          "how-it-works/2gb-limit",
-          "how-it-works/encryption",
-          "security-privacy"
+          {
+            "group": "Get started",
+            "expanded": true,
+            "pages": [
+              "self-hosting/overview",
+              "self-hosting/quickstart",
+              "self-hosting/without-docker",
+              "self-hosting/unraid"
+            ]
+          },
+          {
+            "group": "Configure",
+            "pages": [
+              "self-hosting/configuration",
+              "self-hosting/build-time-url",
+              "self-hosting/images"
+            ]
+          },
+          {
+            "group": "Deploy",
+            "pages": [
+              "self-hosting/reverse-proxy",
+              "self-hosting/production",
+              "self-hosting/turn-relay"
+            ]
+          },
+          {
+            "group": "Operate",
+            "pages": [
+              "self-hosting/operations"
+            ]
+          }
         ]
       },
       {
         "group": "Help",
-        "pages": ["faq", "troubleshooting"]
+        "icon": "life-buoy",
+        "pages": [
+          "troubleshooting",
+          "faq"
+        ]
       },
       {
         "group": "Reference",
+        "icon": "book-open",
         "pages": [
           "reference/architecture",
+          "reference/http-api",
+          "reference/transfer-protocol"
+        ]
+      },
+      {
+        "group": "Changelog",
+        "icon": "history",
+        "pages": [
           "changelog"
         ]
       }
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Quickstart",
+          "href": "/quickstart",
+          "icon": "zap"
+        },
+        {
+          "anchor": "File size limits",
+          "href": "/how-it-works/2gb-limit",
+          "icon": "scale"
+        },
+        {
+          "anchor": "Troubleshooting",
+          "href": "/troubleshooting",
+          "icon": "wrench"
+        },
+        {
+          "anchor": "Self-host with Docker",
+          "href": "/self-hosting/quickstart",
+          "icon": "container"
+        }
+      ]
+    }
+  },
+  "search": {
+    "prompt": "Search the Floe docs"
+  },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude"
     ]
   }
 }

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -1,7 +1,9 @@
 ---
-title: "The 2 GB Relay Limit"
-sidebarTitle: "2 GB limit"
-description: "Why Floe caps relayed transfers at 2 GB per session, how the limit protects the shared TURN server, and how direct peer-to-peer transfers avoid it."
+title: "File size limits and the 2 GB relay cap"
+sidebarTitle: "File size limits"
+description: "Direct Floe transfers have no size limit. Relayed ones are capped at 2 GB per session. What decides which you get, and how to stay on the unlimited path."
+keywords: ["file size limit", "maximum file size", "2 GB", "relay cap", "how big a file"]
+boost: 2
 ---
 
 When your files go through the Floe TURN relay server, every byte of data passes through the infrastructure. That costs real money in server bandwidth. Direct connections cost nothing because files travel entirely between the two devices.

--- a/docs/how-it-works/known-limitations.mdx
+++ b/docs/how-it-works/known-limitations.mdx
@@ -1,0 +1,118 @@
+---
+title: "What Floe does not protect against"
+sidebarTitle: "Known limitations"
+description: "An honest list of Floe's limits: what the signaling server could do in principle, what the relay sees, why there is no verification code yet, and where the browser runs out of room."
+keywords: ["threat model", "security limits", "mitm", "privacy limits", "caveats"]
+---
+
+Floe encrypts every transfer end to end and never puts your files on a server. Both of those
+are true and neither is the whole story. This page is the other half: the things Floe does not
+do, written plainly, so you can decide whether it fits what you are sending.
+
+Nothing here is a bug report. Each item is a design consequence, and each one says what you can
+do about it.
+
+## The signaling server is trusted to introduce you honestly
+
+Two devices agree on encryption keys by exchanging certificate fingerprints, and those
+fingerprints travel through the signaling server during setup. The server cannot read your files
+and never sees one. But a server that wanted to could hand each side a fingerprint it controls
+instead of the other peer's, sit in the middle, and decrypt everything.
+
+This is true of every WebRTC application, not just Floe. It is the reason the next item matters.
+
+**What you can do:** [run your own instance](/self-hosting/overview). A server you operate is a
+server you do not have to trust in this sense. On `api.floe.one` you are trusting the same
+operator who publishes the client, which is the ordinary situation for any hosted service.
+
+## There is no verification code to compare
+
+The usual defense against the previous item is a short code, derived from both certificate
+fingerprints, that the two people read to each other over a channel an attacker does not
+control. If the codes match, nobody is in the middle.
+
+Floe computes that code internally. **No client displays it today.** It has been added and
+removed more than once, and it is not in the web app, Floe Desktop, or the CLI as it ships now.
+Until one of them shows it, there is no way to detect the attack described above from inside
+Floe.
+
+**What you can do:** for anything where that attack is part of your threat model, self-host, or
+encrypt the file yourself before you send it.
+
+## The other person learns your IP address
+
+A direct connection is two devices talking to each other, which means each one knows where the
+other is. That is not a leak, it is how any peer-to-peer connection works, and a video call
+does the same thing.
+
+**What you can do:** Floe Desktop has a [Hide my IP address](/desktop/settings#hide-my-ip-address)
+switch that forces every transfer through the relay, so the other side sees the relay's address
+instead of yours. The web app and the CLI have no equivalent. The trade is speed and the 2 GB
+session cap.
+
+## The relay sees more than the signaling server does
+
+When a direct path is impossible, traffic goes through a TURN relay. The relay cannot read
+anything: the data is encrypted before it arrives and decrypted only on the recipient's device.
+
+But the relay is an endpoint that both peers connect to, so it observes both IP addresses and
+the timing and size of what it forwards. On `floe.one` that relay is Cloudflare's Realtime TURN
+network, which is infrastructure Floe does not own, and your provider may log that metadata for
+its own security purposes.
+
+**What you can do:** stay on a direct connection where you can, or self-host with
+[your own coturn relay](/self-hosting/turn-relay).
+
+## A browser receiver holds each file in memory
+
+The web app keeps each incoming file in memory until that file is complete, then hands it to
+your browser as a download. A large enough file exhausts the tab, and on a phone that ceiling
+arrives sooner than you would like.
+
+Zipping compounds it: **Download ZIP** holds every file at once before it writes the archive.
+
+**What you can do:** receive multi-gigabyte transfers with [Floe Desktop](/desktop/receiving) or
+the [CLI](/cli/receive), which write straight to disk and have no such ceiling. In the browser,
+save files one at a time rather than zipping when the total is large.
+
+## Floe does not hash your files
+
+A completed file is checked against the size the sender announced, and a mismatch in either
+direction discards it. That catches a truncated or over-run transfer, which is what actually
+happens when a connection dies partway.
+
+It is not a content checksum. Floe computes no hash of file contents anywhere, so the docs never
+claim one. In practice the transport already authenticates every packet, so silent corruption in
+flight is not the gap; the gap is that Floe cannot tell you the file on disk is byte-identical to
+the one that left.
+
+**What you can do:** compare hashes yourself when that guarantee matters. `sha256sum` on Linux,
+`shasum -a 256` on macOS, `Get-FileHash` on Windows.
+
+## The public counter is a vanity metric
+
+The total on the homepage is fed by receivers reporting a byte count after a transfer. It is
+protected by a per-IP rate limit and a per-report size cap, and nothing else. Anyone can post a
+plausible number to it.
+
+It is an honest best-effort figure, not an audited one, and it is deliberately built that way:
+adding real integrity would mean identifying the reporter, which is exactly what the counter
+avoids. It carries no file names, no per-transfer records, and no link to anyone. See
+[Aggregate statistics](/security-privacy#aggregate-statistics).
+
+## A self-hosted server runs as a single process
+
+Rooms, room codes, and the rate limiters all live in one process's memory. Running two replicas
+behind a load balancer does not scale Floe out; it silently breaks pairing, because the two
+peers can land on different replicas and never see each other.
+
+**What you can do:** run one instance. A single small server handles a lot, since file data
+never passes through it. If you need redundancy, use a failover pair rather than a load-balanced
+set, and accept that in-flight transfers do not survive the switch.
+
+## Reporting something that is not on this list
+
+If you find a security issue in Floe, report it privately through
+[GitHub Security Advisories](https://github.com/jannskiee/floe/security/advisories/new) or the
+contact in [SECURITY.md](https://github.com/jannskiee/floe/blob/main/SECURITY.md). Please do not
+open a public issue before there is a fix.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,36 +1,71 @@
 ---
-title: "Your files never make a stop."
+title: "Floe documentation"
 sidebarTitle: "Introduction"
-description: "Floe moves files straight between devices over WebRTC. These docs cover the web app, the desktop app, the CLI, and running your own instance."
-keywords: ["overview", "getting started", "p2p file transfer", "webrtc"]
+description: "Send files peer-to-peer with Floe. Documentation for the web app at floe.one, Floe Desktop for Windows, the floe CLI, and running your own instance."
+keywords: ["floe", "docs", "peer to peer file transfer", "webrtc", "send a file", "getting started"]
 boost: 3
 ---
 
-<Columns cols={2}>
-  <Card title="Quickstart" icon="zap" href="/quickstart">
-    Send your first file in under a minute.
+**Your files never make a stop.** Floe sends them straight from one device to another over an
+encrypted connection: no account, no upload, and nothing kept on a server.
+
+## Start here
+
+<Columns cols={3}>
+  <Card title="Send a file right now" icon="zap" href="/quickstart">
+    Under a minute, in a browser.
   </Card>
+  <Card title="Run my own instance" icon="server" href="/self-hosting/quickstart">
+    Two commands with Docker Compose.
+  </Card>
+  <Card title="See how it is encrypted" icon="shield" href="/how-it-works/encryption">
+    What is protected, and by what.
+  </Card>
+</Columns>
+
+## Pick a Floe
+
+All three send to each other in any direction, so this is a question of convenience rather than
+compatibility.
+
+<Columns cols={3}>
   <Card title="Web app" icon="globe" href="/web-app/sending">
-    Send and receive in the browser at floe.one.
+    Nothing to install. Open floe.one, drop a file, share the link.
   </Card>
   <Card title="Desktop app" icon="monitor" href="/desktop/installation">
-    Get Floe Desktop for Windows. Beta.
+    Windows, in beta. Sends folders, pastes screenshots, saves where you choose.
   </Card>
   <Card title="CLI" icon="terminal" href="/cli/installation">
-    Install the `floe` binary and script your transfers.
+    macOS, Windows, Linux. One binary for servers and scripts.
   </Card>
-  <Card title="Self-hosting" icon="server" href="/self-hosting/overview">
-    Run your own instance with Docker Compose.
+</Columns>
+
+Not sure which? [Compare the three](/choosing-floe).
+
+## What you should know
+
+**Encrypted end to end.** Every transfer runs over an encrypted WebRTC data channel, so nobody
+in between can read it, Floe's own servers included. See
+[Security and privacy](/security-privacy), and
+[what Floe does not protect against](/how-it-works/known-limitations) for the honest other half.
+
+**No accounts, no uploads.** The signaling server introduces the two devices and then steps out
+of the way. File data never reaches it. See [How a transfer works](/how-it-works/signaling).
+
+**No size limit on a direct connection.** Most transfers connect directly. When a network makes
+that impossible and the transfer falls back to a relay, it is capped at 2 GB per session to keep
+Floe free. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+
+## Going further
+
+<Columns cols={3}>
+  <Card title="Self-hosting" icon="container" href="/self-hosting/overview">
+    Run the whole stack on your own infrastructure.
+  </Card>
+  <Card title="Reference" icon="book-open" href="/reference/architecture">
+    The architecture, the HTTP API, and the wire protocol.
   </Card>
   <Card title="Changelog" icon="history" href="/changelog">
     Every release across web, desktop, and CLI.
   </Card>
 </Columns>
-
----
-
-**Encrypted end to end.** DTLS protects every transfer; no one, including Floe's servers, can read your files. See [Security & privacy](/security-privacy).
-
-**No accounts, no uploads.** The signaling server only brokers the connection, then steps aside.
-
-**No size limit on direct transfers.** Relayed sessions are capped at 2 GB to keep the service free. See [the 2 GB limit](/how-it-works/2gb-limit).

--- a/docs/reference/http-api.mdx
+++ b/docs/reference/http-api.mdx
@@ -1,0 +1,292 @@
+---
+title: "Floe signaling server HTTP API"
+sidebarTitle: "HTTP API"
+description: "Every HTTP endpoint the Floe signaling server exposes: health checks, room codes, TURN credentials, and the public byte counter, with request and response shapes."
+keywords: ["api", "endpoints", "rest", "health check", "turn credentials", "room code"]
+---
+
+The signaling server exposes seven HTTP endpoints. They exist so the three Floe clients can find
+each other and fetch relay credentials, and they are documented here for self-hosters checking a
+deployment and for contributors.
+
+Treat this as a description of the current implementation rather than a stable public contract.
+Floe ships the clients and the server together, so these shapes change when both sides change.
+There is no authentication on any of them, and no endpoint ever touches file data.
+
+The base URL is your signaling server: `https://api.floe.one` by default, or whatever you set as
+`--server`, `FLOE_SERVER`, or **Server address**.
+
+## Status and health
+
+### GET /
+
+A liveness check that also returns the server's clock.
+
+```json 200 OK
+{ "status": "ok", "timestamp": "2026-08-20T09:15:04.221Z" }
+```
+
+<ResponseField name="status" type="string" required>
+  Always `"ok"`.
+</ResponseField>
+<ResponseField name="timestamp" type="string" required>
+  The server's current time as an ISO 8601 string.
+</ResponseField>
+
+Not rate limited. On a one-domain deployment this path belongs to the web client, so `GET /` on
+the signaling server is only reachable when you address the server directly.
+
+### GET /health
+
+The endpoint to point a monitor at. It survives every deployment layout, including a
+[one-domain reverse proxy](/self-hosting/reverse-proxy).
+
+```json 200 OK
+{ "status": "healthy", "uptime": 1893.4 }
+```
+
+<ResponseField name="status" type="string" required>
+  Always `"healthy"`. Floe Desktop's **Test** button matches this value exactly, so a proxy that
+  answers with anything else fails the check.
+</ResponseField>
+<ResponseField name="uptime" type="number" required>
+  Seconds since the process started, as a float. Useful for confirming a restart actually landed.
+</ResponseField>
+
+Not rate limited.
+
+## Relay credentials
+
+### GET /api/turn-credentials
+
+Returns the ICE server list a client should use. Both the browser and the Go engine call this
+once before connecting.
+
+The response is a **JSON array**, not an object. What is in it depends on how the server is
+configured, and the precedence is fixed: Cloudflare Realtime TURN if both Cloudflare variables
+are set, then coturn if both `TURN_SECRET` and `TURN_DOMAIN` are set, then Google's public STUN
+servers.
+
+<CodeGroup>
+```json Cloudflare
+[
+  { "urls": ["stun:stun.cloudflare.com:3478"] },
+  {
+    "urls": [
+      "turn:turn.cloudflare.com:3478?transport=udp",
+      "turns:turn.cloudflare.com:443?transport=tcp"
+    ],
+    "username": "...",
+    "credential": "..."
+  }
+]
+```
+
+```json Self-hosted coturn
+[
+  { "urls": "stun:turn.example.com:3478" },
+  { "urls": "turn:turn.example.com:3478", "username": "1755690000:floeuser", "credential": "..." },
+  { "urls": "turns:turn.example.com:5349", "username": "1755690000:floeuser", "credential": "..." }
+]
+```
+
+```json No TURN configured
+[
+  { "urls": "stun:stun.l.google.com:19302" },
+  { "urls": "stun:stun1.l.google.com:19302" }
+]
+```
+</CodeGroup>
+
+Note the difference in the `urls` field between the first shape and the other two. Cloudflare
+entries carry an **array** of URLs; coturn and the STUN fallback carry a **string**. Every Floe
+client accepts either, and anything else consuming this endpoint has to as well.
+
+<ResponseField name="urls" type="string | string[]" required>
+  One or more ICE server URLs. STUN and TURN are always split into separate array entries, which
+  is what lets a client strip TURN while keeping STUN when the user refuses the relay.
+</ResponseField>
+<ResponseField name="username" type="string">
+  Present on TURN entries only. For coturn this is `{expiry_unix}:floeuser`.
+</ResponseField>
+<ResponseField name="credential" type="string">
+  Present on TURN entries only. For coturn this is `base64(HMAC-SHA1(TURN_SECRET, username))`.
+</ResponseField>
+
+Both credential paths issue a 24 hour expiry. Cloudflare credentials are minted upstream and
+cached in the server's memory for 12 hours, so a burst of page loads costs one upstream call and
+a restart re-mints.
+
+Cloudflare's raw list is trimmed before it is served, down to one STUN URL, one UDP TURN URL, and
+one TCP-based TURN URL, preferring TLS on port 443. Clients gather ICE candidates per URL per
+network interface, so every redundant URL multiplies connection setup time on a machine with VPN
+or virtual-machine adapters.
+
+**Rate limit:** 20 requests per IP per 60 seconds, configurable with `MAX_TURN_REQUESTS_PER_IP`.
+Over the limit returns `429` with `{ "error": "Too many requests" }`, and the client falls back
+to STUN only without showing an error.
+
+## Room codes
+
+Codes are three lowercase words joined by hyphens, drawn from a 288-word list with a
+cryptographically secure random source. On a collision with a live code the server draws again,
+up to ten times, and only then falls back to a four-word phrase.
+
+### POST /api/code
+
+Registers a short code for a room. Called by `floe send` and by Floe Desktop. The web app never
+calls it.
+
+<ParamField body="roomId" type="string" required>
+  The room UUID, in canonical `8-4-4-4-12` form. Any UUID version is accepted, case-insensitively.
+</ParamField>
+
+```bash Request
+curl -X POST https://api.floe.one/api/code \
+  -H "Content-Type: application/json" \
+  -d '{"roomId":"3f2b9c1e-7a4d-4c2e-9b1f-8e6d5c4b3a21"}'
+```
+
+```json 200 OK
+{ "code": "olive-tiger-castle" }
+```
+
+<ResponseField name="code" type="string" required>
+  The phrase to share. It resolves for 10 minutes from this moment.
+</ResponseField>
+
+| Status | Body | When |
+|---|---|---|
+| `400` | `{ "error": "Invalid room ID" }` | `roomId` is missing or is not a UUID |
+| `429` | `{ "error": "Too many requests" }` | Over the per-IP code limit |
+| `503` | `{ "error": "Server busy, try again shortly" }` | `MAX_ACTIVE_CODES` live codes already registered |
+
+The `503` is a global guard, not a per-IP one. It bounds the memory the code registry can use.
+Only expiry frees a slot: resolving a code does not delete it, and a sweeper clears lapsed
+entries once a minute, so the count can briefly include codes that have already expired.
+
+### GET /api/code/:code
+
+Resolves a code back to its room. Called by `floe receive` and by Floe Desktop's **Receive** tab.
+
+<ParamField path="code" type="string" required>
+  The phrase, matched **exactly**. Codes are always lowercase, so `Olive-Tiger-Castle` does not
+  resolve. Surrounding whitespace is trimmed by the clients, not by the server.
+</ParamField>
+
+```json 200 OK
+{ "roomId": "3f2b9c1e-7a4d-4c2e-9b1f-8e6d5c4b3a21" }
+```
+
+| Status | Body | When |
+|---|---|---|
+| `404` | `{ "error": "Code not found or expired" }` | Unknown code, or past its 10 minutes |
+| `429` | `{ "error": "Too many requests" }` | Over the per-IP code limit |
+
+**Rate limit:** 60 requests per IP per 60 seconds, shared with `POST /api/code` and configurable
+with `MAX_CODE_REQUESTS_PER_IP`.
+
+## Global byte counter
+
+### GET /api/stats
+
+The all-time total shown on the Floe homepage. Answered from an in-memory value, so the homepage
+polling it every 10 seconds never reaches Redis.
+
+```json 200 OK
+{ "totalBytes": 41297834502 }
+```
+
+<ResponseField name="totalBytes" type="integer" required>
+  A single cumulative figure across every transfer this server has been told about. It carries no
+  file names, no per-transfer records, and no link to any user.
+</ResponseField>
+
+Not rate limited. On a self-hosted instance this counter is local to that server, and without
+Upstash Redis configured it lives in memory only and resets to zero on restart.
+
+### POST /api/stats/report
+
+How the counter is fed. Only the **receiving** side of a completed transfer calls this, so each
+transfer is counted once. Senders never report.
+
+<ParamField body="bytes" type="integer" required>
+  A positive integer, no larger than `MAX_REPORT_BYTES` (5 TB by default). Zero, negatives,
+  fractions, and strings are all rejected.
+</ParamField>
+
+```bash Request
+curl -X POST https://api.floe.one/api/stats/report \
+  -H "Content-Type: application/json" \
+  -d '{"bytes":6291456}'
+```
+
+```json 200 OK
+{ "totalBytes": 41297840793 }
+```
+
+| Status | Body | When |
+|---|---|---|
+| `400` | `{ "error": "Invalid byte count" }` | `bytes` is not a positive integer within the cap |
+| `429` | `{ "error": "Too many reports" }` | Over 60 reports from this IP in 60 seconds |
+
+The rate limit here is the one limiter with **no environment override**. Every other limit is
+configurable; this one is fixed at 60 per IP per minute.
+
+Every receiver can opt out before the request is ever made. See
+[Aggregate statistics](/security-privacy#aggregate-statistics).
+
+## GET /api/config belongs to the web client
+
+There is one path that looks like it belongs here and does not. `GET /api/config` is served by
+the **Next.js client**, not by the signaling server, and it is how the browser learns which
+signaling server to use:
+
+```json 200 OK
+{ "socketUrl": "https://api.example.com" }
+```
+
+An empty `socketUrl` means the browser should use its own origin, which is the right answer
+behind a single domain.
+
+<Warning>
+  Route all of `/api/` to the signaling server and this request returns 404. Any signaling URL
+  you configured is then silently discarded and the browser falls back to its own origin. Behind
+  one domain that fallback happens to be correct, so the mistake stays invisible until the day
+  you set a value and nothing happens. See
+  [Run Floe Behind One Domain](/self-hosting/reverse-proxy) for the exact-path rule.
+</Warning>
+
+## Behavior shared by every endpoint
+
+**CORS.** Browser requests are checked against an allow-list: whatever you set as `CLIENT_URL`,
+plus `https://floe.one`, `https://www.floe.one`, and `http://localhost:3000`. The match is exact,
+including the scheme and with no trailing slash, and `CLIENT_URL` holds **one** origin. A
+comma-separated list matches nothing. Requests with no `Origin` header always pass, which is why
+the CLI and the desktop app reach your server regardless of this setting.
+
+A rejected origin does not come back as a recognizable CORS error. The server answers `500` with
+`{ "error": "Internal server error" }` while the browser reports a generic CORS failure. If you
+see that pairing, check `CLIENT_URL` first.
+
+**Errors.** Every failure returns JSON and nothing else. Anything under 500 is
+`{ "error": "Bad request" }`, anything at or above it is `{ "error": "Internal server error" }`,
+and the stack trace goes to the server's own output. This holds at every `NODE_ENV`.
+
+**Request bodies** are parsed at the default 100 kB limit. A larger body gets `413`, and
+malformed JSON gets `400`.
+
+**Client IP.** Per-IP limits read `X-Forwarded-For` according to `TRUSTED_PROXY_COUNT`. Setting
+it higher than your real number of proxy hops lets a client forge the header and slip past every
+limit. See [Configuration](/self-hosting/configuration).
+
+## Related
+
+<Columns cols={2}>
+  <Card title="Transfer protocol" icon="arrow-right-left" href="/reference/transfer-protocol">
+    What happens after the two peers connect, on the data channel itself.
+  </Card>
+  <Card title="Architecture" icon="layers" href="/reference/architecture">
+    The components, the two signaling transports, and how a session fits together.
+  </Card>
+</Columns>

--- a/docs/reference/transfer-protocol.mdx
+++ b/docs/reference/transfer-protocol.mdx
@@ -1,0 +1,268 @@
+---
+title: "Floe data-channel transfer protocol"
+sidebarTitle: "Transfer protocol"
+description: "The wire format Floe peers speak over the WebRTC data channel: message types, framing, protocol versioning, chunk sizing, backpressure, and every timeout."
+keywords: ["wire protocol", "data channel", "webrtc", "protocol version", "backpressure"]
+---
+
+Once the WebRTC data channel opens, the signaling server is out of the picture and the two peers
+speak this protocol directly. The browser, the CLI, and Floe Desktop all implement it and are
+interoperable in every direction. The CLI and the desktop app share one implementation in
+`cli/engine/transfer`; the browser has its own in `client/lib/transfer`.
+
+## The sequence
+
+The sender runs this for each file, in order.
+
+```mermaid
+sequenceDiagram
+    participant S as Sender
+    participant R as Receiver
+    S->>R: metadata
+    R->>S: ack
+    S->>R: binary chunks
+    S->>R: end
+    Note over S,R: repeats per file, in order
+    R->>S: received
+```
+
+The final `received` comes once, after every file, and only from a Go receiver. Everything else
+repeats per file.
+
+## How a frame is classified
+
+There is no length prefix and no envelope. A receiver decides whether an arriving frame is a
+control message or file data by probing it, and the rule is deliberately conservative because
+getting it wrong means either dropping a chunk or writing JSON into a file.
+
+A frame is treated as a control message only when all of these hold:
+
+1. It is at most **1000 bytes**.
+2. Its first non-whitespace byte is `{`.
+3. It parses as JSON with a `type` field naming a message below.
+
+Anything else is file data and gets written, **including a small binary chunk that happens to
+look like a JSON object.** That case is real and the implementations handle it.
+
+Two divergences are worth knowing if you are writing another client:
+
+- The Go receiver applies the 1000-byte cap to **binary** frames only, so an oversized string
+  frame is still parsed. The browser applies it to every frame. A metadata frame larger than
+  1000 bytes, which a deep folder path can produce, is therefore handled by a Go receiver and
+  misread as file data by a browser receiver.
+- **Framing differs by sender.** Go sends `metadata` and `end` as strings but `ack`, `received`,
+  and `incompatible` as binary. The browser sends `metadata`, `ack`, and `end` as strings and
+  `incompatible` as binary. Both work because every receiver decodes bytes and strings alike.
+
+## Message types
+
+### metadata
+
+Sender to receiver, before each file.
+
+```json metadata
+{
+  "type": "metadata",
+  "id": "3f2b9c1e-7a4d-4c2e-9b1f-8e6d5c4b3a21",
+  "fileName": "photo.jpg",
+  "fileSize": 6291456,
+  "index": 1,
+  "total": 3,
+  "totalBytes": 11800000,
+  "pv": 1,
+  "pvMin": 1,
+  "ver": "1.10.4"
+}
+```
+
+<ResponseField name="id" type="string" required>
+  A per-file identifier. The ack echoes it.
+</ResponseField>
+<ResponseField name="fileName" type="string" required>
+  The name as the sender sees it, including any relative path when a folder is being sent. The
+  receiver sanitizes it before writing.
+</ResponseField>
+<ResponseField name="fileSize" type="integer" required>
+  The file's length in bytes. The receiver checks the bytes it wrote against this value.
+</ResponseField>
+<ResponseField name="index" type="integer" required>
+  Position in the batch, **1-based**.
+</ResponseField>
+<ResponseField name="total" type="integer" required>
+  How many files are in the batch.
+</ResponseField>
+<ResponseField name="totalBytes" type="integer" required>
+  The batch's total size. Older senders may send `0` for a single file, in which case a receiver
+  substitutes `fileSize`.
+</ResponseField>
+<ResponseField name="pv" type="integer">
+  Highest protocol version this peer speaks. Absent on releases before v1.6.0, which are treated
+  as version 1.
+</ResponseField>
+<ResponseField name="pvMin" type="integer">
+  Lowest protocol version this peer still supports.
+</ResponseField>
+<ResponseField name="ver" type="string">
+  The human release string, and its shape depends on the build. The CLI sends `1.10.4` with no
+  leading `v`, because GoReleaser strips it. The desktop app sends the tag verbatim, as
+  `desktop-v0.2.7`. A build from source sends `dev`. Browser peers omit the field entirely. It is
+  informational and never gates a transfer.
+</ResponseField>
+
+### ack
+
+Receiver to sender, once per file, before any bytes move.
+
+```json ack
+{ "type": "ack", "id": "3f2b9c1e-...", "offset": 0, "pv": 1, "pvMin": 1, "ver": "1.10.4" }
+```
+
+<ResponseField name="offset" type="integer" required>
+  Where the sender should start reading. Reserved for mid-file resume: both senders honor a
+  non-zero value and seek to it, but **no receiver in any current client emits one**, and no
+  resume state is kept on disk or across connections. In practice it is always `0`.
+</ResponseField>
+
+### Binary chunks
+
+Raw bytes, sent until the file is exhausted. Chunk size is a local sender choice and not part of
+the protocol; every receiver handles any size.
+
+Both implementations size chunks to the connection's negotiated maximum message size, capped at
+256 KB. When that size is unavailable they fall back to different defaults: **16 KB** in the Go
+engine, **64 KB** in the browser.
+
+The browser reads the source file in 4 MB slabs and sub-slices those into chunks. The Go sender
+reads straight into a chunk-sized buffer.
+
+### end
+
+Sender to receiver, after the last chunk of a file.
+
+```json end
+{ "type": "end" }
+```
+
+### received
+
+Receiver to sender, once, after every file in the batch is written.
+
+```json received
+{ "type": "received" }
+```
+
+Only Go receivers send it, and only Go senders act on it: it lets them exit immediately instead
+of polling the SCTP buffer. The browser sender ignores it even when a Go receiver sends it, and
+always waits for its own send buffer to drain to zero instead.
+
+### incompatible
+
+Sent by the receiver **in place of the ack** when the two protocol version ranges do not overlap.
+The receiver aborts before creating any file, so the sender fails fast rather than waiting for an
+ack that never comes. Senders that predate this message type ignore it safely.
+
+```json incompatible
+{
+  "type": "incompatible",
+  "reason": "Cannot transfer: your floe is too old for this peer. ...",
+  "pv": 1,
+  "pvMin": 1,
+  "ver": "desktop-v0.2.7"
+}
+```
+
+## Protocol versioning
+
+The wire protocol carries a version of its own, independent of Floe's release numbers. That is
+what lets peers on different releases interoperate while still catching a genuine breaking
+change cleanly.
+
+- Each peer advertises `pv`, the highest version it speaks, and `pvMin`, the lowest it still
+  supports. **Both are 1 today.**
+- Two peers are compatible when their ranges overlap:
+  `max(localMin, remoteMin) <= min(localMax, remoteMax)`. They operate at the highest common
+  version.
+- A peer that omits the fields is treated as version 1, so every release ever shipped stays
+  compatible.
+- When the ranges miss, the receiver sends `incompatible` and each side prints a remedy for its
+  own surface: `floe update` on the CLI, the Microsoft Store or the download page on the desktop,
+  a page refresh in the browser.
+
+Which side is named depends on who is reading. Go peers do not trust the wire `reason`: they
+rebuild the message locally from the frame's `pv` and `pvMin`, so the side they name is always
+correct. A Go receiver also words the `reason` it puts on the wire from the recipient's point of
+view, for peers that display it verbatim. A browser receiver does not do that second step, so it
+sends the same sentence it shows itself. When a message names a remedy that makes no sense for
+your surface, compare the two version strings it prints and update the older one.
+
+Constants live in `cli/engine/transfer/protocol.go` as `ProtocolVersion` and `MinProtocolVersion`,
+and in `client/lib/transfer/protocol.ts` as `PROTOCOL_VERSION` and `MIN_PROTOCOL_VERSION`. Bump
+`ProtocolVersion` only on a breaking wire change, and raise `MinProtocolVersion` only when
+deliberately dropping support for an old format. Keep the two implementations in step.
+
+## Flow control
+
+The sender pauses when the SCTP send buffer reaches **8 MB** and resumes once it drains below
+**4 MB**. Both implementations use the same two numbers.
+
+If the buffer has not shrunk at all after 60 seconds, the Go sender gives up on the transfer.
+A wait that is merely slow does not trigger it; only a buffer that never moves does.
+
+The browser adds two drains the Go engine does not have: it waits for the buffer to fall below
+64 KB before sending each file's metadata, and it drains to zero before declaring the batch
+complete.
+
+## Integrity
+
+A file is committed only when the bytes written match `fileSize` exactly. A mismatch in either
+direction discards the file, because a short count means truncation and an over-count means a
+frame boundary was wrong, which corrupts the result just as thoroughly.
+
+**Floe computes no hash of file contents at any point.** The check is a byte count. The transport
+already authenticates every packet, so corruption in flight is not the gap being covered here;
+truncation is.
+
+Receivers that write to disk stage each file under a name ending in `.part` and rename it only
+after that check passes, so a killed transfer never leaves a file sitting under its final name.
+See [What Floe does not protect against](/how-it-works/known-limitations).
+
+## Timeouts
+
+Every value the Go engine enforces. The browser shares only the 120 second ack deadline.
+
+| Phase | Limit | What happens |
+|---|---|---|
+| Waiting for the peer's offer or answer | 30 s | Connection attempt fails |
+| ICE, DTLS, and the data channel opening | 30 s | `timed out establishing a connection` |
+| Data channel grace after the peers connect | 10 s | Connection attempt fails |
+| Sender waiting for a file's ack | 120 s | Transfer fails. Sized for a human answering the CLI's `Accept? [Y/n]` prompt |
+| Sender's send buffer not draining at all | 60 s | Transfer fails |
+| Sender waiting for delivery confirmation | 30 s | `timed out waiting for delivery confirmation from peer` |
+| Receiver connected, no data yet | 30 s | `connected, but no data arrived from the sender within 30s` |
+| Receiver mid-transfer with no progress | 60 s | Transfer fails |
+| Receiver grace before teardown | 5 s | Lets the final acknowledgement reach the sender |
+| The byte-count report | 5 s | Abandoned; never affects the files |
+
+A browser sender waits about 2 seconds after the peers connect before it checks the route and
+sends the first byte. A `floe receive` can linger for up to about 10 seconds after printing its
+summary, which is the teardown grace plus the report.
+
+## One SDP detail worth knowing
+
+Pion, the WebRTC stack behind the CLI and the desktop app, omits `a=max-message-size` from the
+answer it generates. RFC 8841 makes the absent default 65536, and Chrome then rejects every chunk
+larger than that. The Go engine patches the attribute into the answer with a value of 1 GB before
+sending it, which is what makes browser-to-CLI transfers work at all.
+
+If you are building another client against Floe, this is the non-obvious part.
+
+## Related
+
+<Columns cols={2}>
+  <Card title="HTTP API" icon="webhook" href="/reference/http-api">
+    The signaling server's endpoints, up to the point where this protocol takes over.
+  </Card>
+  <Card title="Architecture" icon="layers" href="/reference/architecture">
+    Components, transports, and the shape of a whole session.
+  </Card>
+</Columns>

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -40,7 +40,7 @@ which performs no origin check, so they reach your server regardless of that set
 
 ## Contents
 
-<CardGroup cols={2}>
+<Columns cols={2}>
   <Card title="Quick Start" href="/self-hosting/quickstart">
     Get the stack running with Docker Compose in minutes.
   </Card>
@@ -71,4 +71,4 @@ which performs no origin check, so they reach your server regardless of that set
   <Card title="Without Docker" href="/self-hosting/without-docker">
     Run the client and signaling server straight from Node.
   </Card>
-</CardGroup>
+</Columns>


### PR DESCRIPTION
## Summary

Second of five PRs in the documentation overhaul. PR 1 (#325) made the docs true; this one changes how they are organized and adds the four pages the old shape had nowhere to put.

**Every one of the 37 existing URLs still resolves.** Nothing was renamed or moved. Verified by fetching all 41 pages against a local `mint dev`.

### Navigation

- Groups are reordered and carry icons, so the sidebar can be scanned rather than read.
- A new **Core concepts** group collects the pages that describe the transfer itself. That group is where the shared facts will live once PR 3 stops the three sending pages and three receiving pages each restating the 2 GB cap, the one-receiver rule, and the stats opt-out.
- **Self-hosting was eleven flat entries.** It is now four nested groups (Get started / Configure / Deploy / Operate) with only the first expanded, so a browser user scrolling past self-hosting sees four lines instead of eleven.
- A shortcut row sits above the groups: Quickstart, File size limits, Troubleshooting, Self-host with Docker.

### One change from the approved plan, and why

The shortcut row was approved as an ordinary `Popular` **group** listing the same pages a second time. Mintlify accepts that and it renders correctly, but a duplicated page joins the prev/next chain at its **first** occurrence. Measured on a local build: from `/quickstart` the footer's next link went to `/how-it-works/2gb-limit`, skipping the rest of Getting started, and two sidebar entries highlighted at once.

Link objects inside `pages` are rejected outright by the schema (`Invalid type. Field did not match any types in union`).

`navigation.global.anchors` does the same job with no page duplication. It renders as a compact icon list above the groups, and prev/next is correct again: from `/quickstart`, previous is Introduction and next is Which Floe to use. That is what shipped.

### New pages

| Page | Why |
|---|---|
| **Which Floe to use** | A comparison across browser, desktop, and CLI covering folders, where files land, short codes, IP hiding, history, and platforms. The question every first visit actually has, and nothing answered it. |
| **What Floe does not protect against** | The honest list, for a product whose pitch is privacy. Seven items, all verified against the code. |
| **HTTP API** | The seven endpoints, lifted out of the 256-line architecture page into a real reference with request and response fields, status codes, both ICE response shapes, and the CORS and body-limit behavior. |
| **Transfer protocol** | The data-channel wire format, also lifted out: message types, frame classification, framing, versioning, chunk sizing, flow control, integrity, and every timeout. |

The limitations page covers: the signaling server is trusted to relay certificate fingerprints faithfully; no client displays a verification code today; the other peer learns your IP on a direct connection; the relay sees both addresses and traffic timing; a browser receiver holds each file in memory; Floe computes no content hash; the public counter is not audited; and a self-hosted server is single-process, so two replicas silently break pairing.

No API playground on the HTTP reference. These endpoints are a self-hosting surface rather than a public API, and a playground would invite live requests against `api.floe.one` and mint real room codes.

### Introduction

The H1 was `Your files never make a stop.` That is the strongest SEO slot on the site and it matches no query anyone types. It is now **Floe documentation**, and the slogan opens the body where it still lands. The page now routes rather than explains: a "Start here" row splitting the three reasons someone arrives, a row per surface, the three things worth knowing, then everything else.

### Also

- `CardGroup` is undocumented and gone from Mintlify's own component list. `self-hosting/overview` moves to `Columns`.
- The 2 GB page is retitled **File size limits and the 2 GB relay cap** with `sidebarTitle: "File size limits"`. The old title named an internal rule; the query is "floe file size limit". The URL is unchanged, and the inbound link text on other pages is updated in PR 3 when those pages are rewritten.

## Test plan

Run against a local `mint dev` on the built site, not just the source.

- `mint validate` passes.
- `mint broken-links --check-anchors --check-redirects --check-snippets` reports none.
- `mint a11y` reports no MDX issues across 41 files; all images have alt attributes.
- All 41 pages referenced by `docs.json` fetched and confirmed HTTP 200.
- Rendering checked by hand in both light and dark: the anchor row, the nested self-hosting groups, the new Mermaid sequence diagram (renders as a themed SVG), the `CodeGroup` tabs and `ResponseField` pills on the HTTP API page, and the card rows on the introduction.
- prev/next footer chain verified correct after the anchors change.
- No em dashes, no en dashes, no British spellings from the Vale list, no `CardGroup` left anywhere.
- Docs-only change, so the heavy CI jobs skip by design.
