### PR TITLE
docs: remove both diagrams, and purge the single-use claim they sat on

### DIFF
--- a/docs/choosing-floe.mdx
+++ b/docs/choosing-floe.mdx
@@ -78,8 +78,8 @@ These are properties of the transfer itself, so they do not change with the clie
   [Encryption](/how-it-works/encryption).
 - **No size limit on a direct connection**, and a 2 GB cap when the connection has to fall back
   to the relay. See [File size limits](/how-it-works/2gb-limit).
-- **One receiver per transfer.** A room holds exactly two peers, so a link or code is spent once
-  someone joins.
+- **One receiver per transfer.** A room holds exactly two peers, so while one recipient is
+  connected, a second one is turned away.
 - **The sender stays connected** for the whole transfer. Closing the tab, quitting the app, or
   stopping the process ends it.
 - **Versions do not need to match.** A browser sender and a two-year-old CLI receiver transfer

--- a/docs/desktop/receiving.mdx
+++ b/docs/desktop/receiving.mdx
@@ -142,7 +142,7 @@ If you point Floe at your own server, the report goes to that server rather than
 |---|---|
 | That code was not recognized ... | The code was mistyped, has passed its 10 minutes, or belongs to a different server from the one you are on. |
 | This code is no longer active; ask for a new one | The code is still valid but nobody is sharing with it. The transfer already finished, or the sender closed Floe. |
-| Room is full (someone else may already be receiving) | Someone already joined with this code. A room takes one receiver, so ask for a new code. |
+| Room is full (someone else may already be receiving) | Someone else is already connected on this code. The code is still valid, but the room's one receiver seat is taken, so ask the sender to start a new transfer. |
 
 If Floe connects but nothing arrives, it gives up after 30 seconds and says the sender never
 started sending; ask them to try again. If it never connects at all, check that both of you are

--- a/docs/desktop/sending.mdx
+++ b/docs/desktop/sending.mdx
@@ -104,8 +104,9 @@ files one at a time, which behaves inconsistently there. See
 The room code expires 10 minutes after you click Send. The link keeps working for as long as
 Floe is still waiting, so for a longer wait, share the link.
 
-A room takes exactly one receiver. Once someone joins, the code and link are spent, and a second
-person opening the same link gets an error. Send again for a second recipient. See
+A room takes exactly one receiver. While someone is connected, a second person opening the same
+link gets an error. Nothing is used up by that: if the recipient drops off, the seat frees and the
+code and link keep working. Send again for a second recipient. See
 [How a transfer works](/how-it-works/signaling#a-room-holds-exactly-two-people).
 
 Floe handles one transfer at a time, so wait for the current one to finish before starting the

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -31,8 +31,8 @@ networks and even on mobile data.
 
 ## What counts as one session
 
-A session is one sender and one receiver. The room holds exactly two people, so a link cannot be
-opened by two recipients and there is no way for a session to accumulate.
+A session is one sender and one receiver. The room holds exactly two people, so only one recipient
+is ever connected at a time and there is no way for a session to accumulate.
 
 The check happens **once, before any file data moves**. When the connection turns out to be
 relayed, Floe compares the total size of everything you queued against 2 GB and either allows the

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -60,12 +60,12 @@ See [Direct connections](/how-it-works/direct-connection) and
 ## A room holds exactly two people
 
 The room is the transfer. It takes one sender and one receiver, and a third device that tries to
-join is turned away: the web app shows **Link Invalid**, while the CLI and
-the desktop app say `room is full`.
+join is turned away: the web app shows **Link Invalid**, while the CLI and the desktop app say
+`room is full`.
 
 Nothing is used up along the way. A code keeps resolving for its full ten minutes, and a link
-keeps working while the transfer is live. What turns a third device away is the second seat
-already being taken, not the link having been opened once.
+keeps working while the transfer is live. The refusal is about the second seat already being
+taken, not about the link having been opened once.
 
 The seat frees again once that device disconnects and the server notices, which takes up to about
 a minute if the drop was not a clean one. Whether the transfer survives that gap depends on who is

--- a/docs/how-it-works/signaling.mdx
+++ b/docs/how-it-works/signaling.mdx
@@ -13,23 +13,24 @@ That is the entire idea. The rest of this page is what those few seconds consist
 
 ## Step by step
 
-```mermaid
-flowchart LR
-    S["Your device"] -- "1 join a room" --> SV[("Signaling server")]
-    R["Their device"] -- "2 join the same room" --> SV
-    SV -- "3 pass along offer, answer, addresses" --> S
-    SV -- "3 pass along offer, answer, addresses" --> R
-    S == "4 the file, encrypted, straight across" ==> R
-```
+<Steps>
+  <Step title="You create a transfer">
+    Your device makes up a random room id and joins that room. You share a link containing it, or
+    a three-word code that maps to it.
+  </Step>
+  <Step title="They join the same room">
+    The server now has two devices in one room, and tells the first one that someone arrived.
+  </Step>
+  <Step title="The two devices introduce themselves">
+    They pass an offer, an answer, and a list of network addresses through the server, each
+    trying to find a path to the other.
+  </Step>
+  <Step title="The connection opens and the server drops out">
+    Every byte of the file travels over that connection. None of it goes back through the server.
+  </Step>
+</Steps>
 
-1. **You create a transfer.** Your device makes up a random room id and joins that room. You share
-   a link containing it, or a three-word code that maps to it.
-2. **They join the same room.** The server now has two devices in one room and tells the first one
-   that someone arrived.
-3. **The two devices introduce themselves.** They pass an offer, an answer, and a list of network
-   addresses through the server, each trying to find a path to the other.
-4. **The connection opens and the server drops out.** Every byte of the file travels over that
-   connection. None of it goes back through the server.
+Steps 1 to 3 all pass through the server. Step 4 does not.
 
 On most networks the path found in step 3 is direct, device to device. When a firewall or a
 carrier's network makes that impossible, the connection runs through an encrypted relay instead.
@@ -40,7 +41,7 @@ See [Direct connections](/how-it-works/direct-connection) and
 
 - Puts two devices in a room and assigns roles. The first to join sends, the second receives.
 - Passes the connection-setup messages between them.
-- Hands out short-lived credentials for the relay, when one is configured.
+- Hands out time-limited credentials for the relay, when one is configured.
 - Turns a room id into a three-word code, when the sender asks for one, and back again for ten
   minutes.
 - Adds the size of a finished transfer to one public running total, if the receiving side is
@@ -51,15 +52,25 @@ See [Direct connections](/how-it-works/direct-connection) and
 
 - Touch file data. Not in transit, not at rest, not in any form.
 - Store file names, contents, or a record of what you sent or to whom.
-- Keep peer information after the session. The room is dropped as soon as both sides are gone. A
-  short code outlives it by up to ten minutes, and even then it maps to nothing but a random id.
+- Keep peer information after the session. The room is dropped when the last connection to it
+  closes. A short code outlives it by up to ten minutes, and even then it maps to nothing but a
+  random id.
 - Connect the byte total to you. It is one number with no per-user or per-transfer rows behind it.
 
 ## A room holds exactly two people
 
-The room is the transfer. It takes one sender and one receiver, and a third device trying to join
-is turned away. That is why a link or a code is spent once someone opens it, and why a second
-person opening the same link sees an error rather than joining in.
+The room is the transfer. It takes one sender and one receiver, and a third device that tries to
+join is turned away: the web app shows **Link Invalid**, while the CLI and
+the desktop app say `room is full`.
+
+Nothing is used up along the way. A code keeps resolving for its full ten minutes, and a link
+keeps working while the transfer is live. What turns a third device away is the second seat
+already being taken, not the link having been opened once.
+
+The seat frees again once that device disconnects and the server notices, which takes up to about
+a minute if the drop was not a clean one. Whether the transfer survives that gap depends on who is
+sending: the web app holds its room open and waits for whoever arrives next, while `floe send` and
+the desktop app end the transfer as soon as the receiving side goes.
 
 For a second recipient, start a second transfer.
 

--- a/docs/reference/transfer-protocol.mdx
+++ b/docs/reference/transfer-protocol.mdx
@@ -12,22 +12,29 @@ interoperable in every direction. The CLI and the desktop app share one implemen
 
 ## The sequence
 
-The sender runs this for each file, in order.
+The sender runs this for each file, in order:
 
-```mermaid
-sequenceDiagram
-    participant S as Sender
-    participant R as Receiver
-    S->>R: metadata
-    R->>S: ack
-    S->>R: binary chunks
-    S->>R: end
-    Note over S,R: repeats per file, in order
-    R->>S: received
-```
+1. **`metadata`**, sender to receiver, naming the file and its size.
+2. **`ack`**, receiver back to sender, before any bytes move.
+3. **Binary chunks**, sender to receiver, until the file is exhausted.
+4. **`end`**, sender to receiver, closing the file off.
 
-The final `received` comes once, after every file, and only from a Go receiver. Everything else
-repeats per file.
+The next file starts again at step 1. The final `received` comes once, after every file, and only
+from a Go receiver.
+
+Four things that order does not show.
+
+- **Step 3 is zero or more frames.** An empty file is `metadata`, `ack`, `end`, with no binary
+  frame between them at all.
+- **There is no cancel message.** Cancellation is a channel close, and a receiver declining at
+  the CLI's prompt closes the channel without sending anything. Every wait in the Go engine
+  watches for that close as a separate signal and gives up at once. The browser sender does not:
+  it sees a close only through its buffer-drain polls, so a decline reaches it as the full 120
+  second ack timeout instead.
+- **A person can sit between steps 1 and 2.** `floe receive` prints `Accept? [Y/n]` and waits for
+  an answer before it sends the ack. That is the whole reason the ack deadline is 120 seconds.
+- **The end of a batch is a race, not a message.** A Go sender finishes on whichever comes
+  first: the `received` frame, its send buffer reaching zero, or the 30 second timeout expiring.
 
 ## How a frame is classified
 

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -15,7 +15,7 @@ docker compose restart server           # restart only the signaling server
 ```
 
 **Restarting the server is not free.** Rooms and room codes live in that process's memory, so a
-restart ends every transfer in flight and invalidates every short code that has not been used yet.
+restart ends every transfer in flight and invalidates every short code that has not yet expired.
 There is no draining and no warning. Pick a quiet moment, or expect people to need a new link.
 
 The client also waits on the server: Compose starts it only once the server reports healthy. If

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -42,8 +42,9 @@ so several things can hold it up.
 
 The card reads "This link is either expired, already in use, or does not exist."
 
-A room takes exactly one recipient, so the most common cause is that someone has already opened
-this link, including you in another tab. Ask the sender to create a new one.
+A room takes exactly one recipient, so the most common cause is that someone is already connected
+on this link, including you in another tab. Opening a link does not use it up, so closing the other
+tab frees the seat. Otherwise ask the sender for a new link.
 
 ### "Could not connect. Ask the sender to enable "Network Relay" and try again."
 
@@ -117,8 +118,10 @@ is. Ask the sender to start a new session for a fresh code.
 
 ### `this code is no longer active; ask for a new one`
 
-The code resolved, but nobody is sharing on it. The sender finished, quit, or their session ended.
-Codes are single use.
+The code resolved, but nobody is sharing on it. The sender finished, quit, or their session ended,
+and joining the empty room they left behind is what produces this message. A word code stays valid for its
+full ten minutes, and a pasted share link does not expire at all. Either way it now points at a
+room nobody is in, so ask for a new one.
 
 ### `room is full (someone else may already be receiving)`
 

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -34,8 +34,8 @@ Follow the two steps, or tap **Copy link to paste in browser** and open it yours
 Safari, Edge, or Firefox. **Continue anyway (some features may not work)** proceeds regardless.
 
 Until you do one of those, the page has not joined the room. That is deliberate: a room takes
-exactly one recipient, so an in-app browser cannot silently consume your transfer and leave the
-real one with a dead link.
+exactly one recipient, so an in-app browser cannot silently take that seat and lock the real
+browser out.
 
 ## While you wait
 
@@ -146,8 +146,10 @@ See [floe receive](/cli/receive) and [Receive files in the desktop app](/desktop
 
 ## If the link does not work
 
-**"Link Invalid"** means the link is expired, malformed, or already used. A room takes exactly one
-recipient, so a link someone else has already opened will not work for you. Ask for a new one.
+**"Link Invalid"** means the link is malformed or already in use, which are its only two causes.
+A room takes exactly
+one recipient, so a link that someone else is already receiving on will not work for you. Ask for
+a new one.
 
 **A short code that will not resolve** came from `floe send` or Floe Desktop and lasts ten
 minutes. Links from the web app carry no code and stay valid as long as the sender's tab is open.

--- a/docs/web-app/sending.mdx
+++ b/docs/web-app/sending.mdx
@@ -80,8 +80,10 @@ on your two devices. The `?s=` value is eight random hex characters that carry n
 they exist only so each link is a distinct page, which stops a phone that already has Floe open
 from reusing a stale tab.
 
-**One link, one recipient.** The room holds exactly two people. Once someone joins, anyone else
-opening the same link gets a "Link Invalid" card. Create a fresh link for each person.
+**One link, one recipient at a time.** The room holds exactly two people, so while someone is
+connected, anyone else opening the same link gets a "Link Invalid" card. Opening a link does not
+use it up: if that person drops off, the seat frees and the link works again. Create a fresh link
+for each person.
 
 ## Watch the connection
 


### PR DESCRIPTION
## Summary

The signaling flowchart was what made the docs look unprofessional, and it had never been designed
for light mode: mermaid painted it `MediumPurple` there. It and the sequence diagram on the
transfer-protocol page both said less than the prose already beside them, so both are gone. A
repo-wide sweep for every mermaid type, ASCII art, box drawing, arrow chain, embedded SVG and
diagram image confirms these were the only two diagrams anywhere in Floe. The `─────` rules in the
CLI pages are literal terminal output and are untouched.

What replaces them earns its space.

**`how-it-works/signaling.mdx`** - "Step by step" is now `<Steps>`, the component the rest of these
docs already use for a sequence (`quickstart.mdx`, all four self-hosting pages), ending on the one
thing only the arrows carried: steps 1 to 3 pass through the server, step 4 does not.

**`reference/transfer-protocol.mdx`** - "The sequence" is an ordered list plus the four things a
sequence diagram structurally cannot show:

| | |
|---|---|
| Chunks are zero or more frames | an empty file is `metadata`, `ack`, `end` with nothing between them |
| There is no cancel message | cancellation is a channel close; a CLI receiver declining sends nothing at all |
| A person sits inside the ack window | `floe receive` prints `Accept? [Y/n]` and waits, which is why that deadline is 120 s |
| The end of a batch is a race | the `received` frame, a drained send buffer, or the 30 s timeout, whichever comes first |

## The claim underneath the diagram

Verifying the rewrite against the server turned up something worth more than the diagrams. The docs
said **a link or a code is spent once someone opens it.** It is not.

`GET /api/code/:code` never deletes a live entry (`server/server.js:285-292`), so a code resolves as
often as you like inside its ten minutes, and nothing consumes the link either. What refuses a third
device is the room's two seats (`server.js:523-525`), and a seat freed by a disconnect
(`server.js:559-562`) can be filled again.

Seven pages carried that framing, and two contradicted themselves outright:

- `troubleshooting.mdx:121` said "Codes are single use" while `:353` correctly said "resolving a
  code does not delete it, so a code used immediately still holds its slot for the full ten minutes"
- `desktop/sending.mdx:107` said "the code and link are spent" two lines above a deep link to
  `/how-it-works/signaling#a-room-holds-exactly-two-people`, the section that says they are not
- `desktop/receiving.mdx:145` applied a different model than the row directly above it

They all describe seat occupancy now.

## Corrections found while verifying

Each of these was checked against the code and survived an adversarial refutation pass:

- The room is dropped when the last connection to it **closes**, not on a timer
- A freed seat reopens only once the server **notices** the drop, up to about a minute for an
  unclean one, and only a web sender waits for the next arrival. `floe send` and the desktop app end
  the transfer when the receiving side goes
- The browser sender does **not** watch for a channel close the way the Go engine does, so a decline
  reaches it as the full 120 s ack timeout
- "Link Invalid" has exactly two causes, a malformed room fragment and a busy room. Expiry is not
  one of them
- Relay credentials are "time-limited" rather than "short-lived": coturn's TTL is 24 h, behind a
  "Do not shorten" comment
- A restart invalidates every short code that has **not yet expired**, not every "unused" one

## Test plan

- [x] Repo-wide sweep across six independent modalities: zero diagrams remain, CLI transcripts intact
- [x] Every rewritten claim re-verified against `server/server.js`, `cli/engine/transfer/`,
      `client/lib/transfer/`, `client/components/P2PTransfer.tsx` and `desktop/app.go`, each finding
      adversarially refuted before being acted on
- [x] Vale: no em or en dashes, American spelling, both at `level: error`
- [x] MDX parses; `<Steps>`/`<Step>` matches the existing working usages; the edited table is
      well-formed; all 29 internal links and 6 anchors resolve against `docs.json`
- [x] Rendered in `mint dev` and checked in both light and dark, including the deep link from
      `desktop/sending.mdx` into the rewritten section

## Known follow-ups, deliberately not in this PR

- `cli/cmd/floe/main.go:329` and `desktop/app.go:1031` carry the same "codes are single-use" claim in
  a code comment. Fixing them would take this out of the docs-only CI path
- `docs/images/desktop/receive.png` and `send-share.png` still show retired product strings ("no
  storage, no middleman", "DTLS and SRTP"), and `settings.png` predates the Check for updates row.
  All three need a re-capture from a live build
