### PR TITLE
chore: add the floe-release skill, and refuse a desktop pin whose assets do not exist

### DIFF
--- a/.claude/skills/floe-release/SKILL.md
+++ b/.claude/skills/floe-release/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: floe-release
+description: 'Use when cutting a Floe release (a v* or desktop-v* tag): the changelog entry, the release version pins and DESKTOP_VERSION in client/lib/desktopRelease.ts, verifying release assets, or the Microsoft Store submission. Gives the verified order, the paired-release decision and the UTC date rule; the wrong order points floe.one/download at a 404. Not for dependency, action or toolchain bumps.'
+---
+
+# Floe release runbook
+
+Two tag series, one order. `references/tag-and-workflows.md` says what each
+tag fires. Symbols, not lines: `DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE`
+live in `client/lib/desktopRelease.ts`; the changelog contract is the MDX
+comment at the top of `docs/changelog.mdx`; the pin checker is
+`scripts/check-version-pins.mjs`.
+
+Green workflows and four 200s prove that the assets exist at the URLs
+/download will derive; they prove nothing about the update notice, the Store
+listing, or whether the changelog says the right thing, which is what steps 7
+and 8 are for.
+
+## 0. Shape of the release (pairing decision)
+
+- Any `cli/engine` change a desktop user can notice ships on both series,
+  because the desktop is built from `cli/engine`. Receiver-side is the case
+  where both must be cut from the same commit and announced together: a change
+  to what the RECEIVING peer does with bytes or messages
+  (`cli/engine/transfer/receiver.go`, or anything the desktop reaches through
+  `ReceiveFilesWithOptions`) protects nobody until the receiving peer carries
+  it, and the receiver's build decides the outcome (memory
+  `reference_datachannel_early_message_race`; read its correction note before
+  quoting any of its numbers).
+- Sender-only CLI command, server, or web change? `v*` alone (images ride
+  `v*`).
+- `desktop/` or `desktop/frontend` only? `desktop-v*` alone.
+- Nothing user-visible on a surface? No changelog entry for it; the tag still
+  needs a new number.
+
+Never reuse a `v*` number: the `release-tags` ruleset blocks deletion and
+update of `refs/tags/v*`, so a pushed CLI tag is permanent, failed run or not.
+No ruleset covers `desktop-v*`: a desktop tag whose run failed can be deleted
+and re-cut with the same number ("If a workflow fails" under step 4), but a
+number the Store has accepted can never be reused or lowered.
+
+## 1. Code merges
+
+All fix PRs merged, CI green. No code in the prep PR.
+
+## 2. One prep PR: changelog + pins
+
+- Entry per the contract in `docs/changelog.mdx`. Date = the tag's UTC date.
+  Write the date you will tag on (UTC) and tag the same UTC day; if the day
+  slips, correct the `description` in the follow-up PR (labels are immutable
+  once shipped, descriptions are not). If tagging is not imminent, label it
+  `Unreleased` and relabel later (DESKTOP.md step g; precedent d7e432f, #296,
+  which relabeled one `Unreleased` entry into desktop-v0.2.4 and v1.10.1).
+- `node .claude/skills/floe-release/scripts/check-version-pins.mjs --cli v1.10.5 --desktop desktop-v0.2.8 --phase prep`
+  (omit the series you are not releasing). Fix every STALE and MISSING line,
+  rerun until green. It measures the pin surface; it does not know which files
+  ought to carry a version, so read each hit.
+- Do NOT touch `client/lib/desktopRelease.ts`. CI's "Check desktop release
+  assets" step fails a bump whose release does not exist, and /download would
+  point at 404s. The 0.2.3 bump landed 15 minutes after its assets; that
+  margin is the whole reason for the order.
+- `desktop/updatecheck_test.go` version strings are fixtures. Never bump.
+- Squash-merge, then: `gh pr view N --json mergeCommit --jq .mergeCommit.oid`
+
+## 3. Tag (PowerShell tool; annotated, unsigned, deliberate)
+
+Confirm the push with the user first: a `v*` tag is permanent.
+
+```text
+git fetch origin main
+git tag -a v1.10.5 <sha> -m "v1.10.5"
+git tag -a desktop-v0.2.8 <sha> -m "desktop-v0.2.8"
+git push origin v1.10.5 desktop-v0.2.8
+```
+
+UTC date of the tag (this is the changelog date and `DESKTOP_RELEASE_DATE`):
+
+```text
+git for-each-ref --format='%(taggerdate:iso8601-strict)' refs/tags/desktop-v0.2.8
+```
+
+## 4. Watch (the last six runs of each workflow all finished within 5 minutes)
+
+```text
+gh run list --workflow release.yml --limit 1     (and desktop-release.yml, images.yml)
+gh run view <id> --json status,conclusion --jq '.status + " " + .conclusion'
+```
+
+gh's embedded jq only: the jq binary is not on this box and a jq-based loop
+fails silently (memory `project_pnpm_via_corepack`).
+
+If a workflow fails: desktop-release.yml publishes only at its last step, so a
+failed run leaves no release (and any MSIX artifact it uploaded is superseded
+by the re-cut run's). Delete the `desktop-v*` tag
+(`git push origin :refs/tags/desktop-v0.2.8`, then `git tag -d` locally) and
+re-cut the same number on the fixed merge commit; no ruleset covers it. A `v*`
+tag is permanent: `gh run rerun <id> --failed` reruns on the same tag, and a
+fix that needs new code goes out as the next number. Never re-cut a `v*`.
+
+## 5. Verify assets (all four must answer 200 after redirects)
+
+From the PowerShell tool. Name the binary: Git Bash's `curl` is a Schannel
+build here that exits 43 on every https URL, and PowerShell's `curl` is an
+alias of Invoke-WebRequest.
+
+```text
+curl.exe -sIL -o NUL -w '%{http_code} %{url_effective}\n' <url>
+https://github.com/jannskiee/floe/releases/download/desktop-v$V/floe-desktop-setup-$V.exe
+https://github.com/jannskiee/floe/releases/download/desktop-v$V/floe-desktop-$V-windows-amd64.zip
+https://github.com/jannskiee/floe/releases/download/desktop-v$V/SHA256SUMS.txt
+https://github.com/jannskiee/floe/releases/tag/desktop-v$V
+```
+
+(In Git Bash: `/c/Windows/System32/curl.exe` with `-o /dev/null`.)
+
+CLI: `gh release view v1.10.5 --json assets --jq '.assets[].name'` lists six
+archives plus `checksums.txt`.
+
+## 6. Follow-up PR: desktopRelease.ts
+
+Bump `DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE` together; the date is the
+tag's UTC date as "Mon D, YYYY" (`desktopRelease.test.ts` rejects a future
+date against the runner's UTC clock; #324's second commit fixed exactly that).
+Relabel an `Unreleased` entry now if you used one. Run the checker with
+`--phase follow-up` (asserts the new pin and the date against the tag). CI's
+release-asset step is the merge gate.
+
+## 7. Store submission (one in flight at a time)
+
+One in flight is checkable: Partner Center's overview must show the previous
+submission as "In Microsoft Store", not "In certification"; the Start update
+button exists only then. MSIX = the desktop-release.yml run's ARTIFACT
+`floe-desktop-msix-<X.Y.Z>-run<run_number>`, never a release-page asset:
+`gh run list --workflow desktop-release.yml --limit 1` for the run id, then
+`gh run download <id> -n <artifact-name>`. The Partner Center click path and
+its DOM idioms live in memory (`project_floe_store_identity`: standing
+authorization and URLs; `reference_release_automation_traps` and
+`project_release_1_10_3_and_0_2_6`: the flow that worked). Paste a plain-text
+condensation of the entry into "What's new".
+
+## 8. DESKTOP.md step h
+
+Launch the previous build, confirm the update notice names the new version.
+If the previous build is not installed, run
+`floe-desktop-<prev>-windows-amd64.zip` from the previous release page; the
+notice runs only unpackaged (`desktop/updatecheck.go` returns early for a
+packaged build), so the Store install can never show it.
+
+## Done means
+
+All eight steps with evidence in the report. Green workflows and four 200s are
+necessary; step 8 and the certification email are the completion signals.

--- a/.claude/skills/floe-release/SKILL.md
+++ b/.claude/skills/floe-release/SKILL.md
@@ -11,6 +11,10 @@ live in `client/lib/desktopRelease.ts`; the changelog contract is the MDX
 comment at the top of `docs/changelog.mdx`; the pin checker is
 `scripts/check-version-pins.mjs`.
 
+The skill's paths exist on `main` only once PR #343 has merged; from an older
+checkout, run the script by its absolute path from a checkout that has it.
+The CI asset step lands with the same PR.
+
 Green workflows and four 200s prove that the assets exist at the URLs
 /download will derive; they prove nothing about the update notice, the Store
 listing, or whether the changelog says the right thing, which is what steps 7
@@ -45,16 +49,36 @@ All fix PRs merged, CI green. No code in the prep PR.
 
 ## 2. One prep PR: changelog + pins
 
-- Entry per the contract in `docs/changelog.mdx`. Date = the tag's UTC date.
-  Write the date you will tag on (UTC) and tag the same UTC day; if the day
-  slips, correct the `description` in the follow-up PR (labels are immutable
-  once shipped, descriptions are not). If tagging is not imminent, label it
-  `Unreleased` and relabel later (DESKTOP.md step g; precedent d7e432f, #296,
-  which relabeled one `Unreleased` entry into desktop-v0.2.4 and v1.10.1).
+- Entry per the contract in `docs/changelog.mdx`. Date = the tag's UTC date
+  (step 3 has the command for today's UTC date). Write the date you will tag
+  on (UTC) and tag the same UTC day; if the day slips, correct the
+  `description` in the follow-up PR (labels are immutable once shipped,
+  descriptions are not). If tagging is not imminent, label it `Unreleased` and
+  relabel later (DESKTOP.md step g; precedent d7e432f, #296).
+- For a PAIRED release the relabel is a SPLIT: the single `Unreleased` entry
+  becomes two entries with the same UTC date, each with its own bold headline.
+  `desktop-vX.Y.Z` comes first, tags starting with `Desktop`, carrying the
+  bullets a desktop user notices, in desktop wording. Then `vX.Y.Z`, tags
+  `CLI` first and then `Web` / `Self-hosting` as applicable, carrying the CLI
+  bullets, the `Web app:` bullet, and a `Self-hosting:` images-rebuilt bullet
+  whenever `server/` or `client/` changed. d7e432f (#296) is the precedent. A
+  receiver-side change on a PR that is also sender-side or web-side still
+  pairs: receiver-side wins.
 - `node .claude/skills/floe-release/scripts/check-version-pins.mjs --cli v1.10.5 --desktop desktop-v0.2.8 --phase prep`
-  (omit the series you are not releasing). Fix every STALE and MISSING line,
-  rerun until green. It measures the pin surface; it does not know which files
-  ought to carry a version, so read each hit.
+  (omit the series you are not releasing). It measures the tree the script
+  lives in; `--root <dir>` measures another checkout, such as a scratch
+  worktree. By default it sweeps the three newest tags of each series and
+  labels every STALE line with the tag it belongs to; `--old-cli` and
+  `--old-desktop` (comma-separated) override the sweep. Fix every STALE and
+  MISSING line that is a pin and rerun. It does not know which files ought to
+  carry a version, so read each hit: a line that is release history (the
+  history section of DESKTOP.md, a workflow comment naming a past release)
+  stays, so green is not always reachable, and the report says which hits
+  you judged to be history.
+- Make the prep edits with the Edit tool or PowerShell. A Git Bash `sed -i`
+  rewrites a CRLF working copy to LF: harmless to the commit under autocrlf,
+  noisy in the working tree (git warns on every touch, and tools that do not
+  normalize show every line as changed).
 - Do NOT touch `client/lib/desktopRelease.ts`. CI's "Check desktop release
   assets" step fails a bump whose release does not exist, and /download would
   point at 404s. The 0.2.3 bump landed 15 minutes after its assets; that
@@ -64,16 +88,30 @@ All fix PRs merged, CI green. No code in the prep PR.
 
 ## 3. Tag (PowerShell tool; annotated, unsigned, deliberate)
 
-Confirm the push with the user first: a `v*` tag is permanent.
+Confirm the push with the user first: a `v*` tag is permanent. `--no-sign`
+keeps the tag unsigned whatever `tag.gpgSign` says.
 
 ```text
 git fetch origin main
-git tag -a v1.10.5 <sha> -m "v1.10.5"
-git tag -a desktop-v0.2.8 <sha> -m "desktop-v0.2.8"
+git tag -a --no-sign v1.10.5 <sha> -m "v1.10.5"
+git tag -a --no-sign desktop-v0.2.8 <sha> -m "desktop-v0.2.8"
 git push origin v1.10.5 desktop-v0.2.8
 ```
 
-UTC date of the tag (this is the changelog date and `DESKTOP_RELEASE_DATE`):
+Today's UTC date, which the changelog `description` from step 2 must equal on
+the day you push:
+
+```text
+date -u +%F                                              (bash)
+(Get-Date).ToUniversalTime().ToString('yyyy-MM-dd')      (PowerShell)
+```
+
+A Manila evening is still "today" in UTC; the UTC date only catches up with
+Manila at 08:00, so a tag pushed between midnight and 08:00 Manila carries
+yesterday's date.
+
+UTC date of the tag once it exists (this is the changelog date and
+`DESKTOP_RELEASE_DATE`):
 
 ```text
 git for-each-ref --format='%(taggerdate:iso8601-strict)' refs/tags/desktop-v0.2.8
@@ -122,7 +160,11 @@ Bump `DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE` together; the date is the
 tag's UTC date as "Mon D, YYYY" (`desktopRelease.test.ts` rejects a future
 date against the runner's UTC clock; #324's second commit fixed exactly that).
 Relabel an `Unreleased` entry now if you used one. Run the checker with
-`--phase follow-up` (asserts the new pin and the date against the tag). CI's
+`--phase follow-up`: it reads the tag's date from `git for-each-ref`, so the
+tag must exist locally (step 3, or `git fetch --tags`). Without it the checker
+stops with exit 2 and "tag desktop-v0.2.8 is not known here: either run git
+fetch --tags, or you are running follow-up before step 3 (the tag must exist
+first)". With it, it asserts the new pin and the date against the tag. CI's
 release-asset step is the merge gate.
 
 ## 7. Store submission (one in flight at a time)

--- a/.claude/skills/floe-release/references/tag-and-workflows.md
+++ b/.claude/skills/floe-release/references/tag-and-workflows.md
@@ -1,0 +1,48 @@
+# Tags and the workflows they fire
+
+Read from the workflow files on `main` on 2026-08-28. When a workflow changes, reread it; this page describes, it does not decide.
+
+| Trigger             | Workflow                                | Result                                                                                                  |
+| ------------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `v*` push           | `.github/workflows/release.yml`         | CLI release, marked Latest, plus package manager manifests                                              |
+| `v*` push           | `.github/workflows/images.yml`          | `ghcr.io/jannskiee/floe-server` and `floe-client`, tagged `X.Y.Z`, `X.Y`, `latest`                      |
+| `workflow_dispatch` | `.github/workflows/images.yml`          | Rebuilds and republishes the branch tags (`main`, `sha-*`) for the ref it runs on; `latest` never moves |
+| `desktop-v*` push   | `.github/workflows/desktop-release.yml` | Desktop pre-release (exe, zip, `SHA256SUMS.txt`) and the MSIX artifact                                  |
+| `workflow_dispatch` | `.github/workflows/desktop-release.yml` | Dry run: same build and checks, MSIX artifact still uploaded, nothing published                         |
+
+## `v*` and release.yml
+
+- GoReleaser is pinned to an exact `v2.17.1` (a range would resolve through a non-GitHub host inside the step that carries `TAP_GITHUB_TOKEN`); Dependabot does not bump action inputs, so raise it by hand when a release needs a newer one.
+- `.goreleaser.yml` builds linux, darwin and windows for amd64 and arm64: six archives named `floe_X.Y.Z_<os>_<arch>` (zip on windows, tar.gz elsewhere) plus `checksums.txt`.
+- `main.version` is `{{ .Version }}`, the tag WITHOUT the leading `v`, so a `v1.10.5` binary prints `floe 1.10.5`.
+- The release is the repository's Latest. `/releases/latest` must keep resolving to a CLI release: the install scripts, `floe update` and the back-compat CI job depend on it, which is why the desktop series is a pre-release.
+- The same run publishes the Homebrew cask (`jannskiee/homebrew-tap`), the Scoop manifest (`jannskiee/scoop-bucket`) and a PR to `microsoft/winget-pkgs` from the `jannskiee/winget-pkgs` fork, all through `TAP_GITHUB_TOKEN`.
+- The `release-tags` ruleset forbids deletion, update and non-fast-forward on `refs/tags/v*`. A pushed `v*` tag is permanent, so confirm the push with the user first; a failed run is rerun in place with `gh run rerun <id> --failed`.
+
+## `v*` and images.yml
+
+- Runs on `v*` tags and on pushes to `main` that touch `client/`, `server/`, the workflow, or `.github/scripts/*.sh`, plus `workflow_dispatch`. Path filters are not evaluated for tag pushes, so a tag always publishes.
+- Tags: `type=semver` gives `1.10.5` and `1.10`; the default `latest=auto` flavor moves `latest` only on a semver tag, never on a branch push or a dispatch; branch pushes and dispatches get `main` and `sha-<short>`.
+- Four native legs (two images, amd64 and arm64) each push by digest and smoke-test before a single tag moves; both images publish together or not at all.
+
+## `desktop-v*` and desktop-release.yml
+
+- `windows-latest`. Frontend `npm ci`, `npm test`, `npm run build`, then `go test ./...` in `desktop/`, then `wails build -s -nsis`.
+- The tag must be strictly numeric `desktop-vX.Y.Z` (NSIS `VIProductVersion` rejects suffixes) and the version is injected VERBATIM: `-X main.version=desktop-v0.2.8`.
+- `desktop/wails.json` is stamped from the tag in the runner's working tree, never committed, so the committed `productVersion` only feeds the dispatch path. Bump it anyway so the tree matches what shipped.
+- Assets: `floe-desktop-setup-$V.exe` (NSIS installer), `floe-desktop-$V-windows-amd64.zip` (exe plus LICENSE), `SHA256SUMS.txt` (LF endings on purpose, so `sha256sum -c` works). Published with `gh release create --verify-tag --prerelease --latest=false`; both flags are unconditional.
+- The release body is boilerplate; /download's "Release notes" link points at the docs changelog instead.
+- The MSIX is a workflow ARTIFACT, `floe-desktop-msix-<X.Y.Z>-run<run_number>`, built into `dist-msix/` so the release glob never attaches it. The run id comes from `gh run list --workflow desktop-release.yml`; fetch with `gh run download <id> -n <artifact-name>`.
+- Publishing is the last step, so a failed run leaves no release. No ruleset protects `desktop-v*`: delete the tag and re-cut the same number. Once the Store has accepted a version, a lower Identity version is refused, so a shipped desktop number is never reused.
+
+## `workflow_dispatch` on desktop-release.yml
+
+Same steps, version read from `desktop/wails.json`, in-app version string `dev`, nothing published. The MSIX artifact (`floe-desktop-msix-<X.Y.Z>-run<run_number>`) still uploads, and the exe and zip land in `desktop-dryrun-run<run_number>`.
+
+## Consumers of `DESKTOP_VERSION`
+
+`client/lib/desktopRelease.ts` derives every desktop URL from it. Readers: `client/app/download/page.tsx` (/download, which also shows `DESKTOP_RELEASE_DATE`), `client/components/landing/DesktopSection.tsx` and `client/components/landing/AppWindow.tsx` (homepage), `client/lib/desktopRelease.test.ts` (shape, no future date, never `/releases/latest`), and the `Check desktop release assets` step in `.github/workflows/ci.yml`, which asks GitHub whether `desktop-v$DESKTOP_VERSION` carries all three assets before a bump can merge.
+
+## Package managers
+
+GoReleaser opens the winget-pkgs PR. A red `Validation-Installation-Error` there is usually an arm64 host timeout: verify the package, then close and reopen the PR (memory `project_winget_arm64_validation_flake`).

--- a/.claude/skills/floe-release/scripts/check-version-pins.mjs
+++ b/.claude/skills/floe-release/scripts/check-version-pins.mjs
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+/**
+ * Measures the version-pin surface of a Floe release, before the tag (prep)
+ * and after it (follow-up).
+ *
+ * Why measure instead of list: the set of files carrying the current version
+ * string has changed on every release so far, and docs/reference/
+ * transfer-protocol.mdx held five copies of it that no prep PR ever touched.
+ * A hand-maintained "files to bump" list is exactly the thing that goes
+ * stale, so this walks the tree for the OLD strings and reports every
+ * survivor, plus a short list of files that must carry the NEW one.
+ *
+ * Why two phases: client/lib/desktopRelease.ts is the one pin that must NOT
+ * move in the prep PR. /download derives every desktop asset URL from it, so
+ * a bump that lands before the desktop-v* release exists points the page at
+ * 404s; the 0.2.3 bump landed 15 minutes after its assets, and that margin is
+ * the whole reason for the order. In prep the file must still hold the old
+ * version; in follow-up it must hold the new one, and DESKTOP_RELEASE_DATE
+ * must be the tag's UTC date, because desktopRelease.test.ts compares that
+ * date against the CI runner's UTC clock (#324 needed a second commit for
+ * exactly this).
+ *
+ * Usage, from the repo root:
+ *   node .claude/skills/floe-release/scripts/check-version-pins.mjs
+ *       --cli vX.Y.Z and/or --desktop desktop-vX.Y.Z [--phase prep|follow-up]
+ *       [--old-cli vA.B.C] [--old-desktop desktop-vA.B.C] [--allow <path>]...
+ *       [--json]
+ *   node .claude/skills/floe-release/scripts/check-version-pins.mjs --self-test
+ * Exit: 0 green, 1 findings, 2 usage or git errors.
+ */
+import { execFileSync } from 'node:child_process';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// scripts/ -> floe-release/ -> skills/ -> .claude/ -> repo root.
+const ROOT = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    '..',
+    '..'
+);
+const SKIP_DIRS = new Set([
+    '.git',
+    'node_modules',
+    '.next',
+    'dist',
+    'dist-msix',
+    'build',
+    'out',
+    'coverage',
+    '.idea',
+]);
+const SKIP_PATHS = new Set([
+    'desktop/frontend/wailsjs',
+    'desktop/frontend/dist',
+    '.claude/skills/floe-release',
+    // Shipped labels are history; the contract at the top forbids editing them.
+    'docs/changelog.mdx',
+    // Its version strings are fixtures for the comparison logic.
+    'desktop/updatecheck_test.go',
+]);
+const SKIP_NAMES = new Set([
+    'pnpm-lock.yaml',
+    'package-lock.json',
+    'go.sum',
+    'go.work.sum',
+]);
+const BINARY = /\.(png|jpe?g|gif|webp|ico|exe|zip|msix|woff2?|ttf|pdf)$/i;
+const MAX_BYTES = 2 * 1024 * 1024;
+const PIN_FILE = 'client/lib/desktopRelease.ts';
+const MONTHS = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+];
+
+// A version is a pin when it is not embedded in a longer identifier or a
+// longer version. Letters, digits and a dot may not precede it (`x1.10.1`,
+// `10.0.2.7`); a letter, a digit or `.digit` may not follow it (`1.10.10`,
+// `1.10.1.5`). Underscores, hyphens and punctuation may, which is what makes
+// `floe_1.10.4_linux_amd64.tar.gz` and `floe-desktop-setup-0.2.7.exe` pins.
+const BEFORE = '(?<![A-Za-z\\d.])';
+const AFTER = '(?![A-Za-z\\d]|\\.\\d)';
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const versionRe = (kind, num) =>
+    new RegExp(
+        `${BEFORE}${kind === 'cli' ? 'v?' : '(desktop-v)?'}${escapeRe(num)}${AFTER}`
+    );
+
+// [kind, old version, text, must match]. Run with --self-test.
+const SELF_TEST = [
+    ['cli', '1.10.1', 'prints `floe 1.10.1`', true],
+    ['cli', '1.10.1', 'a v1.10.1 tag', true],
+    ['cli', '1.10.4', 'floe_1.10.4_linux_amd64.tar.gz', true],
+    ['cli', '1.10.1', '1.10.10', false],
+    ['cli', '1.10.1', '1.10.1.5', false],
+    ['cli', '1.10.1', 'x1.10.1', false],
+    ['cli', '1.10.1', 'v1.10.15', false],
+    ['desktop', '0.2.7', 'floe-desktop-setup-0.2.7.exe', true],
+    ['desktop', '0.2.7', 'reads `desktop-v0.2.7`', true],
+    ['desktop', '0.2.7', '"productVersion": "0.2.7",', true],
+    ['desktop', '0.2.7', '0.2.70', false],
+    ['desktop', '0.2.7', '10.0.2.7', false],
+    ['desktop', '0.2.7', '0.2.7.0', false],
+    ['desktop', '0.2.7', 'desktop-v0.2.71', false],
+];
+
+function selfTest() {
+    let failed = 0;
+    for (const [kind, old, text, want] of SELF_TEST) {
+        const got = versionRe(kind, old).test(text);
+        if (got !== want) failed += 1;
+        console.log(
+            `${got === want ? 'ok  ' : 'FAIL'} ${kind} ${old} ${want ? 'matches' : 'ignores'} ${JSON.stringify(text)}`
+        );
+    }
+    console.log(
+        `check-version-pins: self-test ${failed ? `${failed} failure(s)` : 'green'} (${SELF_TEST.length} fixtures)`
+    );
+    process.exit(failed ? 1 : 0);
+}
+
+function usage(message) {
+    console.error(`check-version-pins: ${message}`);
+    process.exit(2);
+}
+
+function parseArgs(argv) {
+    const opts = {
+        cli: null,
+        desktop: null,
+        oldCli: null,
+        oldDesktop: null,
+        phase: 'prep',
+        allow: [],
+        json: false,
+    };
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        const value = () => {
+            if (i + 1 >= argv.length) usage(`${arg} needs a value`);
+            return argv[++i];
+        };
+        if (arg === '--cli') opts.cli = value();
+        else if (arg === '--desktop') opts.desktop = value();
+        else if (arg === '--old-cli') opts.oldCli = value();
+        else if (arg === '--old-desktop') opts.oldDesktop = value();
+        else if (arg === '--phase') opts.phase = value();
+        else if (arg === '--allow')
+            opts.allow.push(value().replace(/\\/g, '/').replace(/\/$/, ''));
+        else if (arg === '--json') opts.json = true;
+        else usage(`unknown argument ${arg}`);
+    }
+    if (!opts.cli && !opts.desktop)
+        usage(
+            'pass --cli vX.Y.Z and/or --desktop desktop-vX.Y.Z, or --self-test'
+        );
+    for (const [flag, tag] of [
+        ['--cli', opts.cli],
+        ['--old-cli', opts.oldCli],
+    ]) {
+        if (tag && !/^v\d+\.\d+\.\d+$/.test(tag))
+            usage(`${flag} wants vX.Y.Z, got ${tag}`);
+    }
+    for (const [flag, tag] of [
+        ['--desktop', opts.desktop],
+        ['--old-desktop', opts.oldDesktop],
+    ]) {
+        if (tag && !/^desktop-v\d+\.\d+\.\d+$/.test(tag))
+            usage(`${flag} wants desktop-vX.Y.Z, got ${tag}`);
+    }
+    if (!['prep', 'follow-up'].includes(opts.phase))
+        usage(`--phase wants prep or follow-up, got ${opts.phase}`);
+    return opts;
+}
+
+function git(args) {
+    try {
+        return execFileSync('git', args, {
+            cwd: ROOT,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        }).trim();
+    } catch (err) {
+        return usage(
+            `git ${args.join(' ')} failed: ${(err.stderr || err.message).toString().trim()}`
+        );
+    }
+}
+
+// The newest tag in the series that is not the one being cut, so the answer
+// is the same before the new tag exists and when rerun after it does.
+function previousTag(pattern, newTag) {
+    const tags = git(['tag', '--list', pattern, '--sort=-v:refname'])
+        .split(/\r?\n/)
+        .filter(Boolean);
+    const prev = tags.find((tag) => tag !== newTag);
+    if (!prev)
+        usage(
+            `no ${pattern} tag other than ${newTag} is known here; run git fetch --tags`
+        );
+    return prev;
+}
+
+function tagUtcDate(tag) {
+    const out = git([
+        'for-each-ref',
+        '--format=%(taggerdate:iso8601-strict) %(creatordate:iso8601-strict)',
+        `refs/tags/${tag}`,
+    ]);
+    // taggerdate is empty for a lightweight tag; creatordate then stands in.
+    const iso = out.split(' ').find(Boolean);
+    if (!iso) usage(`tag ${tag} is not known here; run git fetch --tags`);
+    return new Date(iso);
+}
+
+const utcParts = (d) => [d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()];
+const localParts = (d) => [d.getFullYear(), d.getMonth(), d.getDate()];
+const monthDayYear = ([y, m, d]) => `${MONTHS[m]} ${d}, ${y}`;
+
+function readText(rel) {
+    try {
+        return readFileSync(path.join(ROOT, rel), 'utf8');
+    } catch {
+        return null;
+    }
+}
+
+const warnings = [];
+
+function* walk(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const abs = path.join(dir, entry.name);
+        const rel = path.relative(ROOT, abs).replace(/\\/g, '/');
+        if (entry.isDirectory()) {
+            if (SKIP_DIRS.has(entry.name) || SKIP_PATHS.has(rel)) continue;
+            yield* walk(abs);
+        } else if (entry.isFile()) {
+            if (
+                SKIP_PATHS.has(rel) ||
+                SKIP_NAMES.has(entry.name) ||
+                BINARY.test(entry.name)
+            )
+                continue;
+            const size = statSync(abs).size;
+            if (size > MAX_BYTES) {
+                warnings.push(
+                    `${rel}: not scanned, ${size} bytes is over the 2 MiB text cap`
+                );
+                continue;
+            }
+            yield { abs, rel };
+        }
+    }
+}
+
+if (process.argv.includes('--self-test')) selfTest();
+const opts = parseArgs(process.argv.slice(2));
+const series = [];
+if (opts.cli) {
+    const oldTag = opts.oldCli || previousTag('v*', opts.cli);
+    const num = (tag) => tag.slice(1);
+    series.push({
+        name: 'cli',
+        newTag: opts.cli,
+        oldTag,
+        newNum: num(opts.cli),
+        oldNum: num(oldTag),
+        oldRe: versionRe('cli', num(oldTag)),
+        newRe: versionRe('cli', num(opts.cli)),
+    });
+}
+if (opts.desktop) {
+    const oldTag = opts.oldDesktop || previousTag('desktop-v*', opts.desktop);
+    const num = (tag) => tag.replace(/^desktop-v/, '');
+    series.push({
+        name: 'desktop',
+        newTag: opts.desktop,
+        oldTag,
+        newNum: num(opts.desktop),
+        oldNum: num(oldTag),
+        oldRe: versionRe('desktop', num(oldTag)),
+        newRe: versionRe('desktop', num(opts.desktop)),
+    });
+}
+const desktop = series.find((s) => s.name === 'desktop');
+const findings = { stale: [], wrongPhase: [], missing: [], date: [] };
+const allowed = (rel) =>
+    opts.allow.some((a) => rel === a || rel.startsWith(`${a}/`));
+
+// STALE: every surviving old string. In prep the pin file is exempt for the
+// desktop series, because holding the old version there is the point.
+for (const { abs, rel } of walk(ROOT)) {
+    if (allowed(rel)) continue;
+    const lines = readFileSync(abs, 'utf8').split(/\r?\n/);
+    lines.forEach((line, i) => {
+        const hit = series.some((s) => {
+            if (
+                rel === PIN_FILE &&
+                s.name === 'desktop' &&
+                opts.phase === 'prep'
+            )
+                return false;
+            return s.oldRe.test(line);
+        });
+        if (hit) findings.stale.push(`${rel}:${i + 1}: ${line.trim()}`);
+    });
+}
+
+// The pin file: old in prep, new plus the tag's UTC date in follow-up.
+if (desktop) {
+    const pin = readText(PIN_FILE) || '';
+    const version = pin.match(/DESKTOP_VERSION = '([^']*)'/)?.[1];
+    const date = pin.match(/DESKTOP_RELEASE_DATE = '([^']*)'/)?.[1];
+    if (!version || !date) {
+        findings.missing.push(
+            `${PIN_FILE}: DESKTOP_VERSION or DESKTOP_RELEASE_DATE not found`
+        );
+    } else if (opts.phase === 'prep') {
+        if (version === desktop.newNum) {
+            findings.wrongPhase.push(
+                `${PIN_FILE}: DESKTOP_VERSION is already '${version}'; bump it in the follow-up PR, after the assets exist`
+            );
+        } else if (version !== desktop.oldNum) {
+            warnings.push(
+                `${PIN_FILE}: DESKTOP_VERSION is '${version}', expected the previous release '${desktop.oldNum}'`
+            );
+        }
+    } else {
+        if (version !== desktop.newNum) {
+            findings.missing.push(
+                `${PIN_FILE}: DESKTOP_VERSION is '${version}', want '${desktop.newNum}'`
+            );
+        }
+        const want = utcParts(tagUtcDate(desktop.newTag));
+        const parsed = new Date(date);
+        const got = Number.isNaN(parsed.getTime()) ? null : localParts(parsed);
+        if (!got || got.join('-') !== want.join('-')) {
+            findings.date.push(
+                `${PIN_FILE}: DESKTOP_RELEASE_DATE is '${date}', the UTC date of ${desktop.newTag} is '${monthDayYear(want)}'`
+            );
+        }
+    }
+}
+
+// MISSING: the few files that must already carry the new string.
+function expectNew(rel, s, filter, what) {
+    const text = readText(rel);
+    if (text === null) return findings.missing.push(`${rel}: file not found`);
+    const lines = text.split(/\r?\n/).filter(filter);
+    if (!lines.some((line) => s.newRe.test(line)))
+        findings.missing.push(`${rel}: ${what} does not mention ${s.newTag}`);
+}
+for (const s of series) {
+    expectNew('CLAUDE.md', s, () => true, 'the version example');
+    expectNew(
+        '.github/ISSUE_TEMPLATE/bug_report.yml',
+        s,
+        (line) => line.includes('placeholder:'),
+        'the version placeholder'
+    );
+    // A missing entry is a warning, not a finding: contract rule 7 says a
+    // release with nothing user-visible gets none, and only a reader can tell.
+    const changelog = readText('docs/changelog.mdx') || '';
+    const labeled = changelog.includes(`label="${s.newTag}"`);
+    const unreleased = changelog.includes('label="Unreleased"');
+    if (labeled) continue;
+    if (unreleased && opts.phase === 'prep') {
+        warnings.push(
+            `docs/changelog.mdx: no label="${s.newTag}" yet; an Unreleased entry exists, relabel it at tag time`
+        );
+    } else if (unreleased) {
+        findings.missing.push(
+            `docs/changelog.mdx: an Unreleased label remains; relabel it ${s.newTag}`
+        );
+    } else {
+        warnings.push(
+            `docs/changelog.mdx: no entry with label="${s.newTag}"; right only if nothing user-visible shipped (rule 7)`
+        );
+    }
+}
+if (desktop) {
+    expectNew(
+        'DESKTOP.md',
+        desktop,
+        (line) => line.startsWith('Current release:'),
+        'the "Current release:" line'
+    );
+    let productVersion;
+    try {
+        productVersion = JSON.parse(readText('desktop/wails.json')).info
+            .productVersion;
+    } catch {
+        productVersion = undefined;
+    }
+    if (productVersion !== desktop.newNum) {
+        findings.missing.push(
+            `desktop/wails.json: productVersion is '${productVersion}', want '${desktop.newNum}'`
+        );
+    }
+}
+
+const groups = [
+    ['STALE', findings.stale],
+    ['WRONG-PHASE', findings.wrongPhase],
+    ['MISSING', findings.missing],
+    ['DATE', findings.date],
+];
+const total = groups.reduce((n, [, items]) => n + items.length, 0);
+const scope = series.map((s) => `${s.oldTag} -> ${s.newTag}`).join(', ');
+const summary = `check-version-pins: ${opts.phase} for ${scope}: ${total ? `${total} finding(s)` : 'green'}`;
+if (opts.json) {
+    const report = {
+        phase: opts.phase,
+        series: series.map((s) => ({
+            ...s,
+            oldRe: s.oldRe.source,
+            newRe: s.newRe.source,
+        })),
+        findings,
+        warnings,
+        summary,
+        exitCode: total ? 1 : 0,
+    };
+    console.log(JSON.stringify(report, null, 4));
+} else {
+    for (const [label, items] of groups)
+        for (const item of items) console.log(`${label} ${item}`);
+    for (const warning of warnings) console.log(`WARN ${warning}`);
+    console.log(summary);
+}
+process.exit(total ? 1 : 0);

--- a/.claude/skills/floe-release/scripts/check-version-pins.mjs
+++ b/.claude/skills/floe-release/scripts/check-version-pins.mjs
@@ -8,7 +8,10 @@
  * transfer-protocol.mdx held five copies of it that no prep PR ever touched.
  * A hand-maintained "files to bump" list is exactly the thing that goes
  * stale, so this walks the tree for the OLD strings and reports every
- * survivor, plus a short list of files that must carry the NEW one.
+ * survivor, plus a short list of files that must carry the NEW one. The
+ * sweep covers the three newest tags of each series, not only the previous
+ * one: example pins in .env.docker.example and docker-compose.yml sat on
+ * 1.10.1 through three releases because each run only looked one tag back.
  *
  * Why two phases: client/lib/desktopRelease.ts is the one pin that must NOT
  * move in the prep PR. /download derives every desktop asset URL from it, so
@@ -20,27 +23,30 @@
  * date against the CI runner's UTC clock (#324 needed a second commit for
  * exactly this).
  *
- * Usage, from the repo root:
+ * Usage (the current directory does not matter; the tree measured is the one
+ * this script lives in, or the one --root names):
  *   node .claude/skills/floe-release/scripts/check-version-pins.mjs
  *       --cli vX.Y.Z and/or --desktop desktop-vX.Y.Z [--phase prep|follow-up]
- *       [--old-cli vA.B.C] [--old-desktop desktop-vA.B.C] [--allow <path>]...
- *       [--json]
+ *       [--root <dir>] [--old-cli vA.B.C[,vD.E.F...]]
+ *       [--old-desktop desktop-vA.B.C[,...]] [--allow <path>]... [--json]
  *   node .claude/skills/floe-release/scripts/check-version-pins.mjs --self-test
  * Exit: 0 green, 1 findings, 2 usage or git errors.
  */
 import { execFileSync } from 'node:child_process';
-import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // scripts/ -> floe-release/ -> skills/ -> .claude/ -> repo root.
-const ROOT = path.resolve(
+const DEFAULT_ROOT = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     '..',
     '..',
     '..',
     '..'
 );
+let ROOT = DEFAULT_ROOT;
+const SWEEP = 3;
 const SKIP_DIRS = new Set([
     '.git',
     'node_modules',
@@ -61,11 +67,16 @@ const SKIP_PATHS = new Set([
     // Its version strings are fixtures for the comparison logic.
     'desktop/updatecheck_test.go',
 ]);
+// Lockfiles and dependency manifests carry other projects' versions: cobra
+// sat at v1.10.2 while Floe shipped v1.10.2, and no Floe pin lives in them.
 const SKIP_NAMES = new Set([
     'pnpm-lock.yaml',
     'package-lock.json',
+    'package.json',
     'go.sum',
     'go.work.sum',
+    'go.mod',
+    'go.work',
 ]);
 const BINARY = /\.(png|jpe?g|gif|webp|ico|exe|zip|msix|woff2?|ttf|pdf)$/i;
 const MAX_BYTES = 2 * 1024 * 1024;
@@ -136,13 +147,17 @@ function usage(message) {
     process.exit(2);
 }
 
+const CLI_TAG = /^v\d+\.\d+\.\d+$/;
+const DESKTOP_TAG = /^desktop-v\d+\.\d+\.\d+$/;
+
 function parseArgs(argv) {
     const opts = {
         cli: null,
         desktop: null,
-        oldCli: null,
-        oldDesktop: null,
+        oldCli: [],
+        oldDesktop: [],
         phase: 'prep',
+        root: null,
         allow: [],
         json: false,
     };
@@ -152,11 +167,17 @@ function parseArgs(argv) {
             if (i + 1 >= argv.length) usage(`${arg} needs a value`);
             return argv[++i];
         };
+        const list = () =>
+            value()
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean);
         if (arg === '--cli') opts.cli = value();
         else if (arg === '--desktop') opts.desktop = value();
-        else if (arg === '--old-cli') opts.oldCli = value();
-        else if (arg === '--old-desktop') opts.oldDesktop = value();
+        else if (arg === '--old-cli') opts.oldCli.push(...list());
+        else if (arg === '--old-desktop') opts.oldDesktop.push(...list());
         else if (arg === '--phase') opts.phase = value();
+        else if (arg === '--root') opts.root = value();
         else if (arg === '--allow')
             opts.allow.push(value().replace(/\\/g, '/').replace(/\/$/, ''));
         else if (arg === '--json') opts.json = true;
@@ -166,22 +187,23 @@ function parseArgs(argv) {
         usage(
             'pass --cli vX.Y.Z and/or --desktop desktop-vX.Y.Z, or --self-test'
         );
-    for (const [flag, tag] of [
-        ['--cli', opts.cli],
-        ['--old-cli', opts.oldCli],
-    ]) {
-        if (tag && !/^v\d+\.\d+\.\d+$/.test(tag))
-            usage(`${flag} wants vX.Y.Z, got ${tag}`);
+    for (const tag of [opts.cli, ...opts.oldCli]) {
+        if (tag && !CLI_TAG.test(tag))
+            usage(`--cli and --old-cli want vX.Y.Z, got ${tag}`);
     }
-    for (const [flag, tag] of [
-        ['--desktop', opts.desktop],
-        ['--old-desktop', opts.oldDesktop],
-    ]) {
-        if (tag && !/^desktop-v\d+\.\d+\.\d+$/.test(tag))
-            usage(`${flag} wants desktop-vX.Y.Z, got ${tag}`);
+    for (const tag of [opts.desktop, ...opts.oldDesktop]) {
+        if (tag && !DESKTOP_TAG.test(tag))
+            usage(
+                `--desktop and --old-desktop want desktop-vX.Y.Z, got ${tag}`
+            );
     }
     if (!['prep', 'follow-up'].includes(opts.phase))
         usage(`--phase wants prep or follow-up, got ${opts.phase}`);
+    if (opts.root) {
+        opts.root = path.resolve(opts.root);
+        if (!existsSync(path.join(opts.root, 'CLAUDE.md')))
+            usage(`--root ${opts.root} does not look like a Floe checkout`);
+    }
     return opts;
 }
 
@@ -199,18 +221,18 @@ function git(args) {
     }
 }
 
-// The newest tag in the series that is not the one being cut, so the answer
+// The newest tags in the series other than the one being cut, so the answer
 // is the same before the new tag exists and when rerun after it does.
-function previousTag(pattern, newTag) {
+function previousTags(pattern, newTag) {
     const tags = git(['tag', '--list', pattern, '--sort=-v:refname'])
         .split(/\r?\n/)
-        .filter(Boolean);
-    const prev = tags.find((tag) => tag !== newTag);
-    if (!prev)
+        .filter((tag) => tag && tag !== newTag)
+        .slice(0, SWEEP);
+    if (!tags.length)
         usage(
             `no ${pattern} tag other than ${newTag} is known here; run git fetch --tags`
         );
-    return prev;
+    return tags;
 }
 
 function tagUtcDate(tag) {
@@ -221,7 +243,11 @@ function tagUtcDate(tag) {
     ]);
     // taggerdate is empty for a lightweight tag; creatordate then stands in.
     const iso = out.split(' ').find(Boolean);
-    if (!iso) usage(`tag ${tag} is not known here; run git fetch --tags`);
+    if (!iso) {
+        usage(
+            `tag ${tag} is not known here: either run git fetch --tags, or you are running follow-up before step 3 (the tag must exist first)`
+        );
+    }
     return new Date(iso);
 }
 
@@ -267,59 +293,73 @@ function* walk(dir) {
 
 if (process.argv.includes('--self-test')) selfTest();
 const opts = parseArgs(process.argv.slice(2));
-const series = [];
-if (opts.cli) {
-    const oldTag = opts.oldCli || previousTag('v*', opts.cli);
-    const num = (tag) => tag.slice(1);
-    series.push({
-        name: 'cli',
-        newTag: opts.cli,
-        oldTag,
-        newNum: num(opts.cli),
-        oldNum: num(oldTag),
-        oldRe: versionRe('cli', num(oldTag)),
-        newRe: versionRe('cli', num(opts.cli)),
-    });
+if (opts.root) ROOT = opts.root;
+
+function makeSeries(name, newTag, overrides, pattern, num) {
+    const oldTags = overrides.length
+        ? overrides
+        : previousTags(pattern, newTag);
+    return {
+        name,
+        newTag,
+        newNum: num(newTag),
+        newRe: versionRe(name, num(newTag)),
+        olds: oldTags.map((tag) => ({
+            tag,
+            num: num(tag),
+            re: versionRe(name, num(tag)),
+        })),
+    };
 }
+const series = [];
+if (opts.cli)
+    series.push(
+        makeSeries('cli', opts.cli, opts.oldCli, 'v*', (tag) => tag.slice(1))
+    );
 if (opts.desktop) {
-    const oldTag = opts.oldDesktop || previousTag('desktop-v*', opts.desktop);
-    const num = (tag) => tag.replace(/^desktop-v/, '');
-    series.push({
-        name: 'desktop',
-        newTag: opts.desktop,
-        oldTag,
-        newNum: num(opts.desktop),
-        oldNum: num(oldTag),
-        oldRe: versionRe('desktop', num(oldTag)),
-        newRe: versionRe('desktop', num(opts.desktop)),
-    });
+    series.push(
+        makeSeries(
+            'desktop',
+            opts.desktop,
+            opts.oldDesktop,
+            'desktop-v*',
+            (tag) => tag.replace(/^desktop-v/, '')
+        )
+    );
 }
 const desktop = series.find((s) => s.name === 'desktop');
 const findings = { stale: [], wrongPhase: [], missing: [], date: [] };
 const allowed = (rel) =>
     opts.allow.some((a) => rel === a || rel.startsWith(`${a}/`));
 
-// STALE: every surviving old string. In prep the pin file is exempt for the
-// desktop series, because holding the old version there is the point.
+// STALE: every surviving old string, labeled with the tag it belongs to. In
+// prep the pin file is exempt for the desktop series, because holding the old
+// version there is the point.
 for (const { abs, rel } of walk(ROOT)) {
     if (allowed(rel)) continue;
     const lines = readFileSync(abs, 'utf8').split(/\r?\n/);
     lines.forEach((line, i) => {
-        const hit = series.some((s) => {
+        const hits = [];
+        for (const s of series) {
             if (
                 rel === PIN_FILE &&
                 s.name === 'desktop' &&
                 opts.phase === 'prep'
             )
-                return false;
-            return s.oldRe.test(line);
-        });
-        if (hit) findings.stale.push(`${rel}:${i + 1}: ${line.trim()}`);
+                continue;
+            for (const old of s.olds) if (old.re.test(line)) hits.push(old.tag);
+        }
+        if (hits.length)
+            findings.stale.push(
+                `${rel}:${i + 1} (${hits.join(', ')}): ${line.trim()}`
+            );
     });
 }
 
-// The pin file: old in prep, new plus the tag's UTC date in follow-up.
+// The pin file: the previous release in prep, the new one plus the tag's UTC
+// date in follow-up.
 if (desktop) {
+    const previous = desktop.olds[0].num;
     const pin = readText(PIN_FILE) || '';
     const version = pin.match(/DESKTOP_VERSION = '([^']*)'/)?.[1];
     const date = pin.match(/DESKTOP_RELEASE_DATE = '([^']*)'/)?.[1];
@@ -332,9 +372,9 @@ if (desktop) {
             findings.wrongPhase.push(
                 `${PIN_FILE}: DESKTOP_VERSION is already '${version}'; bump it in the follow-up PR, after the assets exist`
             );
-        } else if (version !== desktop.oldNum) {
+        } else if (version !== previous) {
             warnings.push(
-                `${PIN_FILE}: DESKTOP_VERSION is '${version}', expected the previous release '${desktop.oldNum}'`
+                `${PIN_FILE}: DESKTOP_VERSION is '${version}', expected the previous release '${previous}'`
             );
         }
     } else {
@@ -418,15 +458,18 @@ const groups = [
     ['DATE', findings.date],
 ];
 const total = groups.reduce((n, [, items]) => n + items.length, 0);
-const scope = series.map((s) => `${s.oldTag} -> ${s.newTag}`).join(', ');
-const summary = `check-version-pins: ${opts.phase} for ${scope}: ${total ? `${total} finding(s)` : 'green'}`;
+const scope = series
+    .map((s) => `${s.olds.map((o) => o.tag).join(', ')} -> ${s.newTag}`)
+    .join('; ');
+const summary = `check-version-pins: ${opts.phase} for ${scope} in ${ROOT}: ${total ? `${total} finding(s)` : 'green'}`;
 if (opts.json) {
     const report = {
         phase: opts.phase,
+        root: ROOT,
         series: series.map((s) => ({
             ...s,
-            oldRe: s.oldRe.source,
             newRe: s.newRe.source,
+            olds: s.olds.map((o) => ({ ...o, re: o.re.source })),
         })),
         findings,
         warnings,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,23 @@ jobs:
         run: node scripts/check-titles.mjs
         working-directory: client
 
+      # /download derives every desktop asset URL from DESKTOP_VERSION, so a
+      # bump that lands before the desktop-v* release exists points the page at
+      # 404s (the 0.2.3 bump landed 15 minutes after its assets; that margin is
+      # the whole reason for the order). Ask GitHub, not git: the checkout
+      # above is depth 1 without tags. A step rather than a job for the same
+      # reason as the title check.
+      - name: Check desktop release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          v="$(grep -o "DESKTOP_VERSION = '[^']*'" client/lib/desktopRelease.ts | grep -o '[0-9.]\+')"
+          names="$(gh release view "desktop-v$v" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
+          for a in "floe-desktop-setup-$v.exe" "floe-desktop-$v-windows-amd64.zip" SHA256SUMS.txt; do
+            printf '%s\n' "$names" | grep -qxF "$a" || { echo "desktop-v$v is missing asset $a" >&2; exit 1; }
+          done
+          echo "desktop-v$v has all assets"
+
   server:
     name: Server (Node.js)
     runs-on: ubuntu-latest

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -247,10 +247,13 @@ wails.json, the exe version resource, and all marketing. At tag time, bump
 wails.json's `productVersion` and the concrete version examples in
 docs/desktop/installation.mdx and docs/desktop/settings.mdx; the release workflow
 rewrites wails.json only in the runner's working tree, so the committed value
-goes stale otherwise. Bump `DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE` in
-client/lib/desktopRelease.ts in a follow-up only AFTER the release assets are
-published: /download derives its links from them, and bumping early points the
-page at assets that do not exist yet (0.2.2 and 0.2.3 both shipped this way).
+goes stale otherwise. The release order, which files carry a version pin, and
+when `client/lib/desktopRelease.ts` may be bumped are in
+`.claude/skills/floe-release/SKILL.md`: /download derives its links from it,
+so bump only after the assets exist (the 0.2.3 bump landed 15 minutes after
+its assets; that margin is the whole reason for the order). The skill's
+`scripts/check-version-pins.mjs` measures the pin surface instead of listing
+it, and CI refuses a `DESKTOP_VERSION` whose release assets do not exist yet.
 
 Packaged-build behavior (verified empirically 2026-08-02 on a loose-layout
 package of this app): the app's HKCU registry writes are virtualized into the
@@ -286,9 +289,10 @@ binary.
 - [ ] g. Each release after: write the changelog entry BEFORE tagging. Add it
       under `Unreleased` in `docs/changelog.mdx`, merge, then relabel it to
       `desktop-vX.Y.Z` with the date at tag time, the way the CLI already does
-      (see commit b5bc70e). The generated GitHub release body is boilerplate and
-      carries no account of what changed, and /download's "Release notes" link
-      points at the docs changelog, so skipping this leaves that link empty.
+      (see commit d7e432f, #296). The generated GitHub release body is
+      boilerplate and carries no account of what changed, and /download's
+      "Release notes" link points at the docs changelog, so skipping this
+      leaves that link empty.
       Tag the entry `["Desktop"]`; the full contract for labels, dates and tag
       values is the MDX comment at the top of `docs/changelog.mdx`.
       Then paste a plain-text condensation into Partner Center's "What's new in
@@ -297,7 +301,7 @@ binary.
       hand. Judge that by what reaches a user, not by whether code changed:
       `desktop-v0.2.1` did move the Store tile colour, so it earned the short
       entry it now has, whereas a release that is only CI or build plumbing
-      earns nothing.
+      earns nothing. The runbook is `.claude/skills/floe-release/SKILL.md`.
 - [ ] h. Each release after: once the GitHub release is published, launch the
       PREVIOUS build and confirm the update notice fires and names the new
       version (the notice shipped in 0.2.3; the first release after it is the

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -10,8 +10,11 @@ rss: true
   1. `label` is the git tag, verbatim: v1.9.1, desktop-v0.2.2, or Unreleased.
      It also generates the anchor (v1.7.0 becomes #v1-7-0), so never edit a
      label that has already shipped.
-  2. `description` is the release date as YYYY-MM-DD, using the tag's local
-     date. Omit it only while the entry is still Unreleased.
+  2. `description` is the release date as YYYY-MM-DD, using the tag's UTC
+     date (GitHub, CI and DESKTOP_RELEASE_DATE run on UTC; before 08:00 Manila
+     that is yesterday's date). Entries up to v1.8.0, plus desktop-v0.1.0 and
+     desktop-v0.2.0, carry the Manila date. Omit it only while the entry is
+     still Unreleased.
   3. `tags` come from exactly four values, spelled exactly like this:
        "Web"           the web app, and self-hosted web clients
        "Desktop"       the Windows app


### PR DESCRIPTION
## Summary

Five paired releases have shipped with the same two-PR shape, and the order only lived in memory notes and a DESKTOP.md paragraph. The pin surface is unstable too: no prep PR ever touched `docs/reference/transfer-protocol.mdx`, which holds five current-version strings.

- `.claude/skills/floe-release`: the runbook (pairing decision, prep PR, tags, watch, verify assets, follow-up PR with the tag's UTC date, Store from the workflow artifact, update-notice check, what to do when a workflow fails) and `scripts/check-version-pins.mjs`, which measures the pin surface instead of listing it.
- `ci.yml`: a step at the end of `build-and-lint` asks GitHub whether `desktop-v$DESKTOP_VERSION` exists with its three assets, so a pin bump can never merge ahead of its release.
- `DESKTOP.md` points at the skill and drops a claim the record contradicts (the 0.2.2 and 0.2.3 pin bumps both landed after their assets; the margin was 15 minutes).
- `docs/changelog.mdx` rule 2 says UTC and names the nine older entries that carry the Manila date.

## Test plan

- `check-version-pins.mjs --phase follow-up` for the current release: green. `--phase prep` for 1.10.5 / 0.2.8 on a scratch worktree of main: 19 stale pins across 10 files, including `transfer-protocol.mdx` and `installation.mdx:96`; bumping all but one leaves exactly that one; a wrong `DESKTOP_RELEASE_DATE` fails the date check; a pin bumped in prep phase is refused. 14-fixture regex self-test green.
- CI step: this PR runs it against 0.2.7 (assets exist); the same shell with `v=9.9.9` exits 1 naming the missing asset. `actionlint` clean.
- The four derived URLs for desktop-v0.2.7 answer 200 via `curl.exe`.
- Independent adversarial audit of the skill; every finding applied.
