### PR TITLE
chore(ci): give the desktop surface routine dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,15 @@
 # limit, so the monthly cadence only throttles routine version bumps.
 version: 2
 updates:
-  # client/ (pnpm, packageManager pnpm@11.1.2) and server/ (plain npm) share
-  # one npm entry via the multi-directory form. Grouping is per directory,
-  # so client and server still arrive as separate single grouped PRs.
+  # client/ (pnpm, packageManager pnpm@11.1.2), server/ (plain npm) and
+  # desktop/frontend/ (plain npm) share one npm entry via the multi-directory
+  # form. Grouping is per directory, so each still arrives as its own single
+  # grouped PR.
   - package-ecosystem: "npm"
     directories:
       - "/client"
       - "/server"
+      - "/desktop/frontend"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -30,13 +32,30 @@ updates:
           - "minor"
           - "patch"
 
+  # The two Go modules the root go.work joins. desktop/ had no entry until
+  # now, so it moved only when a security advisory landed and drifted from
+  # cli/ in between: #345 arrived as a four-module jump because nothing
+  # routine had touched desktop/go.mod. That drift is not contained to the
+  # desktop app, because goreleaser builds the CLI with the workspace active,
+  # so a version only desktop/ requires still reaches the released binary.
   - package-ecosystem: "gomod"
-    directory: "/cli"
+    directories:
+      - "/cli"
+      - "/desktop"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    # Wails is never Dependabot's call. ci.yml pins WAILS_VERSION and greps
+    # desktop/go.mod for that exact string, because the Wails CLI embeds
+    # runtime assets that must match the library and this repo has eaten one
+    # version drift already (#262). Any bump, major, minor or patch, fails
+    # the desktop job on arrival unless ci.yml and desktop-release.yml move
+    # in the same commit. Wails moves by hand. Security advisories ignore
+    # this block.
+    ignore:
+      - dependency-name: "github.com/wailsapp/wails/v2"
     groups:
       go-deps:
         patterns:


### PR DESCRIPTION
## Summary

`.github/dependabot.yml` had a `gomod` entry for `/cli` only and no `npm` entry for `desktop/frontend`, so neither desktop surface ever received a routine version update. Both moved only when a security advisory landed, which is why every desktop dependency PR in this repo's history (#102, #110, #114, #345) has been a security update.

#345 showed the cost. With nothing routine touching `desktop/go.mod`, a single echo advisory arrived as a four-module jump, and `desktop/` had drifted from `cli/` in between.

That drift is not contained to the desktop app. `.goreleaser.yml:10` builds the CLI with `dir: cli` and never sets `GOWORK=off`, so the root `go.work` puts both modules in one MVS graph and a version only `desktop/` requires still reaches the released `floe` binary. #345 raised `golang.org/x/time` to 0.15.0 for the CLI that way, while `cli/go.mod:38` still pins 0.14.0.

## Changes

- `gomod` becomes multi-directory, `/cli` plus `/desktop`, matching the form the `npm` and `docker` entries already use. Grouping is per directory, so the two still arrive as separate single grouped PRs.
- `desktop/frontend` joins the existing `npm` entry, inheriting its minor-and-patch grouping so majors (react 18, vite 6) still arrive as individual PRs judged on their own.
- Wails is ignored outright. `ci.yml:304` pins `WAILS_VERSION` and `ci.yml:349` greps `desktop/go.mod` for that exact string, because the Wails CLI embeds runtime assets that must match the library and this repo has eaten one version drift already (#262). Any bump of it, major, minor or patch, fails the desktop job on arrival unless `ci.yml` and `desktop-release.yml` move in the same commit. Security advisories ignore the block, so an advisory against Wails would still open a PR.

## Test plan

- Parses as valid YAML, and the four entries resolve to the intended directories and ignore lists: npm `[/client, /server, /desktop/frontend]`, gomod `[/cli, /desktop]` ignoring `github.com/wailsapp/wails/v2`, docker `[/client, /server]` ignoring `node`, github-actions `[/]`.
- No behavior change to the existing client, server, docker or actions entries; the diff touches only the npm `directories` list, its comment, and the gomod entry.
- The real check is the next monthly run: `/desktop` and `/desktop/frontend` should each open their own grouped PR, and no Wails bump should appear in the gomod one.
