### PR TITLE
docs: stop the tab titles saying Floe twice, settle on sentence case

### DIFF
--- a/docs/choosing-floe.mdx
+++ b/docs/choosing-floe.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Which Floe should I use?"
+title: "Which app should I use?"
 sidebarTitle: "Which Floe to use"
 description: "Compare the Floe web app, Floe Desktop for Windows, and the floe CLI: what each one can send, where files land, and which features only one of them has."
 keywords: ["web vs desktop", "web vs cli", "compare", "which version", "difference"]

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe CLI Flags Reference"
+title: "CLI flags reference"
 sidebarTitle: "Flags"
 description: "Complete reference for every floe CLI flag: global server, relay and interface options, receive and update flags, and supported environment variables."
 keywords: ["flags", "options", "environment variables", "exit codes", "timeouts"]

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -16,7 +16,7 @@ Every command accepts these, but only `send` and `receive` act on them. `floe ve
 | `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: `https://api.floe.one` maps to `https://floe.one`, `http://localhost:3001` maps to `http://localhost:3000`, and any other server maps to itself, on the assumption that one origin serves both the API and the web app. Set `--web` only when your web app has its own hostname. |
 | `--iface <name>` | _(all interfaces)_ | Restrict WebRTC to network interfaces whose name contains this value (case-insensitive). Repeat the flag or separate names with commas, so `--iface Ethernet --iface Wi-Fi` and `--iface Ethernet,Wi-Fi` do the same thing. Use it when a VPN or virtual-machine adapter (Tailscale, VMware, WSL, Hyper-V) slows connection setup. See [Troubleshooting](/troubleshooting). |
 
-The desktop app has equivalents for two of these. `--server` and `--web` are **Server address** and **Share link address**, under Advanced in **Settings**. `--no-relay` has no desktop equivalent: the **Hide my IP address** toggle does the opposite, forcing every transfer through the relay rather than refusing it. See [Desktop Settings](/desktop/settings).
+The desktop app has equivalents for two of these. `--server` and `--web` are **Server address** and **Share link address**, under Advanced in **Settings**. `--no-relay` has no desktop equivalent: the **Hide my IP address** toggle does the opposite, forcing every transfer through the relay rather than refusing it. See [Desktop app settings](/desktop/settings).
 
 ## Help and version flags
 
@@ -154,4 +154,4 @@ Save received files to a specific folder and auto-accept:
 floe receive olive-tiger-castle -o ~/Downloads -y
 ```
 
-See [Against a Self-Hosted Server](/cli/self-hosted-server) for more server configuration examples.
+See [Use a self-hosted server](/cli/self-hosted-server) for more server configuration examples.

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Install the Floe CLI"
+title: "Install the CLI"
 sidebarTitle: "Installation"
 description: "Install the floe CLI in one command on macOS, Windows, or Linux to send and receive files peer-to-peer from the terminal without an account."
 keywords: ["install floe", "brew", "winget", "scoop", "go install", "download cli"]

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -88,7 +88,7 @@ Pass `-y` to skip this prompt and accept automatically.
 | `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
 | `--no-report` | | `false` | Do not report the transferred byte count to Floe's public global counter. Set `FLOE_NO_STATS=1` to opt out permanently. |
 
-See [Flags Reference](/cli/flags) for the global flags that matter here (`--server`, `--no-relay`, `--iface`) and full opt-out documentation.
+See [CLI flags reference](/cli/flags) for the global flags that matter here (`--server`, `--no-relay`, `--iface`) and full opt-out documentation.
 
 ## Notes
 

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -31,7 +31,7 @@ floe send photo.jpg
 
 A flag always beats the variable, so you can still override it for a single
 command. Use `FLOE_WEB` the same way when your web app has its own hostname. See
-[Flags Reference](/cli/flags#environment-variables).
+[CLI flags reference](/cli/flags#environment-variables).
 
 ## When the web client is on a different host
 
@@ -68,7 +68,7 @@ the app can reach it. Leave **Share link address** blank on a one-domain deploym
 the app derives the share link from the server address using the same rule the CLI
 uses. Fill it in only when your web app has its own hostname. **Use default server**
 appears once a custom address is set and clears both fields back to `api.floe.one`.
-See [Desktop Settings](/desktop/settings#advanced) for what Test checks and what each
+See [Desktop app settings](/desktop/settings#advanced) for what Test checks and what each
 result means.
 
 See [Self-Hosting](/self-hosting/overview) for instructions on running your own Floe instance.

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Use the Floe CLI with a Self-Hosted Server"
+title: "Use a self-hosted server"
 sidebarTitle: "Self-hosted server"
 description: "Point the floe CLI at your own self-hosted Floe signaling server instead of floe.one to send and receive files on your own infrastructure."
 keywords: ["--server", "FLOE_SERVER", "custom server", "self-hosted cli"]

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -91,7 +91,7 @@ and fails to read. Copy what you mean to send, or send the target path directly.
 
 ## Flags
 
-See [Flags Reference](/cli/flags) for `--server`, `--no-relay`, `--web`, and `--iface`.
+See [CLI flags reference](/cli/flags) for `--server`, `--no-relay`, `--web`, and `--iface`.
 
 ## Notes
 

--- a/docs/cli/update.mdx
+++ b/docs/cli/update.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Update the Floe CLI"
+title: "Update the CLI"
 sidebarTitle: "floe update"
 description: "Keep the floe CLI up to date on macOS, Windows, and Linux using the built-in self-update command or by reinstalling the latest release binary."
 keywords: ["floe update", "upgrade floe", "self update"]

--- a/docs/desktop/installation.mdx
+++ b/docs/desktop/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Install Floe Desktop"
+title: "Install the desktop app"
 sidebarTitle: "Installation"
 description: "Install Floe Desktop for Windows from the Microsoft Store or a GitHub release, what differs between the two channels, plus updating and uninstalling."
 keywords: ["install desktop", "microsoft store", "windows app", "smartscreen", "webview2"]

--- a/docs/desktop/keyboard-shortcuts.mdx
+++ b/docs/desktop/keyboard-shortcuts.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe Desktop Keyboard Shortcuts"
+title: "Keyboard shortcuts"
 sidebarTitle: "Keyboard shortcuts"
 description: "Every keyboard shortcut in Floe Desktop for Windows: adding files, sending, pasting from the clipboard, opening history, settings, and starting over."
 keywords: ["shortcuts", "hotkeys", "start over", "undo"]

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Receiving Files with Floe Desktop"
+title: "Receive files in the desktop app"
 sidebarTitle: "Receiving files"
 description: "Receive files in Floe Desktop by entering a room code or share link, choosing where they are saved, and opening them as soon as the transfer finishes."
 keywords: ["save folder", "where do my files go", "history", "mark of the web"]

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Sending Files with Floe Desktop"
+title: "Send files from the desktop app"
 sidebarTitle: "Sending files"
 description: "Send files, folders, or a typed note from Floe Desktop on Windows by dragging, pasting, or picking them, then sharing a room code, link, or QR code."
 keywords: ["send with floe", "send a folder", "paste a screenshot", "room code"]

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -72,7 +72,7 @@ and no request is made at all.
 
 The same opt-out exists on every surface: a checkbox on the receiver view in the browser, and
 `--no-report` or `FLOE_NO_STATS=1` for the CLI. See
-[Security and Privacy](/security-privacy#aggregate-statistics).
+[Security and privacy](/security-privacy#aggregate-statistics).
 
 The report follows whichever server the app is set to, so pointing Floe at your own instance
 sends your byte counts to that server's counter rather than to floe.one.
@@ -180,7 +180,7 @@ row below reaches the screen as
 | The server is running, but its API answered with HTTP ... If it is behind a reverse proxy, check that /api/ is being forwarded. | Stage three failed. |
 | The server is running, but it did not return usable connection details. | Stage three answered, but with no ICE servers in the list. |
 
-See [Run Floe Behind One Domain](/self-hosting/reverse-proxy) for a proxy configuration that
+See [Run behind one domain](/self-hosting/reverse-proxy) for a proxy configuration that
 forwards all three.
 
 ### Share link address
@@ -193,7 +193,7 @@ API is on `api.example.com` and the web app on `app.example.com`, needs it. With
 share link would point at the API, which serves no web app, and the link would be dead.
 
 This mirrors the CLI's `--web` flag. See
-[Use the Floe CLI with a Self-Hosted Server](/cli/self-hosted-server).
+[Use a self-hosted server](/cli/self-hosted-server).
 
 ## About
 

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe Desktop Settings"
+title: "Desktop app settings"
 sidebarTitle: "Settings"
 description: "Every Floe Desktop setting: where received files are saved, Hide my IP, global stats, the File Explorer entry, and pointing the app at your own server."
 keywords: ["hide my ip", "server address", "right-click menu", "reset settings"]

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -106,7 +106,7 @@ else. Every receiver can turn it off.
 The signaling server is trusted to introduce the two devices honestly, no client shows a
 verification code today, and a browser receiver holds each file in memory. There are eight of
 these and they are all written down.
-[What Floe does not protect against](/how-it-works/known-limitations)
+[Known limitations](/how-it-works/known-limitations)
 
 ### Is Floe open source?
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe FAQ"
+title: "Frequently asked questions"
 sidebarTitle: "FAQ"
 description: "Short answers to the questions that come up most about Floe: where files go, size limits, folders, privacy, accounts, and whether versions have to match."
 keywords: ["faq", "questions", "is floe safe", "do i need an account", "how does floe work"]

--- a/docs/how-it-works/direct-connection.mdx
+++ b/docs/how-it-works/direct-connection.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Direct connections in Floe"
+title: "Direct connections"
 sidebarTitle: "Direct connections"
 description: "A direct Floe transfer goes device to device with nothing in between, which is why it has no size limit. How two devices on different networks manage to find each other."
 keywords: ["direct connection", "peer to peer", "stun", "nat traversal", "hole punching"]

--- a/docs/how-it-works/encryption.mdx
+++ b/docs/how-it-works/encryption.mdx
@@ -39,7 +39,7 @@ each side a fingerprint it controls, sit in the middle, and read everything. Thi
 application built on WebRTC, and the usual defense is a short code the two people compare out of
 band. **Floe computes that code internally but no client shows it today.**
 
-Read [What Floe does not protect against](/how-it-works/known-limitations) for that and the seven
+Read [Known limitations](/how-it-works/known-limitations) for that and the seven
 others in plain language. A privacy claim is worth more when the exceptions are published
 alongside it.
 

--- a/docs/how-it-works/encryption.mdx
+++ b/docs/how-it-works/encryption.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How Floe encrypts your files"
+title: "How your files are encrypted"
 sidebarTitle: "Encryption"
 description: "Every Floe transfer is encrypted end to end with keys that exist only on the two devices involved. What that protects, what it does not, and how it actually works."
 keywords: ["encryption", "end to end", "dtls", "is floe secure", "can floe read my files"]

--- a/docs/how-it-works/known-limitations.mdx
+++ b/docs/how-it-works/known-limitations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "What Floe does not protect against"
+title: "Known limitations"
 sidebarTitle: "Known limitations"
 description: "An honest list of what Floe does not protect against: what the signaling server could do, what the relay sees, and why there is no verification code yet."
 keywords: ["threat model", "security limits", "mitm", "privacy limits", "caveats"]

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -40,7 +40,7 @@ session. See [File size limits](/how-it-works/2gb-limit).
 both IP addresses and the timing and size of what it forwards. It cannot see contents. On
 floe.one the relay is Cloudflare's Realtime TURN network, which means a relayed transfer does
 cross infrastructure Floe does not own. See
-[What Floe does not protect against](/how-it-works/known-limitations).
+[Known limitations](/how-it-works/known-limitations).
 
 ## Turning it off, and the opposite
 

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How a Floe transfer works"
+title: "How a transfer works"
 sidebarTitle: "How a transfer works"
 description: "Floe's server introduces two devices to each other and then gets out of the way. What it does during those few seconds, and what it never does at any point."
 keywords: ["how it works", "signaling", "webrtc", "peer to peer", "does floe store files"]

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe documentation"
+title: "Introduction"
 sidebarTitle: "Introduction"
 description: "Send files peer-to-peer with Floe. Documentation for the web app at floe.one, Floe Desktop for Windows, the floe CLI, and running your own instance."
 keywords: ["floe", "docs", "peer to peer file transfer", "webrtc", "send a file", "getting started"]

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Send your first file with Floe"
+title: "Send your first file"
 sidebarTitle: "Quickstart"
 description: "Send a file peer-to-peer in about a minute, with no signup and nothing to install. Try it between two browser tabs, then from the desktop app or the terminal."
 keywords: ["quickstart", "get started", "send a file", "first transfer", "try it"]

--- a/docs/reference/architecture.mdx
+++ b/docs/reference/architecture.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How Floe is put together"
+title: "How the pieces fit together"
 sidebarTitle: "Architecture"
 description: "The parts of Floe, the two signaling transports they share, and how one transfer session fits together. For contributors and advanced self-hosters."
 keywords: ["architecture", "components", "signaling", "socket.io", "websocket", "design"]

--- a/docs/reference/http-api.mdx
+++ b/docs/reference/http-api.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe signaling server HTTP API"
+title: "Signaling server HTTP API"
 sidebarTitle: "HTTP API"
 description: "Every HTTP endpoint the Floe signaling server exposes: health checks, room codes, TURN credentials, and the public byte counter, with request and response shapes."
 keywords: ["api", "endpoints", "rest", "health check", "turn credentials", "room code"]

--- a/docs/reference/http-api.mdx
+++ b/docs/reference/http-api.mdx
@@ -253,7 +253,7 @@ Route all of `/api/` to the signaling server and this request returns 404. Any s
 you configured is then silently discarded and the browser falls back to its own origin. Behind
 one domain that fallback happens to be correct, so the mistake stays invisible until the day
 you set a value and nothing happens. See
-[Run Floe Behind One Domain](/self-hosting/reverse-proxy) for the exact-path rule.
+[Run behind one domain](/self-hosting/reverse-proxy) for the exact-path rule.
 
 ## Behavior shared by every endpoint
 

--- a/docs/reference/transfer-protocol.mdx
+++ b/docs/reference/transfer-protocol.mdx
@@ -236,7 +236,7 @@ has shipped in a long time.
 
 Receivers that write to disk stage each file under a name ending in `.part` and rename it only
 after that check passes, so a killed transfer never leaves a file sitting under its final name.
-See [What Floe does not protect against](/how-it-works/known-limitations).
+See [Known limitations](/how-it-works/known-limitations).
 
 ## Timeouts
 

--- a/docs/reference/transfer-protocol.mdx
+++ b/docs/reference/transfer-protocol.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe data-channel transfer protocol"
+title: "Data-channel transfer protocol"
 sidebarTitle: "Transfer protocol"
 description: "The wire format Floe peers speak over the WebRTC data channel: message types, framing, protocol versioning, chunk sizing, backpressure, and every timeout."
 keywords: ["wire protocol", "data channel", "webrtc", "protocol version", "backpressure"]

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Security and privacy in Floe"
+title: "Security and privacy"
 sidebarTitle: "Security & privacy"
 description: "Exactly what Floe's signaling server, its relay, and floe.one itself can see, what none of them can, and every switch you have for turning the optional parts off."
 keywords: ["privacy", "security", "what data does floe collect", "telemetry", "analytics", "logs"]

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -12,7 +12,7 @@ two devices and never see file data. That is the short version, and the rest of 
 detail behind it.
 
 For the other half of an honest answer, the limits of all this, see
-[What Floe does not protect against](/how-it-works/known-limitations).
+[Known limitations](/how-it-works/known-limitations).
 
 ## What the signaling server can see
 
@@ -146,7 +146,7 @@ receiving plaintext file data no matter who operates them, so running your own i
 the same encryption and puts the infrastructure under your control.
 
 It also removes the one dependency that encryption alone cannot cover, described in
-[What Floe does not protect against](/how-it-works/known-limitations#the-signaling-server-is-trusted-to-introduce-you-honestly).
+[Known limitations](/how-it-works/known-limitations#the-signaling-server-is-trusted-to-introduce-you-honestly).
 
 See [Self-hosting](/self-hosting/overview) to run one.
 

--- a/docs/self-hosting/build-time-url.mdx
+++ b/docs/self-hosting/build-time-url.mdx
@@ -1,5 +1,5 @@
 ---
-title: "How the Client Finds the Signaling Server"
+title: "How the client finds the server"
 sidebarTitle: "Server discovery"
 description: "How a self-hosted Floe web client resolves its signaling server address at runtime with SOCKET_URL, and when a rebuild is still required."
 keywords: ["SOCKET_URL", "NEXT_PUBLIC_SOCKET_URL", "api/config", "server discovery"]

--- a/docs/self-hosting/build-time-url.mdx
+++ b/docs/self-hosting/build-time-url.mdx
@@ -25,7 +25,7 @@ The first match wins.
   or step 3 always returns 404 and any `SOCKET_URL` you set is silently
   discarded in favor of step 4. With an empty `SOCKET_URL` step 4 is the answer
   you wanted anyway, so the mistake stays invisible until the day you set one.
-  See [Run Floe Behind One Domain](/self-hosting/reverse-proxy) for the
+  See [Run behind one domain](/self-hosting/reverse-proxy) for the
   exact-path rule that keeps `/api/config` on the client.
 </Warning>
 
@@ -70,4 +70,4 @@ docker compose -f docker-compose.yml -f docker-compose.build.yml up -d
 
 This affects only SEO and link previews. Transfers, signaling, and the relay are
 unaffected, and all of those are configured at runtime. See
-[Container Images](/self-hosting/images).
+[Container images](/self-hosting/images).

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Self-Hosted Floe Configuration"
+title: "Configuration reference"
 sidebarTitle: "Configuration"
 description: "Environment variable reference for a self-hosted Floe instance, covering client build-time URLs, CORS, TURN credentials, and stats persistence."
 keywords: ["environment variables", "CLIENT_URL", "settings", "env file"]

--- a/docs/self-hosting/configuration.mdx
+++ b/docs/self-hosting/configuration.mdx
@@ -12,7 +12,7 @@ Under Docker Compose, every setting below is read from an optional `.env` file n
 | Variable | Service | Required | Default | Purpose |
 |----------|---------|----------|---------|---------|
 | `NEXT_PUBLIC_SOCKET_URL` | client (runtime) | No | `http://localhost:3001` | URL the **browser** uses to reach the signaling server. Read at runtime, so changing it needs only `docker compose up -d`, no rebuild. Set it **empty** when both services share one origin behind a [reverse proxy](/self-hosting/reverse-proxy); the browser then uses its own. Docker Compose passes this into the client container as `SOCKET_URL`, which is the name the container itself reads, so outside Compose set `SOCKET_URL` directly. See [how the client finds the server](/self-hosting/build-time-url). |
-| `FLOE_IMAGE_TAG` | compose | No | `latest` | Which published image tag to run, for example `1.10.4`, `1.10`, `main`, or `sha-fed7ebb`. See [Container Images](/self-hosting/images). Not to be confused with `FLOE_VERSION`, which belongs to the CLI installer and carries a leading `v`. |
+| `FLOE_IMAGE_TAG` | compose | No | `latest` | Which published image tag to run, for example `1.10.4`, `1.10`, `main`, or `sha-fed7ebb`. See [Container images](/self-hosting/images). Not to be confused with `FLOE_VERSION`, which belongs to the CLI installer and carries a leading `v`. |
 | `NEXT_PUBLIC_SITE_URL` | client (build) | No | _(none)_ | Canonical public origin of your client (e.g. `https://app.your-domain.com`), used for canonical, Open Graph, JSON-LD, and sitemap URLs. Inlined at build time, so the published image cannot carry it and omits those tags instead of claiming `floe.one`. Set it only when building the client yourself. |
 | `PORT` | server | No | `3001` | **Host** port the signaling server is published on. Inside the container it always listens on 3001; Docker Compose maps `${PORT}` to it. Outside Docker this is the port the server process binds directly. Change this and you must also update `NEXT_PUBLIC_SOCKET_URL` to match, then run `docker compose up -d`, or browsers keep dialing the old port. No rebuild is needed, because the client reads that address at runtime. |
 | `CLIENT_PORT` | client | No | `3000` | **Host** port the web client is published on. Inside the container it always listens on 3000. Compose-only; it has no effect outside Docker. |
@@ -45,7 +45,7 @@ seconds. Every other limit on this page is configurable; that one is not.
 
 For local testing nothing needs setting. Every value has a working default, and the client already points at `http://localhost:3001` with no `.env` file at all.
 
-The first case that genuinely needs one is reaching the app from another device on your network, which takes `NEXT_PUBLIC_SOCKET_URL` and `CLIENT_URL` together. See [Quick Start](/self-hosting/quickstart).
+The first case that genuinely needs one is reaching the app from another device on your network, which takes `NEXT_PUBLIC_SOCKET_URL` and `CLIENT_URL` together. See [Docker quickstart](/self-hosting/quickstart).
 
 ## Production configuration
 
@@ -65,4 +65,4 @@ CLOUDFLARE_TURN_KEY_API_TOKEN=your-api-token
 # TURN_DOMAIN=turn.your-domain.com
 ```
 
-See [Production Deployment](/self-hosting/production) for the full setup.
+See [Production deployment](/self-hosting/production) for the full setup.

--- a/docs/self-hosting/images.mdx
+++ b/docs/self-hosting/images.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Container Images"
+title: "Container images"
 sidebarTitle: "Container images"
 description: "The prebuilt Floe container images on ghcr.io: names, tags, how to pin a version or a digest, and which architectures are supported."
 keywords: ["ghcr", "container image", "docker tag", "pin a version"]

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -40,7 +40,7 @@ docker compose --profile turn up -d
 
 Setting `COMPOSE_PROFILES=turn` in your `.env` applies it to every later `docker compose` command.
 
-Changing `NEXT_PUBLIC_SOCKET_URL` needs only `docker compose up -d`; the client reads it at runtime. See [How the Client Finds the Signaling Server](/self-hosting/build-time-url). `NEXT_PUBLIC_SITE_URL` is the exception: it is written into the page at build time, so the published image omits those tags entirely rather than pointing them at somebody else's domain. See [Container Images](/self-hosting/images) if you want your own.
+Changing `NEXT_PUBLIC_SOCKET_URL` needs only `docker compose up -d`; the client reads it at runtime. See [How the client finds the server](/self-hosting/build-time-url). `NEXT_PUBLIC_SITE_URL` is the exception: it is written into the page at build time, so the published image omits those tags entirely rather than pointing them at somebody else's domain. See [Container images](/self-hosting/images) if you want your own.
 
 ## The server does not log anything
 

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Self-Hosted Floe Operations"
+title: "Day-to-day operations"
 sidebarTitle: "Operations"
 description: "Day-to-day operations for a self-hosted Floe instance: common Compose commands, updating to the latest images, and the health endpoints to point a monitor at."
 keywords: ["logs", "update containers", "health check", "restart"]

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -31,8 +31,8 @@ them can transfer with each other on your server.
 | Client | How it points at your instance |
 |--------|-------------------------------|
 | Web app | Loads from your `client` container. Nothing for the user to configure. |
-| CLI | `floe send --server https://floe.example.com`. See [Use the Floe CLI with a Self-Hosted Server](/cli/self-hosted-server). |
-| Floe Desktop | Settings, **Advanced**, then **Server address**. **Test** checks the address before you rely on it, and **Use default server** returns the app to `api.floe.one`. See [Desktop Settings](/desktop/settings#server). |
+| CLI | `floe send --server https://floe.example.com`. See [Use a self-hosted server](/cli/self-hosted-server). |
+| Floe Desktop | Settings, **Advanced**, then **Server address**. **Test** checks the address before you rely on it, and **Use default server** returns the app to `api.floe.one`. See [Desktop app settings](/desktop/settings#server). |
 
 Both peers must be on the same server. Servers do not talk to each other.
 
@@ -52,10 +52,10 @@ which performs no origin check, so they reach your server regardless of that set
 ## Contents
 
 <Columns cols={2}>
-  <Card title="Quick Start" href="/self-hosting/quickstart">
+  <Card title="Docker quickstart" href="/self-hosting/quickstart">
     Get the stack running with Docker Compose in minutes.
   </Card>
-  <Card title="Container Images" href="/self-hosting/images">
+  <Card title="Container images" href="/self-hosting/images">
     The prebuilt images on ghcr.io: tags, pinning a version or digest, and supported architectures.
   </Card>
   <Card title="Unraid" href="/self-hosting/unraid">
@@ -64,13 +64,13 @@ which performs no origin check, so they reach your server regardless of that set
   <Card title="Configuration" href="/self-hosting/configuration">
     Environment variable reference for all settings.
   </Card>
-  <Card title="How the Client Finds the Signaling Server" href="/self-hosting/build-time-url">
+  <Card title="How the client finds the server" href="/self-hosting/build-time-url">
     Runtime `SOCKET_URL` resolution, and the one value that is still baked in at build time.
   </Card>
   <Card title="Reverse Proxy" href="/self-hosting/reverse-proxy">
     Serve the client and signaling server from one domain, with Caddy and nginx examples.
   </Card>
-  <Card title="Production Deployment" href="/self-hosting/production">
+  <Card title="Production deployment" href="/self-hosting/production">
     HTTPS, custom domains, and the two-subdomain layout.
   </Card>
   <Card title="TURN Relay" href="/self-hosting/turn-relay">

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Self-Hosting Floe Overview"
+title: "Self-hosting overview"
 sidebarTitle: "Overview"
 description: "Run your own Floe signaling server, web client, and optional TURN relay on your own infrastructure for full control over peer-to-peer file transfer."
 keywords: ["self host", "run your own", "on premise", "private instance"]

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -65,7 +65,7 @@ fully supported.
 
     Without `--web`, the share link points at the signaling API rather than the web app, because a self-hosted server is otherwise assumed to serve both from one origin.
 
-    In the desktop app, open Settings, expand **Advanced**, and fill in both **Server address** (`https://api.your-domain.com`) and **Share link address** (`https://app.your-domain.com`), then press **Test**. See [Desktop Settings](/desktop/settings#server).
+    In the desktop app, open Settings, expand **Advanced**, and fill in both **Server address** (`https://api.your-domain.com`) and **Share link address** (`https://app.your-domain.com`), then press **Test**. See [Desktop app settings](/desktop/settings#server).
   </Step>
 </Steps>
 

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Production Deployment for Self-Hosted Floe"
+title: "Production deployment"
 sidebarTitle: "Production"
 description: "Deploy a self-hosted Floe instance in production with HTTPS, a reverse proxy, custom domain, WebSocket support, and secure TURN relay credentials."
 keywords: ["production", "https", "subdomain", "deploy"]

--- a/docs/self-hosting/quickstart.mdx
+++ b/docs/self-hosting/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Self-Hosting Quick Start"
+title: "Docker quickstart"
 sidebarTitle: "Docker quickstart"
 description: "Spin up a local Floe instance with Docker Compose in a few minutes to try self-hosted peer-to-peer file transfer on your own machine before deploying."
 keywords: ["docker compose", "try self hosting", "get started"]

--- a/docs/self-hosting/reverse-proxy.mdx
+++ b/docs/self-hosting/reverse-proxy.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Run Floe Behind One Domain"
+title: "Run behind one domain"
 sidebarTitle: "Reverse proxy"
 description: "Serve the Floe web client and signaling server from one domain using a reverse proxy, with copy-pasteable Caddy and nginx configs for WebSocket support."
 keywords: ["nginx", "caddy", "reverse proxy", "one domain", "websocket upgrade"]

--- a/docs/self-hosting/reverse-proxy.mdx
+++ b/docs/self-hosting/reverse-proxy.mdx
@@ -152,7 +152,7 @@ docker compose up -d
 `NEXT_PUBLIC_SITE_URL` is the only build-time value here, which is why the
 comment above tells you the running stack does not read it. The published image
 cannot carry it, so canonical links and share previews are omitted rather than
-pointed somewhere wrong. See [Container Images](/self-hosting/images) to build the
+pointed somewhere wrong. See [Container images](/self-hosting/images) to build the
 client with your own domain baked in.
 
 `CLIENT_URL` is matched exactly, including the scheme and with no trailing
@@ -185,7 +185,7 @@ signaling server, that the realtime `/ws` connection is accepted, and that
 forwards only some of those is named in the failure message instead of breaking
 silently later. Leave **Share link address** blank on a one-domain instance and
 the app derives the link from the server address. See
-[Desktop Settings](/desktop/settings#server).
+[Desktop app settings](/desktop/settings#server).
 
 The test deliberately does not follow redirects, so a proxy that answers
 `/health` with a 301 is reported as "may be the web app rather than the
@@ -215,4 +215,4 @@ check.
 
 Splitting the client and server across `app.your-domain.com` and
 `api.your-domain.com` is still fully supported. See
-[Production Deployment](/self-hosting/production).
+[Production deployment](/self-hosting/production).

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Add a TURN Relay to Self-Hosted Floe"
+title: "Add a TURN relay"
 sidebarTitle: "TURN relay"
 description: "Add a coturn TURN relay to a self-hosted Floe instance so peers behind strict NAT, CGNAT, or corporate firewalls can still complete file transfers."
 keywords: ["coturn", "turn server", "cloudflare turn", "cgnat"]

--- a/docs/self-hosting/unraid.mdx
+++ b/docs/self-hosting/unraid.mdx
@@ -11,7 +11,7 @@ instance.
 
 Both templates pull the same multi-architecture images the Docker Compose stack
 uses, so amd64 and arm64 Unraid hosts are covered by the same template and nothing
-is built on your server. See [Container Images](/self-hosting/images).
+is built on your server. See [Container images](/self-hosting/images).
 
 ## Before you start
 
@@ -59,7 +59,7 @@ as its CORS allow-list entry.
     That value is the container's `SOCKET_URL`. The client hands it to the browser
     from `GET /api/config` on every page load, so changing it later takes a
     container restart and never a rebuild. See
-    [How the Client Finds the Signaling Server](/self-hosting/build-time-url).
+    [How the client finds the server](/self-hosting/build-time-url).
 
   </Step>
   <Step title="Open and test Floe">
@@ -101,7 +101,7 @@ place produces a client that loads perfectly and never connects.
 
 Copy-pasteable Caddy and nginx configurations for exactly this routing, including
 the exact-path rule that keeps `/api/config` on the client, are in
-[Run Floe Behind One Domain](/self-hosting/reverse-proxy).
+[Run behind one domain](/self-hosting/reverse-proxy).
 
 ## Two hostnames behind a reverse proxy
 
@@ -136,4 +136,4 @@ Both templates follow the `latest` image tag, which changes only when Floe
 publishes a version tag. Use Unraid's normal container update flow to pull a new
 release. The containers store no files or application settings in volumes, so
 there is no appdata directory to migrate. To pin a specific version or a digest
-instead, see [Container Images](/self-hosting/images).
+instead, see [Container images](/self-hosting/images).

--- a/docs/self-hosting/unraid.mdx
+++ b/docs/self-hosting/unraid.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Deploy Floe on Unraid"
+title: "Deploy on Unraid"
 sidebarTitle: "Unraid"
 description: "Install the Floe web client and signaling server as two coordinated Unraid containers, with direct LAN, single domain, and two hostname configuration examples."
 keywords: ["unraid", "community applications", "template"]

--- a/docs/self-hosting/without-docker.mdx
+++ b/docs/self-hosting/without-docker.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Run Self-Hosted Floe Without Docker"
+title: "Run without Docker"
 sidebarTitle: "Without Docker"
 description: "Run the Floe signaling server and web client directly with Node.js, pnpm, and Go instead of Docker Compose for custom self-hosted deployments."
 keywords: ["node", "pnpm", "manual install", "no docker"]

--- a/docs/self-hosting/without-docker.mdx
+++ b/docs/self-hosting/without-docker.mdx
@@ -66,7 +66,7 @@ canonical tags, share previews and a sitemap advertising floe.one instead of its
 Set it to your own origin, or accept that those tags point somewhere else. It is inlined at build
 time, so changing it later means another `pnpm build`.
 
-`NEXT_PUBLIC_SOCKET_URL` is inlined when the client is built, so on this path changing it later needs another `pnpm build`. To change the address without rebuilding, leave it unset and set the unprefixed `SOCKET_URL` in the environment of the process that runs `pnpm start` instead; the browser then reads it per request from `/api/config`. See [How the Client Finds the Signaling Server](/self-hosting/build-time-url). Leave both empty when the client and the signaling server share one origin behind a reverse proxy.
+`NEXT_PUBLIC_SOCKET_URL` is inlined when the client is built, so on this path changing it later needs another `pnpm build`. To change the address without rebuilding, leave it unset and set the unprefixed `SOCKET_URL` in the environment of the process that runs `pnpm start` instead; the browser then reads it per request from `/api/config`. See [How the client finds the server](/self-hosting/build-time-url). Leave both empty when the client and the signaling server share one origin behind a reverse proxy.
 
 Also set `NODE_ENV=production` in `server/.env`. Docker sets it for you; a direct Node run does not. Floe registers its own final error handler that returns a generic JSON error at every setting, so this is not a stack-trace leak. Set it anyway: `production` is what both the published image and `server/.env.example` use, so a direct Node run matches what is tested.
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -176,7 +176,7 @@ through the Microsoft Store or by reinstalling from the download page.
 
 The binary was built from source or installed with `go install`, so it carries no version to
 compare and cannot replace itself. Install through a package manager or the install script for a
-release build with working self-update. See [Install the Floe CLI](/cli/installation).
+release build with working self-update. See [Install the CLI](/cli/installation).
 
 ### `installed via homebrew - run 'brew upgrade floe' to update`
 
@@ -245,7 +245,7 @@ twenty seconds. If you recently changed **Server address**, check it with **Test
 check that /ws is being forwarded." The address is a Floe signaling server but the WebSocket
 upgrade at `/ws` is not reaching it, which is nearly always a proxy that forwards ordinary
 requests without forwarding the upgrade. See
-[Run Floe Behind One Domain](/self-hosting/reverse-proxy).
+[Run behind one domain](/self-hosting/reverse-proxy).
 
 ### The Test button says the API answered with an HTTP error
 
@@ -286,7 +286,7 @@ it applies even on a network that could have connected directly. An oversized se
 If the Microsoft Edge WebView2 runtime is missing and the machine cannot reach Microsoft's
 download, Floe cannot start and says so. Install
 [WebView2](https://developer.microsoft.com/microsoft-edge/webview2/) yourself, then start Floe
-again. See [Install Floe Desktop](/desktop/installation).
+again. See [Install the desktop app](/desktop/installation).
 
 ## On a self-hosted instance
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Floe troubleshooting: fixes by error message"
+title: "Troubleshooting: fixes by error message"
 sidebarTitle: "Troubleshooting"
 description: "Every message Floe can show you, what causes it, and what to do. Covers the browser, Floe Desktop, the floe CLI, and self-hosted instances."
 keywords: ["error", "not working", "cannot connect", "failed", "stuck", "troubleshooting"]

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -142,7 +142,7 @@ a three-word code instead, pass that:
 floe receive olive-tiger-castle
 ```
 
-See [floe receive](/cli/receive) and [Receiving files with Floe Desktop](/desktop/receiving).
+See [floe receive](/cli/receive) and [Receive files in the desktop app](/desktop/receiving).
 
 ## If the link does not work
 


### PR DESCRIPTION
## Summary

Mintlify composes every docs tab title as `{frontmatter title} - {docs.json name}`, and that separator is not configurable. With `name` set to `Floe`, any title containing the word rendered the brand twice:

```
Floe documentation - Floe
How Floe encrypts your files - Floe
Self-Hosting Floe Overview - Floe
```

**30 of the 41 pages did that.** Google's title-link guidance lists "duplication of site name" among its reasons for replacing a title in search results.

Casing had drifted too: the `title` field was split 21 sentence case to 16 Title Case, roughly along directory lines, with parallel pages contradicting each other (`web-app/sending` was "Send files from your browser" while `desktop/sending` was "Sending Files with Floe Desktop").

### Why sentence case

It is already the house style everywhere it is enforced: **all 40 `sidebarTitle` values and all 9 navigation group headings use it.** Only the `title` field ever drifted. It is also what Mintlify's own docs use ("Quickstart", "Global settings", "Reusable snippets"), and what every major docs site sampled uses. Title Case would have made `title` the sole sentence-case-violating surface in the whole config.

### Why the brand comes out entirely

The ` - Floe` suffix already supplies it. Titles now name the surface generically, so "Sending Files with Floe Desktop" becomes "Send files from the desktop app". The qualifier has to stay: without it that page and its web-app counterpart would both be "Sending files" and ship identical tab titles and identical SERP entries.

`Install the desktop app - Floe` still contains both tokens someone searching "install Floe Desktop" types, since Google matches the full `<title>`, and the product name survives verbatim in that page's `description`, which is the snippet rendered beneath the title link.

## Result

- **33 titles changed, 8 deliberately unchanged** (no brand duplication, already sentence case, including `how-it-works/2gb-limit`, which has `boost: 2` and a `"2 GB"` keyword so its number stays in the title)
- **All 41 rendered titles are unique**
- **All are 60 characters or under**
- **None of the 41 still contains the brand**

## Three inconsistencies settled

1. **web-app vs desktop.** All four send/receive pages now share one imperative pattern.
2. **`Quickstart` vs `Quick Start`.** One word, always. The bare word now appears exactly once in the product, as the top-level sidebar entry, so the collision is gone rather than merely recased.
3. **`Self-Hosted` / `Self-Hosting` / `Self-hosting`.** Three spellings of one compound across title, sidebarTitle and nav group. The nav group form wins, removing "Self-Hosted Floe" from six titles at once.

## Not touched

**`docs.json`.** `name` stays `"Floe"` rather than becoming `"Floe Docs"`. The same key also defaults `applicationName`, `apple-mobile-web-app-title`, and the structured-data **Organization** name, and the organization is Floe. These docs are proxied onto the same `floe.one` origin as the marketing site, so publishing two competing site names would make Google's site-name selection worse, not better. Recorded here so it is not "fixed" later.

**`changelog.mdx`.** The only page with no `sidebarTitle`, so its `title` is also its sidebar label, and `rss: true` makes that title the feed's channel name. Its title was already correct under either convention.

## Second commit: link text

41 labels across 21 files named a page by a title that no longer exists. **Nothing was broken by this** — every link addresses its page by path and every anchor targets a body h2/h3 slug, so no URL and no anchor moves in this PR. Verified mechanically: the complete set of link targets in `docs/**` is byte-identical before and after.

Only labels quoting a former title verbatim were touched. Natural prose is left alone ("one-domain deployment", "TURN relay", "Hide my IP address"), as is `introduction.mdx`'s lowercase "[what Floe does not protect against]", where the words are a clause rather than a citation. Two labels were already stale before this branch and are corrected in passing.

## Test plan

- Diff is surgical: commit 1 changes only `title:` lines in 33 files; commit 2 changes only link labels
- No en dash or em dash in any added line (`docs/styles/Floe/EmDash.yml` is `level: error`, and a single error-level hit aborts the whole Vale run)
- All 41 composed titles verified unique and within 60 characters
- Link targets verified byte-identical before and after

The companion PR #336 moves floe.one onto the same ` - ` separator, which it had never used: it was shipping `Download | Floe` alongside `Privacy Policy · Floe`.

## Full before and after

| Page | Before | After |
| --- | --- | --- |
| `changelog` | `Changelog - Floe` | *unchanged* |
| `choosing-floe` | `Which Floe should I use? - Floe` | **`Which app should I use? - Floe`** |
| `cli/flags` | `Floe CLI Flags Reference - Floe` | **`CLI flags reference - Floe`** |
| `cli/installation` | `Install the Floe CLI - Floe` | **`Install the CLI - Floe`** |
| `cli/receive` | `floe receive command - Floe` | *unchanged* |
| `cli/self-hosted-server` | `Use the Floe CLI with a Self-Hosted Server - Floe` | **`Use a self-hosted server - Floe`** |
| `cli/send` | `floe send command - Floe` | *unchanged* |
| `cli/update` | `Update the Floe CLI - Floe` | **`Update the CLI - Floe`** |
| `cli/version` | `floe version command - Floe` | *unchanged* |
| `desktop/installation` | `Install Floe Desktop - Floe` | **`Install the desktop app - Floe`** |
| `desktop/keyboard-shortcuts` | `Floe Desktop Keyboard Shortcuts - Floe` | **`Keyboard shortcuts - Floe`** |
| `desktop/receiving` | `Receiving Files with Floe Desktop - Floe` | **`Receive files in the desktop app - Floe`** |
| `desktop/sending` | `Sending Files with Floe Desktop - Floe` | **`Send files from the desktop app - Floe`** |
| `desktop/settings` | `Floe Desktop Settings - Floe` | **`Desktop app settings - Floe`** |
| `faq` | `Floe FAQ - Floe` | **`Frequently asked questions - Floe`** |
| `how-it-works/2gb-limit` | `File size limits and the 2 GB relay cap - Floe` | *unchanged* |
| `how-it-works/direct-connection` | `Direct connections in Floe - Floe` | **`Direct connections - Floe`** |
| `how-it-works/encryption` | `How Floe encrypts your files - Floe` | **`How your files are encrypted - Floe`** |
| `how-it-works/known-limitations` | `What Floe does not protect against - Floe` | **`Known limitations - Floe`** |
| `how-it-works/relay-connection` | `Relay fallback when a direct connection is impossible - Floe` | *unchanged* |
| `how-it-works/signaling` | `How a Floe transfer works - Floe` | **`How a transfer works - Floe`** |
| `introduction` | `Floe documentation - Floe` | **`Introduction - Floe`** |
| `quickstart` | `Send your first file with Floe - Floe` | **`Send your first file - Floe`** |
| `reference/architecture` | `How Floe is put together - Floe` | **`How the pieces fit together - Floe`** |
| `reference/http-api` | `Floe signaling server HTTP API - Floe` | **`Signaling server HTTP API - Floe`** |
| `reference/transfer-protocol` | `Floe data-channel transfer protocol - Floe` | **`Data-channel transfer protocol - Floe`** |
| `security-privacy` | `Security and privacy in Floe - Floe` | **`Security and privacy - Floe`** |
| `self-hosting/build-time-url` | `How the Client Finds the Signaling Server - Floe` | **`How the client finds the server - Floe`** |
| `self-hosting/configuration` | `Self-Hosted Floe Configuration - Floe` | **`Configuration reference - Floe`** |
| `self-hosting/images` | `Container Images - Floe` | **`Container images - Floe`** |
| `self-hosting/operations` | `Self-Hosted Floe Operations - Floe` | **`Day-to-day operations - Floe`** |
| `self-hosting/overview` | `Self-Hosting Floe Overview - Floe` | **`Self-hosting overview - Floe`** |
| `self-hosting/production` | `Production Deployment for Self-Hosted Floe - Floe` | **`Production deployment - Floe`** |
| `self-hosting/quickstart` | `Self-Hosting Quick Start - Floe` | **`Docker quickstart - Floe`** |
| `self-hosting/reverse-proxy` | `Run Floe Behind One Domain - Floe` | **`Run behind one domain - Floe`** |
| `self-hosting/turn-relay` | `Add a TURN Relay to Self-Hosted Floe - Floe` | **`Add a TURN relay - Floe`** |
| `self-hosting/unraid` | `Deploy Floe on Unraid - Floe` | **`Deploy on Unraid - Floe`** |
| `self-hosting/without-docker` | `Run Self-Hosted Floe Without Docker - Floe` | **`Run without Docker - Floe`** |
| `troubleshooting` | `Floe troubleshooting: fixes by error message - Floe` | **`Troubleshooting: fixes by error message - Floe`** |
| `web-app/receiving` | `Receive files in your browser - Floe` | *unchanged* |
| `web-app/sending` | `Send files from your browser - Floe` | *unchanged* |
