### PR TITLE
docs: fix the last 14 link labels naming pages by titles they do not have

### DIFF
--- a/docs/choosing-floe.mdx
+++ b/docs/choosing-floe.mdx
@@ -77,7 +77,7 @@ These are properties of the transfer itself, so they do not change with the clie
 - **Encryption.** Every transfer runs over an encrypted WebRTC data channel. See
   [Encryption](/how-it-works/encryption).
 - **No size limit on a direct connection**, and a 2 GB cap when the connection has to fall back
-  to the relay. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+  to the relay. See [File size limits](/how-it-works/2gb-limit).
 - **One receiver per transfer.** A room holds exactly two peers, so a link or code is spent once
   someone joins.
 - **The sender stays connected** for the whole transfer. Closing the tab, quitting the app, or

--- a/docs/cli/installation.mdx
+++ b/docs/cli/installation.mdx
@@ -158,7 +158,7 @@ For script or manual installs, run:
 floe update
 ```
 
-See [Updating floe](/cli/update) for details.
+See [Update the CLI](/cli/update) for details.
 
 ## Build from source
 

--- a/docs/cli/self-hosted-server.mdx
+++ b/docs/cli/self-hosted-server.mdx
@@ -71,4 +71,4 @@ appears once a custom address is set and clears both fields back to `api.floe.on
 See [Desktop app settings](/desktop/settings#advanced) for what Test checks and what each
 result means.
 
-See [Self-Hosting](/self-hosting/overview) for instructions on running your own Floe instance.
+See [Self-hosting](/self-hosting/overview) for instructions on running your own Floe instance.

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -95,7 +95,7 @@ See [CLI flags reference](/cli/flags) for `--server`, `--no-relay`, `--web`, and
 
 ## Notes
 
-- Relayed transfers are capped at 2 GB per session; direct connections have no size limit. When the selected route runs through the TURN relay and the queued files total more than 2 GB, `floe send` blocks the transfer before any file data moves. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+- Relayed transfers are capped at 2 GB per session; direct connections have no size limit. When the selected route runs through the TURN relay and the queued files total more than 2 GB, `floe send` blocks the transfer before any file data moves. See [File size limits](/how-it-works/2gb-limit).
 - Press `Ctrl+C` at any time to cancel the transfer and close the session.
 - If the short code cannot be registered (for example, the signaling server is unreachable), Floe prints a warning and continues with the link only.
 - Files are streamed in the order they are listed. For multiple files, progress is shown per file.

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -99,7 +99,7 @@ Click **Send**. Floe registers a room and shows three ways to hand it over.
 
 A phone receives in its browser. On iOS, tell them to use **Download ZIP** rather than saving
 files one at a time, which behaves inconsistently there. See
-[Receiving Files with the Floe Web App](/web-app/receiving).
+[Receiving files](/web-app/receiving).
 
 The room code expires 10 minutes after you click Send. The link keeps working for as long as
 Floe is still waiting, so for a longer wait, share the link.
@@ -163,7 +163,7 @@ Turning on [**Hide my IP**](/desktop/settings#hide-my-ip-address) forces every t
 the relay, so the 2 GB cap always applies while it is on. Floe says so in the error when that
 is what caused the block.
 
-See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+See [File size limits](/how-it-works/2gb-limit).
 
 ## Keyboard
 

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -40,7 +40,7 @@ both are unavoidable rather than bugs:
 - **Transfers are slower**, because every byte takes a detour through the relay.
 - **Transfers are capped at 2 GB per session**, because relay bandwidth costs real money. A
   larger transfer is refused before any data moves, not partway through. See
-  [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+  [File size limits](/how-it-works/2gb-limit).
 
 The setting applies to your side only, and the person on the other end does not need it on.
 Their app shows the connection as **Relay**, which is exactly what it shows whenever a direct

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -54,7 +54,7 @@ of the way. File data never reaches it. See [How a transfer works](/how-it-works
 
 **No size limit on a direct connection.** Most transfers connect directly. When a network makes
 that impossible and the transfer falls back to a relay, it is capped at 2 GB per session to keep
-Floe free. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+Floe free. See [File size limits](/how-it-works/2gb-limit).
 
 ## Going further
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -34,7 +34,7 @@ size limit and no upload to wait for.
 
 The badge at the top of the card said **Direct** once that path was open. On a network that
 blocks direct connections it would have said **Relay** instead, and the file would have traveled
-through an encrypted relay that cannot read it. See [How Floe connects](/how-it-works/signaling).
+through an encrypted relay that cannot read it. See [How a transfer works](/how-it-works/signaling).
 
 ## The same thing from the desktop app or the terminal
 

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -21,7 +21,7 @@ The signaling server brokers WebRTC connection setup (offer, answer, ICE candida
 
 Those are the ports inside the containers. In production you normally put both
 behind a single domain, so your users never see either one. See
-[Reverse Proxy](/self-hosting/reverse-proxy).
+[Run behind one domain](/self-hosting/reverse-proxy).
 
 ## Who can connect
 
@@ -67,13 +67,13 @@ which performs no origin check, so they reach your server regardless of that set
   <Card title="How the client finds the server" href="/self-hosting/build-time-url">
     Runtime `SOCKET_URL` resolution, and the one value that is still baked in at build time.
   </Card>
-  <Card title="Reverse Proxy" href="/self-hosting/reverse-proxy">
+  <Card title="Reverse proxy" href="/self-hosting/reverse-proxy">
     Serve the client and signaling server from one domain, with Caddy and nginx examples.
   </Card>
   <Card title="Production deployment" href="/self-hosting/production">
     HTTPS, custom domains, and the two-subdomain layout.
   </Card>
-  <Card title="TURN Relay" href="/self-hosting/turn-relay">
+  <Card title="TURN relay" href="/self-hosting/turn-relay">
     Use Cloudflare's managed TURN or add coturn to support peers behind strict NAT or CGNAT.
   </Card>
   <Card title="Operations" href="/self-hosting/operations">

--- a/docs/self-hosting/production.mdx
+++ b/docs/self-hosting/production.mdx
@@ -9,7 +9,7 @@ For a deployment accessible beyond a single machine, follow these steps.
 
 The simplest production layout puts the client and the signaling server behind
 **one** domain, so there is a single certificate and a single URL to configure.
-See [Reverse Proxy](/self-hosting/reverse-proxy) for copy-pasteable Caddy and
+See [Run behind one domain](/self-hosting/reverse-proxy) for copy-pasteable Caddy and
 nginx configuration. This page covers the two-subdomain layout, which is still
 fully supported.
 

--- a/docs/self-hosting/turn-relay.mdx
+++ b/docs/self-hosting/turn-relay.mdx
@@ -134,4 +134,4 @@ Credentials are minted from Cloudflare once and then **cached in memory for 12 h
 
 The signaling server generates time-limited credentials using HMAC-SHA1. The username is `{expiry_unix_timestamp}:floeuser` and the password is `base64(HMAC-SHA1(TURN_SECRET, username))`. coturn validates these against the shared secret without needing a database of user accounts.
 
-Relayed transfers stay capped at 2 GB per session even on a relay you run yourself. The cap is compiled into the browser client, the CLI, and the desktop app, not read from your server, so raising it means building all three from modified source. Direct connections are unaffected and have no size limit. See [The 2 GB Relay Limit](/how-it-works/2gb-limit).
+Relayed transfers stay capped at 2 GB per session even on a relay you run yourself. The cap is compiled into the browser client, the CLI, and the desktop app, not read from your server, so raising it means building all three from modified source. Direct connections are unaffected and have no size limit. See [File size limits](/how-it-works/2gb-limit).


### PR DESCRIPTION
## Summary

A 14-agent adversarial audit of all 47 rendered titles after #336 and #337 confirmed the **titles themselves are correct** — 47/47 unique, all pure ASCII, one `<title>` per document, separator always ` - `, correct Title Case on the 5 marketing pages and sentence case on all 41 docs pages, none over 60 characters.

It also found the **reference layer around them was not finished**. 14 labels across 11 files still named a page by a title it does not have. This PR closes that.

**No URL or anchor changes.** The complete set of link targets under `docs/` is byte-identical before and after, verified mechanically.

## Six labels for a page this rename never touched

`how-it-works/2gb-limit` kept its title, but the docs were split **exactly 6 to 6** on what to call it:

| Form | Count | Where |
| --- | --- | --- |
| `The 2 GB Relay Limit` (no page has this title) | 6 | choosing-floe, cli/send, desktop/sending, desktop/settings, introduction, self-hosting/turn-relay |
| `File size limits` (matches the sidebar) | 6 | faq, how-it-works/relay-connection, troubleshooting ×2, web-app/sending, and a `<Card>` in quickstart |

The stale form was also Title Case, against the convention settled in #337. All six now match the other six.

This one is worth noting because it explains a gap in the previous pass: #337 searched only for titles it was itself changing, so a page that kept its title but was *mis-named elsewhere* was invisible to it.

## Four that had gone stale earlier

- **`Receiving Files with the Floe Web App`** — retired back in #327. Three other links to that page already say "Receiving files". This one also carried Title Case and the brand inside the link text, breaking two conventions at once.
- **`Updating floe`** — for a page `cli/flags.mdx` already links as "Update the CLI".
- **`How Floe connects`** — for the signaling page, a name it has never had, while four other links quote its real title.
- **`[Self-Hosting]`** — the settled compound is `Self-hosting`, which `security-privacy.mdx` already writes correctly.

## Four casing fixes

`<Card title="TURN Relay">` was the **only** capital R among eight references to that page, and it survived both #330 and #332 — whose stated purpose was exactly this normalization.

`Reverse Proxy` with a capital P appeared three times and matched nothing past or present: that page is titled "Run behind one domain" and its `sidebarTitle` has been lowercase "Reverse proxy" since #269. The two `<Card>` labels now mirror their sidebar labels; the two prose links now quote the page title, which is what four sibling links already do.

## Test plan

- 14 replacements, each asserted against an expected occurrence count; the script fails if any count is off
- Link targets byte-identical before and after (zero URL changes)
- Repo-wide sweep for all 16 known dead or superseded page titles returns **zero** hits outside `changelog.mdx`
- `changelog.mdx` untouched, as its shipped entries describe releases as they were worded at the time
- Vale passes (no en dash or em dash introduced)

## Not a defect, deliberately not touched

The audit also flagged that Mintlify's "Related topics" block still renders pre-rewrite page names. That is **search-index lag, not a repo problem** — there is nothing to edit. The evidence: a page retitled six days ago by #327 already shows its current label, and the served page's own metadata rebuilt one minute after #337 merged. It resolves on reindex.
