### PR TITLE
docs: fix what docs-verify found on its first run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ For most contributions (UI, pages, components), you only need to run the client.
 ### Prerequisites
 
 - **Node.js 22 or newer** for the client and the signaling server (CI tests the client on Node 22 and the server on Node 20).
-- **pnpm 11** for the client. The repo pins `pnpm@11.1.2` through the `packageManager` field: install it directly with `npm install -g pnpm@11`, or run `corepack enable` once (Corepack ships with Node 22 and picks up the pinned version automatically; on Windows run it from an elevated terminal).
+- **pnpm 11** for the client. The repo pins `pnpm@11.1.2` through the `packageManager` field: install it directly with `npm install -g pnpm@11`, or run `corepack enable` once (Corepack ships with Node 22 through 24 and picks up the pinned version automatically; Node 25 dropped it, so run `npm install -g corepack` first there; on Windows run it from an elevated terminal).
 - **Go 1.25 or newer** for the CLI and the desktop app.
 - **Docker** (optional) for the full-stack Compose setup below.
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -1,4 +1,4 @@
-# Self-Hosting Floe
+# Self-hosting Floe
 
 Run your own Floe instance (the web client and the signaling server) on your own
 infrastructure, independent of `floe.one`. File data still flows peer-to-peer; the

--- a/client/components/layout/Footer.tsx
+++ b/client/components/layout/Footer.tsx
@@ -22,10 +22,10 @@ const columns: {
         label: 'Documentation',
         links: [
             { name: 'Quickstart', href: 'https://www.floe.one/docs/quickstart', external: true },
-            { name: 'Web App', href: 'https://www.floe.one/docs/web-app/sending', external: true },
+            { name: 'Web app', href: 'https://www.floe.one/docs/web-app/sending', external: true },
             { name: 'CLI', href: 'https://www.floe.one/docs/cli/installation', external: true },
-            { name: 'Desktop App', href: 'https://www.floe.one/docs/desktop/installation', external: true },
-            { name: 'Self-Hosting', href: 'https://www.floe.one/docs/self-hosting/overview', external: true },
+            { name: 'Desktop app', href: 'https://www.floe.one/docs/desktop/installation', external: true },
+            { name: 'Self-hosting', href: 'https://www.floe.one/docs/self-hosting/overview', external: true },
             { name: 'FAQ', href: 'https://www.floe.one/docs/faq', external: true },
             { name: 'Changelog', href: 'https://www.floe.one/docs/changelog', external: true },
         ],

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -78,7 +78,7 @@
             "href": "https://www.floe.one/docs/quickstart"
           },
           {
-            "label": "Web App",
+            "label": "Web app",
             "href": "https://www.floe.one/docs/web-app/sending"
           },
           {
@@ -86,11 +86,11 @@
             "href": "https://www.floe.one/docs/cli/installation"
           },
           {
-            "label": "Desktop App",
+            "label": "Desktop app",
             "href": "https://www.floe.one/docs/desktop/installation"
           },
           {
-            "label": "Self-Hosting",
+            "label": "Self-hosting",
             "href": "https://www.floe.one/docs/self-hosting/overview"
           },
           {

--- a/docs/web-app/receiving.mdx
+++ b/docs/web-app/receiving.mdx
@@ -16,7 +16,7 @@ their own. There is nothing to install, no account, and nothing to click to star
 Click the link, or point your phone's camera at the QR code. The page joins the sender's room by
 itself and starts negotiating the connection.
 
-### If Floe says "Open in your browser"
+### If Floe says "Open in your browser" {#if-floe-says-open-in-your-browser}
 
 Apps like Facebook, Messenger, Instagram, TikTok, Snapchat, LINE, X, and WeChat open links in
 their own built-in browser rather than in Chrome or Safari. Those built-in browsers handle file

--- a/server/.env.example
+++ b/server/.env.example
@@ -4,9 +4,9 @@ CLIENT_URL=http://localhost:3000
 PORT=3001
 
 # Standard Node.js runtime flag. Leave this at production for any deployment.
-# Express only suppresses stack traces in its built-in error responses when this
-# is exactly "production"; unset, blank, or "development" all leak them. The
-# server Docker image sets this for you, so it matters most for bare-metal runs.
+# Floe never reads it and registers its own final error handler, so an error
+# response is a generic JSON message at every setting (#239). Express and some
+# dependencies still consult it, and the server Docker image sets it for you.
 NODE_ENV=production
 
 # Number of trusted reverse-proxy hops in front of this server.
@@ -35,7 +35,7 @@ MAX_TURN_REQUESTS_PER_IP=20
 # Optional: managed TURN via Cloudflare Realtime (recommended, no public IP needed).
 # Create a TURN key at https://dash.cloudflare.com (Realtime > TURN Server) and paste
 # the Turn Token ID + its API token below. These take precedence over the coturn vars.
-# The API token is a secret — keep it out of version control.
+# The API token is a secret; keep it out of version control.
 CLOUDFLARE_TURN_KEY_ID=
 CLOUDFLARE_TURN_KEY_API_TOKEN=
 
@@ -45,7 +45,7 @@ CLOUDFLARE_TURN_KEY_API_TOKEN=
 TURN_SECRET=
 TURN_DOMAIN=
 
-# Upstash Redis — global transfer stats counter (durable across redeploys)
+# Upstash Redis: global transfer stats counter (durable across redeploys)
 # Create a free database at https://console.upstash.com and copy the REST URL + token.
 # IMPORTANT: use the read+write REST token (shown as the default token in the console),
 # NOT the read-only token. The server needs write access to INCRBY the counter; with the


### PR DESCRIPTION
## Summary

The first run of the new `docs-verify` skill (arriving in a separate PR) over the whole tree turned up six small pieces of drift, all real, all fixed here:

- `server/.env.example` explained `NODE_ENV` with the Express stack-trace behavior that #239 made irrelevant (Floe registers its own final error handler). Two em dashes in the same file are gone.
- `CONTRIBUTING.md` said Corepack ships with Node 22 without qualification; it was dropped in Node 25.
- The site footer (`Footer.tsx`) and the docs footer (`docs.json`) are mirrors and both still said "Web App", "Desktop App" and "Self-Hosting" after #337 settled sentence case and #338 settled the "Self-hosting" compound. `SELF_HOSTING.md`'s title follows.
- Mintlify keeps quotes in a heading's generated id, so the two links to `/web-app/receiving#if-floe-says-open-in-your-browser` (faq.mdx:62, troubleshooting.mdx:24) landed on nothing on the live site. The heading now carries that id explicitly.

## Test plan

- `docs-check.mjs all` against this branch: 0 hard; the only link note left is the by-design directory URL in SELF_HOSTING.md.
- Byte scan: zero U+2014 / U+2013 in the six touched files.
- `corepack pnpm lint` in `client/` (the Footer change is three string literals).
- After merge: open `https://www.floe.one/docs/web-app/receiving#if-floe-says-open-in-your-browser` and confirm the page scrolls to the heading.
