### PR TITLE
docs(client): point the download page at desktop-v0.2.8

### DIFF
--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.7';
-export const DESKTOP_RELEASE_DATE = 'Aug 19, 2026';
+export const DESKTOP_VERSION = '0.2.8';
+export const DESKTOP_RELEASE_DATE = 'Aug 27, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
## Summary

Bumps `DESKTOP_VERSION` to `0.2.8` and `DESKTOP_RELEASE_DATE` to the tag's UTC date, after the `desktop-v0.2.8` release assets were verified live. `/download` derives every desktop link from these two constants, which is why this lands in its own PR after the release (the floe-release runbook, step 6).

## Test plan

- `check-version-pins.mjs --phase follow-up`: the pin equals the tag and the date equals the tag's UTC date.
- `curl.exe -sIL` on the setup exe, the zip, `SHA256SUMS.txt`, and the release page: all 200.
- CI's `Check desktop release assets` step is the merge gate and confirms the three assets by name.
