### PR TITLE
docs: take the last accent out of the Related topics hover

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -599,3 +599,56 @@ html:not(.dark) #content-area a.link {
 .dark #sidebar a:hover span {
   color: rgb(255 255 255);
 }
+
+/* Related topics, monochrome on hover as well (user call, 2026-08-26).
+
+   Mintlify's related-pages add-on renders up to five page links below the
+   article, painted `text-gray-950 dark:text-gray-50 hover:text-primary
+   dark:hover:text-primary-light`. With the ice colors config that hover is
+   rgb(0,163,201) on the light page and rgb(177,221,235) on the dark one: the
+   last accent left on a resting docs page, after the sidebar, TOC, tabs,
+   chips and assistant were each taken neutral before it.
+
+   Neutralising the hover alone would have taken the affordance with the
+   colour. Unlike every other hover in this file, the rest state here is
+   already the full foreground (rgb(10,15,16) light, rgb(242,247,249) dark,
+   measured on floe.one/docs 2026-08-26), so a hover landing on rgb(17,17,17)
+   or white is a step of a few units that nobody sees. The rows are quieted to
+   72 percent instead and hover to the full foreground, which is the grammar
+   the footer links (0.62 to 0.85) and the sidebar (gray to white) already use
+   above. That composites to rgb(84,84,84) at rest in light and
+   rgb(187,187,188) in dark, 7.6:1 and 10.1:1, both past AA for a 14px label,
+   and the hover is a 67-unit step in either mode.
+
+   The label span carries no colour class of its own, so it inherits. The file
+   glyph does not: it is a real stroked svg with its own text-gray-500, and it
+   keeps that gray through the hover exactly as Mintlify draws it. That gray
+   leans 7 units blue, as does the block's heading, because Mintlify derives
+   its gray ramp from the primary hue (the same tint the changelog chips
+   further up were de-tinted for), but at that magnitude it is below the
+   visible threshold and not worth a rule. The focus ring stays ice on
+   purpose, like every other focus ring on the site.
+
+   The hook is the wrapper's utility string, because Mintlify ships this block
+   with no id, no data-component-part and no semantic class. Verified on
+   floe.one/docs 2026-08-26, both themes, post-hydration: the selector matches
+   exactly one element per page and it is the only .my-8 in the content area.
+   If the ice ever comes back, that string moved; re-read the rendered DOM. No
+   !important is needed, for the usual reason: both hover utilities live in
+   @layer utilities and carry none of their own, and this sheet is
+   unlayered. */
+#content-area > div.my-8.flex.flex-col a {
+  color: rgb(17 17 17 / 0.72);
+}
+
+#content-area > div.my-8.flex.flex-col a:hover {
+  color: rgb(17 17 17);
+}
+
+.dark #content-area > div.my-8.flex.flex-col a {
+  color: rgb(255 255 255 / 0.72);
+}
+
+.dark #content-area > div.my-8.flex.flex-col a:hover {
+  color: rgb(255 255 255);
+}


### PR DESCRIPTION
## Summary

Mintlify's related-pages add-on renders a **Related topics** block below each article and paints its rows `hover:text-primary dark:hover:text-primary-light`. With the ice `colors` config that hover resolves to `rgb(0,163,201)` on the light page and `rgb(177,221,235)` on the dark one, the last accent left on a resting docs page after the sidebar, TOC, tabs, chips and assistant were each taken neutral (#270, #278, #286, #287, #292, #334).

| | rest | hover |
|---|---|---|
| dark, before | `rgb(242,247,249)` | `rgb(177,221,235)` ice |
| dark, after | `rgb(187,187,188)` | `rgb(255,255,255)` |
| light, before | `rgb(10,15,16)` | `rgb(0,163,201)` ice |
| light, after | `rgb(84,84,84)` | `rgb(17,17,17)` |

**Why the rest state moved.** Neutralising only the hover would have removed the affordance along with the colour. Unlike every other hover in this stylesheet, the rest state here is already the full foreground, so a hover landing on near-black or white is a step of a few units nobody sees. The rows are quieted to 72 percent instead and hover to the full foreground, which is the grammar the footer links (0.62 to 0.85) and the sidebar (gray to white) already use in the same file. Contrast at rest is 7.6:1 in light and 10.1:1 in dark, both past AA for a 14px label, and the hover is a 67-unit step per channel in either mode.

**What deliberately did not change.** The file glyph is a real stroked svg carrying its own `text-gray-500`, so it does not inherit the row colour and keeps its gray through the hover exactly as Mintlify draws it. The focus ring stays ice, like every other focus ring on the site, per the doctrine already written into the assistant rules.

The hook is the wrapper's utility string, because Mintlify ships this block with no id, no `data-component-part` and no semantic class. No `!important` is needed: both hover utilities live in `@layer utilities` and carry none of their own, and this sheet is unlayered.

## Test plan

Verified against the live floe.one/docs by injecting the exact rules into the page (headless Chromium, `localStorage.isDarkMode` seeded and the rendered theme asserted), on `/docs/cli/send`, `/docs/introduction` and `/docs/quickstart`, in both themes:

- 26 rows measured, and no colour at rest or on hover is within 40 per channel of `[0,163,201]`, the same accent test `client/e2e/docs-visual-qa.mjs` uses
- rest is exactly `rgba(255,255,255,0.72)` / `rgba(17,17,17,0.72)`, hover exactly `rgb(255,255,255)` / `rgb(17,17,17)`
- the label span inherits the row colour on every row
- `#content-area > div.my-8.flex.flex-col` matches exactly one element per page, and is the only `.my-8` in the content area
- the whole stylesheet still parses: 53 rules, all four new ones present

Docs-only diff, so the heavy CI jobs skip.
