### PR TITLE
fix(ci): make the desktop frontend step fail on the first error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,11 @@ jobs:
         # Must precede any Go command in desktop/: main.go embeds
         # frontend/dist, which does not exist on a fresh checkout.
         working-directory: desktop/frontend
+        # bash, not the Windows default pwsh: GitHub's pwsh wrapper appends
+        # `exit $LASTEXITCODE`, so only the LAST command decides the step
+        # result and a failing `npm ci` is not reliably fatal. bash runs with
+        # -e, so the first failure stops the step and is the one reported.
+        shell: bash
         run: |
           npm ci
           npm test

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -94,6 +94,11 @@ jobs:
         # Must precede any Go command in desktop/: main.go embeds frontend/dist,
         # which does not exist on a fresh checkout.
         working-directory: desktop/frontend
+        # bash, not the Windows default pwsh: GitHub's pwsh wrapper appends
+        # `exit $LASTEXITCODE`, so only the LAST command decides the step
+        # result and a failing `npm ci` is not reliably fatal. bash runs with
+        # -e, so the first failure stops the step and is the one reported.
+        shell: bash
         run: |
           npm ci
           npm test


### PR DESCRIPTION
## Summary

The desktop frontend step runs three commands in one block:

```yaml
run: |
  npm ci
  npm test
  npm run build
```

Both jobs are `runs-on: windows-latest` with no `shell:`, so they get the default pwsh, and GitHub's pwsh wrapper appends `exit $LASTEXITCODE`. Only the **last** command decides the step result, and a native command's non-zero exit does not stop the script. A failing `npm ci` is therefore not reliably fatal: if a later command happened to succeed, the step would report success on a broken install.

Today the cascade rescues it, because with no `node_modules` the `vitest` and `tsc` binaries are missing too, so the last command fails as well. That is luck rather than design, and it makes the log actively misleading. Dependabot #357 is the worked example:

```
npm error code ERESOLVE          <- the actual cause
'vitest' is not recognized       <- cascade
'tsc' is not recognized          <- cascade, and this is what set the exit code
```

Three stacked errors for one root cause, with the real one scrolled off the top.

## Changes

`shell: bash` on the `Frontend install, test, build` step in both `.github/workflows/ci.yml` and `.github/workflows/desktop-release.yml`, with a comment explaining why. GitHub runs bash with `-e`, so the first failure stops the step and is the one reported.

Nothing new is introduced: both workflows already use `shell: bash` on this same Windows runner (`ci.yml:342,354,368,380` and `desktop-release.yml:49,109,115,137`).

## Test plan

- Editing `.github/workflows/` matches the `changes` job filter at `ci.yml:84`, so `Lint workflows` (actionlint) runs on this PR rather than skipping.
- The `Desktop (Wails, windows-latest)` job exercises the changed `ci.yml` step directly on this PR; a green run is the proof that `shell: bash` resolves and the three commands still work on the Windows runner.
- The `desktop-release.yml` change is identical and cannot be exercised without a `desktop-v*` tag. It is the same one-line edit to the same step shape, and actionlint parses the file.
