### PR TITLE
chore(ci): fix two defects in the dependabot config from #352

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,15 +53,24 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
-    # Wails is never Dependabot's call. ci.yml pins WAILS_VERSION and greps
-    # desktop/go.mod for that exact string, because the Wails CLI embeds
-    # runtime assets that must match the library and this repo has eaten one
-    # version drift already (#262). Any bump, major, minor or patch, fails
-    # the desktop job on arrival unless ci.yml and desktop-release.yml move
-    # in the same commit. Wails moves by hand. Security advisories ignore
-    # this block.
+    # Wails is never Dependabot's call for a routine bump. ci.yml pins
+    # WAILS_VERSION and greps desktop/go.mod for that exact string, because
+    # the Wails CLI embeds runtime assets that must match the library and this
+    # repo has eaten one version drift already (#262). Any routine bump, major,
+    # minor or patch, fails the desktop job on arrival unless ci.yml and
+    # desktop-release.yml move in the same commit, so Wails moves by hand.
+    # The three update-types are spelled out rather than left as a bare
+    # dependency-name on purpose. An ignore applies to version updates AND
+    # security updates, but update-types scopes it to version updates only
+    # ("update-types only affects version updates, not security updates"), so
+    # a Wails advisory can still open its own PR. A bare dependency-name would
+    # have silenced that too. Same shape as the node ignore below.
     ignore:
       - dependency-name: "github.com/wailsapp/wails/v2"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       go-deps:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,11 @@ version: 2
 updates:
   # client/ (pnpm, packageManager pnpm@11.1.2), server/ (plain npm) and
   # desktop/frontend/ (plain npm) share one npm entry via the multi-directory
-  # form. Grouping is per directory, so each still arrives as its own single
-  # grouped PR.
+  # form. A group spans those directories rather than splitting by them: #182
+  # and #256 both landed as a single "across 2 directories" PR, as did the
+  # docker group in #227. That is the intent, one PR per ecosystem per month,
+  # but it does mean one bad bump in any directory holds up the rest, which is
+  # the same reason majors are excluded from the group below.
   - package-ecosystem: "npm"
     directories:
       - "/client"
@@ -38,6 +41,9 @@ updates:
   # routine had touched desktop/go.mod. That drift is not contained to the
   # desktop app, because goreleaser builds the CLI with the workspace active,
   # so a version only desktop/ requires still reaches the released binary.
+  # The two arrive in one "across 2 directories" PR, which is what we want:
+  # the root go.work puts both modules in one MVS graph, so moving them in
+  # the same PR is what keeps them from diverging again.
   - package-ecosystem: "gomod"
     directories:
       - "/cli"


### PR DESCRIPTION
## Summary

Two defects in the dependabot config that #352 landed. One I carried forward from the existing file, one I introduced.

## 1. A bare `ignore` also silences security PRs

#352 ignored `github.com/wailsapp/wails/v2` with a bare `dependency-name` and a comment claiming "Security advisories ignore this block". They do not. An `ignore` applies to the pull requests Dependabot opens for **version updates and security updates**; it is `update-types` that narrows an ignore to version updates only. From the [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated):

> `update-types` only affects *version* updates, not *security* updates. Security updates will always be created regardless of the `update-types` setting.

So as written, a future advisory against Wails itself would have opened no PR. The alert would still show in the Security tab, because `dependabot.yml` has no interaction with alerts, but the automatic fix PR would have been silenced. That is a bad trade for avoiding a CI grep failure, and it is the worst place in the repo to have it: Wails is the framework the desktop app is built from, and `desktop/go.mod`'s only advisory to date (echo, alert #115) arrived through the Wails subtree.

Spelling out all three `version-update:semver-*` types blocks every routine bump, which is what the `ci.yml` `WAILS_VERSION` grep needs, while leaving security updates able to open their own PR. It is also the shape the `node` ignore in this same file already uses.

## 2. The grouping comment is factually wrong

The file has claimed that "grouping is per directory, so client and server still arrive as separate single grouped PRs". The repo's own merged history refutes it:

| PR | Title | Files |
|----|-------|-------|
| #182 | `bump the npm-deps group across 2 directories with 16 updates` | `client/` + `server/` |
| #256 | `bump the npm-deps group across 2 directories with 6 updates` | `client/` + `server/` |
| #227 | `bump the docker-deps group across 2 directories with 1 update` | `client/` + `server/` |

A group spans its directories rather than splitting by them. #352 reworded that sentence while adding `desktop/frontend`, carrying the wrong claim to a third directory. This states what actually happens, plus the consequence the file already reasons about a few lines down: one bad bump in any directory holds up the rest, which is exactly why majors are excluded from the npm group.

For `gomod` the combined PR is the shape we want, so the comment now says so. The root `go.work` puts `cli/` and `desktop/` in one MVS graph, and `.goreleaser.yml` builds the CLI with the workspace active, so moving both modules in one PR is what stops them diverging the way #345 showed they can (`golang.org/x/time` 0.15.0 in `desktop/go.mod` against 0.14.0 in `cli/go.mod`).

## Test plan

- Parses as valid YAML. The four entries resolve to the same directories as before: npm `[/client, /server, /desktop/frontend]`, gomod `[/cli, /desktop]`, docker `[/client, /server]`, github-actions `[/]`.
- The only behavioral change is the wails ignore gaining its three `update-types`. Routine Wails bumps stay suppressed; security updates are no longer suppressed.
- The real check is the first monthly run after this merges: the gomod PR should be one "across 2 directories" PR carrying no Wails bump.
