### PR TITLE
fix(client): drop the tile from the favicon, and let the bolt follow the theme

### DIFF
--- a/.github/assets/floe-mark-dark.svg
+++ b/.github/assets/floe-mark-dark.svg
@@ -1,5 +1,5 @@
 <!-- The Floe mark for DARK backgrounds (GitHub's dark theme). White ink.
-     Paired with floe-mark-light.svg by the <picture> element in README.md.
+     Paired with floe-mark-light.svg by the picture element in README.md.
      See that file for why the ink is pinned rather than driven by a media
      query. -->
 <svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/.github/assets/floe-mark-dark.svg
+++ b/.github/assets/floe-mark-dark.svg
@@ -1,0 +1,8 @@
+<!-- The Floe mark for DARK backgrounds (GitHub's dark theme). White ink.
+     Paired with floe-mark-light.svg by the <picture> element in README.md.
+     See that file for why the ink is pinned rather than driven by a media
+     query. -->
+<svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z"
+          fill="#fff" stroke="#fff" stroke-width="1" stroke-linejoin="round"/>
+</svg>

--- a/.github/assets/floe-mark-light.svg
+++ b/.github/assets/floe-mark-light.svg
@@ -1,11 +1,11 @@
 <!-- The Floe mark for LIGHT backgrounds (GitHub's light theme). Dark ink.
-     Paired with floe-mark-dark.svg by the <picture> element in README.md.
+     Paired with floe-mark-dark.svg by the picture element in README.md.
 
      Same artwork as client/app/icon.svg, but with the ink pinned instead of
-     driven by a media query, because GitHub renders README images through
-     <img> and may sanitize <style> out of them. <picture> is GitHub's own
-     documented mechanism for theme-aware images, so it is used here rather
-     than relying on what survives sanitizing. -->
+     driven by a media query, because GitHub renders README images through an
+     img tag and may sanitize the style block out of them. The picture element
+     is GitHub's own documented mechanism for theme-aware images, so it is used
+     here rather than relying on what survives sanitizing. -->
 <svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z"
           fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>

--- a/.github/assets/floe-mark-light.svg
+++ b/.github/assets/floe-mark-light.svg
@@ -1,0 +1,12 @@
+<!-- The Floe mark for LIGHT backgrounds (GitHub's light theme). Dark ink.
+     Paired with floe-mark-dark.svg by the <picture> element in README.md.
+
+     Same artwork as client/app/icon.svg, but with the ink pinned instead of
+     driven by a media query, because GitHub renders README images through
+     <img> and may sanitize <style> out of them. <picture> is GitHub's own
+     documented mechanism for theme-aware images, so it is used here rather
+     than relying on what survives sanitizing. -->
+<svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z"
+          fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center">
-  <img src="client/app/icon.svg" alt="Floe" width="100" height="100" />
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset=".github/assets/floe-mark-dark.svg">
+    <img src=".github/assets/floe-mark-light.svg" alt="Floe" width="100" height="100" />
+  </picture>
 </p>
 
 <h1 align="center">Floe</h1>

--- a/client/app/icon.svg
+++ b/client/app/icon.svg
@@ -1,9 +1,14 @@
 <!-- The Floe mark: a bare lightning bolt, no tile.
 
-     Same path and construction as docs/favicon.svg, so the tab icon reads the
-     same on floe.one and on floe.one/docs. The round-joined stroke rides the
-     path as a shape modifier rather than an outline: it softens every corner
-     and fattens the mark in one move, which is what makes it legible at 16px.
+     Same path and stroke as docs/favicon.svg, so the two tab icons are the
+     same artwork in light mode. They diverge in dark mode, and not by choice:
+     Mintlify rasterizes its favicon at build time and serves PNGs, so a media
+     query in that file is flattened away. Fixing the docs side needs a
+     light/dark pair in docs.json, not a rule in the SVG.
+
+     The round-joined stroke rides the path as a shape modifier rather than an
+     outline: it softens every corner and fattens the mark in one move, which
+     is what makes it legible at 16px.
 
      Color is a presentation attribute and dark mode is a CSS rule, in that
      order on purpose. Presentation attributes sit at specificity 0, so the

--- a/client/app/icon.svg
+++ b/client/app/icon.svg
@@ -1,4 +1,26 @@
-<svg width="64" height="64" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="24" height="24" fill="#0a0a0a"/>
-  <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" fill="white" stroke="white" stroke-width="0.5" stroke-linejoin="round" transform="translate(12 12) scale(0.8) translate(-12 -12)"/>
+<!-- The Floe mark: a bare lightning bolt, no tile.
+
+     Same path and construction as docs/favicon.svg, so the tab icon reads the
+     same on floe.one and on floe.one/docs. The round-joined stroke rides the
+     path as a shape modifier rather than an outline: it softens every corner
+     and fattens the mark in one move, which is what makes it legible at 16px.
+
+     Colour is a presentation attribute and dark mode is a CSS rule, in that
+     order on purpose. Presentation attributes sit at specificity 0, so the
+     media query wins wherever it is honoured, and any consumer that drops
+     <style> still gets the dark-ink bolt rather than nothing. The query
+     follows the viewer's browser/OS theme, not the site's: a favicon lives in
+     the tab strip, not on the page.
+
+     The app-icon rasters beside this file keep their #0a0a0a tile on purpose.
+     App icons are always tiles, and theirs are proportioned to match the
+     desktop icon and the Store assets (see commit fc878c0). -->
+<svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        @media (prefers-color-scheme: dark) {
+            .bolt { fill: #fff; stroke: #fff; }
+        }
+    </style>
+    <path class="bolt" d="M13 2L3 14H12L11 22L21 10H12L13 2Z"
+          fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>
 </svg>

--- a/client/app/icon.svg
+++ b/client/app/icon.svg
@@ -7,14 +7,15 @@
 
      Color is a presentation attribute and dark mode is a CSS rule, in that
      order on purpose. Presentation attributes sit at specificity 0, so the
-     media query wins wherever it is honored, and any consumer that drops
-     <style> still gets the dark-ink bolt rather than nothing. The query
+     media query wins wherever it is honored, and any consumer that drops the
+     style block still gets the dark-ink bolt rather than nothing. The query
      follows the viewer's browser/OS theme, not the site's: a favicon lives in
      the tab strip, not on the page.
 
-     The app-icon rasters beside this file keep their #0a0a0a tile on purpose.
-     App icons are always tiles, and theirs are proportioned to match the
-     desktop icon and the Store assets (see commit fc878c0). -->
+     The app-icon rasters keep their #0a0a0a tile on purpose: apple-icon.png
+     and favicon.ico here, icon-192/512 and icon-maskable-512 in public/. An
+     app icon is a tile on every platform, and these are proportioned to match
+     the desktop icon and the Store assets (see commit fc878c0). -->
 <svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <style>
         @media (prefers-color-scheme: dark) {

--- a/client/app/icon.svg
+++ b/client/app/icon.svg
@@ -5,9 +5,9 @@
      path as a shape modifier rather than an outline: it softens every corner
      and fattens the mark in one move, which is what makes it legible at 16px.
 
-     Colour is a presentation attribute and dark mode is a CSS rule, in that
+     Color is a presentation attribute and dark mode is a CSS rule, in that
      order on purpose. Presentation attributes sit at specificity 0, so the
-     media query wins wherever it is honoured, and any consumer that drops
+     media query wins wherever it is honored, and any consumer that drops
      <style> still gets the dark-ink bolt rather than nothing. The query
      follows the viewer's browser/OS theme, not the site's: a favicon lives in
      the tab strip, not on the page.

--- a/desktop/build/appicon.svg
+++ b/desktop/build/appicon.svg
@@ -52,10 +52,14 @@
     />
   </g>
 
-  <!-- bolt mark. The round-joined stroke is what softens every corner, and it
-       is the same construction floe.one uses in client/app/icon.svg, so the
-       desktop icon and the website mark stay identical in proportion:
-       18 path units wide + 0.5 stroke, scaled 31.5, is 61.7% of the squircle. -->
+  <!-- bolt mark. The round-joined stroke is what softens every corner, the same
+       construction every Floe surface uses. Proportion inside the tile: 18 path
+       units wide + 0.5 stroke, scaled 31.5, is 61.7% of the squircle, matching
+       the web app-icon rasters (icon-192/512, apple-icon).
+
+       The web favicon is the one surface this does not track. client/app/icon.svg
+       is a bare, full-bleed mark at stroke 1, with no tile to be proportioned
+       against, so it is deliberately weighted differently. -->
   <path
     d="M13 2L3 14H12L11 22L21 10H12L13 2Z"
     transform="translate(134,134) scale(31.5)"

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,3 +1,17 @@
-<svg width="64" height="64" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>
+<!-- The Floe mark, matching client/app/icon.svg exactly: same path, same
+     stroke, same dark-mode rule. Mintlify serves this as the docs tab icon.
+
+     The ink follows the viewer's browser theme, not the docs appearance
+     setting. A favicon is painted into the tab strip, so the strip's own
+     colour is the thing it has to survive; docs.json's dark default governs
+     the page, which is a different surface. Without the rule this bolt was
+     #09090b on a #202124 strip, a dark silhouette on dark. -->
+<svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        @media (prefers-color-scheme: dark) {
+            .bolt { fill: #fff; stroke: #fff; }
+        }
+    </style>
+    <path class="bolt" d="M13 2L3 14H12L11 22L21 10H12L13 2Z"
+          fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>
 </svg>

--- a/docs/favicon.svg
+++ b/docs/favicon.svg
@@ -1,17 +1,3 @@
-<!-- The Floe mark, matching client/app/icon.svg exactly: same path, same
-     stroke, same dark-mode rule. Mintlify serves this as the docs tab icon.
-
-     The ink follows the viewer's browser theme, not the docs appearance
-     setting. A favicon is painted into the tab strip, so the strip's own
-     colour is the thing it has to survive; docs.json's dark default governs
-     the page, which is a different surface. Without the rule this bolt was
-     #09090b on a #202124 strip, a dark silhouette on dark. -->
-<svg width="64" height="64" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-    <style>
-        @media (prefers-color-scheme: dark) {
-            .bolt { fill: #fff; stroke: #fff; }
-        }
-    </style>
-    <path class="bolt" d="M13 2L3 14H12L11 22L21 10H12L13 2Z"
-          fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>
+<svg width="64" height="64" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M13 2L3 14H12L11 22L21 10H12L13 2Z" fill="#09090b" stroke="#09090b" stroke-width="1" stroke-linejoin="round"/>
 </svg>

--- a/docs/logo/dark.svg
+++ b/docs/logo/dark.svg
@@ -5,9 +5,13 @@
      artwork and vice versa. The bolt and the word "Floe" invert between the two
      files; "Docs" and the separator stay grey in both.
 
-     THE BOLT IS UNCHANGED. It is the exact path and stroke from
-     client/app/icon.svg, so this logo stays identical to the favicon, the PWA
-     icons and the desktop app icon. Only the lockup around it was rebuilt.
+     THE BOLT IS UNCHANGED. It is the exact path every Floe surface draws, at
+     the 0.5 stroke it shares with the PWA icons and the desktop app icon. Only
+     the lockup around it was rebuilt.
+
+     The two favicons draw that same path at stroke 1 instead: favicon.svg here
+     and client/app/icon.svg are bare, full-bleed marks with no tile, and they
+     need the extra weight to read at 16px. Same shape, weighted per surface.
 
      Metrics come from vercel.com/docs, measured off its rendered DOM rather
      than eyeballed: an 8px gap between every part (their `gap-2`), an 18px

--- a/docs/logo/light.svg
+++ b/docs/logo/light.svg
@@ -5,9 +5,13 @@
      artwork and vice versa. The bolt and the word "Floe" invert between the two
      files; "Docs" and the separator stay grey in both.
 
-     THE BOLT IS UNCHANGED. It is the exact path and stroke from
-     client/app/icon.svg, so this logo stays identical to the favicon, the PWA
-     icons and the desktop app icon. Only the lockup around it was rebuilt.
+     THE BOLT IS UNCHANGED. It is the exact path every Floe surface draws, at
+     the 0.5 stroke it shares with the PWA icons and the desktop app icon. Only
+     the lockup around it was rebuilt.
+
+     The two favicons draw that same path at stroke 1 instead: favicon.svg here
+     and client/app/icon.svg are bare, full-bleed marks with no tile, and they
+     need the extra weight to read at 16px. Same shape, weighted per surface.
 
      Metrics come from vercel.com/docs, measured off its rendered DOM rather
      than eyeballed: an 8px gap between every part (their `gap-2`), an 18px


### PR DESCRIPTION
## Summary

The browser tab showed the Floe bolt knocked out of a hard-edged `#0a0a0a` square, while the docs tab showed the bolt on its own. Same product, two marks. This makes the website's tab icon the docs one, and makes both of them legible on a dark tab strip.

Nothing was redrawn. The path `M13 2L3 14H12L11 22L21 10H12L13 2Z` was already byte-identical across the web favicon, the docs favicon, the docs lockups and the desktop icon; only the treatment differed. Removing the `<rect>` and the `scale(0.8)` inset and widening the round-joined stroke from `0.5` to `1` makes `client/app/icon.svg` render **pixel-identical to `docs/favicon.svg`** (0 of 65536 samples differ at 128px).

Losing the tile costs the contrast the tile was providing, so the ink now follows `prefers-color-scheme`.

It is also more legible. The bare bolt uses the whole canvas instead of insetting to 80% inside a tile: `18 + 0.5` stroke at `scale(0.8)` is 61.7% of the viewBox, `18 + 1` full-bleed is 79.2%, so at 16px the mark goes from **9.9px to 12.7px** across, a 28% gain.

## The dark-mode mechanism is verified on the real code path

Worth being explicit, because the obvious way to test this is wrong. A linked favicon is not rendered by the document pipeline; it is fetched as an icon resource, rasterized into the browser's icon store, and painted by the tab strip. Rendering the SVG in a page or as a standalone document proves nothing about that path, and if the query were ignored there the icon would fall back to `#09090b` on a `#202124` strip: about 1.3:1 contrast, an invisible favicon for every dark-theme user. The current tiled icon cannot fail that way, so this had to be measured rather than assumed.

Measured by launching a real Chromium window, loading a page that links the actual file, capturing the window with `PrintWindow`, and reading the tab strip pixels:

| browser UI | tab strip | bolt |
|---|---|---|
| dark (`--force-dark-mode`) | `rgb(31,32,32)` | **white**, legible |
| light | `rgb(211,227,253)` | **near-black**, legible |

Chromium evaluates the query against the **browser UI theme**, not the page's reported scheme. The probe confirmed the page reported `light` while the UI was dark and the bolt still flipped white. That is the behaviour you want: the icon tracks the surface it is actually drawn on, which is the strip, not the page.

Not verified locally: Firefox and Safari (the Playwright cache here is Chromium-only). Safari's outcome is by design the existing `favicon.ico` tile.

## The docs favicon has the same bug, and is NOT fixed here

The same probe against `docs/favicon.svg` showed a dark silhouette on a dark strip: it is `#09090b` with no media query, and `docs.json` sets the docs to dark by default.

I tried the same two-line fix and backed it out, because it does nothing. Mintlify rasterizes the docs favicon at build time and serves PNGs. Checked against the live site, `floe.one/docs` emits six raster icon links and not one SVG link, and the two generated sets are byte-identical:

```
_generated/favicon/favicon-32x32.png       media="(prefers-color-scheme: light)"   437 B  md5 551bdb43...
_generated/favicon-dark/favicon-32x32.png  media="(prefers-color-scheme: dark)"    437 B  md5 551bdb43...
```

The machinery is already there; both sets are just fed the same file, because `docs.json` passes `favicon` as a bare string. The real fix is the `{light, dark}` object the schema allows plus a white-ink source file, and it belongs in its own PR: the schema's wording ("the file for the light version of the favicon used in dark mode") inverts against Mintlify's own generated folder names, and which key feeds which set can only be settled by deploying it. Guessing wrong reproduces the bug inverted.

So `docs/favicon.svg` is byte-identical to `main` in this PR, and the docs keep the bug for now. Recorded, scoped out, worth a follow-up.

## Scope

Deliberately stops at the tab.

- **`favicon.ico` keeps its tile.** It is only reached by clients that ignore the SVG, and a tile cannot be invisible on any strip colour. Its build hash is unchanged in this PR, which confirms it was not touched. (Google does accept SVG favicons and picks by its own heuristics, so this is a safety net rather than a guarantee about the SERP; worth a look in Search Console after deploy.)
- **The app-icon rasters keep theirs.** An app icon is a tile on every platform, and these are proportioned to match the desktop icon and the 62 MSIX Store assets. Nothing under `client/public/` changed, so the Unraid templates that hotlink `icon-512.png` and the `/og.png?v=3` social card are untouched.
- **No in-page mark.** The navbar and footer stay text-only; the brand pill already carries a live status dot.

This does not contradict the existing doctrine, which fc878c0 stated outright: *"The website mark is flat black because it is a favicon; an app icon keeps the depth."* Web and desktop were never meant to share a treatment, only the bolt's path and its proportion **within a tile**. A bare bolt has no tile, so that constraint does not apply to it. It still applies to the rasters, which is another reason to leave them alone.

Two comments that asserted parity with the favicon's stroke are corrected in the same PR, since both went false the moment it widened: `docs/logo/{dark,light}.svg` and `desktop/build/appicon.svg`. Comment text only, all three re-rendered and pixel-diffed against HEAD (0 of 60480, 0 of 60480, 0 of 262144 samples differ). A comment that is false the moment it lands is worse than the one it replaced: read literally, the old wording invites someone to "fix" the lockup to match the favicon and break the docs header.

## README

`README.md` rendered `client/app/icon.svg` directly, and GitHub has both a light and a dark theme, so it moves to GitHub's `<picture>` pattern over a pinned light/dark pair in `.github/assets/`.

Relying on the adaptive SVG there would have been a bet on GitHub's sanitizer. Measured both ways in Chromium, rendering through `<img>` as a README hero does:

| | light | dark |
|---|---|---|
| adaptive SVG | `rgb(9,9,11)` | `rgb(255,255,255)` |
| same SVG, style block stripped | `rgb(9,9,11)` | `rgb(9,9,11)` - near-black on a dark page |

So the failure mode is an invisible hero, not a wrong shade. `<picture>` is GitHub's documented mechanism and sidesteps the question.

The pair cannot live in `client/app/`: Next's icon convention matches `icon\d?(-\w{6})?\.svg` (`is-metadata-route.js`), and `icon-light.svg` escapes it only because `-light` is five characters, not six. A six-letter suffix would quietly become a second emitted favicon route.

## No cache work needed

App-dir icon routes are content-hashed and serve `cache-control: public, max-age=0, must-revalidate`, and the hash rotated with this edit (`icon.271lb9u_oyw06.svg` to `icon.04cn-uu6mrwsy.svg`). `client/public/sw.js` runtime-caches only `/_next/static/`, so icons already bypass the worker; no `CACHE_NAME` bump.

One honest caveat: browsers cache the *rasterized* favicon keyed by URL, so an existing visitor who later switches OS theme may keep the old ink until the icon URL changes or they clear site data. The query is evaluated at rasterization, not continuously.

## Test plan

- `pnpm lint` - clean (2 pre-existing `window.location.href` warnings, untouched here)
- `pnpm test` - 227 passed / 19 files, including the `serviceWorker.test.ts` fixture on `icon.svg`
- `pnpm build` - `icon.svg` hash rotated, `favicon.ico` and `apple-icon.png` hashes unchanged, route still `image/svg+xml` with the style block served verbatim
- Served over HTTP from the production build and rendered in Chromium: `light -> rgb(9,9,11)`, `dark -> rgb(255,255,255)`
- **Real Chromium tab strip captured via PrintWindow in both browser themes** (table above)
- Pixel-diffed `icon.svg` against `docs/favicon.svg`: 0 of 65536 samples differ
- Confirmed the two README assets share an identical silhouette (3815 opaque px each) with opposite ink

Worth a look after merge: the README hero under both GitHub theme settings, and the tab icon in Firefox and Safari.
