### PR TITLE
chore(deps): move the desktop frontend to React 19

### DIFF
--- a/desktop/frontend/package-lock.json
+++ b/desktop/frontend/package-lock.json
@@ -11,14 +11,14 @@
         "@fontsource-variable/geist": "^5.3.0",
         "@fontsource-variable/geist-mono": "^5.3.0",
         "lucide-react": "^1.34.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
         "react-qr-code": "^2.2.0"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
-        "@types/react": "^18.0.17",
-        "@types/react-dom": "^18.0.6",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.5",
         "@vitejs/plugin-react": "^4.3.0",
         "tailwindcss": "^4.3.3",
         "typescript": "^5.6.0",
@@ -1315,9 +1315,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1335,9 +1332,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1355,9 +1349,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1375,9 +1366,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1602,32 +1590,24 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.31",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2521,28 +2501,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {
@@ -2620,13 +2596,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -13,14 +13,14 @@
     "@fontsource-variable/geist": "^5.3.0",
     "@fontsource-variable/geist-mono": "^5.3.0",
     "lucide-react": "^1.34.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "react-qr-code": "^2.2.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
-    "@types/react": "^18.0.17",
-    "@types/react-dom": "^18.0.6",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.5",
     "@vitejs/plugin-react": "^4.3.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^5.6.0",


### PR DESCRIPTION
Supersedes #357 and #358.

## Why those two could not be merged

Dependabot split this across two PRs because `react` and `react-dom` are two npm packages. They are a version-locked pair, so each half failed `npm ci` with ERESOLVE on the `Desktop (Wails, windows-latest)` job, and neither could ever go green alone:

| PR | Conflict |
|----|----------|
| #357 | `@types/react-dom@19.2.5` needs peer `@types/react@^19.2.0`; root declared `^18.0.17` |
| #358 | `@types/react@19.2.18` installed, but `@types/react-dom@18.3.7` needs peer `@types/react@^18.0.0` |

They are mirror images of each other. Moving all four specifiers together resolves cleanly.

## Why this is low risk

This is alignment rather than a leap. `client/package.json` already pins the identical `react` and `react-dom` **19.2.8**. `desktop/frontend` sat on 18 only because the Wails template scaffolded it there and, until #352 gave the directory a Dependabot entry, nothing routine ever moved it.

No source changes are required, and that is not an assumption. `main.tsx:10` already uses `createRoot`, and `desktop/frontend/src` contains none of what React 19 removed: no `ReactDOM.render`/`hydrate`/`findDOMNode`/`unmountComponentAtNode`, no `defaultProps`, no `propTypes`, no string refs, no legacy context, no `React.FC`, no class components, no `React.Children`, no `react-dom/test-utils`, zero `forwardRef` call sites, and all 29 `useRef` calls pass an argument. The whole hook surface is `useState`, `useEffect`, `useRef`, `useCallback`, `useId` and `useLayoutEffect`, none of which changed.

Both third-party React libraries are clear: `lucide-react`'s peer already lists `^19.0.0`, and `react-qr-code@2.2.0` (already the latest published version) declares `react: "*"` and uses `forwardRef` with destructuring defaults rather than `defaultProps`, so no defaults are silently dropped.

## Test plan

Verified locally before pushing:

- `npm ci` resolves with no ERESOLVE, 0 vulnerabilities
- `npm test` - 91 tests across 7 files pass
- `npm run build` (`tsc && vite build`) succeeds; `tsc` is the real gate here, since `@types/react` 19 is stricter
- `go vet ./...` and `go test -count=1 ./...` in `desktop/` pass against the rebuilt embed

**What CI does not prove.** None of those 91 tests renders a React component; they are pure string and number logic, and neither jsdom nor `@testing-library/react` is installed, so `vite.config.ts` has no `test` block at all. `tsc` plus a manual pass over the running app is the entire safety net. `desktop-release.yml` triggers only on a `desktop-v*` tag push, so this soaks on `main` until `desktop-v0.2.9` is cut deliberately, and the manual pass belongs before that tag rather than before this merge.

`desktop/frontend/package.json.md5` is deliberately left stale. It is Wails' cache stamp for `frontend:install`, so a mismatch makes Wails re-run `npm install` locally, which is the safe direction. CI and release never consult it, since both use `wails build -s`.
