### PR TITLE
chore(skills): fix the unstable-heading fixture, and stop scanning test fixtures for pins

### DIFF
--- a/.claude/skills/docs-verify/scripts/docs-check.test.mjs
+++ b/.claude/skills/docs-verify/scripts/docs-check.test.mjs
@@ -114,17 +114,20 @@ test('an anchor that matches nothing on a page with only stable headings is HARD
 
 test('a link to an unstable heading (the live-id case) is NOTE, not HARD', () => {
     const root = fresh();
+    // #340 gave the live heading an explicit id, so synthesize an unstable
+    // one: Mintlify keeps the quotes in the id it generates for it.
+    appendLine(root, 'docs/faq.mdx', '### Says "hello" to the reader');
     const n = appendLine(
         root,
         'docs/faq.mdx',
-        'See [x](/web-app/receiving#if-floe-says-open-in-your-browser).'
+        'See [x](/faq#says-hello-to-the-reader).'
     );
     const r = run(root);
     assert.equal(r.status, 0, r.out);
     assert.match(
         r.out,
         new RegExp(
-            `NOTE  links  docs/faq\\.mdx:${n}  #if-floe-says-open-in-your-browser targets an unstable heading`
+            `NOTE  links  docs/faq\\.mdx:${n}  #says-hello-to-the-reader targets an unstable heading`
         )
     );
     assert.doesNotMatch(r.out, new RegExp(`HARD  links  docs/faq\\.mdx:${n}`));

--- a/.claude/skills/floe-release/scripts/check-version-pins.mjs
+++ b/.claude/skills/floe-release/scripts/check-version-pins.mjs
@@ -69,6 +69,9 @@ const SKIP_PATHS = new Set([
 ]);
 // Lockfiles and dependency manifests carry other projects' versions: cobra
 // sat at v1.10.2 while Floe shipped v1.10.2, and no Floe pin lives in them.
+// Test fixtures carry example versions, never pins: a Go table row that
+// says "v1.10.4" is test data, and a slug fixture is not a download link.
+const TEST_FIXTURE = /(_test\.go|\.test\.(ts|tsx|mjs|js))$/;
 const SKIP_NAMES = new Set([
     'pnpm-lock.yaml',
     'package-lock.json',
@@ -276,6 +279,7 @@ function* walk(dir) {
             if (
                 SKIP_PATHS.has(rel) ||
                 SKIP_NAMES.has(entry.name) ||
+                TEST_FIXTURE.test(entry.name) ||
                 BINARY.test(entry.name)
             )
                 continue;

--- a/cli/engine/transfer/format.go
+++ b/cli/engine/transfer/format.go
@@ -15,7 +15,7 @@ import (
 // a compatibility surface) or anything on the wire.
 const (
 	maxDisplayName   = 200 // the browser's MAX_SEGMENT, so both surfaces agree
-	maxDisplayVer    = 64  // real values: "v1.10.4", "desktop-v0.2.7", "dev"
+	maxDisplayVer    = 64  // real values look like "v1.2.3", "desktop-v0.1.2", "dev"
 	maxDisplayReason = 300 // a current peer's reason is three short lines
 )
 


### PR DESCRIPTION
## Summary

Two findings from the closing audit of today's skills and release work:

- `docs-check.test.mjs` was red on main: its "unstable heading" fixture linked to the live `web-app/receiving.mdx` heading, which #340 gave an explicit id in the same batch, so the NOTE it asserted could never fire. The fixture now writes its own quoted heading into the temporary copy.
- `check-version-pins.mjs` reported two test rows and a Go example comment on every follow-up run. Test fixtures (`*_test.go`, `*.test.{ts,tsx,mjs,js}`) are now skipped, and `format.go`'s example versions no longer look like real tags. The only follow-up hit left on main is the history comment in `desktop-release.yml`.

## Test plan

- `node --test .claude/skills/docs-verify/scripts/docs-check.test.mjs`: 13 pass, 0 fail (was 12/1).
- `check-version-pins.mjs --phase follow-up` on this branch: 1 finding, the `desktop-release.yml` history comment. `--self-test`: green, 14 fixtures.
- `go build ./...` in `cli/` (comment-only change); gofmt clean.
- Prettier clean on both scripts.
