### PR TITLE
docs: finish normalizing the TURN relay link casing

### DIFF
--- a/docs/self-hosting/reverse-proxy.mdx
+++ b/docs/self-hosting/reverse-proxy.mdx
@@ -194,7 +194,7 @@ signaling server" rather than passing.
 ## TURN does not go through the proxy
 
 If you run the optional coturn relay, its ports stay directly exposed. TURN is not
-HTTP, so a reverse proxy cannot carry it. See [TURN Relay](/self-hosting/turn-relay)
+HTTP, so a reverse proxy cannot carry it. See [TURN relay](/self-hosting/turn-relay)
 for the port list and firewall rules.
 
 ## Verify it works

--- a/docs/self-hosting/unraid.mdx
+++ b/docs/self-hosting/unraid.mdx
@@ -128,7 +128,7 @@ Trusted Proxy Count: 1
 The default STUN-only configuration works on many networks. To support peers
 behind strict NAT or CGNAT, expand the advanced Floe-Server settings and add a
 Cloudflare Realtime TURN key. You can also run coturn separately and fill in the
-self-hosted TURN domain and secret. See [TURN Relay](/self-hosting/turn-relay).
+self-hosted TURN domain and secret. See [TURN relay](/self-hosting/turn-relay).
 
 ## Container updates
 


### PR DESCRIPTION
## Summary

Finishes what #330 started. That automated pass lowercased the link label in
`docs/desktop/settings.mdx`, but its stated rationale (matching "every other prose usage")
was only half true: it scanned `docs/desktop/` alone, so it never saw the two remaining
Title Case links to the same page.

Lowercase is the right side of the split:

- `docs/self-hosting/turn-relay.mdx` sets `sidebarTitle: "TURN relay"`, and `docs.json`
  carries no label override, so that is what a reader actually sees in the nav.
- The term is lowercase in prose everywhere it appears (20 occurrences, no exceptions).
- The Title Case page `title` predates that `sidebarTitle` decision.

`unraid.mdx` had the same self-contradiction `settings.mdx` did: its own H2 five lines above
the link already reads `## TURN relay`.

Inline prose links to `/self-hosting/turn-relay` are now 6-0 lowercase.

## Changes

- `docs/self-hosting/reverse-proxy.mdx:197` - `[TURN Relay]` to `[TURN relay]`
- `docs/self-hosting/unraid.mdx:131` - `[TURN Relay]` to `[TURN relay]`

## Deliberately left alone

- The Card at `docs/self-hosting/overview.mdx:76`. Its grid is ten uniformly Title Case
  cards, so lowercasing one entry would make it the odd one out. That grid should change as
  a unit or not at all.
- The `title:` in `docs/self-hosting/turn-relay.mdx`, which follows the Title Case SEO-title
  convention shared with about a dozen other pages.
- `[your own coturn relay]` in `docs/how-it-works/known-limitations.mdx:64`, which is
  descriptive prose rather than a term reference.
- `docs/changelog.mdx`, whose shipped entries are historical.

## Test plan

- Docs-only change, so the `changes` job skips the heavy suite and `CI green` reports fast.
- Mintlify Deployment and the Vale spellcheck should pass (both are casing-blind here, so
  this only confirms nothing else broke).
- After merge, `grep -rn "self-hosting/turn-relay" docs/` should show six `[TURN relay]`
  inline links, with the only remaining Title Case references being the `overview.mdx` Card
  and the page `title`.
