### PR TITLE
chore(skills): add the store-submit skill for the Microsoft Store submission

### DIFF
--- a/.claude/skills/floe-release/SKILL.md
+++ b/.claude/skills/floe-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: floe-release
-description: 'Use when cutting a Floe release (a v* or desktop-v* tag): the changelog entry, the release version pins and DESKTOP_VERSION in client/lib/desktopRelease.ts, verifying release assets, or the Microsoft Store submission. Gives the verified order, the paired-release decision and the UTC date rule; the wrong order points floe.one/download at a 404. Not for dependency, action or toolchain bumps.'
+description: 'Use when cutting a Floe release (a v* or desktop-v* tag): the changelog entry, the release version pins and DESKTOP_VERSION in client/lib/desktopRelease.ts, or verifying release assets. Gives the verified order, the paired-release decision and the UTC date rule; the wrong order points floe.one/download at a 404. Not for dependency, action or toolchain bumps, and not for the Microsoft Store (Partner Center) submission itself; that is store-submit.'
 ---
 
 # Floe release runbook
@@ -182,16 +182,14 @@ release-asset step is the merge gate.
 
 ## 7. Store submission (one in flight at a time)
 
-One in flight is checkable: Partner Center's overview must show the previous
-submission as "In Microsoft Store", not "In certification"; the Start update
-button exists only then. MSIX = the desktop-release.yml run's ARTIFACT
-`floe-desktop-msix-<X.Y.Z>-run<run_number>`, never a release-page asset:
-`gh run list --workflow desktop-release.yml --limit 1` for the run id, then
-`gh run download <id> -n <artifact-name>`. The Partner Center click path and
-its DOM idioms live in memory (`project_floe_store_identity`: standing
-authorization and URLs; `reference_release_automation_traps` and
-`project_release_1_10_3_and_0_2_6`: the flow that worked). Paste a plain-text
-condensation of the entry into "What's new".
+Run `.claude/skills/store-submit/SKILL.md`. It checks that Partner Center
+shows the previous submission as "In Microsoft Store" (Start update exists
+only then), fetches and verifies the tag's MSIX from the desktop-release.yml
+run's ARTIFACT `floe-desktop-msix-<X.Y.Z>-run<run_number>` (never a
+release-page asset; a canceled twin run holds no artifact, 2026-08-27),
+renders this release's changelog entry into the plain-text "What's new"
+field, and drives Partner Center through Submit for certification. Come
+back here for step 8 once it reports "Update in certification".
 
 ## 8. DESKTOP.md step h
 

--- a/.claude/skills/floe-release/references/tag-and-workflows.md
+++ b/.claude/skills/floe-release/references/tag-and-workflows.md
@@ -32,7 +32,7 @@ Read from the workflow files on `main` on 2026-08-28. When a workflow changes, r
 - `desktop/wails.json` is stamped from the tag in the runner's working tree, never committed, so the committed `productVersion` only feeds the dispatch path. Bump it anyway so the tree matches what shipped.
 - Assets: `floe-desktop-setup-$V.exe` (NSIS installer), `floe-desktop-$V-windows-amd64.zip` (exe plus LICENSE), `SHA256SUMS.txt` (LF endings on purpose, so `sha256sum -c` works). Published with `gh release create --verify-tag --prerelease --latest=false`; both flags are unconditional.
 - The release body is boilerplate; /download's "Release notes" link points at the docs changelog instead.
-- The MSIX is a workflow ARTIFACT, `floe-desktop-msix-<X.Y.Z>-run<run_number>`, built into `dist-msix/` so the release glob never attaches it. The run id comes from `gh run list --workflow desktop-release.yml`; fetch with `gh run download <id> -n <artifact-name>`.
+- The MSIX is a workflow ARTIFACT, `floe-desktop-msix-<X.Y.Z>-run<run_number>`, built into `dist-msix/` so the release glob never attaches it. The run id comes from `gh run list --workflow desktop-release.yml`; fetch with `gh run download <id> -n <artifact-name>`. `.claude/skills/store-submit/scripts/msix-preflight.mjs` does both, skips a canceled twin run (2026-08-27), and verifies the manifest inside.
 - Publishing is the last step, so a failed run leaves no release. No ruleset protects `desktop-v*`: delete the tag and re-cut the same number. Once the Store has accepted a version, a lower Identity version is refused, so a shipped desktop number is never reused.
 
 ## `workflow_dispatch` on desktop-release.yml

--- a/.claude/skills/floe-release/scripts/check-version-pins.mjs
+++ b/.claude/skills/floe-release/scripts/check-version-pins.mjs
@@ -62,6 +62,9 @@ const SKIP_PATHS = new Set([
     'desktop/frontend/wailsjs',
     'desktop/frontend/dist',
     '.claude/skills/floe-release',
+    // Its SKILL.md examples, the submission history in references/ and the
+    // version-mapping self-test all name shipped versions on purpose.
+    '.claude/skills/store-submit',
     // Shipped labels are history; the contract at the top forbids editing them.
     'docs/changelog.mdx',
     // Its version strings are fixtures for the comparison logic.

--- a/.claude/skills/store-submit/SKILL.md
+++ b/.claude/skills/store-submit/SKILL.md
@@ -1,0 +1,398 @@
+---
+name: store-submit
+description: "Use when submitting a Floe Desktop release to the Microsoft Store: Partner Center, the MSIX artifact, Start update, a Store submission, certification, or the What's new notes for 9NBQ8ZQ1065L. Verifies the MSIX from the desktop-release.yml run, renders the changelog entry to plain text, and drives Partner Center through Submit for certification, or stops before it as a rehearsal. Not for writing the changelog entry, the tag, or the pin order; that is floe-release. Not for localStorage, storing a file, the App Store, or winget."
+---
+
+# Store submission runbook
+
+One product, one package per release, one submission in flight. This is
+floe-release step 7: it runs after the follow-up PR (step 6) and before the
+update-notice check (step 8), which stays in floe-release. Symbols, not
+lines: the Store ID is `DESKTOP_STORE_ID` in `client/lib/desktopRelease.ts`;
+the package identity is the `<Identity>` element of
+`desktop/build/msix/AppxManifest.xml`; the version mapping is the
+`$identityVersion` line of `desktop/build/msix/pack.ps1`; the artifact is the
+"Upload MSIX artifact" step of `.github/workflows/desktop-release.yml`. Every
+URL, selector and JS idiom is in `references/partner-center.md`; the page
+wins over that file, and the file gets the correction with the date.
+
+The skill's paths exist on `main` once its PR has merged; from an older
+checkout, run the scripts by absolute path from a checkout that has them.
+
+Browser work uses the Claude-in-Chrome tools. Load them once, in one call:
+
+```text
+ToolSearch "select:mcp__claude-in-chrome__tabs_context_mcp,mcp__claude-in-chrome__navigate,mcp__claude-in-chrome__find,mcp__claude-in-chrome__read_page,mcp__claude-in-chrome__get_page_text,mcp__claude-in-chrome__javascript_tool,mcp__claude-in-chrome__file_upload,mcp__claude-in-chrome__computer"
+```
+
+Clicking and waiting: most Partner Center controls are `he-button` web
+components. Click a ref with `computer` (`left_click` with the `ref` that
+`find` returned); wait with `computer` (`wait`, up to 10 s per call);
+reload by `navigate` to the same URL; bring a control into view with
+`computer` (`scroll_to` with its ref). A ref click worked on Start update,
+the Packages Save, Remove and dialog buttons, and no-op'd on the listing
+Save, Delete submission and View product details (measured 2026-08-28).
+The rule for every control: click the ref, wait 3 s, and when nothing
+changed take a fresh screenshot and click the visible button by
+coordinates; when that fails too, JS `.click()` on the `he-button` through
+`javascript_tool`. Only the page changing counts. On the overview card,
+Delete submission and Submit for certification sit side by side: before
+any coordinate click there, `zoom` on the card and read the label under
+the cursor.
+
+Run both scripts from the repo root, in the PowerShell tool or the Bash
+tool. The examples use forward slashes, which both shells and Node accept;
+a backslash path survives only PowerShell.
+
+The standing rule (owner, 2026-08-16, memory `project_floe_store_identity`):
+do the whole submission including Submit, and verify every field after every
+save by reloading and reading it back; the SPA has shown a value it never
+saved (2026-08-14, `form_input` on What's new). Two lines never move: the
+USER signs in (never type into a sign-in form), and one session drives the
+browser at a time (never hand a subagent the browser tools while a draft is
+open; every Save lands on the page that carries Submit).
+
+Green from both scripts is a gate, not proof: they cannot see whether Partner
+Center saved what you typed, whether the package the Store signs is the one
+you verified, or whether certification will pass. The read-backs and the
+certification email are the proof.
+
+## 0. Preconditions (one in flight; 0.2.7 waited for Submission 8 to clear, 2026-08-19)
+
+- The tag exists and its `desktop-release.yml` run succeeded (floe-release
+  steps 3 to 5). The follow-up PR (step 6) is merged, so `DESKTOP_VERSION`
+  equals the version you are submitting; the preflight warns when it does
+  not, which is expected only in a rehearsal.
+- `gh auth status` prints a logged-in account; every gh call the preflight
+  makes in `--out` mode (repo view, run list, api, run download) needs it,
+  and `--file` makes none.
+- The Partner Center overview
+  `https://partner.microsoft.com/en-us/dashboard/products/9NBQ8ZQ1065L/overview`
+  shows the previous submission as "In Microsoft Store". "In certification"
+  means one is in flight: stop, tell the user, wait for the email (20 minutes
+  submit-to-live for Submission 10, about 36 minutes tag-to-live for
+  Submission 7; the docs say up to 3 business days). The Start update control exists only in the first state.
+- A draft already exists (an unsubmitted Submission N+1 and no Start update):
+  a previous session died mid-way. Open it, read Packages (which version is
+  listed, which is struck through) and the en-US What's new (`.value` through
+  `javascript_tool`, never innerText), and resume from the first step whose
+  result you cannot read back. Deleting the draft and starting over is also
+  correct (step 9 does exactly that).
+- Sign-in: sometimes the session is reused (2026-08-19), sometimes Partner
+  Center forces `prompt=login` (2026-08-28). When the tab shows a Microsoft
+  sign-in, say so and wait; the user signs in; then `navigate` to the
+  overview again.
+- "View product details" under Store presence opens the PUBLISHED
+  submission's own pages, with an enabled Save (2026-08-28). Read there,
+  never save there; a draft's URLs carry a different 19-digit submission id.
+- Everything `file_upload` sends must live under THIS session's scratchpad:
+  the tool refused other paths on 2026-08-02 and 2026-08-14. Pass a
+  directory under it as the preflight's `--out`.
+
+## 1. Fetch and verify the MSIX (a naive --limit 1 lands on the canceled twin, 2026-08-27)
+
+```text
+node .claude/skills/store-submit/scripts/msix-preflight.mjs --desktop desktop-v0.2.8 --out <scratchpad>/store
+```
+
+In order, it maps the tag to the Identity version and file name (`0.2.8` to
+`1.2.8.0`, `FloeDesktop_1.2.8.0_x64.msix`, the `(major+1).minor.patch.0`
+rule of pack.ps1); lists the tag's `desktop-release.yml` runs and picks the
+successful one that holds a `floe-desktop-msix-X.Y.Z-run*` artifact, warning
+about twins (run 33109832188, created one second after 33109830152 and
+canceled later, holds zero artifacts); refuses an expired artifact (exit 4; retention is 90 days
+from the run's start, 2026-11-25 for 0.2.8); downloads with
+`gh run download`; reads `AppxManifest.xml` out of the package with its own
+Zip64 reader (makeappx writes Zip64 with data descriptors, so a reader that
+trusts local headers extracts nothing); checks every entry's crc32 (a
+flipped byte anywhere fails it); asserts Identity Name, Publisher, Version
+and ProcessorArchitecture against the template and the tag; prints size,
+sha256, absolute path and a READY block. Exit codes: 0 ready, 1
+findings, 2 usage, 3 no successful run or artifact, 4 expired, 5 gh failure.
+
+Carry the READY block's lines (path, identity, sha256) into the step 6
+record. `--desktop <tag> --file <path.msix>` verifies a package already on
+disk without gh; `--desktop` stays required, because the expected version
+comes from the tag.
+Manual cross-check when in doubt (bsdtar reads MSIX):
+
+```text
+C:\Windows\System32\tar.exe -xOf <msix> AppxManifest.xml
+Get-FileHash <msix>
+```
+
+The MSIX is never a release-page asset (`dist-msix/` sits outside the release
+glob on purpose). The artifact ZIP also carries `priconfig.xml`,
+`resources.pri` and `resources-dump.xml`: build residue, not uploads.
+
+## 2. Render What's new (1,306 characters persisted for 0.2.8; the field takes 1,500)
+
+```text
+node .claude/skills/store-submit/scripts/release-notes.mjs --desktop desktop-v0.2.8 --out <scratchpad>/store/whats-new-desktop-v0.2.8.txt
+```
+
+It finds `<Update label="desktop-v0.2.8" ...>` in `docs/changelog.mdx`,
+renders the body to plain text under a title line `Floe Desktop 0.2.8` (the
+convention Submission 10 shipped by hand, whose 1,306 characters predate
+the script; bold and code marks dropped,
+links reduced to their text with the URL reported, bullets kept as `- `;
+1,429 characters for 0.2.8), and checks it: HARD
+when over 1,500 characters, when an em or en dash survives, when markdown or
+MDX residue survives, when nothing is left under the title line, or when
+the entry is missing (an `Unreleased` entry means floe-release step 6's
+relabel has not happened). NOTE when the first body line is not a bold
+headline (contract rule 4). NOTE for
+external-channel words (`github.com`, `floe.one/download`,
+`releases/download`, winget, Homebrew,
+Scoop, "GitHub release", `apps.microsoft.com`): the listing docs keep URLs
+out of listing fields, and Store policy 10.1.5 (formerly 10.8.5) confines
+software acquisition to the Store, so reword or drop the sentence. It also
+NOTEs a first tag other than `Desktop`, and any bullet starting `Web app:`
+or `Self-hosting:`, which a Store reader has no use for.
+
+Over the limit: condense by hand in the `--out` file (never in the
+changelog), keep the headline and the bullets a Store user notices, then
+`release-notes.mjs --check <file>` until it is green. 0.2.3 and 0.2.5 would
+both need this (3,318 and 2,805 characters).
+
+The script prints the length, a `djb2` fingerprint, and a `json:` line
+holding the text as a JSON string literal; the literal is what step 5 pastes,
+so quotes and newlines are already escaped.
+
+## 3. Overview and Start update (every recorded submission since 5 began here)
+
+`navigate` to the overview URL and confirm with `get_page_text` that the
+page names the previous submission as "In Microsoft Store" and offers Start
+update (the "Update your product" row under "Product release"). `find`
+"Start update" and click its ref (worked 2026-08-28). The draft appears on
+the overview itself (2026-08-28), as a card "Product update: In draft (Submission N: Last
+modified on <date>)" with "Delete submission" and "Submit for certification"
+side by side and a status chip "Update in draft" next to "In Microsoft
+Store"; the section rows below it (Pricing and availability, Properties, Age
+ratings, Packages, Store listings, Submission options) carry chips such as
+Unchanged, Complete or Updated. Note the submission number for the report.
+Submit is enabled from the first second on an update (2026-08-28; on the
+first public submission, 2026-08-02, it stayed gray until the sections were
+saved), so nothing in this runbook clicks near it until step 6.
+
+The section rows are links to `.../submissions/<19-digit id>/<section>`.
+Learn the id by clicking the Packages row: every browser tool result ends
+with the tab's URL (so does `tabs_context_mcp`), and the id is the number
+after `/submissions/`. From then on `navigate` to the section URLs
+directly; a row click that changes nothing is the SPA no-op from
+2026-08-02.
+
+## 4. Packages: upload, wait, confirm the swap, Save (40 to 80 s across recorded runs)
+
+- Open Packages (`.../submissions/<id>/packages`). The page lists the
+  carried-over package (name, version, architecture, device family); its
+  version is the `replaces` value of the step 6 record. `find`
+  "file input for uploading a package"; it comes back as a file-type button
+  with an empty label (2026-08-28). Hand its ref plus the READY path to `file_upload`.
+  Never click the input or "browse your files": a native click opens an
+  invisible OS picker that no tool can close (2026-08-19).
+- Poll, do not sleep: `get_page_text` every 10 to 15 s. While validation
+  runs, the upload row reads "<file> <size> 100 Analyzing package Cancel
+  Pause" and a modal reads "Validating…" at the same time (both, 2026-08-28;
+  the ellipsis is the single character U+2026, so match on "Validating");
+  the row disappears when it ends: about 40 s on 2026-08-19, about 80 s for
+  Submission 10, 50 to 60 s for 7.6 MB in the 2026-08-28 rehearsal. Past 5
+  minutes,
+  reload once and re-read; upload again only if the package is absent, never
+  twice without a reload. The extension can drop for one call mid-poll;
+  retry the same call.
+- Success: the new Identity version is listed and the previous one is struck
+  through, or marked for removal (Partner Center marks the lower version
+  itself; 2026-08-02 and every run since). A package the Store already holds
+  is listed a second time, ranked 2 in the device-family table, under a red
+  alert: "Multiple uploaded files contain the same package
+  (JanCarloParedes.FloeDesktop_1.2.8.0_x64\_\_r1y5w9chaxnzc). Please keep only
+  one of the duplicate packages to continue." (2026-08-28). Then step 8.
+- To drop a package: its "Remove" button (a real button, ref click works)
+  marks it "This package will be removed after you save this page. Revert",
+  and the page says "Click Save to confirm removal of the indicated
+  package(s) from this submission." Nothing is removed until Save.
+- Click Save (ref click worked 2026-08-28). A real Save REDIRECTS, through
+  `.../submissions/<id>`, to the overview, whose Packages chip now reads
+  "Updated"; staying on Packages means nothing was saved: read the page for
+  an error, fix it, Save again. Reopen Packages after a reload and confirm
+  the same lines.
+
+## 5. Store listing, en-US: What's new (programmatic sets are ignored; 2026-08-14)
+
+Open the en-US listing by URL
+(`.../submissions/<id>/listings?languageid=4&languagecode=en-us`). The
+What's new textarea is `#releaseNotes`, `maxlength="1500"` (measured
+2026-08-28); it opens holding the previous submission's text (1,306
+characters for Submission 10, beginning "Floe Desktop 0.2.8"). The SPA
+ignores `form_input` and a plain `.value =` assignment; it registers the
+native setter plus events. Run this with `javascript_tool`, pasting the
+`json:` literal from step 2 as `text`:
+
+```text
+const ta = document.querySelector('#releaseNotes');
+if (!ta) throw new Error('no #releaseNotes on this page');
+const text = <json literal from release-notes.mjs>;
+Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(ta, text);
+for (const t of ['input', 'change', 'blur']) ta.dispatchEvent(new Event(t, { bubbles: true }));
+JSON.stringify({ len: ta.value.length });
+```
+
+Click Save: the ref click no-op'd on 2026-08-28; `scroll_to` the Save ref,
+take a fresh screenshot, and a coordinate click on the visible Save button
+redirected to the overview within 5 s. No redirect means nothing was saved: read the page
+for validation errors and record them. Then `navigate` to the listing URL
+again and read the field back with the read-back snippet in the reference
+(it returns `len`, `djb2`, head and tail). `len` and `djb2` must equal the
+script's; on 2026-08-28 an 83-character text read back byte for byte. A
+`len` short by exactly the number of newlines means the SPA stored CRLF or
+trimmed: read the head and tail, judge, and record what you saw in the
+reference.
+
+Do not touch keywords, descriptions, screenshots, features or the display
+name on a routine update; they carry over. Keyword chips silently drop when
+Save happens while the chip input has focus (2026-08-02); the only defense
+is never being in that field.
+
+## 6. Submit for certification (the record goes in the same message as the click)
+
+Standing authorization means you click Submit; it does not mean you click
+silently. In the SAME message as the click, state what is being submitted,
+as a record and not a request:
+
+```text
+Submitting Floe Desktop desktop-v0.2.8 as Submission <N, from the draft card>:
+  package  FloeDesktop_1.2.8.0_x64.msix, 7,587,775 bytes, sha256 <hex>
+           from artifact floe-desktop-msix-0.2.8-run12 (run 33109830152), replacing <version Packages listed before the upload>
+  listing  en-US What's new, <N> chars, djb2 <hex>, read back after save
+  untouched: audience, pricing, properties, age ratings, descriptions, screenshots, keywords, submission options
+```
+
+- The "Submission options: Incomplete" badge is advisory; the Submit button
+  enabling is the gate (2026-08-02, and every run since).
+- `find` "Submit for certification" and click the ref (worked 2026-08-19 and
+  2026-08-28). Wait 3 s; if nothing changed, take a fresh screenshot, `zoom`
+  on the card to confirm the label (Delete submission is its neighbor), and
+  click the visible blue button by coordinates (what worked on 2026-08-14,
+  when the ref was a non-interactive wrapper). The flip itself can take a
+  few seconds more. Proof is the page flipping to "Update in certification" with the
+  submission timeline; nothing else counts.
+- A satisfaction survey pops up after submit: Cancel it. Never answer it for
+  the user.
+
+## 7. After submit (same day so far: 20 min submit-to-live for 10, 36 min tag-to-live for 7)
+
+- The overview shows "Update in certification" and the timeline; the
+  previous submission keeps serving until this one publishes.
+- Tell the user: certification usually finishes the same day; the docs say
+  up to three business days, then the listing updates within about 15
+  minutes of a pass, and the account owner is notified by email and in the
+  Action Center either way. Do not poll Partner Center for hours; check once
+  later or when the user says the email landed.
+- Submitted by mistake: the Certification status card on the overview has a
+  three-dot menu with "Cancel certification" (docs page updated 2026-04-09); it works until
+  the Publishing phase begins. Say what happened in the same message.
+- Live means the overview says "Congrats! Your product is now updated" and
+  Store presence names this submission. On this machine, once the Store app
+  has updated, this prints the new Identity version:
+  `Get-AppxPackage JanCarloParedes.FloeDesktop | Select-Object Version`.
+  The Store build never shows the in-app update notice
+  (`desktop/updatecheck.go` returns early when `isPackaged()`), so
+  floe-release step 8 runs on the GitHub build.
+- Record in the report: submission number, run id, artifact name, sha256,
+  identity version, notes length and fingerprint, submit time, and later the
+  live time.
+
+## 8. When it goes wrong
+
+- A package the Store already holds (same identity, version and
+  architecture) uploads and validates, then is listed a second time under
+  the duplicate alert, and the page says it cannot continue until one row
+  is removed (step 4, 2026-08-28). A shipped version can never ship again:
+  the docs allow packages in any order, but every recorded run saw Partner
+  Center mark the lower version for removal, so treat the next number as
+  the only fix (floe-release step 0); never delete and re-cut the tag for
+  the Store's sake.
+- Identity mismatch (Name or Publisher) from the preflight: the artifact was
+  not built from `desktop/build/msix/AppxManifest.xml` as committed. Never
+  hand-edit the manifest and repack (the block map would no longer match);
+  fix the template on `main` and cut the next number.
+- Expired artifact (preflight exit 4): do NOT rerun or dispatch
+  `desktop-release.yml`. A rerun is refused after 30 days anyway, and a
+  dispatch stamps `main.version=dev` and reuses the committed `wails.json`
+  version, which the Store already holds. Cut the next number with
+  floe-release; being here means the submission slipped more than 90 days
+  past the tag, and the report says so.
+- Sign-in expired mid-flow (`prompt=login`, 2026-08-28): the user signs in,
+  then `navigate` back to the overview; the draft survives server-side.
+- A ref click that does nothing: the control is an `he-button` wrapper
+  (listing Save, Delete submission, View product details on 2026-08-28;
+  Submit on 2026-08-14). Screenshot, click the visible button by
+  coordinates, verify by the page changing.
+- The SPA lies: a value shown is not a value saved (2026-08-14); a Save that
+  does not redirect saved nothing; the a11y ref for Submit can be a wrapper
+  (2026-08-14); a canceled twin run has no artifact (2026-08-27); textarea
+  values never appear in innerText (2026-08-02). Every read-back step above
+  exists because of one of these.
+
+## 9. Rehearsal (stop before Submit, then delete the draft; done 2026-08-28)
+
+Purpose: exercise every idiom above without shipping, and fill the unknowns
+in the reference. It proves the click path, not the package: with the
+shipped artifact the upload is flagged at step 4 as a duplicate, and that
+alert text is itself worth recording.
+
+- Steps 0 to 3 as written. Step 1 with `--desktop <tag> --file <the shipped
+msix>` (no gh) or the live download, either is fine.
+- Step 4 with the shipped package, expecting the duplicate alert (record
+  its wording), then Remove the duplicate row and Save. With the next real
+  artifact instead, the swap is real and you must still stop before Submit.
+- Step 5 with a marker text from `release-notes.mjs --check` on a
+  hand-written file (2026-08-28: `DRY RUN 2026-08-28: store-submit skill
+rehearsal. Not a release. Delete this draft.`), so the read-back is
+  unmistakable. Never step 6: read the Submit button's state from the page
+  text and leave it.
+- Delete the draft from the overview card: "Delete submission" (a ref click
+  no-op'd on 2026-08-28; a coordinate click opened the dialog "Delete
+  submission? This will delete your product submission. Do you want to
+  continue?" with Yes and No; Yes is a real button and its ref click
+  worked). Within 5 s the overview is back to "In Microsoft Store" with the
+  Congrats banner, Start update, Store presence naming the live submission,
+  and no draft. The deleted draft's URLs render an empty page shell with a
+  disabled Save and "Status: OK, FaultCode: undefined".
+- Confirm the live listing is unchanged: "View product details" under Store
+  presence opens the published submission (JS `.click()` on the
+  `he-button` worked when ref and coordinate clicks did not); read
+  `#releaseNotes` on its listing URL and compare `len` and `djb2` with the
+  values you read before the rehearsal. Do not save anything there.
+- Every label, URL or selector that differs from the reference is corrected
+  there with the date, in the same PR as the rehearsal report. The draft
+  consumed a submission number (11 on 2026-08-28); whether the next Start
+  update reuses it is measured at the next release.
+
+## Done means
+
+Submit clicked with the record message, the overview showing "Update in
+certification", and the report carrying: run id, artifact name and expiry,
+sha256, identity version, the preflight's `ok` lines, notes length and
+fingerprint from both the script and the read-back, submission number, and
+the submit time. Later: the certification email or the "Congrats" overview,
+and `Get-AppxPackage` showing the new version.
+
+## Pointers
+
+- floe-release SKILL.md steps 0, 4, 6, 7 and 8, and its
+  `references/tag-and-workflows.md`; DESKTOP.md "Microsoft Store plan" and
+  steps c, d and g.
+- `desktop/build/msix/pack.ps1` and `AppxManifest.xml`;
+  `.github/workflows/desktop-release.yml`; the MDX contract at the top of
+  `docs/changelog.mdx`; `client/lib/desktopRelease.ts`.
+- Memory: project_floe_store_identity (authorization, identity, Submissions
+  1 and 2), reference_release_automation_traps (textarea setter, the
+  `file_upload` path rule, the 2026-08-14 Submit note),
+  project_release_0_2_5_and_1_10_2 (Submission 7),
+  project_release_1_10_3_and_0_2_6 (Submission 8, the flow that worked),
+  project_release_1_10_5_and_0_2_8 (Submission 10, `prompt=login`),
+  project_desktop_next_steps_2026_08 (Submission 5, `input[name=fileuploader]`,
+  1,342 characters), project_desktop_0_2_4_release and
+  project_desktop_0_2_4_plan (Submission 6).

--- a/.claude/skills/store-submit/references/partner-center.md
+++ b/.claude/skills/store-submit/references/partner-center.md
@@ -1,0 +1,135 @@
+# Partner Center: URLs, identity, idioms, history
+
+Recorded from Partner Center sessions on 2026-08-02, 2026-08-13, 2026-08-14, 2026-08-16, 2026-08-19 and 2026-08-28 (the last one a full rehearsal: draft created, duplicate upload refused, listing marker saved and read back, draft deleted). Partner Center is a shadow-DOM SPA that changes without notice: when a label, URL or selector here does not match the page, the page wins, and this file gets the correction with the date. Nothing here is a permission; the standing authorization is in SKILL.md.
+
+## URLs
+
+| Page                                             | URL                                                                                                                             | Recorded   |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| Product overview (the draft card lives here too) | `https://partner.microsoft.com/en-us/dashboard/products/9NBQ8ZQ1065L/overview`                                                  | 2026-08-28 |
+| Packages page of a submission                    | `https://partner.microsoft.com/en-us/dashboard/products/9NBQ8ZQ1065L/submissions/<id>/packages`                                 | 2026-08-28 |
+| en-US Store listing of a submission              | `https://partner.microsoft.com/en-us/dashboard/products/9NBQ8ZQ1065L/submissions/<id>/listings?languageid=4&languagecode=en-us` | 2026-08-28 |
+| Submission page (Save bounces through it)        | `https://partner.microsoft.com/en-us/dashboard/products/9NBQ8ZQ1065L/submissions/<id>`                                          | 2026-08-28 |
+| Public listing                                   | `https://apps.microsoft.com/detail/9NBQ8ZQ1065L` (404 until the app was live; live since 2026-08-02)                            | 2026-08-02 |
+| Private-audience listing (private era)           | `https://apps.microsoft.com/detail/restricted/9NBQ8ZQ1065L`                                                                     | 2026-08-02 |
+| Store policies                                   | `https://learn.microsoft.com/en-us/windows/apps/publish/store-policies`                                                         | 2026-08-28 |
+
+`<id>` is a 19-digit submission id (Submission 10 is 1152921505701756193; the 2026-08-28 draft was 1152921505701763224). The draft's sections are reached from the overview card's rows; "View product details" under Store presence opens the published submission's pages with an enabled Save, so read there and never save. Section links inside the SPA sometimes no-op (2026-08-02); direct navigation to a section URL always works. A deleted draft's URLs render an empty page shell with a disabled Save and "Status: OK, FaultCode: undefined" (2026-08-28).
+
+## Identity (frozen by the first reservation)
+
+| Field                 | Value                                       | Source                                                            |
+| --------------------- | ------------------------------------------- | ----------------------------------------------------------------- |
+| Store ID              | `9NBQ8ZQ1065L`                              | `DESKTOP_STORE_ID` in `client/lib/desktopRelease.ts`              |
+| Identity Name         | `JanCarloParedes.FloeDesktop`               | `desktop/build/msix/AppxManifest.xml`                             |
+| Identity Publisher    | `CN=5D497A40-D927-4850-8A83-E21F677E80E3`   | `desktop/build/msix/AppxManifest.xml`                             |
+| PublisherDisplayName  | `Jan Carlo Paredes`                         | `desktop/build/msix/AppxManifest.xml`                             |
+| DisplayName           | `Floe Desktop`                              | `desktop/build/msix/AppxManifest.xml`                             |
+| ProcessorArchitecture | `x64`                                       | `desktop/build/msix/AppxManifest.xml`                             |
+| MinVersion            | `10.0.19041.0`                              | `desktop/build/msix/AppxManifest.xml`                             |
+| Package Family Name   | `JanCarloParedes.FloeDesktop_r1y5w9chaxnzc` | memory `project_floe_store_identity` (Partner Center, 2026-08-02) |
+
+Name and Publisher are case and punctuation sensitive; a mismatch is an upload FAILURE, not a warning (2026-08-02). The first reservation froze Name and the Package Family Name for good; only the per-language display name can change.
+
+## Version mapping
+
+`desktop-vX.Y.Z` becomes Identity Version `(X+1).Y.Z.0` (the Store rejects a first octet of 0 and reserves the fourth; `desktop/build/msix/pack.ps1`): `desktop-v0.2.8` is `1.2.8.0`, `desktop-v0.10.0` is `1.10.0.0`, `desktop-v1.0.0` is `2.0.0.0`. The package file is `FloeDesktop_<identity>_x64.msix`. The Store requires every package, published or uploaded, to have a unique full name (identity, version, architecture), so a shipped version can never be uploaded again. The docs say packages may be submitted in any order; every recorded run saw Partner Center mark the lower version for removal when a higher one arrived (2026-08-02 and since).
+
+## Click path (a routine update touches Packages and the en-US What's new, nothing else)
+
+| Page                | Action                   | What worked                                                                                                         | Success signal                                                                                                                                                 | Recorded                                   |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Overview            | Start update             | `find`, click the ref                                                                                               | the draft card "Product update: In draft (Submission N: ...)" with Delete submission and Submit for certification; chip "Update in draft"                      | 2026-08-28                                 |
+| Packages            | upload the MSIX          | `file_upload` on the ref of the file input (`find` "file input for uploading a package"; empty-labeled file button) | "Validating…" modal plus "Analyzing package" on the upload row, 50 to 60 s; then the new version listed and the old one struck through, or the duplicate alert | 2026-08-28                                 |
+| Packages            | Remove a package         | `find` "Remove", click the ref                                                                                      | "This package will be removed after you save this page. Revert" and "Click Save to confirm removal..."                                                         | 2026-08-28                                 |
+| Packages            | Save                     | `find`, click the ref                                                                                               | redirect through `.../submissions/<id>` to the overview; Packages chip "Updated"                                                                               | 2026-08-28                                 |
+| Store listing en-US | fill What's new          | `javascript_tool`, native setter on `#releaseNotes` (maxlength 1500)                                                | the snippet returns `len`                                                                                                                                      | 2026-08-28                                 |
+| Store listing en-US | Save                     | ref click no-op'd; `computer` click on the visible Save by coordinates                                              | redirect to the overview within 5 s                                                                                                                            | 2026-08-28                                 |
+| Store listing en-US | read back                | `javascript_tool` after `navigate` to the listing URL                                                               | `len` and `djb2` equal the script's                                                                                                                            | 2026-08-28                                 |
+| Overview            | Submit for certification | `find`, click the ref; coordinates as fallback                                                                      | "Update in certification" with the submission timeline                                                                                                         | 2026-08-28 (ref), 2026-08-14 (coordinates) |
+| Survey              | Cancel                   | `find`, click the ref                                                                                               | the survey closes                                                                                                                                              | 2026-08-19                                 |
+| Overview            | Delete submission        | ref click no-op'd; `computer` click by coordinates                                                                  | dialog "Delete submission? This will delete your product submission. Do you want to continue?" Yes / No                                                        | 2026-08-28                                 |
+| Dialog              | Yes                      | `find`, click the ref (a real button)                                                                               | overview back to "In Microsoft Store", Start update present, no draft, within 5 s                                                                              | 2026-08-28                                 |
+| Overview            | View product details     | ref and coordinate clicks no-op'd; JS `.click()` on the `he-button`                                                 | the published submission's Packages page                                                                                                                       | 2026-08-28                                 |
+
+## JS idioms (run with `javascript_tool`)
+
+Fill What's new. The SPA ignores `form_input` and a plain `.value =` assignment (2026-08-14); it registers the native setter plus `input`, `change` and `blur`:
+
+```text
+const ta = document.querySelector('#releaseNotes');
+if (!ta) throw new Error('no #releaseNotes on this page');
+const text = <json literal from release-notes.mjs>;
+Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(ta, text);
+for (const t of ['input', 'change', 'blur']) ta.dispatchEvent(new Event(t, { bubbles: true }));
+JSON.stringify({ len: ta.value.length });
+```
+
+Read What's new back after a full reload. Textarea values never appear in innerText (2026-08-02), so read `.value`. The fingerprint is djb2 over LF-normalized text, iterated by code point, which is what `release-notes.mjs` prints:
+
+```text
+const v = (document.querySelector('#releaseNotes')?.value ?? '').replace(/\r\n/g, '\n');
+let h = 5381; for (const c of v) h = (Math.imul(h, 33) + c.codePointAt(0)) >>> 0;
+JSON.stringify({ len: v.length, djb2: h.toString(16).padStart(8, '0'), head: v.slice(0, 60), tail: v.slice(-60) });
+```
+
+Struck-through package rows, when `get_page_text` is ambiguous (unverified; the recorded check is `get_page_text` showing both version strings):
+
+```text
+[...document.querySelectorAll('*')].filter((e) => getComputedStyle(e).textDecorationLine.includes('line-through')).map((e) => e.textContent.trim()).filter(Boolean).slice(0, 10);
+```
+
+Clickable controls include `he-button` web components; when clicking through JS, query `'button, a, [role=button], he-button'` (2026-08-02). Never `.click()` the file input: a native click opens an invisible OS picker that no tool can close (2026-08-19).
+
+## Which clicks register (`he-button` wrappers)
+
+- 2026-08-14 (Submission 6): the a11y-tree "button" ref for Submit was a non-interactive wrapper; clicking it did nothing; a click on the visible blue button by screenshot coordinates worked.
+- 2026-08-19 (Submission 8): a coordinate click on Submit was ignored; `find` plus a click on the ref worked.
+- 2026-08-28 (Submission 10): `find` plus a click on the ref worked for Submit.
+- 2026-08-28 (rehearsal): ref clicks worked on Start update, the Packages Save, Remove, and the dialog's Yes; ref clicks did nothing on the listing Save, Delete submission and View product details; coordinates worked on the first two and JS `.click()` on the third.
+
+Rule: ref first, wait 3 s, then coordinates from a fresh screenshot, then JS `.click()` on the `he-button`; only the page changing counts. A satisfaction survey follows the Submit flip; Cancel it.
+
+## Submission history (recorded facts only)
+
+| Submission | Date       | Package | What changed                                                                                           | Certification                                           | Source                                                                                                           |
+| ---------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| 1          | 2026-08-02 | 1.2.0.0 | first submission, private audience                                                                     | passed the same day                                     | memory `project_floe_store_identity`                                                                             |
+| 2          | 2026-08-02 | 1.2.1.0 | tile color fix; audience Private to Public; second screenshot; captions; What's new                    | outcome recorded only as "listing public on 2026-08-02" | DESKTOP.md step d; `client/lib/desktopRelease.ts`                                                                |
+| 3, 4       |            |         | not recorded                                                                                           |                                                         |                                                                                                                  |
+| 5          | 2026-08-13 | 1.2.3.0 | package and What's new (1,342 characters)                                                              | published before 0.2.4 began                            | memory `project_desktop_next_steps_2026_08` (flow, 1,342 characters); published per `project_desktop_0_2_4_plan` |
+| 6          | 2026-08-14 | 1.2.4.0 | package and What's new                                                                                 | submitted; outcome never written down                   | memory `project_desktop_0_2_4_release`                                                                           |
+| 7          | 2026-08-16 | 1.2.5.0 | package and What's new                                                                                 | live the same day, about 36 minutes after the tag       | memory `project_release_0_2_5_and_1_10_2`                                                                        |
+| 8          | 2026-08-19 | 1.2.6.0 | package and What's new                                                                                 | submitted; outcome never written down                   | memory `project_release_1_10_3_and_0_2_6`                                                                        |
+| 9          |            | 1.2.7.0 | not recorded (expected after 8 cleared)                                                                |                                                         |                                                                                                                  |
+| 10         | 2026-08-28 | 1.2.8.0 | package from `floe-desktop-msix-0.2.8-run12` (run 33109830152); What's new, 1,306 characters persisted | live about 20 minutes after submit                      | memory `project_release_1_10_5_and_0_2_8`                                                                        |
+
+On 2026-08-28 a rehearsal created draft Submission 11 (id 1152921505701763224), had the live 1.2.8.0 package refused as a duplicate, saved a marker into What's new, and deleted the draft; the overview returned to Submission 10 and the live What's new read back unchanged (1,306 characters, djb2 0954a1b5). Whether the next Start update reuses number 11 is measured at the next release. Submissions 3, 4 and 9 happened (the numbering says so) and were never written down; do not claim which package rode which.
+
+## Never touched on a routine update
+
+- Audience: Public is a one-way door; public to private is permanently forbidden.
+- Pricing and availability, markets.
+- Properties: category Utilities & tools > File managers; privacy URL `https://www.floe.one/privacy`; support URL (the GitHub issues page).
+- Age ratings (IARC questionnaire, done once).
+- Store listing: descriptions and features (product first, requirements last; 7 features), screenshots (two, 1366x768, with captions), display name, keywords (the docs allow 7 keywords of up to 40 characters and at most 21 words across them; the project recorded 30 on 2026-08-02; never the app name; chips drop when Save happens while the chip input has focus, 2026-08-02).
+- Submission options: the runFullTrust justification (775 characters) and the certification notes (890 characters, product-level under Additional Testing Information: pair with floe.one in a browser, since one reviewer on one machine cannot test a two-peer app) carry over. The "Submission options: Incomplete" badge is advisory and did not block Submit on any recorded run.
+
+## Policy notes (Microsoft Store Policies v7.19, effective 2025-10-14; read 2026-08-28)
+
+The project's 2026-08 notes cited 10.8.5 for "no links to other channels"; the change history says 7.10 moved that rule to 10.2.6 and 7.11 republished it as 10.1.5. Quote the current text from `https://learn.microsoft.com/en-us/windows/apps/publish/store-policies` when you touch this section.
+
+- 10.1.1: all metadata must accurately describe the product; the title must be unique and carry no marketing or descriptive text or extraneous keywords; the product must not claim to be from an entity without permission.
+- 10.1.3: search terms are at most seven unique terms or phrases, relevant to the product, without pricing terms or other publishers' product titles.
+- 10.1.5: a product may enable acquisition of other products only when they are also distributed through the Store and acquired through it. This is why the rendered What's new drops GitHub, winget and download links; the listing docs also say to keep URLs out of the description and use the designated support and website fields.
+- 10.3, 10.3.1, 10.3.2: the product must be testable; a login needs a demo account in Notes for certification; a required server must be functional during review. A two-peer app with a single-instance lock is the "anything else testers need" case: the notes describe pairing with floe.one in a browser, and api.floe.one must be up during review.
+
+## What the docs say (Microsoft Learn, read 2026-08-28; verify on the page before relying on any of it)
+
+- Start update "will create a new submission for the application, using the info from your previous submission as a starting point" (publish-update-to-your-app-on-store, updated 2026-08-24).
+- A draft can be deleted: "From the Product submission (or product update card in case of an update submission) card, click Delete submission", then confirm (app-submission-control, updated 2026-04-09). A submitted one can be canceled from the Certification status card's three-dot menu, "Cancel certification", until the Publishing phase begins (same page; app-certification-process).
+- Certification "can take up to three business days"; after a pass "customers will be able to see the app's listing within 15 minutes"; phases Preprocessing, Certification, Release, Publishing, In the Store; the account owner is notified by email and the Action Center (app-certification-process, manage-submission-options).
+- Package version numbering: the fourth octet is reserved for the Store and must be 0; the first octet cannot be 0; packages "can be submitted in any order"; every package needs a unique full identity; manifest identity values are case and punctuation sensitive and a mismatch is an upload failure (app-package-requirements, view-app-identity-details, updated 2026-08-24).
+- A package that fails validation shows a message; remove it with the Remove link at the bottom of its Details section, fix, upload again. The Packages section reads "Incomplete" until every required field is set, even when each package shows "Validated" (upload-app-packages, ms.date 2026-04-21; create-app-submission).
+- What's new "has a 1500 character limit" (previously called Release notes). The description takes 10,000 characters of plain text, with no HTML, code or URLs (add-and-edit-store-listing-info, updated 2026-08-24).
+- Not in the docs: a "package version must be greater than" error. What Partner Center shows for a package it already holds, measured 2026-08-28: "Multiple uploaded files contain the same package (JanCarloParedes.FloeDesktop_1.2.8.0_x64\_\_r1y5w9chaxnzc). Please keep only one of the duplicate packages to continue." A Microsoft Q&A thread recorded a sibling wording: "All .msix and .appx packages (including previously published and currently uploaded) must be uniquely identified by their full names ... Please remove one of these packages, or increment current package versions to continue."

--- a/.claude/skills/store-submit/scripts/msix-preflight.mjs
+++ b/.claude/skills/store-submit/scripts/msix-preflight.mjs
@@ -1,0 +1,955 @@
+#!/usr/bin/env node
+/**
+ * Measures whether the MSIX a desktop-v* tag produced is the one to hand to
+ * Partner Center: the right desktop-release.yml run, an artifact that still
+ * exists, a package makeappx built, and a manifest whose Identity matches the
+ * Store product and the tag.
+ *
+ * Why the run is chosen instead of taken from `gh run list --limit 1`: the
+ * 2026-08-27 release pushed two tags in one push and every tag workflow fired
+ * twice. desktop-release.yml run 33109832188 (number 13) was created one
+ * second after run 33109830152 (number 12), was canceled, and holds zero
+ * artifacts, yet it is the newest run for desktop-v0.2.8. A candidate here
+ * must be status completed, conclusion success, AND carry the
+ * floe-desktop-msix-<X.Y.Z>-run<N> artifact; every other run for the tag is
+ * reported as a twin so the reader sees why it lost.
+ *
+ * Why an expired artifact is a hard stop with its own exit: the MSIX is only
+ * a workflow artifact (path dist-msix/, 90 days from the run's createdAt),
+ * never a release asset, and both ways of getting it back produce the wrong
+ * package. A rerun is refused after 30 days, and a workflow_dispatch stamps
+ * main.version=dev and reuses the committed wails.json version. The remedy
+ * is the next number with floe-release, so the script says so and stops.
+ *
+ * Why the package is read in-process: makeappx writes Zip64 with data
+ * descriptors (general-purpose flag bit 3), so every local header carries
+ * crc and sizes of 0 and the real values sit in the central directory's
+ * 0x0001 extra field. Nothing on PATH validates that (tar.exe streams an
+ * entry but checks no crc), so this is a reader over the central directory
+ * only, with zlib.inflateRawSync and zlib.crc32 from Node 22. The manifest is
+ * compared attribute by attribute against desktop/build/msix/
+ * AppxManifest.xml, not byte for byte, because the packed copy carries the
+ * line endings of the runner's checkout (CRLF on the 2026-08-27 build,
+ * 2,740 bytes; an LF checkout stamps 2,676) and pack.ps1 stamps the version
+ * into the template's comment as well as the Identity.
+ *
+ * Why --out must sit under a scratchpad: the browser file_upload tool refused
+ * every other path on 2026-08-02 and 2026-08-14, and that upload is the step
+ * this preflight exists for.
+ *
+ * Green does NOT prove that the exe inside is the tagged commit's build, that
+ * the package installs (it is unsigned by design; only Partner Center's
+ * re-signed copy installs), that Partner Center accepts the Identity (it
+ * validates Name and Publisher against the product on upload), or that the
+ * version is higher than the one the Store lists today.
+ *
+ * Usage:
+ *   node .claude/skills/store-submit/scripts/msix-preflight.mjs
+ *       --desktop desktop-vX.Y.Z --out <dir> [--repo owner/name]
+ *       [--root <dir>] [--json]
+ *   node .claude/skills/store-submit/scripts/msix-preflight.mjs
+ *       --desktop desktop-vX.Y.Z --file <path.msix> [--root <dir>] [--json]
+ *   node .claude/skills/store-submit/scripts/msix-preflight.mjs --self-test
+ * Tests:
+ *   node --test .claude/skills/store-submit/scripts/msix-preflight.test.mjs
+ * Exit: 0 ready, 1 findings, 2 usage, 3 no successful run or no artifact,
+ * 4 artifact expired, 5 gh failure. A usage error prints its message on
+ * stderr and nothing on stdout, --json included, so a caller parsing stdout
+ * sees an empty document with exit 2.
+ */
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+    existsSync,
+    mkdirSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    statSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import zlib from 'node:zlib';
+
+// scripts/ -> store-submit/ -> skills/ -> .claude/ -> repo root.
+const DEFAULT_ROOT = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    '..',
+    '..'
+);
+const TEMPLATE = 'desktop/build/msix/AppxManifest.xml';
+const PIN_FILE = 'client/lib/desktopRelease.ts';
+const WORKFLOW = 'desktop-release.yml';
+const MANIFEST = 'AppxManifest.xml';
+// makeappx writes these two next to the manifest in every package; a zip
+// without them was not packed by makeappx, whatever its extension says.
+const REQUIRED = ['AppxBlockMap.xml', '[Content_Types].xml'];
+// Mirrors the "Derive version" step of desktop-release.yml: strictly numeric
+// X.Y.Z after the prefix, no suffix (NSIS VIProductVersion rejects one).
+const DESKTOP_TAG = /^desktop-v(\d+)\.(\d+)\.(\d+)$/;
+// The 0.2.8 package is 7,587,775 bytes; anything under a mebibyte is a
+// download that stopped early, not a package.
+const MIN_MSIX_BYTES = 1024 * 1024;
+const EXPIRY_WARN_DAYS = 7;
+const DAY_MS = 86400000;
+// The zip comment can be up to 64 KiB, so the EOCD record can sit that far
+// from the end of the file.
+const EOCD_SCAN = 65536 + 22;
+const SIG = {
+    local: 0x04034b50,
+    central: 0x02014b50,
+    eocd: 0x06054b50,
+    zip64Locator: 0x07064b50,
+    zip64Record: 0x06064b50,
+};
+const IDENTITY_KEYS = ['Name', 'Publisher', 'Version', 'ProcessorArchitecture'];
+const PROPERTY_KEYS = ['DisplayName', 'PublisherDisplayName', 'MinVersion'];
+
+// [tag, identity version, or null when the tag is refused]. Run with
+// --self-test.
+const SELF_TEST = [
+    ['desktop-v0.2.8', '1.2.8.0'],
+    ['desktop-v1.0.0', '2.0.0.0'],
+    ['desktop-v0.10.0', '1.10.0.0'],
+    ['desktop-v0.2.8-rc1', null],
+    ['v0.2.8', null],
+    ['desktop-v0.2', null],
+];
+
+export function parseTag(tag) {
+    const m = DESKTOP_TAG.exec(tag || '');
+    if (!m) return null;
+    const [major, minor, patch] = m.slice(1).map(Number);
+    return { tag, version: `${major}.${minor}.${patch}`, major, minor, patch };
+}
+
+// pack.ps1's rule: the Store rejects an Identity Version whose first octet
+// is 0 and reserves the fourth, so (major+1).minor.patch.0 keeps the mapping
+// mechanical and monotonic (0.2.8 -> 1.2.8.0, 1.0.0 -> 2.0.0.0).
+export function identityVersion(tag) {
+    const t = parseTag(tag);
+    return t ? `${t.major + 1}.${t.minor}.${t.patch}.0` : null;
+}
+
+export const fileNameFor = (identity) => `FloeDesktop_${identity}_x64.msix`;
+
+function selfTest() {
+    let failed = 0;
+    for (const [tag, want] of SELF_TEST) {
+        const got = identityVersion(tag);
+        const pass = got === want;
+        if (!pass) failed += 1;
+        console.log(
+            `${pass ? 'ok  ' : 'FAIL'} ${tag} -> ${want === null ? 'refused' : want}${pass ? '' : `, got ${got}`}`
+        );
+    }
+    console.log(
+        `msix-preflight: self-test ${failed ? `${failed} failure(s)` : 'green'} (${SELF_TEST.length} fixtures)`
+    );
+    process.exit(failed ? 1 : 0);
+}
+
+function usage(message) {
+    console.error(`msix-preflight: ${message}`);
+    return 2;
+}
+
+export function parseArgs(argv, { root = DEFAULT_ROOT } = {}) {
+    const opts = {
+        desktop: null,
+        out: null,
+        file: null,
+        repo: null,
+        root,
+        json: false,
+    };
+    const value = (flag, v) => {
+        if (v === undefined || v.startsWith('--'))
+            throw new Error(`${flag} needs a value`);
+        return v;
+    };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--desktop') opts.desktop = value(a, argv[++i]);
+        else if (a === '--out') opts.out = value(a, argv[++i]);
+        else if (a === '--file') opts.file = value(a, argv[++i]);
+        else if (a === '--repo') opts.repo = value(a, argv[++i]);
+        else if (a === '--root') opts.root = value(a, argv[++i]);
+        else if (a === '--json') opts.json = true;
+        else throw new Error(`unknown argument ${a}`);
+    }
+    if (!opts.desktop)
+        throw new Error(
+            'pass --desktop desktop-vX.Y.Z (no default: a stale local tag list would silently pick the previous release), or --self-test'
+        );
+    if (!parseTag(opts.desktop))
+        throw new Error(
+            `--desktop wants desktop-vX.Y.Z, strictly numeric, got ${opts.desktop}`
+        );
+    if (opts.file && opts.out)
+        throw new Error(
+            '--file and --out are exclusive: --file skips gh, --out is where gh downloads'
+        );
+    if (!opts.file && !opts.out)
+        throw new Error(
+            'pass --out <dir> (download the artifact with gh) or --file <path.msix> (a package already on disk)'
+        );
+    if (opts.repo && opts.file)
+        throw new Error('--repo only applies with --out');
+    opts.root = path.resolve(opts.root);
+    if (!existsSync(path.join(opts.root, TEMPLATE)))
+        throw new Error(`--root ${opts.root} has no ${TEMPLATE}`);
+    // Both paths are stat-checked here so a directory or a stray file is a
+    // usage error, not an EISDIR from readFileSync (--file) or an ENOTDIR
+    // from mkdirSync after three gh calls have already run (--out).
+    if (opts.file) {
+        opts.file = path.resolve(opts.file);
+        const st = statSync(opts.file, { throwIfNoEntry: false });
+        if (!st) throw new Error(`--file ${opts.file} does not exist`);
+        if (st.isDirectory())
+            throw new Error(`--file ${opts.file} is a directory, not a file`);
+        if (!st.isFile())
+            throw new Error(`--file ${opts.file} is not a regular file`);
+    }
+    if (opts.out) {
+        opts.out = path.resolve(opts.out);
+        const st = statSync(opts.out, { throwIfNoEntry: false });
+        if (st && !st.isDirectory())
+            throw new Error(`--out ${opts.out} is a file, not a directory`);
+    }
+    return opts;
+}
+
+class GhError extends Error {}
+
+// argv arrays and no shell: PowerShell 5.1 mangles quoted arguments to
+// native executables, and jq is absent here, so JSON is parsed in Node.
+function gh(args, cwd) {
+    try {
+        return execFileSync('gh', args, {
+            cwd,
+            encoding: 'utf8',
+            windowsHide: true,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        }).trim();
+    } catch (e) {
+        const detail = (e.stderr || e.message || '').toString().trim();
+        throw new GhError(
+            `gh ${args.join(' ')} failed: ${JSON.stringify(detail)}; run gh auth status`
+        );
+    }
+}
+
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const artifactRe = (version) =>
+    new RegExp(`^floe-desktop-msix-${escapeRe(version)}-run\\d+$`);
+const num = (n) => n.toLocaleString('en-US');
+const describeRun = (run) =>
+    `${run.databaseId} (number ${run.number}, ${run.conclusion || run.status}, ${run.createdAt}, sha ${(run.headSha || '').slice(0, 7) || '?'})`;
+
+// The artifact for this version among a run's artifacts, with its expiry
+// read the way GitHub reports it: `expired` flips to true after the fact and
+// `expires_at` is the deadline, so both are honored.
+export function pickArtifact(artifacts, version, now = Date.now()) {
+    const re = artifactRe(version);
+    const artifact = (artifacts || []).find((a) => re.test(a.name)) || null;
+    if (!artifact) {
+        return {
+            artifact: null,
+            expired: false,
+            expiresAt: null,
+            daysLeft: null,
+            guidance: null,
+        };
+    }
+    const expiresAt = artifact.expires_at || null;
+    const ms = expiresAt ? Date.parse(expiresAt) : NaN;
+    const daysLeft = Number.isNaN(ms) ? null : Math.floor((ms - now) / DAY_MS);
+    const expired =
+        artifact.expired === true || (!Number.isNaN(ms) && ms <= now);
+    const guidance = expired
+        ? `artifact ${artifact.name} expired on ${expiresAt || 'an unknown date'}: do not rerun or dispatch desktop-release.yml (a rerun is refused after 30 days; a dispatch stamps main.version=dev and reuses the committed wails.json version); cut the next number with floe-release`
+        : null;
+    return { artifact, expired, expiresAt, daysLeft, guidance };
+}
+
+// The artifact line of the report. An artifact record without expires_at
+// (GitHub omits it on some listings) says "expires unknown" and carries no
+// days-left clause, rather than "expires null, null days left".
+export function describeArtifact(a, picked) {
+    const days =
+        picked.daysLeft === null ? '' : `, ${picked.daysLeft} days left`;
+    const expiry = picked.expiresAt
+        ? `expires ${picked.expiresAt}${days}`
+        : 'expires unknown';
+    return `${a.name} (id ${a.id}, ${num(a.size_in_bytes)} bytes, ${expiry})`;
+}
+
+// Pure decision over the runs for a tag and their artifact lists (a Map or
+// an object keyed by databaseId). Exported so msix-preflight.test.mjs can
+// replay the 2026-08-27 twin without a network.
+export function chooseRun(runs, artifactsByRun, version) {
+    const lookup = (id) =>
+        artifactsByRun instanceof Map
+            ? (artifactsByRun.get(id) ?? artifactsByRun.get(String(id)))
+            : artifactsByRun?.[id];
+    const candidates = [];
+    const twins = [];
+    for (const run of runs || []) {
+        const artifacts = lookup(run.databaseId) || [];
+        const picked = pickArtifact(artifacts, version);
+        if (
+            run.status === 'completed' &&
+            run.conclusion === 'success' &&
+            picked.artifact
+        ) {
+            candidates.push({ run, artifacts, artifact: picked.artifact });
+        } else {
+            twins.push({
+                run,
+                artifacts,
+                line: `twin ${describeRun(run)} holds ${artifacts.length} artifact${artifacts.length === 1 ? '' : 's'}; ignored`,
+            });
+        }
+    }
+    candidates.sort(
+        (a, b) => Date.parse(b.run.createdAt) - Date.parse(a.run.createdAt)
+    );
+    const chosen = candidates[0] || null;
+    const warnings = twins.map((t) => t.line);
+    for (const c of candidates.slice(1)) {
+        warnings.push(
+            `older candidate ${describeRun(c.run)} also holds ${c.artifact.name}; the newest run wins`
+        );
+    }
+    const message = chosen
+        ? null
+        : `no successful ${WORKFLOW} run with a floe-desktop-msix-${version} artifact for desktop-v${version}; a run still in progress or a failed run points at floe-release step 4 (re-cut, never rerun)`;
+    return {
+        chosen: chosen ? chosen.run : null,
+        artifact: chosen ? chosen.artifact : null,
+        artifacts: chosen ? chosen.artifacts : [],
+        candidates: candidates.map((c) => c.run),
+        twins,
+        warnings,
+        message,
+    };
+}
+
+const u16 = (b, o) => b.readUInt16LE(o);
+const u32 = (b, o) => b.readUInt32LE(o);
+function u64(b, o, what) {
+    const v = b.readBigUInt64LE(o);
+    if (v >= 2n ** 53n)
+        throw new Error(`${what} ${v} is beyond 2^53; refusing to address it`);
+    return Number(v);
+}
+const hex8 = (n) => n.toString(16).padStart(8, '0');
+
+// The central directory of a zip, classic or Zip64. Every size and offset
+// comes from here and never from a local header: under flag bit 3 the local
+// header carries zeros and the truth follows the data in a descriptor.
+export function readCentralDirectory(buf) {
+    const len = buf.length;
+    let eocd = -1;
+    for (let i = len - 22; i >= Math.max(0, len - EOCD_SCAN); i--) {
+        if (u32(buf, i) === SIG.eocd) {
+            eocd = i;
+            break;
+        }
+    }
+    if (eocd < 0)
+        throw new Error('not a zip: no end-of-central-directory record');
+    let entries = u16(buf, eocd + 10);
+    let cdSize = u32(buf, eocd + 12);
+    let cdOff = u32(buf, eocd + 16);
+    const locator = eocd - 20;
+    const hasLocator = locator >= 0 && u32(buf, locator) === SIG.zip64Locator;
+    const saturated =
+        entries === 0xffff || cdSize === 0xffffffff || cdOff === 0xffffffff;
+    let zip64 = false;
+    if (saturated || hasLocator) {
+        if (!hasLocator)
+            throw new Error(
+                'zip64 sizes in the end-of-central-directory record but no zip64 locator before it'
+            );
+        const rec = u64(buf, locator + 8, 'zip64 record offset');
+        if (rec + 56 > len || u32(buf, rec) !== SIG.zip64Record)
+            throw new Error(
+                `no zip64 end-of-central-directory record at offset ${rec}`
+            );
+        entries = u64(buf, rec + 32, 'zip64 entry count');
+        cdSize = u64(buf, rec + 40, 'zip64 central directory size');
+        cdOff = u64(buf, rec + 48, 'zip64 central directory offset');
+        zip64 = true;
+    }
+    if (cdOff + cdSize > len)
+        throw new Error(
+            `central directory (${cdSize} bytes at ${cdOff}) runs past the end of the ${len}-byte file`
+        );
+    const records = [];
+    let p = cdOff;
+    for (let i = 0; i < entries; i++) {
+        if (p + 46 > len || u32(buf, p) !== SIG.central)
+            throw new Error(
+                `central directory entry ${i} at offset ${p} has no 0x02014b50 signature`
+            );
+        const flags = u16(buf, p + 8);
+        const method = u16(buf, p + 10);
+        const crc = u32(buf, p + 16);
+        let csz = u32(buf, p + 20);
+        let usz = u32(buf, p + 24);
+        const nameLen = u16(buf, p + 28);
+        const extraLen = u16(buf, p + 30);
+        const commentLen = u16(buf, p + 32);
+        let lho = u32(buf, p + 42);
+        const name = buf.toString('utf8', p + 46, p + 46 + nameLen);
+        let q = p + 46 + nameLen;
+        const qEnd = q + extraLen;
+        while (q + 4 <= qEnd) {
+            const id = u16(buf, q);
+            const size = u16(buf, q + 2);
+            const fieldEnd = q + 4 + size;
+            if (id === 0x0001) {
+                // Only the saturated fields are present, in this order.
+                let r = q + 4;
+                const take = (what) => {
+                    if (r + 8 > fieldEnd)
+                        throw new Error(
+                            `${name}: zip64 extra field is too short for its ${what}`
+                        );
+                    const v = u64(buf, r, `${name} zip64 ${what}`);
+                    r += 8;
+                    return v;
+                };
+                if (usz === 0xffffffff) usz = take('uncompressed size');
+                if (csz === 0xffffffff) csz = take('compressed size');
+                if (lho === 0xffffffff) lho = take('local header offset');
+            }
+            q = fieldEnd;
+        }
+        records.push({ name, flags, method, crc, csz, usz, lho });
+        p += 46 + nameLen + extraLen + commentLen;
+    }
+    return { zip64, entries, names: records.map((r) => r.name), records };
+}
+
+// One entry's bytes, verified: sizes from the central directory, method 0
+// as-is, method 8 through inflateRawSync, then length and crc32 checked.
+// Throws a reader-facing message; a missing entry carries `names` on the
+// error so the caller can still say what the package does contain.
+function extractRecord(buf, rec) {
+    const { name, lho, csz, usz, crc, method } = rec;
+    if (lho + 30 > buf.length || u32(buf, lho) !== SIG.local)
+        throw new Error(`${name}: no 0x04034b50 local header at offset ${lho}`);
+    const start = lho + 30 + u16(buf, lho + 26) + u16(buf, lho + 28);
+    if (start + csz > buf.length)
+        throw new Error(`${name}: data runs past the end of the file`);
+    const raw = buf.subarray(start, start + csz);
+    let data;
+    if (method === 0) data = raw;
+    else if (method === 8) {
+        try {
+            data = zlib.inflateRawSync(raw);
+        } catch (e) {
+            throw new Error(`${name}: inflate failed: ${e.message}`);
+        }
+    } else {
+        throw new Error(
+            `${name}: compression method ${method} is neither stored (0) nor deflate (8)`
+        );
+    }
+    if (data.length !== usz)
+        throw new Error(
+            `${name}: ${method === 8 ? 'inflated to' : 'holds'} ${data.length} bytes, the central directory says ${usz}`
+        );
+    const got = zlib.crc32(data);
+    if (got !== crc)
+        throw new Error(
+            `${name}: crc32 ${hex8(got)} does not match the central directory's ${hex8(crc)}`
+        );
+    return data;
+}
+
+export function readZipEntry(buf, name) {
+    const cd = readCentralDirectory(buf);
+    const rec = cd.records.find((r) => r.name === name);
+    if (!rec) {
+        const err = new Error(
+            `${name} is not in the package (${cd.entries} entries)`
+        );
+        err.names = cd.names;
+        err.entries = cd.entries;
+        throw err;
+    }
+    const data = extractRecord(buf, rec);
+    return {
+        data,
+        method: rec.method,
+        csz: rec.csz,
+        usz: rec.usz,
+        crc: rec.crc,
+        entries: cd.entries,
+        names: cd.names,
+        zip64: cd.zip64,
+    };
+}
+
+// Every entry, not only the manifest: a package whose entries all inflate
+// and match their crc32 is the package CI built, and a flipped byte inside
+// a stored asset is invisible to the manifest check (measured 2026-08-28:
+// offset 600 of the 1.2.8.0 package passed the manifest-only version).
+export function verifyEntries(buf, cd = readCentralDirectory(buf)) {
+    const failures = [];
+    for (const rec of cd.records) {
+        try {
+            extractRecord(buf, rec);
+        } catch (e) {
+            failures.push({ name: rec.name, message: e.message });
+        }
+    }
+    return { checked: cd.records.length, failures };
+}
+
+const XML_ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"', apos: "'" };
+const decodeXml = (s) =>
+    s.replace(/&(amp|lt|gt|quot|apos);/g, (_, e) => XML_ENTITIES[e]);
+// XML allows either quote style around an attribute value; makeappx keeps
+// the template's double quotes, a hand-edited manifest may not.
+function attrsOf(s) {
+    const attrs = {};
+    for (const m of s.matchAll(
+        /([A-Za-z_][\w:.-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g
+    ))
+        attrs[m[1]] = decodeXml(m[2] ?? m[3]);
+    return attrs;
+}
+
+// The Identity element's own attributes (the template's comment above it
+// mentions versions too, so a whole-file search would be wrong), the two
+// Properties names, and the TargetDeviceFamily MinVersion. Comments go
+// first: a commented-out <Identity> ahead of the real one would otherwise
+// be the one read.
+export function parseManifest(text) {
+    const src = String(text)
+        .replace(/^\uFEFF/, '')
+        .replace(/<!--[\s\S]*?-->/g, '');
+    const identity = attrsOf(src.match(/<Identity\b([\s\S]*?)\/?>/)?.[1] ?? '');
+    const props =
+        src.match(/<Properties\b[^>]*>([\s\S]*?)<\/Properties>/)?.[1] ?? '';
+    const element = (tag) => {
+        const m = props.match(
+            new RegExp(`<${tag}(?:\\s[^>]*)?>([^<]*)</${tag}>`)
+        );
+        return m ? decodeXml(m[1].trim()) : null;
+    };
+    const family = attrsOf(
+        src.match(/<TargetDeviceFamily\b([\s\S]*?)\/?>/)?.[1] ?? ''
+    );
+    return {
+        Name: identity.Name ?? null,
+        Publisher: identity.Publisher ?? null,
+        Version: identity.Version ?? null,
+        ProcessorArchitecture: identity.ProcessorArchitecture ?? null,
+        DisplayName: element('DisplayName'),
+        PublisherDisplayName: element('PublisherDisplayName'),
+        MinVersion: family.MinVersion ?? null,
+    };
+}
+
+function walkFiles(dir, out = []) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) walkFiles(abs, out);
+        else if (entry.isFile()) out.push(abs);
+    }
+    return out;
+}
+
+const fmt = (status, check, message) =>
+    `${status.padEnd(4)}  ${check.padEnd(9)} ${message}`;
+const quoted = (v) => (v === null ? '(missing)' : `"${v}"`);
+const plain = (v) => (v === null ? '(missing)' : v);
+
+function main(argv) {
+    let opts;
+    try {
+        opts = parseArgs(argv);
+    } catch (e) {
+        return usage(e.message);
+    }
+    const tag = opts.desktop;
+    const { version } = parseTag(tag);
+    const identity = identityVersion(tag);
+    const fileName = fileNameFor(identity);
+    const report = {
+        tag,
+        version,
+        identityVersion: identity,
+        fileName,
+        mode: opts.file ? 'file' : 'gh',
+        run: null,
+        twins: [],
+        artifact: null,
+        msix: null,
+        manifest: null,
+        expected: null,
+        checks: [],
+        findings: [],
+        warnings: [],
+        summary: '',
+        exitCode: 0,
+    };
+    const lines = [
+        `msix-preflight: ${tag} -> identity ${identity}, file ${fileName}`,
+    ];
+    const say = (status, check, message) => {
+        lines.push(fmt(status, check, message));
+        report.checks.push({ status, check, message });
+        if (status === 'FAIL') report.findings.push(`${check}: ${message}`);
+        if (status === 'WARN') report.warnings.push(`${check}: ${message}`);
+    };
+    const finish = (code, summary) => {
+        report.summary = summary;
+        report.exitCode = code;
+        if (opts.json) {
+            console.log(JSON.stringify(report, null, 4));
+        } else {
+            for (const line of lines) console.log(line);
+            console.log(summary);
+        }
+        return code;
+    };
+    const findingsSummary = () =>
+        `msix-preflight: ${tag}: ${report.findings.length} finding(s)`;
+
+    // The template is the source of every expected value except Version.
+    const templatePath = path.join(opts.root, TEMPLATE);
+    const expected = parseManifest(readFileSync(templatePath, 'utf8'));
+    for (const key of [...IDENTITY_KEYS, ...PROPERTY_KEYS]) {
+        if (key !== 'Version' && !expected[key])
+            return usage(
+                `${templatePath} has no ${key}; cannot know what to expect`
+            );
+    }
+    expected.Version = identity;
+    expected.fileName = fileName;
+    report.expected = expected;
+
+    let msixPath;
+    if (opts.file) {
+        msixPath = opts.file;
+    } else {
+        if (!/scratchpad/i.test(opts.out)) {
+            say(
+                'WARN',
+                'out',
+                `${opts.out} is not under a scratchpad directory; the browser file_upload tool refuses other paths (2026-08-02, 2026-08-14)`
+            );
+        }
+        let repo = opts.repo;
+        let runs;
+        const artifactsByRun = new Map();
+        try {
+            if (!repo) {
+                repo = gh(
+                    [
+                        'repo',
+                        'view',
+                        '--json',
+                        'nameWithOwner',
+                        '--jq',
+                        '.nameWithOwner',
+                    ],
+                    opts.root
+                );
+            }
+            runs = JSON.parse(
+                gh(
+                    [
+                        'run',
+                        'list',
+                        '--workflow',
+                        WORKFLOW,
+                        '--branch',
+                        tag,
+                        '--event',
+                        'push',
+                        '--limit',
+                        '50',
+                        '--json',
+                        'databaseId,number,conclusion,status,createdAt,headSha',
+                        '--repo',
+                        repo,
+                    ],
+                    opts.root
+                )
+            );
+            for (const run of runs) {
+                const body = JSON.parse(
+                    gh(
+                        [
+                            'api',
+                            `repos/${repo}/actions/runs/${run.databaseId}/artifacts`,
+                        ],
+                        opts.root
+                    )
+                );
+                artifactsByRun.set(run.databaseId, body.artifacts || []);
+            }
+        } catch (e) {
+            if (!(e instanceof GhError)) throw e;
+            say('FAIL', 'gh', e.message);
+            return finish(5, `msix-preflight: ${tag}: gh failed`);
+        }
+        const choice = chooseRun(runs, artifactsByRun, version);
+        report.twins = choice.twins.map((t) => ({
+            ...t.run,
+            artifacts: t.artifacts.length,
+        }));
+        if (!choice.chosen) {
+            for (const w of choice.warnings) say('WARN', 'run', w);
+            say('FAIL', 'run', choice.message);
+            return finish(3, `msix-preflight: ${tag}: ${choice.message}`);
+        }
+        const run = choice.chosen;
+        report.run = run;
+        say('ok', 'run', describeRun(run));
+        for (const w of choice.warnings) say('WARN', 'run', w);
+        const picked = pickArtifact(choice.artifacts, version);
+        const a = picked.artifact;
+        report.artifact = {
+            id: a.id,
+            name: a.name,
+            size: a.size_in_bytes,
+            expiresAt: picked.expiresAt,
+            daysLeft: picked.daysLeft,
+            expired: picked.expired,
+        };
+        if (picked.expired) {
+            say('FAIL', 'artifact', picked.guidance);
+            return finish(4, `msix-preflight: ${tag}: artifact expired`);
+        }
+        const detail = describeArtifact(a, picked);
+        if (picked.daysLeft !== null && picked.daysLeft < EXPIRY_WARN_DAYS) {
+            say(
+                'WARN',
+                'artifact',
+                `${detail}; under ${EXPIRY_WARN_DAYS} days, upload before it is gone`
+            );
+        } else {
+            say('ok', 'artifact', detail);
+        }
+        // A directory this script names, never --out itself, so a rerun can
+        // wipe it without touching anything else the caller keeps there.
+        const dir = path.join(opts.out, a.name);
+        try {
+            rmSync(dir, { recursive: true, force: true });
+            mkdirSync(dir, { recursive: true });
+            gh(
+                [
+                    'run',
+                    'download',
+                    String(run.databaseId),
+                    '-n',
+                    a.name,
+                    '--dir',
+                    dir,
+                    '--repo',
+                    repo,
+                ],
+                opts.root
+            );
+        } catch (e) {
+            if (!(e instanceof GhError)) {
+                say('FAIL', 'download', `${dir}: ${e.message}`);
+                return finish(1, findingsSummary());
+            }
+            say('FAIL', 'gh', e.message);
+            return finish(5, `msix-preflight: ${tag}: gh failed`);
+        }
+        say('ok', 'download', dir);
+        // gh extracts the artifact flat into --dir today; walk anyway in
+        // case a later gh nests it under the artifact name.
+        const found = walkFiles(dir).filter((f) =>
+            f.toLowerCase().endsWith('.msix')
+        );
+        msixPath = found.find((f) => path.basename(f) === fileName) || null;
+        for (const other of found) {
+            if (other !== msixPath)
+                say('WARN', 'msix', `also found ${other}; ignored`);
+        }
+        if (!msixPath) {
+            say(
+                'FAIL',
+                'msix',
+                found.length
+                    ? `${fileName} not in ${dir}; found ${found.map((f) => path.basename(f)).join(', ')}`
+                    : `no .msix under ${dir}`
+            );
+            return finish(1, findingsSummary());
+        }
+    }
+
+    let buf;
+    try {
+        buf = readFileSync(msixPath);
+    } catch (e) {
+        say('FAIL', 'msix', `${msixPath}: ${e.message}`);
+        return finish(1, findingsSummary());
+    }
+    const size = buf.length;
+    const sha256 = createHash('sha256').update(buf).digest('hex');
+    report.msix = { path: msixPath, size, sha256 };
+    const base = path.basename(msixPath);
+    if (base !== fileName) {
+        say(
+            'FAIL',
+            'msix',
+            `${msixPath} (${num(size)} bytes): file name ${base}, expected ${fileName}`
+        );
+    } else if (!opts.file && size < MIN_MSIX_BYTES) {
+        say(
+            'FAIL',
+            'msix',
+            `${msixPath} (${num(size)} bytes): truncated download, under 1 MiB`
+        );
+    } else {
+        say('ok', 'msix', `${msixPath} (${num(size)} bytes)`);
+    }
+    say('ok', 'sha256', sha256);
+
+    let cd;
+    try {
+        cd = readCentralDirectory(buf);
+    } catch (e) {
+        say('FAIL', 'package', e.message);
+        return finish(1, findingsSummary());
+    }
+    const kind = cd.zip64 ? 'Zip64' : 'classic zip';
+    // readZipEntry takes the first record with a name, so a second
+    // AppxManifest.xml would be read or ignored by position alone. makeappx
+    // never writes a name twice, and which copy Partner Center reads is
+    // undefined, so duplicates fail closed here.
+    const seen = new Set();
+    const dupes = new Set();
+    for (const n of cd.names) (seen.has(n) ? dupes : seen).add(n);
+    if (dupes.size) {
+        say(
+            'FAIL',
+            'package',
+            `duplicate entries: ${[...dupes].join(', ')} (${kind}, ${num(cd.entries)} entries; makeappx never writes a name twice, and which copy Partner Center reads is undefined)`
+        );
+    }
+    const missing = REQUIRED.filter((n) => !cd.names.includes(n));
+    if (missing.length) {
+        say(
+            'FAIL',
+            'package',
+            `not a makeappx package: ${missing.join(' and ')} missing (${kind}, ${num(cd.entries)} entries)`
+        );
+    } else if (!dupes.size) {
+        say(
+            'ok',
+            'package',
+            `${kind}, ${num(cd.entries)} entries, ${REQUIRED.join(' and ')} present`
+        );
+    }
+    const integrity = verifyEntries(buf, cd);
+    if (integrity.failures.length) {
+        say(
+            'FAIL',
+            'integrity',
+            `${integrity.failures.length} of ${num(integrity.checked)} entries fail: ${integrity.failures[0].message}`
+        );
+    } else {
+        say(
+            'ok',
+            'integrity',
+            `${num(integrity.checked)} entries inflate and match their crc32`
+        );
+    }
+    let entry;
+    try {
+        entry = readZipEntry(buf, MANIFEST);
+    } catch (e) {
+        say('FAIL', 'manifest', e.message);
+        return finish(1, findingsSummary());
+    }
+    say(
+        'ok',
+        'manifest',
+        `${MANIFEST} (${entry.method === 8 ? 'deflate' : 'stored'}, ${num(entry.usz)} bytes, crc ok)`
+    );
+    const manifest = parseManifest(entry.data.toString('utf8'));
+    report.manifest = manifest;
+    for (const key of IDENTITY_KEYS) {
+        if (manifest[key] === expected[key]) {
+            say('ok', 'Identity', `${key} ${manifest[key]}`);
+        } else {
+            say(
+                'FAIL',
+                'Identity',
+                `${key} ${plain(manifest[key])}, expected ${expected[key]} from ${key === 'Version' ? tag : TEMPLATE}`
+            );
+        }
+    }
+    const badProps = PROPERTY_KEYS.filter((k) => manifest[k] !== expected[k]);
+    if (!badProps.length) {
+        say(
+            'ok',
+            'Properties',
+            `DisplayName ${quoted(manifest.DisplayName)}, PublisherDisplayName ${quoted(manifest.PublisherDisplayName)}, MinVersion ${manifest.MinVersion}`
+        );
+    }
+    for (const key of badProps) {
+        const show = key === 'MinVersion' ? plain : quoted;
+        say(
+            'FAIL',
+            'Properties',
+            `${key} ${show(manifest[key])}, expected ${show(expected[key])} from ${TEMPLATE}`
+        );
+    }
+
+    // The pin moves in floe-release step 6, after the assets exist, so a
+    // mismatch is expected during a rehearsal and only a warning here.
+    let pin = null;
+    try {
+        pin =
+            readFileSync(path.join(opts.root, PIN_FILE), 'utf8').match(
+                /DESKTOP_VERSION = '([^']*)'/
+            )?.[1] ?? null;
+    } catch {
+        pin = null;
+    }
+    if (pin === version) {
+        say('ok', 'pin', `${PIN_FILE} DESKTOP_VERSION ${pin}`);
+    } else {
+        say(
+            'WARN',
+            'pin',
+            `${PIN_FILE} DESKTOP_VERSION is ${pin === null ? 'missing' : `'${pin}'`}, the tag says ${version}; floe-release step 6 has not merged, or this is a rehearsal`
+        );
+    }
+
+    if (report.findings.length) return finish(1, findingsSummary());
+    lines.push(
+        'READY',
+        `  ${'upload'.padEnd(10)}${msixPath}`,
+        `  ${'identity'.padEnd(10)}${manifest.Name} ${manifest.Version} ${manifest.ProcessorArchitecture}`,
+        `  ${'sha256'.padEnd(10)}${sha256}`,
+        `  ${'replaces'.padEnd(10)}the package Partner Center lists today; expect it struck through after upload`
+    );
+    return finish(0, `msix-preflight: ${tag} ready`);
+}
+
+const invokedDirectly =
+    process.argv[1] &&
+    path.resolve(process.argv[1]).toLowerCase() ===
+        fileURLToPath(import.meta.url).toLowerCase();
+if (invokedDirectly) {
+    if (process.argv.includes('--self-test')) selfTest();
+    process.exit(main(process.argv.slice(2)));
+}

--- a/.claude/skills/store-submit/scripts/msix-preflight.test.mjs
+++ b/.claude/skills/store-submit/scripts/msix-preflight.test.mjs
@@ -1,0 +1,821 @@
+/**
+ * Fixture tests for msix-preflight.mjs.
+ *
+ * The package under test is built here the way makeappx builds one: a Zip64
+ * end-of-central-directory record and locator, general-purpose flag bit 3
+ * with data descriptors (so every local header says crc and sizes 0), the
+ * manifest deflated, assets stored, and the 24-byte 0x0001 extra field on
+ * every central entry. A reader that only handles a classic zip would pass
+ * on a naive fixture and fail on the real thing, which is the wrong way
+ * round, so makeZip builds both shapes and the baseline runs the makeappx
+ * one. The manifest fixture is the repo template with __IDENTITY_VERSION__
+ * stamped everywhere it appears (comment included), exactly what pack.ps1's
+ * .Replace() does, so the expected values come from the same file the script
+ * reads at runtime. The tag is desktop-v3.4.5 (identity 4.4.5.0) so no
+ * shipped number is pinned by a test.
+ *
+ * Each package test injects one defect and asserts on the exit code and the
+ * printed line a reader would see. The live 2026-08-27 artifact is the
+ * integration proof and runs only with STORE_SUBMIT_LIVE=1 (it needs gh, the
+ * network, and about 8 MB).
+ *
+ * Run: node --test .claude/skills/store-submit/scripts/msix-preflight.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { after, test } from 'node:test';
+import zlib from 'node:zlib';
+import {
+    chooseRun,
+    describeArtifact,
+    identityVersion,
+    parseArgs,
+    parseManifest,
+    parseTag,
+    pickArtifact,
+    readZipEntry,
+} from './msix-preflight.mjs';
+
+const SCRIPT = fileURLToPath(import.meta.url).replace(/\.test\.mjs$/, '.mjs');
+const REPO = resolve(dirname(SCRIPT), '..', '..', '..', '..');
+const TEMPLATE = readFileSync(
+    join(REPO, 'desktop/build/msix/AppxManifest.xml'),
+    'utf8'
+);
+const TAG = 'desktop-v3.4.5';
+const IDENTITY = '4.4.5.0';
+const FILE = `FloeDesktop_${IDENTITY}_x64.msix`;
+const MAKEAPPX = { zip64: true, descriptor: true, deflate: true };
+const made = [];
+
+function fresh() {
+    const dir = mkdtempSync(join(tmpdir(), 'msix-preflight-'));
+    made.push(dir);
+    return dir;
+}
+
+// A freshly written .msix can still hold a delete-pending handle on Windows,
+// so the wipe retries instead of failing the run on the last step.
+after(() => {
+    for (const d of made)
+        rmSync(d, {
+            recursive: true,
+            force: true,
+            maxRetries: 5,
+            retryDelay: 100,
+        });
+});
+
+// A valid zip in memory, in either shape. Returns the bytes plus where each
+// entry's (possibly compressed) data starts, so a test can corrupt it.
+function makeZip(
+    entries,
+    { zip64 = false, descriptor = false, deflate = false }
+) {
+    const parts = [];
+    let offset = 0;
+    const push = (b) => {
+        parts.push(b);
+        offset += b.length;
+    };
+    const central = [];
+    const offsets = {};
+    const version = zip64 ? 45 : 20;
+    for (const { name, data, store = false } of entries) {
+        const nameBuf = Buffer.from(name, 'utf8');
+        const method = deflate && !store ? 8 : 0;
+        const payload = method === 8 ? zlib.deflateRawSync(data) : data;
+        const crc = zlib.crc32(data);
+        const flags = descriptor ? 0x0008 : 0;
+        const lho = offset;
+        const local = Buffer.alloc(30);
+        local.writeUInt32LE(0x04034b50, 0);
+        local.writeUInt16LE(version, 4);
+        local.writeUInt16LE(flags, 6);
+        local.writeUInt16LE(method, 8);
+        local.writeUInt16LE(0, 10);
+        local.writeUInt16LE(0x21, 12);
+        local.writeUInt32LE(descriptor ? 0 : crc, 14);
+        local.writeUInt32LE(descriptor ? 0 : payload.length, 18);
+        local.writeUInt32LE(descriptor ? 0 : data.length, 22);
+        local.writeUInt16LE(nameBuf.length, 26);
+        local.writeUInt16LE(0, 28);
+        push(local);
+        push(nameBuf);
+        offsets[name] = { dataStart: offset, csz: payload.length };
+        push(payload);
+        if (descriptor) {
+            const d = Buffer.alloc(zip64 ? 24 : 16);
+            d.writeUInt32LE(0x08074b50, 0);
+            d.writeUInt32LE(crc, 4);
+            if (zip64) {
+                d.writeBigUInt64LE(BigInt(payload.length), 8);
+                d.writeBigUInt64LE(BigInt(data.length), 16);
+            } else {
+                d.writeUInt32LE(payload.length, 8);
+                d.writeUInt32LE(data.length, 12);
+            }
+            push(d);
+        }
+        central.push({
+            nameBuf,
+            method,
+            flags,
+            crc,
+            csz: payload.length,
+            usz: data.length,
+            lho,
+        });
+    }
+    const cdOff = offset;
+    for (const c of central) {
+        const extra = Buffer.alloc(zip64 ? 28 : 0);
+        if (zip64) {
+            extra.writeUInt16LE(0x0001, 0);
+            extra.writeUInt16LE(24, 2);
+            extra.writeBigUInt64LE(BigInt(c.usz), 4);
+            extra.writeBigUInt64LE(BigInt(c.csz), 12);
+            extra.writeBigUInt64LE(BigInt(c.lho), 20);
+        }
+        const h = Buffer.alloc(46);
+        h.writeUInt32LE(0x02014b50, 0);
+        h.writeUInt16LE(version, 4);
+        h.writeUInt16LE(version, 6);
+        h.writeUInt16LE(c.flags, 8);
+        h.writeUInt16LE(c.method, 10);
+        h.writeUInt16LE(0, 12);
+        h.writeUInt16LE(0x21, 14);
+        h.writeUInt32LE(c.crc, 16);
+        h.writeUInt32LE(zip64 ? 0xffffffff : c.csz, 20);
+        h.writeUInt32LE(zip64 ? 0xffffffff : c.usz, 24);
+        h.writeUInt16LE(c.nameBuf.length, 28);
+        h.writeUInt16LE(extra.length, 30);
+        h.writeUInt16LE(0, 32);
+        h.writeUInt16LE(0, 34);
+        h.writeUInt16LE(0, 36);
+        h.writeUInt32LE(0, 38);
+        h.writeUInt32LE(zip64 ? 0xffffffff : c.lho, 42);
+        push(h);
+        push(c.nameBuf);
+        push(extra);
+    }
+    const cdSize = offset - cdOff;
+    if (zip64) {
+        const recOff = offset;
+        const rec = Buffer.alloc(56);
+        rec.writeUInt32LE(0x06064b50, 0);
+        rec.writeBigUInt64LE(44n, 4);
+        rec.writeUInt16LE(45, 12);
+        rec.writeUInt16LE(45, 14);
+        rec.writeUInt32LE(0, 16);
+        rec.writeUInt32LE(0, 20);
+        rec.writeBigUInt64LE(BigInt(central.length), 24);
+        rec.writeBigUInt64LE(BigInt(central.length), 32);
+        rec.writeBigUInt64LE(BigInt(cdSize), 40);
+        rec.writeBigUInt64LE(BigInt(cdOff), 48);
+        push(rec);
+        const loc = Buffer.alloc(20);
+        loc.writeUInt32LE(0x07064b50, 0);
+        loc.writeUInt32LE(0, 4);
+        loc.writeBigUInt64LE(BigInt(recOff), 8);
+        loc.writeUInt32LE(1, 16);
+        push(loc);
+    }
+    const eocd = Buffer.alloc(22);
+    eocd.writeUInt32LE(0x06054b50, 0);
+    eocd.writeUInt16LE(0, 4);
+    eocd.writeUInt16LE(0, 6);
+    eocd.writeUInt16LE(zip64 ? 0xffff : central.length, 8);
+    eocd.writeUInt16LE(zip64 ? 0xffff : central.length, 10);
+    eocd.writeUInt32LE(zip64 ? 0xffffffff : cdSize, 12);
+    eocd.writeUInt32LE(zip64 ? 0xffffffff : cdOff, 16);
+    eocd.writeUInt16LE(0, 20);
+    push(eocd);
+    return { buf: Buffer.concat(parts), offsets };
+}
+
+const manifest = (version = IDENTITY, edit = (s) => s) =>
+    Buffer.from(edit(TEMPLATE.replaceAll('__IDENTITY_VERSION__', version)));
+
+function entries({ manifestText = manifest(), blockMap = true } = {}) {
+    const list = [
+        { name: 'AppxManifest.xml', data: manifestText },
+        {
+            name: '[Content_Types].xml',
+            data: Buffer.from(
+                '<?xml version="1.0" encoding="UTF-8"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="png" ContentType="image/png" /><Default Extension="xml" ContentType="application/vnd.ms-appx.manifest+xml" /></Types>'
+            ),
+        },
+        {
+            name: 'Assets/StoreLogo.png',
+            data: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+            store: true,
+        },
+    ];
+    if (blockMap) {
+        list.splice(1, 0, {
+            name: 'AppxBlockMap.xml',
+            data: Buffer.from(
+                '<?xml version="1.0" encoding="UTF-8"?><BlockMap xmlns="http://schemas.microsoft.com/appx/2010/blockmap" HashMethod="http://www.w3.org/2001/04/xmlenc#sha256"></BlockMap>'
+            ),
+        });
+    }
+    return list;
+}
+
+function pack(dir, { name = FILE, list = entries(), shape = MAKEAPPX } = {}) {
+    const { buf, offsets } = makeZip(list, shape);
+    const file = join(dir, name);
+    writeFileSync(file, buf);
+    return { file, buf, offsets };
+}
+
+function run(args) {
+    const r = spawnSync(process.execPath, [SCRIPT, ...args], {
+        encoding: 'utf8',
+    });
+    return { status: r.status, out: r.stdout + r.stderr, stdout: r.stdout };
+}
+
+const fileMode = (file) => ['--desktop', TAG, '--file', file, '--root', REPO];
+
+test('a makeappx-shaped package (Zip64, data descriptors, deflate) is ready with the identity from the tag', () => {
+    const { file } = pack(fresh());
+    const r = run(fileMode(file));
+    assert.equal(r.status, 0, r.out);
+    assert.match(
+        r.out,
+        /^msix-preflight: desktop-v3\.4\.5 -> identity 4\.4\.5\.0, file FloeDesktop_4\.4\.5\.0_x64\.msix$/m
+    );
+    assert.match(r.out, /^ok    package   Zip64, 4 entries/m);
+    assert.match(r.out, /^ok    manifest  AppxManifest\.xml \(deflate, /m);
+    assert.match(r.out, /^ok    Identity  Version 4\.4\.5\.0$/m);
+    assert.match(r.out, /^ok    Properties DisplayName "Floe Desktop"/m);
+    const sha = createHash('sha256').update(readFileSync(file)).digest('hex');
+    assert.match(r.out, new RegExp(`^ok    sha256    ${sha}$`, 'm'));
+    assert.match(r.out, /^READY$/m);
+    assert.match(r.out, new RegExp(`^  sha256    ${sha}$`, 'm'));
+    assert.match(
+        r.out,
+        /^  identity  JanCarloParedes\.FloeDesktop 4\.4\.5\.0 x64$/m
+    );
+    assert.match(r.out, /^msix-preflight: desktop-v3\.4\.5 ready$/m);
+    assert.doesNotMatch(r.out, /^FAIL/m);
+});
+
+test('a plain stored classic zip with the same layout is ready too', () => {
+    const { file } = pack(fresh(), { shape: {} });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 0, r.out);
+    assert.match(r.out, /^ok    package   classic zip, 4 entries/m);
+    assert.match(r.out, /^ok    manifest  AppxManifest\.xml \(stored, /m);
+    assert.match(r.out, /^READY$/m);
+});
+
+test('--json reports the same verdict as an object', () => {
+    const { file } = pack(fresh());
+    const r = run([...fileMode(file), '--json']);
+    assert.equal(r.status, 0, r.out);
+    const report = JSON.parse(r.stdout);
+    assert.equal(report.tag, TAG);
+    assert.equal(report.identityVersion, IDENTITY);
+    assert.equal(report.mode, 'file');
+    assert.equal(report.manifest.Version, IDENTITY);
+    assert.equal(report.expected.Version, IDENTITY);
+    assert.equal(report.findings.length, 0);
+    assert.equal(report.exitCode, 0);
+    assert.equal(report.msix.path, file);
+});
+
+test('a manifest stamped with the previous identity version is a Version finding', () => {
+    const { file } = pack(fresh(), {
+        list: entries({ manifestText: manifest('4.4.4.0') }),
+    });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  Identity  Version 4\.4\.4\.0, expected 4\.4\.5\.0 from desktop-v3\.4\.5$/m
+    );
+    assert.match(r.out, /^msix-preflight: desktop-v3\.4\.5: 1 finding\(s\)$/m);
+    assert.doesNotMatch(r.out, /^READY$/m);
+});
+
+test('a manifest whose Publisher differs from the template is a Publisher finding', () => {
+    const { file } = pack(fresh(), {
+        list: entries({
+            manifestText: manifest(IDENTITY, (s) =>
+                s.replace(
+                    'Publisher="CN=5D497A40-D927-4850-8A83-E21F677E80E3"',
+                    'Publisher="CN=00000000-0000-0000-0000-000000000000"'
+                )
+            ),
+        }),
+    });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  Identity  Publisher CN=00000000-0000-0000-0000-000000000000, expected CN=5D497A40-D927-4850-8A83-E21F677E80E3/m
+    );
+});
+
+test('a package without AppxManifest.xml is a manifest finding', () => {
+    const { file } = pack(fresh(), {
+        list: entries().filter((e) => e.name !== 'AppxManifest.xml'),
+    });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  manifest  AppxManifest\.xml is not in the package \(3 entries\)$/m
+    );
+});
+
+test('a package with two AppxManifest.xml entries is a package finding, not a read of whichever copy comes first', () => {
+    const { file } = pack(fresh(), {
+        list: [
+            ...entries(),
+            { name: 'AppxManifest.xml', data: manifest('4.4.4.0') },
+        ],
+    });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  package   duplicate entries: AppxManifest\.xml \(/m
+    );
+    assert.doesNotMatch(r.out, /^ok    package/m);
+    assert.doesNotMatch(r.out, /^READY$/m);
+});
+
+test('a text file renamed .msix is not a zip', () => {
+    const dir = fresh();
+    const file = join(dir, FILE);
+    writeFileSync(file, 'this is not a package\n'.repeat(40));
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  package   not a zip: no end-of-central-directory record$/m
+    );
+});
+
+test('one flipped byte inside the deflated manifest is a crc or inflate finding', () => {
+    const dir = fresh();
+    const { file, buf, offsets } = pack(dir);
+    const { dataStart, csz } = offsets['AppxManifest.xml'];
+    assert.ok(csz > 16, 'the deflated manifest must be long enough to hit');
+    const at = dataStart + Math.floor(csz / 2);
+    buf[at] ^= 0xff;
+    writeFileSync(file, buf);
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(r.out, /^FAIL  manifest  AppxManifest\.xml: .*(crc|inflate)/m);
+});
+
+test('one flipped byte inside a stored asset is an integrity finding', () => {
+    const dir = fresh();
+    const { file, buf, offsets } = pack(dir);
+    const asset = offsets['Assets/StoreLogo.png'];
+    assert.ok(asset && asset.csz > 0, 'the fixture carries a stored asset');
+    buf[asset.dataStart] ^= 0xff;
+    writeFileSync(file, buf);
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  integrity 1 of \d+ entries fail: Assets\/StoreLogo\.png: crc32/m
+    );
+    assert.match(r.out, /^ok    manifest  AppxManifest\.xml/m);
+});
+
+test('a zip without AppxBlockMap.xml is not a makeappx package', () => {
+    const { file } = pack(fresh(), { list: entries({ blockMap: false }) });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  package   not a makeappx package: AppxBlockMap\.xml missing/m
+    );
+});
+
+test('a file named for the previous identity while the manifest says the new one is a file-name finding', () => {
+    const { file } = pack(fresh(), { name: 'FloeDesktop_4.4.4.0_x64.msix' });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^FAIL  msix      .*: file name FloeDesktop_4\.4\.4\.0_x64\.msix, expected FloeDesktop_4\.4\.5\.0_x64\.msix$/m
+    );
+    assert.match(r.out, /^ok    Identity  Version 4\.4\.5\.0$/m);
+});
+
+test('usage errors exit 2 before anything is read', () => {
+    const { file } = pack(fresh());
+    const cases = [
+        ['--desktop', 'desktop-v3.4.5-rc1', '--file', file],
+        ['--desktop', 'v3.4.5', '--file', file],
+        ['--desktop', TAG, '--file', file, '--out', fresh()],
+        ['--file', file],
+        ['--desktop', TAG],
+        ['--desktop', TAG, '--file', file, '--root', fresh()],
+    ];
+    for (const args of cases) {
+        const r = run(args);
+        assert.equal(r.status, 2, `${args.join(' ')}\n${r.out}`);
+        assert.match(r.out, /^msix-preflight: /m);
+    }
+});
+
+test('--file on a directory or a missing path is a usage error, not a stack trace', () => {
+    const dir = fresh();
+    const r = run(['--desktop', TAG, '--file', dir, '--root', REPO, '--json']);
+    assert.equal(r.status, 2, r.out);
+    assert.match(
+        r.out,
+        /^msix-preflight: --file .* is a directory, not a file$/m
+    );
+    assert.doesNotMatch(r.out, /EISDIR/);
+    assert.equal(
+        r.stdout,
+        '',
+        '--json prints nothing on stdout on a usage error'
+    );
+    const missing = run([
+        '--desktop',
+        TAG,
+        '--file',
+        join(dir, 'nope.msix'),
+        '--root',
+        REPO,
+    ]);
+    assert.equal(missing.status, 2, missing.out);
+    assert.match(missing.out, /^msix-preflight: --file .* does not exist$/m);
+    assert.throws(
+        () => parseArgs(['--desktop', TAG, '--file', dir, '--root', REPO]),
+        /is a directory, not a file/
+    );
+});
+
+test('--out pointing at an existing file is a usage error before any gh call', () => {
+    const file = join(fresh(), 'notes.txt');
+    writeFileSync(file, 'x\n');
+    assert.throws(
+        () => parseArgs(['--desktop', TAG, '--out', file, '--root', REPO]),
+        /--out .* is a file, not a directory/
+    );
+    const r = run(['--desktop', TAG, '--out', file, '--root', REPO]);
+    assert.equal(r.status, 2, r.out);
+    assert.match(
+        r.out,
+        /^msix-preflight: --out .* is a file, not a directory$/m
+    );
+    assert.doesNotMatch(r.out, /^(ok|WARN|FAIL) /m);
+});
+
+test('--self-test is green', () => {
+    const r = run(['--self-test']);
+    assert.equal(r.status, 0, r.out);
+    assert.match(r.out, /self-test green \(6 fixtures\)/);
+    assert.doesNotMatch(r.out, /^FAIL/m);
+});
+
+test('parseTag and identityVersion accept only strictly numeric desktop-v tags', () => {
+    assert.deepEqual(parseTag('desktop-v0.10.0'), {
+        tag: 'desktop-v0.10.0',
+        version: '0.10.0',
+        major: 0,
+        minor: 10,
+        patch: 0,
+    });
+    assert.equal(identityVersion('desktop-v0.10.0'), '1.10.0.0');
+    assert.equal(identityVersion('desktop-v1.0.0'), '2.0.0.0');
+    assert.equal(identityVersion('desktop-v0.2'), null);
+    assert.equal(identityVersion('desktop-v0.2.8-rc1'), null);
+    assert.equal(identityVersion('v0.2.8'), null);
+    assert.equal(identityVersion(undefined), null);
+});
+
+test('parseArgs throws on every malformed combination and resolves the rest', () => {
+    const { file } = pack(fresh());
+    const a = parseArgs(['--desktop', TAG, '--file', file, '--root', REPO]);
+    assert.equal(a.file, file);
+    assert.equal(a.root, REPO);
+    assert.equal(a.json, false);
+    assert.throws(() => parseArgs([]), /--desktop/);
+    assert.throws(
+        () => parseArgs(['--desktop', 'v1.2.3', '--out', 'x']),
+        /strictly numeric/
+    );
+    assert.throws(() => parseArgs(['--desktop', TAG]), /--out/);
+    assert.throws(
+        () => parseArgs(['--desktop', TAG, '--file', file, '--out', 'x']),
+        /exclusive/
+    );
+    assert.throws(
+        () => parseArgs(['--desktop', TAG, '--file', file, '--repo', 'o/r']),
+        /--repo only applies/
+    );
+    assert.throws(() => parseArgs(['--desktop']), /needs a value/);
+    assert.throws(() => parseArgs(['--desktop', TAG, '--bogus']), /unknown/);
+});
+
+// The recorded 2026-08-27 shapes: `gh run list` for desktop-v0.2.8 and the
+// artifacts endpoint of each run. Run 13 was created one second after run 12
+// and holds nothing.
+const RUN_12 = {
+    databaseId: 33109830152,
+    number: 12,
+    conclusion: 'success',
+    status: 'completed',
+    createdAt: '2026-08-27T19:43:39Z',
+    headSha: '608dee7a9abc446b6cbb744aedefe3236847d332',
+};
+const RUN_13 = {
+    databaseId: 33109832188,
+    number: 13,
+    conclusion: 'cancelled',
+    status: 'completed',
+    createdAt: '2026-08-27T19:43:40Z',
+    headSha: '608dee7a9abc446b6cbb744aedefe3236847d332',
+};
+const ARTIFACT_12 = {
+    id: 9662107967,
+    name: 'floe-desktop-msix-0.2.8-run12',
+    size_in_bytes: 7471955,
+    expired: false,
+    created_at: '2026-08-27T19:46:11Z',
+    expires_at: '2026-11-25T19:43:39Z',
+};
+
+test('chooseRun picks the successful run with the artifact and lists the canceled twin', () => {
+    const byRun = new Map([
+        [RUN_13.databaseId, []],
+        [RUN_12.databaseId, [ARTIFACT_12]],
+    ]);
+    const c = chooseRun([RUN_13, RUN_12], byRun, '0.2.8');
+    assert.equal(c.chosen.databaseId, 33109830152);
+    assert.equal(c.artifact.name, 'floe-desktop-msix-0.2.8-run12');
+    assert.equal(c.twins.length, 1);
+    assert.equal(c.twins[0].run.databaseId, 33109832188);
+    assert.deepEqual(c.warnings, [
+        'twin 33109832188 (number 13, cancelled, 2026-08-27T19:43:40Z, sha 608dee7) holds 0 artifacts; ignored',
+    ]);
+    assert.equal(c.message, null);
+    // A plain object keyed by id works as well as a Map.
+    const viaObject = chooseRun(
+        [RUN_13, RUN_12],
+        { [RUN_12.databaseId]: [ARTIFACT_12], [RUN_13.databaseId]: [] },
+        '0.2.8'
+    );
+    assert.equal(viaObject.chosen.databaseId, 33109830152);
+});
+
+test('chooseRun with no candidate says so and names floe-release step 4', () => {
+    const inProgress = { ...RUN_12, status: 'in_progress', conclusion: '' };
+    const c = chooseRun(
+        [RUN_13, inProgress],
+        new Map([
+            [RUN_13.databaseId, []],
+            [RUN_12.databaseId, []],
+        ]),
+        '0.2.8'
+    );
+    assert.equal(c.chosen, null);
+    assert.equal(c.twins.length, 2);
+    assert.equal(
+        c.message,
+        'no successful desktop-release.yml run with a floe-desktop-msix-0.2.8 artifact for desktop-v0.2.8; a run still in progress or a failed run points at floe-release step 4 (re-cut, never rerun)'
+    );
+    // A success run whose artifact is for another version is not a candidate.
+    const other = chooseRun(
+        [RUN_12],
+        new Map([[RUN_12.databaseId, [ARTIFACT_12]]]),
+        '0.2.9'
+    );
+    assert.equal(other.chosen, null);
+    assert.equal(chooseRun([], new Map(), '0.2.8').chosen, null);
+});
+
+test('chooseRun with two candidates keeps the newest and warns about the older', () => {
+    const older = {
+        ...RUN_12,
+        databaseId: 1,
+        number: 11,
+        createdAt: '2026-08-27T19:00:00Z',
+    };
+    const c = chooseRun(
+        [older, RUN_12],
+        new Map([
+            [1, [{ ...ARTIFACT_12, name: 'floe-desktop-msix-0.2.8-run11' }]],
+            [RUN_12.databaseId, [ARTIFACT_12]],
+        ]),
+        '0.2.8'
+    );
+    assert.equal(c.chosen.databaseId, 33109830152);
+    assert.equal(c.warnings.length, 1);
+    assert.match(c.warnings[0], /^older candidate 1 \(number 11/);
+});
+
+test('pickArtifact reports an expired artifact with its date and the guidance', () => {
+    const now = Date.parse('2026-08-28T12:00:00Z');
+    const live = pickArtifact([ARTIFACT_12], '0.2.8', now);
+    assert.equal(live.expired, false);
+    assert.equal(live.daysLeft, 89);
+    assert.equal(live.guidance, null);
+    const flagged = pickArtifact(
+        [{ ...ARTIFACT_12, expired: true }],
+        '0.2.8',
+        now
+    );
+    assert.equal(flagged.expired, true);
+    assert.equal(flagged.expiresAt, '2026-11-25T19:43:39Z');
+    assert.equal(
+        flagged.guidance,
+        'artifact floe-desktop-msix-0.2.8-run12 expired on 2026-11-25T19:43:39Z: do not rerun or dispatch desktop-release.yml (a rerun is refused after 30 days; a dispatch stamps main.version=dev and reuses the committed wails.json version); cut the next number with floe-release'
+    );
+    const past = pickArtifact(
+        [ARTIFACT_12],
+        '0.2.8',
+        Date.parse('2026-12-01T00:00:00Z')
+    );
+    assert.equal(past.expired, true);
+    assert.ok(past.daysLeft < 0);
+    assert.equal(pickArtifact([ARTIFACT_12], '0.2.9', now).artifact, null);
+    assert.equal(pickArtifact([], '0.2.8', now).artifact, null);
+});
+
+test('describeArtifact says expires unknown when GitHub sends no expires_at', () => {
+    const now = Date.parse('2026-08-28T12:00:00Z');
+    assert.equal(
+        describeArtifact(
+            ARTIFACT_12,
+            pickArtifact([ARTIFACT_12], '0.2.8', now)
+        ),
+        'floe-desktop-msix-0.2.8-run12 (id 9662107967, 7,471,955 bytes, expires 2026-11-25T19:43:39Z, 89 days left)'
+    );
+    const bare = { ...ARTIFACT_12 };
+    delete bare.expires_at;
+    const picked = pickArtifact([bare], '0.2.8', now);
+    assert.equal(picked.expiresAt, null);
+    assert.equal(picked.daysLeft, null);
+    assert.equal(picked.expired, false);
+    assert.equal(
+        describeArtifact(bare, picked),
+        'floe-desktop-msix-0.2.8-run12 (id 9662107967, 7,471,955 bytes, expires unknown)'
+    );
+    assert.doesNotMatch(describeArtifact(bare, picked), /null/);
+});
+
+test('readZipEntry verifies an entry in both builder shapes', () => {
+    const list = entries();
+    for (const shape of [MAKEAPPX, {}, { zip64: true }, { descriptor: true }]) {
+        const { buf } = makeZip(list, shape);
+        const e = readZipEntry(buf, 'AppxManifest.xml');
+        assert.equal(e.entries, 4, JSON.stringify(shape));
+        assert.deepEqual(e.names, [
+            'AppxManifest.xml',
+            'AppxBlockMap.xml',
+            '[Content_Types].xml',
+            'Assets/StoreLogo.png',
+        ]);
+        assert.equal(e.method, shape.deflate ? 8 : 0);
+        assert.equal(e.zip64, Boolean(shape.zip64));
+        assert.equal(e.usz, manifest().length);
+        assert.ok(e.data.equals(manifest()), JSON.stringify(shape));
+        const png = readZipEntry(buf, 'Assets/StoreLogo.png');
+        assert.equal(png.method, 0);
+        assert.equal(png.data.length, 8);
+        assert.throws(
+            () => readZipEntry(buf, 'nope.xml'),
+            (err) =>
+                err.message.includes('not in the package') &&
+                err.names.length === 4
+        );
+    }
+    assert.throws(
+        () =>
+            readZipEntry(Buffer.from('not a zip at all, not even close'), 'x'),
+        /not a zip/
+    );
+});
+
+test('parseManifest reads only the Identity element and the Properties block', () => {
+    const m = parseManifest(
+        `\uFEFF${TEMPLATE.replaceAll('__IDENTITY_VERSION__', '9.9.9.0')}`
+    );
+    assert.equal(m.Name, 'JanCarloParedes.FloeDesktop');
+    assert.equal(m.Publisher, 'CN=5D497A40-D927-4850-8A83-E21F677E80E3');
+    assert.equal(m.Version, '9.9.9.0');
+    assert.equal(m.ProcessorArchitecture, 'x64');
+    assert.equal(m.DisplayName, 'Floe Desktop');
+    assert.equal(m.PublisherDisplayName, 'Jan Carlo Paredes');
+    assert.equal(m.MinVersion, '10.0.19041.0');
+    // Attribute order and line breaks inside the element do not matter.
+    const reordered = parseManifest(
+        '<Package><Identity ProcessorArchitecture="x64"\n  Version="1.0.0.0" Publisher="CN=x" Name="A.B"/><Properties><DisplayName>D</DisplayName><PublisherDisplayName>P</PublisherDisplayName></Properties><Dependencies><TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" /></Dependencies></Package>'
+    );
+    assert.deepEqual(reordered, {
+        Name: 'A.B',
+        Publisher: 'CN=x',
+        Version: '1.0.0.0',
+        ProcessorArchitecture: 'x64',
+        DisplayName: 'D',
+        PublisherDisplayName: 'P',
+        MinVersion: '10.0.0.0',
+    });
+    assert.equal(parseManifest('<Package></Package>').Name, null);
+});
+
+const REAL = {
+    Name: 'A.B',
+    Publisher: 'CN=x',
+    Version: '1.0.0.0',
+    ProcessorArchitecture: 'x64',
+    DisplayName: 'D',
+    PublisherDisplayName: 'P',
+    MinVersion: '10.0.0.0',
+};
+
+test('parseManifest skips a commented-out Identity ahead of the real one', () => {
+    const m = parseManifest(
+        [
+            '<Package>',
+            '<!-- <Identity Name="Old.App" Publisher="CN=old" Version="0.0.0.1"',
+            '  ProcessorArchitecture="x86" /> -->',
+            '<Identity Name="A.B" Publisher="CN=x" Version="1.0.0.0" ProcessorArchitecture="x64"/>',
+            '<Properties><!-- <DisplayName>Old</DisplayName> --><DisplayName>D</DisplayName><PublisherDisplayName>P</PublisherDisplayName></Properties>',
+            '<Dependencies><!-- <TargetDeviceFamily Name="Windows.Desktop" MinVersion="1.0.0.0" /> --><TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.0.0" /></Dependencies>',
+            '</Package>',
+        ].join('\n')
+    );
+    assert.deepEqual(m, REAL);
+    // The same defect inside a package still comes out READY.
+    const { file } = pack(fresh(), {
+        list: entries({
+            manifestText: manifest(IDENTITY, (s) =>
+                s.replace(
+                    '<Identity',
+                    '<!-- <Identity Name="Old.App" Version="0.0.0.1" /> -->\n  <Identity'
+                )
+            ),
+        }),
+    });
+    const r = run(fileMode(file));
+    assert.equal(r.status, 0, r.out);
+    assert.match(r.out, /^ok    Identity  Name JanCarloParedes\.FloeDesktop$/m);
+});
+
+test('parseManifest accepts single-quoted attributes, in either mix', () => {
+    const single = parseManifest(
+        "<Package><Identity Name='A.B' Publisher='CN=x' Version='1.0.0.0' ProcessorArchitecture='x64'/><Properties><DisplayName>D</DisplayName><PublisherDisplayName>P</PublisherDisplayName></Properties><Dependencies><TargetDeviceFamily Name='Windows.Desktop' MinVersion='10.0.0.0' /></Dependencies></Package>"
+    );
+    assert.deepEqual(single, REAL);
+    // Mixed quotes, with each style's opposite quote inside a value.
+    const mixed = parseManifest(
+        `<Package><Identity Name='A.B' Publisher="CN=O'Brien" Version='1.0.0.0' ProcessorArchitecture='x"64'/><Properties><DisplayName>D</DisplayName><PublisherDisplayName>P</PublisherDisplayName></Properties><Dependencies><TargetDeviceFamily Name="Windows.Desktop" MinVersion='10.0.0.0' /></Dependencies></Package>`
+    );
+    assert.equal(mixed.Publisher, "CN=O'Brien");
+    assert.equal(mixed.ProcessorArchitecture, 'x"64');
+    assert.equal(mixed.MinVersion, '10.0.0.0');
+});
+
+test(
+    'the live 2026-08-27 artifact passes gh mode end to end',
+    { skip: !process.env.STORE_SUBMIT_LIVE },
+    () => {
+        const out = fresh();
+        const r = run([
+            '--desktop',
+            'desktop-v0.2.8',
+            '--out',
+            out,
+            '--root',
+            REPO,
+        ]);
+        assert.ok([0, 4].includes(r.status), r.out);
+        if (r.status === 0) {
+            assert.match(
+                r.out,
+                /^ok    run       33109830152 \(number 12, success/m
+            );
+            assert.match(
+                r.out,
+                /^WARN  run       twin 33109832188 \(number 13, cancelled/m
+            );
+            assert.match(r.out, /^ok    Identity  Version 1\.2\.8\.0$/m);
+            assert.match(r.out, /^READY$/m);
+        } else {
+            assert.match(
+                r.out,
+                /^FAIL  artifact  artifact floe-desktop-msix-0\.2\.8-run12 expired on/m
+            );
+        }
+    }
+);

--- a/.claude/skills/store-submit/scripts/release-notes.mjs
+++ b/.claude/skills/store-submit/scripts/release-notes.mjs
@@ -1,0 +1,418 @@
+#!/usr/bin/env node
+/**
+ * Renders a desktop-v* entry of docs/changelog.mdx into the plain text the
+ * Microsoft Store's "What's new in this version" field takes, and measures
+ * it against the field's limits before anyone pastes it.
+ *
+ * Why it exists: the Store field is 1,500 characters of plain text. The
+ * changelog is MDX with bold, backticks and links, so a raw paste leaves
+ * `**` and backticks in the listing. The text opens with a title line,
+ * "Floe Desktop X.Y.Z", the convention Submission 10 shipped by hand (its
+ * 1,306 characters began "Floe Desktop 0.2.8"). With it the desktop-v0.2.8
+ * entry renders to 1,429 characters (measured 2026-08-28), a margin of 71,
+ * so the length check is not theoretical: the next entry of that shape overflows, and the
+ * field silently truncates rather than refusing. The per-line list printed
+ * on an overflow shows what to trim.
+ *
+ * Why the checks are what they are: the changelog contract (the MDX comment
+ * at the top of the file) makes `label` the tag verbatim, so the entry is
+ * found by label and never by position, and an `Unreleased` label at tag
+ * time is the step that has not happened yet (floe-release step 6). The
+ * first tag is the primary surface, so an entry whose first tag is not
+ * Desktop is a note, and rule 6's "Web app:" and "Self-hosting:" prefixes
+ * mark bullets a Store reader has no use for. Store policy refuses "What's
+ * new" text that points at other download sources, so github.com, the
+ * floe.one download page, winget, Homebrew and Scoop are noted with the
+ * line they sit on. The no-dash rule is enforced by Vale in docs/ only; the
+ * Store text lives outside docs/, so it is re-checked here. A `<` or `>`
+ * left in the text is residue only when it forms a tag: `&lt;` decodes to a
+ * bare `<`, and the shipped desktop-v0.2.6 entry holds `< > : " | ? *` in
+ * a code span. For a rendered entry, nothing under the title line is a hard
+ * stop; a hand-written --check file is judged whole, so one line is a valid
+ * paste. A first body line that is not bold is noted against contract rule 4.
+ *
+ * --out writes the file even when a HARD finding is reported, so a hand
+ * condensation starts from the over-limit plain text, never from the MDX.
+ *
+ * Green does NOT prove the text reads well for a Store reader (a desktop
+ * entry may still say `floe` where the reader has no CLI), that Partner
+ * Center accepted it, or that the entry describes what the tag shipped.
+ *
+ * Usage:
+ *   node .claude/skills/store-submit/scripts/release-notes.mjs
+ *       --desktop desktop-vX.Y.Z [--out <file>] [--root <dir>] [--json]
+ *   node .claude/skills/store-submit/scripts/release-notes.mjs
+ *       --check <file> [--json]
+ * Tests:
+ *   node --test .claude/skills/store-submit/scripts/release-notes.test.mjs
+ * Exit: 0 no HARD finding, 1 any HARD finding, 2 usage.
+ */
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// scripts/ -> store-submit/ -> skills/ -> .claude/ -> repo root.
+const DEFAULT_ROOT = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    '..',
+    '..',
+    '..',
+    '..'
+);
+const CHANGELOG = 'docs/changelog.mdx';
+export const STORE_MAX = 1500;
+// Phrases that point a Store reader at another download source.
+export const EXTERNAL =
+    /github\.com|floe\.one\/download|releases\/download|apps\.microsoft\.com|\bwinget\b|homebrew|\bscoop\b|github release/i;
+const DESKTOP_TAG = /^desktop-v\d+\.\d+\.\d+$/;
+const DASH = /[\u2013\u2014]/;
+// What survives rendering when a construct was not reduced. Angle brackets
+// count only as a tag (`<kbd>`, `</Update>`): a bare `<` is legitimate text
+// once `&lt;` is decoded or a code span holding `< > : " | ? *` is restored.
+const RESIDUE = /\*\*|\]\(|`|<\/?[A-Za-z][^>]*>/;
+const SURFACE = /^- (Web app|Self-hosting): /;
+const ENTITIES = { amp: '&', lt: '<', gt: '>', quot: '"' };
+
+// djb2 over code points, 8 lowercase hex digits: the same text pasted from
+// the Store form can be fingerprinted in a browser snippet with this loop.
+export function djb2(text) {
+    let h = 5381;
+    for (const ch of text) h = (Math.imul(h, 33) + ch.codePointAt(0)) >>> 0;
+    return h.toString(16).padStart(8, '0');
+}
+
+// The entry for a label: from the line starting `<Update label="<label>"` to
+// the next line that is exactly `</Update>`. Null when the label is absent.
+export function findEntry(text, label) {
+    const lines = String(text).split(/\r?\n/);
+    const start = lines.findIndex((l) =>
+        l.trim().startsWith(`<Update label="${label}"`)
+    );
+    if (start < 0) return null;
+    let end = -1;
+    for (let i = start + 1; i < lines.length; i++) {
+        if (lines[i].trim() === '</Update>') {
+            end = i;
+            break;
+        }
+    }
+    if (end < 0) return null;
+    const head = lines[start];
+    const tags = (head.match(/tags=\{\[([^\]]*)\]\}/)?.[1] ?? '')
+        .split(',')
+        .map((s) => s.trim().replace(/^"|"$/g, ''))
+        .filter(Boolean);
+    return {
+        label,
+        line: start + 1,
+        head,
+        tags,
+        description: head.match(/description="([^"]*)"/)?.[1] ?? null,
+        body: lines.slice(start + 1, end),
+    };
+}
+
+// Reduces one line of markdown to text. Code spans are lifted out first so
+// their contents are never mistaken for emphasis or a link, and restored
+// into the link text too, so a NOTE never shows the placeholder.
+function inline(line, urls) {
+    const codes = [];
+    const restore = (s) =>
+        s.replace(/\u0000(\d+)\u0000/g, (_, i) => codes[Number(i)]);
+    let s = line.replace(/`([^`]*)`/g, (_, code) => {
+        codes.push(code);
+        return `\u0000${codes.length - 1}\u0000`;
+    });
+    s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, (_, text, url) => {
+        urls.push({ text: restore(text), url });
+        return text;
+    });
+    s = s.replace(/\*\*(.+?)\*\*/g, '$1');
+    s = s.replace(/(^|[^*\w])\*(?!\s)([^*]+?)(?<!\s)\*(?![*\w])/g, '$1$2');
+    s = s.replace(/&(amp|lt|gt|quot);/g, (_, e) => ENTITIES[e]);
+    return restore(s);
+}
+
+// Plain text from an entry body: an optional title line first, then the
+// common indent stripped, the headline followed by one blank line, bullets as `- `, inline markdown
+// reduced, entities decoded, LF, trimmed. A body line starting with `<` is
+// MDX this renderer does not understand and is returned, never dropped.
+// `headline` is the source line the headline came from (null for an empty
+// body), so check() can see whether it was bold.
+export function render(body, title = null) {
+    const urls = [];
+    const mdx = [];
+    const lead = (l) => /^ */.exec(l)[0].length;
+    const nonEmpty = body.filter((l) => l.trim() !== '');
+    const indent = nonEmpty.length ? Math.min(...nonEmpty.map(lead)) : 0;
+    const out = title ? [title, ''] : [];
+    let headline = null;
+    for (const raw of body) {
+        const line = raw.slice(Math.min(indent, lead(raw))).replace(/\s+$/, '');
+        if (line.trim() === '') {
+            out.push('');
+        } else if (line.trimStart().startsWith('<')) {
+            mdx.push(line.trim());
+        } else if (headline === null) {
+            headline = line.trim();
+            out.push(inline(headline, urls), '');
+        } else {
+            out.push(inline(line.replace(/^\s*- /, '- '), urls));
+        }
+    }
+    const text = out
+        .join('\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+    return { text, urls, mdx, headline };
+}
+
+// HARD findings block the paste; NOTE findings are for the reader.
+export function check(text, context = {}) {
+    const {
+        tag = null,
+        tags = null,
+        urls = [],
+        mdx = [],
+        headline = null,
+        entryMissing = false,
+        unreleased = false,
+        titled = false,
+    } = context;
+    const hard = [];
+    const notes = [];
+    if (entryMissing) {
+        hard.push({
+            check: 'entry',
+            message: `no <Update label="${tag}"> in ${CHANGELOG}${unreleased ? '; an Unreleased entry exists, relabel it first (floe-release step 6)' : ''}`,
+        });
+    }
+    for (const line of mdx) {
+        hard.push({
+            check: 'mdx',
+            message: `unsupported MDX inside the entry: ${line}`,
+        });
+    }
+    const lines = text.split('\n');
+    // Nothing at all is not a paste, and neither is a title the script
+    // added itself ("Floe Desktop X.Y.Z") with nothing under it. A hand-written
+    // file (--check) is judged whole: one line is a valid What's new. A
+    // missing entry is already HARD entry.
+    const pasted = titled ? lines.slice(1) : lines;
+    if (!entryMissing && pasted.join('\n').trim() === '') {
+        hard.push({ check: 'empty', message: 'nothing to paste' });
+    }
+    if (text.length > STORE_MAX) {
+        const detail = lines
+            .map(
+                (l, i) =>
+                    `      ${String(l.length).padStart(5)}  ${i + 1}: ${l.length > 60 ? `${l.slice(0, 57)}...` : l}`
+            )
+            .join('\n');
+        hard.push({
+            check: 'length',
+            message: `${text.length} chars, ${STORE_MAX} allowed; trim ${text.length - STORE_MAX}\n${detail}`,
+        });
+    }
+    lines.forEach((l, i) => {
+        if (DASH.test(l))
+            hard.push({
+                check: 'dashes',
+                message: `line ${i + 1} has an em or en dash: ${l}`,
+            });
+        const residue = RESIDUE.exec(l);
+        if (residue)
+            hard.push({
+                check: 'residue',
+                message: `line ${i + 1} keeps "${residue[0]}": ${l}`,
+            });
+        for (const m of l.matchAll(new RegExp(EXTERNAL.source, 'gi'))) {
+            notes.push({
+                check: 'external',
+                message: `"${m[0]}" on line ${i + 1}: ${l}`,
+            });
+        }
+        const surface = SURFACE.exec(l);
+        if (surface)
+            notes.push({
+                check: 'surface',
+                message: `line ${i + 1} is about ${surface[1]}, which a Store reader does not have: ${l}`,
+            });
+    });
+    for (const u of urls) {
+        notes.push({
+            check: 'link',
+            message: `dropped ${u.url} (kept "${u.text}")`,
+        });
+        // The url is gone from the text, so the phrase it carried is only
+        // visible here.
+        for (const m of u.url.matchAll(new RegExp(EXTERNAL.source, 'gi'))) {
+            notes.push({
+                check: 'external',
+                message: `"${m[0]}" in the dropped link ${u.url} (kept "${u.text}")`,
+            });
+        }
+    }
+    // A leading bullet is promoted to the headline slot silently, so the
+    // source line is checked, not the rendered one.
+    if (headline !== null && !headline.startsWith('**')) {
+        notes.push({
+            check: 'headline',
+            message:
+                'first line is not a bold headline (changelog contract rule 4)',
+        });
+    }
+    if (tags && tags[0] !== 'Desktop') {
+        notes.push({
+            check: 'tags',
+            message: `first tag is "${tags[0] ?? ''}", expected "Desktop"; the entry's primary surface is not the desktop app`,
+        });
+    }
+    return { hard, notes };
+}
+
+function usage(message) {
+    console.error(`release-notes: ${message}`);
+    return 2;
+}
+
+export function parseArgs(argv, { root = DEFAULT_ROOT } = {}) {
+    const opts = { desktop: null, check: null, out: null, root, json: false };
+    const value = (flag, v) => {
+        if (v === undefined || v.startsWith('--'))
+            throw new Error(`${flag} needs a value`);
+        return v;
+    };
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a === '--desktop') opts.desktop = value(a, argv[++i]);
+        else if (a === '--check') opts.check = value(a, argv[++i]);
+        else if (a === '--out') opts.out = value(a, argv[++i]);
+        else if (a === '--root') opts.root = value(a, argv[++i]);
+        else if (a === '--json') opts.json = true;
+        else throw new Error(`unknown argument ${a}`);
+    }
+    if (opts.desktop && opts.check)
+        throw new Error('--desktop and --check are exclusive');
+    if (!opts.desktop && !opts.check)
+        throw new Error(
+            'pass --desktop desktop-vX.Y.Z (render the changelog entry) or --check <file> (validate a text file)'
+        );
+    if (opts.desktop && !DESKTOP_TAG.test(opts.desktop))
+        throw new Error(`--desktop wants desktop-vX.Y.Z, got ${opts.desktop}`);
+    // Stat-checked here so a directory is a usage error rather than an
+    // EISDIR from readFileSync, and a missing parent an error rather than an
+    // ENOENT from writeFileSync after the text was rendered.
+    if (opts.check) {
+        if (opts.out) throw new Error('--out only applies with --desktop');
+        opts.check = path.resolve(opts.check);
+        const st = statSync(opts.check, { throwIfNoEntry: false });
+        if (!st) throw new Error(`--check ${opts.check} does not exist`);
+        if (st.isDirectory())
+            throw new Error(`--check ${opts.check} is a directory, not a file`);
+        if (!st.isFile())
+            throw new Error(`--check ${opts.check} is not a regular file`);
+    } else {
+        opts.root = path.resolve(opts.root);
+        if (!existsSync(path.join(opts.root, CHANGELOG)))
+            throw new Error(`--root ${opts.root} has no ${CHANGELOG}`);
+    }
+    if (opts.out) {
+        opts.out = path.resolve(opts.out);
+        if (statSync(opts.out, { throwIfNoEntry: false })?.isDirectory())
+            throw new Error(`--out ${opts.out} is a directory, not a file`);
+        const dir = path.dirname(opts.out);
+        if (!statSync(dir, { throwIfNoEntry: false })?.isDirectory())
+            throw new Error(
+                `--out ${opts.out}: its directory ${dir} does not exist`
+            );
+    }
+    return opts;
+}
+
+function main(argv) {
+    let opts;
+    try {
+        opts = parseArgs(argv);
+    } catch (e) {
+        return usage(e.message);
+    }
+    let text = '';
+    let context = {};
+    let subject;
+    if (opts.check) {
+        subject = opts.check;
+        text = readFileSync(opts.check, 'utf8')
+            .replace(/^\uFEFF/, '')
+            .replace(/\r\n/g, '\n')
+            .trim();
+    } else {
+        subject = opts.desktop;
+        const changelog = readFileSync(path.join(opts.root, CHANGELOG), 'utf8');
+        const entry = findEntry(changelog, opts.desktop);
+        if (!entry) {
+            context = {
+                tag: opts.desktop,
+                entryMissing: true,
+                unreleased: findEntry(changelog, 'Unreleased') !== null,
+            };
+        } else {
+            const rendered = render(
+                entry.body,
+                `Floe Desktop ${opts.desktop.replace(/^desktop-v/, '')}`
+            );
+            text = rendered.text;
+            context = {
+                titled: true,
+                tags: entry.tags,
+                urls: rendered.urls,
+                mdx: rendered.mdx,
+                headline: rendered.headline,
+            };
+        }
+    }
+    const { hard, notes } = check(text, context);
+    const fingerprint = djb2(text);
+    if (opts.out && !context.entryMissing)
+        writeFileSync(opts.out, `${text}\n`, 'utf8');
+    const written = opts.out && !context.entryMissing;
+    const summary = `release-notes: ${subject}: ${hard.length} hard, ${notes.length} notes, ${text.length}/${STORE_MAX} chars${written ? `, written to ${opts.out}` : ''}`;
+    const exitCode = hard.length ? 1 : 0;
+    if (opts.json) {
+        console.log(
+            JSON.stringify(
+                {
+                    tag: opts.desktop,
+                    text,
+                    len: text.length,
+                    djb2: fingerprint,
+                    hard,
+                    notes,
+                    urls: context.urls || [],
+                    out: written ? opts.out : null,
+                    summary,
+                    exitCode,
+                },
+                null,
+                4
+            )
+        );
+        return exitCode;
+    }
+    for (const h of hard) console.log(`HARD  ${h.check}  ${h.message}`);
+    for (const n of notes) console.log(`NOTE  ${n.check}  ${n.message}`);
+    if (!context.entryMissing) {
+        console.log(`--- text (${text.length} chars, djb2 ${fingerprint}) ---`);
+        console.log(text);
+        console.log('--- end ---');
+        console.log(`json: ${JSON.stringify(text)}`);
+    }
+    console.log(summary);
+    return exitCode;
+}
+
+const invokedDirectly =
+    process.argv[1] &&
+    path.resolve(process.argv[1]).toLowerCase() ===
+        fileURLToPath(import.meta.url).toLowerCase();
+if (invokedDirectly) process.exit(main(process.argv.slice(2)));

--- a/.claude/skills/store-submit/scripts/release-notes.test.mjs
+++ b/.claude/skills/store-submit/scripts/release-notes.test.mjs
@@ -1,0 +1,519 @@
+/**
+ * Fixture tests for release-notes.mjs.
+ *
+ * Each test builds a temp root whose docs/changelog.mdx is the repo's own
+ * file (line endings forced to CRLF, as the working copy is under
+ * core.autocrlf=true) with one synthetic entry, desktop-v9.9.9, inserted
+ * before the first real <Update>. The synthetic entry is what every test
+ * renders, so no shipped number is pinned and a real entry changing shape
+ * cannot break these; the real file is still underneath so the search has
+ * to find the label among forty entries. One injected defect per test, and
+ * the assertion is on the exit code and the printed line.
+ *
+ * Run: node --test .claude/skills/store-submit/scripts/release-notes.test.mjs
+ */
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { after, test } from 'node:test';
+import { check, djb2, findEntry, parseArgs, render } from './release-notes.mjs';
+
+const SCRIPT = fileURLToPath(import.meta.url).replace(/\.test\.mjs$/, '.mjs');
+const REPO = resolve(dirname(SCRIPT), '..', '..', '..', '..');
+const SOURCE = readFileSync(join(REPO, 'docs/changelog.mdx'), 'utf8').replace(
+    /\r?\n/g,
+    '\n'
+);
+const TAG = 'desktop-v9.9.9';
+const HEAD = `<Update label="${TAG}" description="2026-01-01" tags={["Desktop"]}>`;
+const BODY = [
+    '  **A synthetic headline for the release-notes test**',
+    '',
+    '  - First bullet with `floe receive` and **bold** text.',
+    '  - Second bullet with *italic*, an &amp; entity, and a &quot;quoted&quot; word.',
+];
+const EXPECTED = [
+    'Floe Desktop 9.9.9',
+    '',
+    'A synthetic headline for the release-notes test',
+    '',
+    '- First bullet with floe receive and bold text.',
+    '- Second bullet with italic, an & entity, and a "quoted" word.',
+].join('\n');
+const EM_DASH = String.fromCharCode(0x2014);
+const made = [];
+
+function fresh() {
+    const dir = mkdtempSync(join(tmpdir(), 'release-notes-'));
+    made.push(dir);
+    return dir;
+}
+
+after(() => {
+    for (const d of made) rmSync(d, { recursive: true, force: true });
+});
+
+// The contract allows one Unreleased entry between a merge and its tag, and
+// floe-release step 6 (when this script runs) is exactly that window, so
+// the real file may carry one. The fixture strips it: a test that wants an
+// Unreleased entry inserts its own through `extra`.
+const UNRELEASED =
+    /^[ \t]*<Update label="Unreleased"[^\n]*\n[\s\S]*?^[ \t]*<\/Update>[ \t]*\n(?:[ \t]*\n)?/gm;
+
+// A root whose changelog carries the synthetic entry (and optionally more
+// entries) before the first real one.
+function fixture({ head = HEAD, body = BODY, extra = [], lf = false } = {}) {
+    const root = fresh();
+    mkdirSync(join(root, 'docs'), { recursive: true });
+    const eol = lf ? '\n' : '\r\n';
+    const source = SOURCE.replace(UNRELEASED, '');
+    assert.doesNotMatch(source, /label="Unreleased"/);
+    const at = source.indexOf('<Update label=');
+    assert.ok(at > 0, 'the repo changelog has an <Update label= line');
+    const entries = [[head, ...body, '</Update>'], ...extra];
+    const inserted = entries.map((e) => `${e.join('\n')}\n\n`).join('');
+    const text = source.slice(0, at) + inserted + source.slice(at);
+    writeFileSync(join(root, 'docs/changelog.mdx'), text.replace(/\n/g, eol));
+    return root;
+}
+
+function run(args) {
+    const r = spawnSync(process.execPath, [SCRIPT, ...args], {
+        encoding: 'utf8',
+    });
+    return { status: r.status, out: r.stdout + r.stderr, stdout: r.stdout };
+}
+
+const forTag = (root, tag = TAG) => ['--desktop', tag, '--root', root];
+
+function textBlock(out) {
+    const m = out.match(
+        /^--- text \((\d+) chars, djb2 ([0-9a-f]{8})\) ---\n([\s\S]*?)\n--- end ---$/m
+    );
+    assert.ok(m, out);
+    return { len: Number(m[1]), djb2: m[2], text: m[3] };
+}
+
+test('the synthetic entry renders to plain text with a fingerprint and a json line that round-trips', () => {
+    const r = run(forTag(fixture()));
+    assert.equal(r.status, 0, r.out);
+    const block = textBlock(r.out);
+    assert.equal(block.text, EXPECTED);
+    assert.equal(block.len, EXPECTED.length);
+    assert.equal(block.djb2, djb2(EXPECTED));
+    const json = r.out.match(/^json: (.*)$/m);
+    assert.ok(json, r.out);
+    assert.equal(JSON.parse(json[1]), EXPECTED);
+    assert.match(
+        r.out,
+        new RegExp(
+            `^release-notes: ${TAG}: 0 hard, 0 notes, ${EXPECTED.length}/1500 chars$`,
+            'm'
+        )
+    );
+    assert.doesNotMatch(r.out, /^(HARD|NOTE)/m);
+});
+
+test('--json carries the text, its length, the fingerprint and the exit code', () => {
+    const r = run([...forTag(fixture()), '--json']);
+    assert.equal(r.status, 0, r.out);
+    const report = JSON.parse(r.stdout);
+    assert.equal(report.tag, TAG);
+    assert.equal(report.text, EXPECTED);
+    assert.equal(report.len, EXPECTED.length);
+    assert.equal(report.djb2, djb2(EXPECTED));
+    assert.deepEqual(report.hard, []);
+    assert.deepEqual(report.notes, []);
+    assert.deepEqual(report.urls, []);
+    assert.equal(report.out, null);
+    assert.equal(report.exitCode, 0);
+});
+
+test('--out writes the text with LF, no BOM and one trailing newline', () => {
+    const out = join(fresh(), 'whats-new.txt');
+    const r = run([...forTag(fixture()), '--out', out]);
+    assert.equal(r.status, 0, r.out);
+    const bytes = readFileSync(out);
+    assert.notEqual(bytes[0], 0xef, 'no BOM');
+    assert.equal(bytes.toString('utf8'), `${EXPECTED}\n`);
+    assert.ok(!bytes.includes('\r'), 'no CR');
+    assert.match(r.out, new RegExp(`, written to .*whats-new\\.txt$`, 'm'));
+});
+
+test('a label that is not in the changelog is HARD entry', () => {
+    const r = run(forTag(fixture(), 'desktop-v8.8.8'));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^HARD  entry  no <Update label="desktop-v8\.8\.8"> in docs\/changelog\.mdx$/m
+    );
+    assert.doesNotMatch(r.out, /^--- text/m);
+    assert.match(r.out, /^release-notes: desktop-v8\.8\.8: 1 hard, 0 notes/m);
+});
+
+test('a missing label while an Unreleased entry exists says to relabel it', () => {
+    const root = fixture({
+        extra: [
+            [
+                '<Update label="Unreleased" tags={["Desktop"]}>',
+                '  **Not yet tagged**',
+                '</Update>',
+            ],
+        ],
+    });
+    const r = run(forTag(root, 'desktop-v8.8.8'));
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^HARD  entry  .*an Unreleased entry exists, relabel it first \(floe-release step 6\)$/m
+    );
+});
+
+test('a body past 1,500 characters is HARD length with a per-line list', () => {
+    const long = `  - ${'A long bullet that keeps going. '.repeat(50).trim()}`;
+    const r = run(forTag(fixture({ body: [...BODY, long] })));
+    assert.equal(r.status, 1, r.out);
+    assert.match(r.out, /^HARD  length  \d+ chars, 1500 allowed; trim \d+$/m);
+    const list = r.out.match(/^ {6} *\d+  \d+: /gm);
+    assert.ok(list && list.length === EXPECTED.split('\n').length + 1, r.out);
+});
+
+test('an em dash in the rendered text is HARD dashes', () => {
+    const r = run(
+        forTag(
+            fixture({ body: [...BODY, `  - A bullet ${EM_DASH} with a dash.`] })
+        )
+    );
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^HARD  dashes  line 7 has an em or en dash: - A bullet /m
+    );
+});
+
+test('a link keeps its text, drops its url as NOTE link and flags github.com as NOTE external', () => {
+    const r = run(
+        forTag(
+            fixture({
+                body: [
+                    ...BODY,
+                    '  - See [the release](https://github.com/jannskiee/floe/releases/tag/desktop-v9.9.9) for details.',
+                ],
+            })
+        )
+    );
+    assert.equal(r.status, 0, r.out);
+    const block = textBlock(r.out);
+    assert.equal(
+        block.text.split('\n').at(-1),
+        '- See the release for details.'
+    );
+    assert.equal(r.out.match(/^NOTE  link  /gm).length, 1);
+    assert.match(
+        r.out,
+        /^NOTE  link  dropped https:\/\/github\.com\/jannskiee\/floe\/releases\/tag\/desktop-v9\.9\.9 \(kept "the release"\)$/m
+    );
+    // The url is gone from the text, so its phrase is reported on the link.
+    assert.equal(r.out.match(/^NOTE  external  /gm).length, 1);
+    assert.match(
+        r.out,
+        /^NOTE  external  "github\.com" in the dropped link https:\/\/github\.com\/jannskiee\/floe\/releases\/tag\/desktop-v9\.9\.9 \(kept "the release"\)$/m
+    );
+    const r2 = run(
+        forTag(
+            fixture({
+                body: [...BODY, '  - Also on winget and as a GitHub release.'],
+            })
+        )
+    );
+    assert.equal(r2.status, 0, r2.out);
+    assert.equal(r2.out.match(/^NOTE  external  /gm).length, 2);
+    assert.match(r2.out, /^NOTE  external  "winget" on line 7: /m);
+    assert.match(r2.out, /^NOTE  external  "GitHub release" on line 7: /m);
+});
+
+test('a link whose text is a code span reports the code in NOTE link, not the placeholder', () => {
+    const r = run(
+        forTag(
+            fixture({
+                body: [
+                    ...BODY,
+                    '  - Run [`floe update`](/docs/cli) to upgrade.',
+                ],
+            })
+        )
+    );
+    assert.equal(r.status, 0, r.out);
+    assert.match(
+        r.out,
+        /^NOTE  link  dropped \/docs\/cli \(kept "floe update"\)$/m
+    );
+    assert.equal(
+        textBlock(r.out).text.split('\n').at(-1),
+        '- Run floe update to upgrade.'
+    );
+    assert.deepEqual(render(['**H**', '', '- [`a b`](x) and `c`']).urls, [
+        { text: 'a b', url: 'x' },
+    ]);
+});
+
+test('a literal < or > that is not a tag is not residue; an inline HTML tag still is', () => {
+    const r = run(
+        forTag(
+            fixture({
+                body: [
+                    ...BODY,
+                    '  - The characters `< > : " | ? *` become underscores, 2 &lt; 3 -> ok.',
+                ],
+            })
+        )
+    );
+    assert.equal(r.status, 0, r.out);
+    assert.doesNotMatch(r.out, /^HARD/m);
+    assert.equal(
+        textBlock(r.out).text.split('\n').at(-1),
+        '- The characters < > : " | ? * become underscores, 2 < 3 -> ok.'
+    );
+    const r2 = run(
+        forTag(fixture({ body: [...BODY, '  - Press <kbd>x</kbd> to go.'] }))
+    );
+    assert.equal(r2.status, 1, r2.out);
+    assert.match(
+        r2.out,
+        /^HARD  residue  line 7 keeps "<kbd>": - Press <kbd>x<\/kbd> to go\.$/m
+    );
+    // The hand-written path sees the same rule.
+    assert.deepEqual(check('T\n\n2 < 3 -> ok, < > : " | ? *').hard, []);
+    assert.deepEqual(
+        check('T\n\n<kbd>x</kbd>').hard.map((h) => h.check),
+        ['residue']
+    );
+    assert.deepEqual(
+        check('T\n\n</Update>').hard.map((h) => h.check),
+        ['residue']
+    );
+});
+
+test('the shipped desktop-v0.2.6 entry, whose code span holds < > : " | ? *, has no residue finding', () => {
+    // The entry is immutable per the changelog contract, so the repo's own
+    // file is read. It is over the Store limit (1,879 chars on 2026-08-28),
+    // so length is the one HARD it may carry.
+    const r = run(['--desktop', 'desktop-v0.2.6', '--root', REPO, '--json']);
+    const report = JSON.parse(r.stdout);
+    assert.ok(
+        report.text.includes('The characters < > : " | ? * become underscores'),
+        report.text
+    );
+    assert.deepEqual(
+        report.hard.filter((h) => h.check !== 'length'),
+        []
+    );
+});
+
+test('nothing under the title line is HARD empty', () => {
+    const blank = join(fresh(), 'blank.txt');
+    writeFileSync(blank, ' \r\n\t\r\n');
+    const r = run(['--check', blank]);
+    assert.equal(r.status, 1, r.out);
+    assert.match(r.out, /^HARD  empty  nothing to paste$/m);
+    // A hand-written file is judged whole: one line is a valid paste (the
+    // rehearsal marker is one line).
+    const oneLine = join(fresh(), 'marker.txt');
+    writeFileSync(oneLine, 'REHEARSAL, delete this draft.\n');
+    const r2 = run(['--check', oneLine]);
+    assert.equal(r2.status, 0, r2.out);
+    assert.doesNotMatch(r2.out, /^HARD  empty/m);
+    const r3 = run(forTag(fixture({ body: [] })));
+    assert.equal(r3.status, 1, r3.out);
+    assert.match(r3.out, /^HARD  empty  nothing to paste$/m);
+    assert.equal(textBlock(r3.out).text, 'Floe Desktop 9.9.9');
+    // A missing entry is reported once, as HARD entry.
+    const r4 = run(forTag(fixture(), 'desktop-v8.8.8'));
+    assert.doesNotMatch(r4.out, /^HARD  empty/m);
+});
+
+test('a body whose first line is not a bold headline is NOTE headline', () => {
+    const r = run(
+        forTag(
+            fixture({
+                body: [
+                    '  - A bullet where the headline should be.',
+                    '  - Another bullet.',
+                ],
+            })
+        )
+    );
+    assert.equal(r.status, 0, r.out);
+    assert.match(
+        r.out,
+        /^NOTE  headline  first line is not a bold headline \(changelog contract rule 4\)$/m
+    );
+    assert.equal(r.out.match(/^NOTE  headline/gm).length, 1);
+    assert.doesNotMatch(run(forTag(fixture())).out, /^NOTE  headline/m);
+});
+
+test('a JSX line inside the entry is HARD mdx, never dropped silently', () => {
+    const r = run(
+        forTag(
+            fixture({
+                body: [
+                    ...BODY,
+                    '  <Note>Something the renderer does not know.</Note>',
+                ],
+            })
+        )
+    );
+    assert.equal(r.status, 1, r.out);
+    assert.match(
+        r.out,
+        /^HARD  mdx  unsupported MDX inside the entry: <Note>Something the renderer does not know\.<\/Note>$/m
+    );
+    assert.equal(textBlock(r.out).text, EXPECTED);
+});
+
+test('an entry whose first tag is not Desktop is NOTE tags', () => {
+    const r = run(
+        forTag(
+            fixture({
+                head: `<Update label="${TAG}" description="2026-01-01" tags={["CLI", "Desktop"]}>`,
+            })
+        )
+    );
+    assert.equal(r.status, 0, r.out);
+    assert.match(r.out, /^NOTE  tags  first tag is "CLI", expected "Desktop"/m);
+});
+
+test('a bullet about another surface is NOTE surface', () => {
+    const r = run(
+        forTag(
+            fixture({
+                body: [...BODY, '  - Web app: something for the browser.'],
+            })
+        )
+    );
+    assert.equal(r.status, 0, r.out);
+    assert.match(r.out, /^NOTE  surface  line 7 is about Web app/m);
+});
+
+test('--check validates a hand-written file and prints the fingerprint the helper computes', () => {
+    const file = join(fresh(), 'notes.txt');
+    const text =
+        'Hello from a hand-written file\n\n- one thing\n- another thing';
+    writeFileSync(file, `\uFEFF${text.replace(/\n/g, '\r\n')}\r\n`);
+    const r = run(['--check', file]);
+    assert.equal(r.status, 0, r.out);
+    const block = textBlock(r.out);
+    assert.equal(block.text, text);
+    assert.equal(block.djb2, djb2(text));
+    assert.match(
+        r.out,
+        new RegExp(
+            `^release-notes: .*notes\\.txt: 0 hard, 0 notes, ${text.length}/1500 chars$`,
+            'm'
+        )
+    );
+    const bad = join(fresh(), 'bad.txt');
+    writeFileSync(bad, 'Still **bold** and a `code` span\n');
+    const r2 = run(['--check', bad]);
+    assert.equal(r2.status, 1, r2.out);
+    assert.match(r2.out, /^HARD  residue  line 1 keeps "\*\*"/m);
+});
+
+test('usage errors exit 2', () => {
+    const root = fixture();
+    const file = join(fresh(), 'x.txt');
+    writeFileSync(file, 'x\n');
+    const cases = [
+        ['--desktop', '0.2.8', '--root', root],
+        ['--check', file, '--desktop', TAG],
+        ['--root', root],
+        ['--check', file, '--out', 'y.txt'],
+        ['--desktop', TAG, '--root', fresh()],
+        ['--desktop', TAG, '--root', root, '--bogus'],
+    ];
+    for (const args of cases) {
+        const r = run(args);
+        assert.equal(r.status, 2, `${args.join(' ')}\n${r.out}`);
+        assert.match(r.out, /^release-notes: /m);
+    }
+});
+
+test('--out into a missing directory and --check on a directory are usage errors, not stack traces', () => {
+    const root = fixture();
+    const out = join(fresh(), 'missing', 'notes.txt');
+    const r = run([...forTag(root), '--out', out]);
+    assert.equal(r.status, 2, r.out);
+    assert.match(
+        r.out,
+        /^release-notes: --out .*: its directory .* does not exist$/m
+    );
+    assert.doesNotMatch(r.out, /ENOENT/);
+    const dir = fresh();
+    const r2 = run([...forTag(root), '--out', dir]);
+    assert.equal(r2.status, 2, r2.out);
+    assert.match(
+        r2.out,
+        /^release-notes: --out .* is a directory, not a file$/m
+    );
+    const r3 = run(['--check', dir]);
+    assert.equal(r3.status, 2, r3.out);
+    assert.match(
+        r3.out,
+        /^release-notes: --check .* is a directory, not a file$/m
+    );
+    assert.doesNotMatch(r3.out, /EISDIR/);
+});
+
+test('a CRLF changelog and an LF changelog render the same text and fingerprint', () => {
+    const crlf = run(forTag(fixture()));
+    const lf = run(forTag(fixture({ lf: true })));
+    assert.equal(crlf.status, 0, crlf.out);
+    assert.equal(lf.status, 0, lf.out);
+    assert.deepEqual(textBlock(crlf.out), textBlock(lf.out));
+    assert.equal(crlf.stdout, lf.stdout);
+});
+
+test('findEntry, render, check and djb2 as units', () => {
+    const entry = findEntry(
+        `x\r\n${HEAD}\r\n${BODY.join('\r\n')}\r\n</Update>\r\n`,
+        TAG
+    );
+    assert.equal(entry.line, 2);
+    assert.deepEqual(entry.tags, ['Desktop']);
+    assert.equal(entry.description, '2026-01-01');
+    assert.deepEqual(entry.body, BODY);
+    assert.equal(findEntry('nothing here', TAG), null);
+    const rendered = render(BODY, 'Floe Desktop 9.9.9');
+    assert.equal(rendered.text, EXPECTED);
+    assert.deepEqual(rendered.urls, []);
+    assert.deepEqual(rendered.mdx, []);
+    // A title line first: a text with nothing under it is HARD empty.
+    const c = check(`T\n\na ${EM_DASH} b`, { tags: ['Web'] });
+    assert.deepEqual(
+        c.hard.map((h) => h.check),
+        ['dashes']
+    );
+    assert.deepEqual(
+        c.notes.map((n) => n.check),
+        ['tags']
+    );
+    assert.equal(djb2(''), '00001505');
+    assert.equal(
+        djb2('a'),
+        ((Math.imul(5381, 33) + 97) >>> 0).toString(16).padStart(8, '0')
+    );
+    const a = parseArgs(['--desktop', TAG, '--root', REPO]);
+    assert.equal(a.desktop, TAG);
+    assert.equal(a.root, REPO);
+    assert.throws(() => parseArgs([]), /--desktop/);
+    assert.throws(() => parseArgs(['--desktop', 'v1']), /desktop-vX\.Y\.Z/);
+});

--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -310,8 +310,10 @@ binary.
       leaves that link empty.
       Tag the entry `["Desktop"]`; the full contract for labels, dates and tag
       values is the MDX comment at the top of `docs/changelog.mdx`.
-      Then paste a plain-text condensation into Partner Center's "What's new in
-      this version" (optional, 1500 characters, no markdown). A release with
+      Then submit with `.claude/skills/store-submit/SKILL.md`, which renders the
+      entry into Partner Center's plain-text "What's new in this version" field
+      (1500 characters, no markdown, no links to other channels) and drives the
+      submission. A release with
       nothing a user can see gets no entry, which is the point of writing it by
       hand. Judge that by what reaches a user, not by whether code changed:
       `desktop-v0.2.1` did move the Store tile colour, so it earned the short


### PR DESCRIPTION
## Summary

- New project skill `.claude/skills/store-submit/`: the Partner Center runbook for a Floe Desktop Store submission (preconditions, MSIX fetch and verification, What's new rendering, the click path with the `he-button` rule, the same-message record before Submit, after-submit expectations, failure modes, and a rehearsal mode that stops before Submit and deletes the draft), plus `references/partner-center.md` with the URLs, identity constants, JS idioms, submission history and the Microsoft Learn facts, all dated.
- `scripts/msix-preflight.mjs`: picks the successful `desktop-release.yml` run for a `desktop-v*` tag (skipping the canceled twin that 0.2.8 has), refuses an expired artifact, downloads the MSIX, reads `AppxManifest.xml` with a zero-dependency Zip64 reader, checks every entry's crc32, and asserts Name / Publisher / Version / ProcessorArchitecture against the template and the tag. `--desktop <tag> --file <msix>` verifies a package on disk without gh; `--self-test` covers the version mapping.
- `scripts/release-notes.mjs`: renders a `docs/changelog.mdx` entry to plain text for the 1,500-character What's new field, with HARD findings for length, dashes, MDX residue and a missing entry, NOTEs for other-channel references, a djb2 fingerprint the browser read-back reproduces, and `--check` for a hand-condensed file.
- Hand-off edits: floe-release's description and step 7 now point at store-submit; `tag-and-workflows.md` names the preflight; `check-version-pins.mjs` skips `.claude/skills/store-submit`; DESKTOP.md step g points at the skill.

## Test plan

- `node --test` on both test files: 27 pass, 1 skipped (the live gh test behind `STORE_SUBMIT_LIVE`) and 21 pass. A no-browser adherence rehearsal by a fresh agent ran both scripts from the runbook's own commands and found one command defect (`--file` also needs `--desktop`) and the unstated mechanics (which tool clicks a ref, how to wait, reload, scroll, and learn the submission id), all fixed in the text. `--self-test` 6/6. `node --check` and Prettier clean on all four scripts and both markdown files; no em or en dash, no BOM, LF.
- Preflight on the real 0.2.8 artifact: `--file` exit 0 (Zip64, 67 entries, manifest crc ok, identity 1.2.8.0 x64, sha256 `eb21f152fe8d2506bd33c4ca57c7c5e04e598c10b2817466e0bfc411e0b3bf56`, equal to `sha256sum`; the reader's manifest bytes hash to the same value as `tar.exe -xOf`). Live gh mode: run 33109830152 chosen, twin 33109832188 warned, artifact `floe-desktop-msix-0.2.8-run12` (expires 2026-11-25), same sha256, idempotent on a second run. `desktop-v0.2.9` exit 3; a zeroed tail exit 1 ("not a zip"); one flipped byte in a stored asset exit 1 (`FAIL  integrity`); `GH_TOKEN=invalid` exit 5 quoting gh's 401; malformed tags exit 2.
- Release notes: `desktop-v0.2.8` renders to 1,429 characters under the "Floe Desktop 0.2.8" title line the shipped text also carried (djb2 `501967b3`, 0 hard, 0 notes); `desktop-v9.9.9` exit 1 (`HARD  entry`); `--check` on the rehearsal marker 83 characters, `db552b16`.
- Pin checker on this branch: `--phase follow-up` reports only the known `desktop-release.yml:223` history line and zero lines under `.claude/skills/store-submit`. docs-check: 0 hard.
- Partner Center rehearsal on 2026-08-28 (Submission 10 live, nothing submitted): Start update created draft Submission 11 on the overview card with Delete submission present; the live 1.2.8.0 upload was refused after 50 to 60 s with "Multiple uploaded files contain the same package (JanCarloParedes.FloeDesktop_1.2.8.0_x64__r1y5w9chaxnzc). Please keep only one of the duplicate packages to continue."; the duplicate row was removed and the Packages Save redirected to the overview; the marker text was written into `#releaseNotes` (maxlength 1500) with the native setter, the listing Save needed a coordinate click, and a full reload read back 83 characters / `db552b16`; Submit for certification was never clicked; Delete submission (coordinate click) opened "Delete submission? This will delete your product submission. Do you want to continue?", Yes returned the overview to "In Microsoft Store" / Submission 10 / Start update within 5 s; the live listing's What's new read back unchanged (1,306 characters, `0954a1b5`). Every measured label, URL and click idiom is dated in the reference.
- Independent checks: a claim-by-claim audit of the runbook and reference against the repo, the memory files and Microsoft Learn (FIX-THEN-SHIP on the first pass: 17 items, all applied, among them the gh calls the preflight needs, the twin-run wording, two memory citations, unbacked Submission 9 claims and the validation timing across runs); a description router test over the six skills (19/20, zero misfires on the six negatives); an adversarial script audit with 27 edge inputs (FIX-THEN-SHIP on the first pass: a duplicate-manifest fail-open, a false-positive HARD on the shipped desktop-v0.2.6 code span, and raw crash paths for --file on a directory, --out into a missing directory and --check on a directory, plus smaller items; each fix landed with its own test); and a closing audit that re-ran every check on the final branch.
