### PR TITLE
feat(cli): add --relay-only and print the connection path

### DIFF
--- a/.claude/skills/docs-verify/references/claim-map.md
+++ b/.claude/skills/docs-verify/references/claim-map.md
@@ -39,9 +39,10 @@ The map names where a value is stated; grep the old literal repo-wide before fin
 
 ## CLI flags and environment
 
-- cli/cmd/floe/main.go: `flagServer` (`--server`, with its compiled default), `flagNoRelay`, `flagWebURL` (`--web`), `flagIface` (`--iface`, repeatable), `flagOutput` (`-o`, with its default), `flagAutoAccept` (`-y`), `flagNoReport`, `flagUpdateCheck` (`--check`); `FLOE_SERVER` and `FLOE_WEB` in the root `PersistentPreRunE`, `FLOE_NO_STATS` in the receive command.
+- cli/cmd/floe/main.go: `flagServer` (`--server`, with its compiled default), `flagNoRelay`, `flagRelayOnly` (`--relay-only`, mutually exclusive with `--no-relay` via `MarkFlagsMutuallyExclusive`), `flagWebURL` (`--web`), `flagIface` (`--iface`, repeatable), `flagOutput` (`-o`, with its default), `flagAutoAccept` (`-y`), `flagNoReport`, `flagUpdateCheck` (`--check`); `FLOE_SERVER`, `FLOE_WEB` and `FLOE_RELAY_ONLY` in `applyEnv` (called from the root `PersistentPreRunE`; a typed `--no-relay` beats `FLOE_RELAY_ONLY`), `FLOE_NO_STATS` in the receive command.
+- cli/cmd/floe/main.go `connectedLine`: the `Connected (direct)` / `Connected (relay)` / bare `Connected` status line, read once from `Connection.ConnectionType()` after setup.
 - cli/internal/selfupdate/selfupdate.go: `FLOE_NO_UPDATE_CHECK`.
-- Docs: docs/cli/flags.mdx (every table), docs/cli/receive.mdx, docs/cli/update.mdx, docs/cli/self-hosted-server.mdx, docs/snippets/stats-optout.mdx, README.md CLI section.
+- Docs: docs/cli/flags.mdx (every table), docs/cli/send.mdx and docs/cli/receive.mdx ("Output" quotes the `Connected` line), docs/cli/update.mdx, docs/cli/self-hosted-server.mdx, docs/snippets/stats-optout.mdx, README.md CLI section. `--relay-only` is also described as the twin of Hide my IP in docs/how-it-works/relay-connection.mdx (the badge row, "Turning it off, and the opposite", and the accordion), docs/desktop/settings.mdx "Hide my IP address", docs/choosing-floe.mdx (the "Force the relay" row), docs/how-it-works/known-limitations.mdx, docs/security-privacy.mdx, docs/how-it-works/2gb-limit.mdx "One case that catches people out", and docs/troubleshooting.mdx `timed out establishing a connection`.
 
 ## Versions
 

--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -36,10 +36,11 @@ var version = "dev"
 
 // Shared flags
 var (
-	flagServer  string
-	flagNoRelay bool
-	flagWebURL  string
-	flagIface   []string
+	flagServer    string
+	flagNoRelay   bool
+	flagRelayOnly bool
+	flagWebURL    string
+	flagIface     []string
 )
 
 // ── Root command ─────────────────────────────────────────────────────────────
@@ -63,27 +64,44 @@ Documentation: https://www.floe.one/docs`,
 	// hook would silently disable this one. Do not add one without moving this
 	// logic somewhere both paths reach.
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-		// Precedence: an explicit flag beats the environment, which beats the
-		// compiled default. Changed() is load-bearing rather than a string
-		// compare against the default, because --server HAS a non-empty default
-		// and so a compare cannot tell "typed the default" from "typed nothing".
-		// It is also what keeps a stray FLOE_SERVER in a developer or CI shell
-		// from retargeting the e2e suite, whose spawned CLI children inherit the
-		// parent environment.
-		if !cmd.Flags().Changed("server") {
-			if v := os.Getenv("FLOE_SERVER"); v != "" {
-				flagServer = v
-			}
-		}
-		if !cmd.Flags().Changed("web") {
-			if v := os.Getenv("FLOE_WEB"); v != "" {
-				flagWebURL = v
-			}
-		}
+		applyEnv(cmd, os.Getenv)
 		flagServer = serverurl.Normalize(flagServer)
 		flagWebURL = serverurl.Normalize(flagWebURL)
 		return nil
 	},
+}
+
+// applyEnv fills in, from the environment, every shared flag the user did not
+// type. getenv is a parameter so tests can drive it without touching the
+// process environment.
+//
+// Precedence: an explicit flag beats the environment, which beats the
+// compiled default. Changed() is load-bearing rather than a string compare
+// against the default, because --server HAS a non-empty default and so a
+// compare cannot tell "typed the default" from "typed nothing". It is also
+// what keeps a stray FLOE_SERVER in a developer or CI shell from retargeting
+// the e2e suite, whose spawned CLI children inherit the parent environment.
+func applyEnv(cmd *cobra.Command, getenv func(string) string) {
+	if !cmd.Flags().Changed("server") {
+		if v := getenv("FLOE_SERVER"); v != "" {
+			flagServer = v
+		}
+	}
+	if !cmd.Flags().Changed("web") {
+		if v := getenv("FLOE_WEB"); v != "" {
+			flagWebURL = v
+		}
+	}
+	// FLOE_RELAY_ONLY is a standing preference; a typed --no-relay is a
+	// decision about this one transfer and wins over it, the same way a typed
+	// --server beats FLOE_SERVER. Cobra's mutual-exclusion check only looks at
+	// flags that were typed, so this is the one place the pair is reconciled
+	// when one half came from the environment.
+	if !cmd.Flags().Changed("relay-only") && !cmd.Flags().Changed("no-relay") {
+		if getenv("FLOE_RELAY_ONLY") == "1" {
+			flagRelayOnly = true
+		}
+	}
 }
 
 func init() {
@@ -92,6 +110,11 @@ func init() {
 		"signaling server URL (use http://localhost:3001 for local testing) [env: FLOE_SERVER]")
 	rootCmd.PersistentFlags().BoolVar(&flagNoRelay, "no-relay", false,
 		"disable TURN relay (direct connections only)")
+	rootCmd.PersistentFlags().BoolVar(&flagRelayOnly, "relay-only", false,
+		"route through the TURN relay only, hiding your IP from the peer (2 GB cap applies) [env: FLOE_RELAY_ONLY]")
+	// One refuses the relay, the other requires it; together they describe no
+	// connection at all.
+	rootCmd.MarkFlagsMutuallyExclusive("relay-only", "no-relay")
 	rootCmd.PersistentFlags().StringVar(&flagWebURL, "web", "",
 		"web app URL shown in the browser link (auto-detected if not set) [env: FLOE_WEB]")
 	rootCmd.PersistentFlags().StringSliceVar(&flagIface, "iface", nil,
@@ -105,6 +128,34 @@ func init() {
 	// Enable `floe --version` (and -v) in addition to the `version` subcommand.
 	rootCmd.Version = version
 	rootCmd.SetVersionTemplate("floe {{.Version}}\n")
+}
+
+// peerOptions translates the shared flags into the engine's connection
+// options. Both send and receive build their peer from the same flags, so this
+// is the one place the mapping lives.
+func peerOptions() []peer.Option {
+	opts := []peer.Option{peer.WithInterfaceAllowlist(flagIface)}
+	if flagRelayOnly {
+		opts = append(opts, peer.WithRelayOnly())
+	}
+	return opts
+}
+
+// connectedLine is the status line printed once the data channel is open. It
+// names the route ICE settled on, "direct" or "relay", so a user can tell at a
+// glance whether the transfer is device to device or through the TURN relay.
+// It fails open to the bare word: a route that cannot be read (or one this
+// build does not know) must never turn a working connection into a confusing
+// line, and other tooling matches "  Connected" as a prefix.
+func connectedLine(ct string, err error) string {
+	if err != nil {
+		return "  Connected"
+	}
+	switch ct {
+	case "direct", "relay":
+		return "  Connected (" + ct + ")"
+	}
+	return "  Connected"
 }
 
 // ── floe send ────────────────────────────────────────────────────────────────
@@ -219,7 +270,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 	_ = peerId // used internally by signaling routing
 
 	// 8. Set up WebRTC as the initiator (sender creates offer + data channel)
-	conn, err := peer.New(iceServers, sc, peer.WithInterfaceAllowlist(flagIface))
+	conn, err := peer.New(iceServers, sc, peerOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to create peer connection: %w", err)
 	}
@@ -231,7 +282,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("WebRTC setup failed: %w", err)
 	}
 
-	fmt.Println("  Connected")
+	fmt.Println(connectedLine(conn.ConnectionType()))
 	fmt.Println()
 
 	// 9. Send files. The pump comes from the connection, not from SendFiles: see
@@ -339,7 +390,7 @@ func runReceive(cmd *cobra.Command, args []string) error {
 	fmt.Println("  Connecting to sender...")
 
 	// 6. Set up WebRTC as the responder (receiver waits for offer)
-	conn, err := peer.New(iceServers, sc, peer.WithInterfaceAllowlist(flagIface))
+	conn, err := peer.New(iceServers, sc, peerOptions()...)
 	if err != nil {
 		return fmt.Errorf("failed to create peer connection: %w", err)
 	}
@@ -350,7 +401,7 @@ func runReceive(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("WebRTC setup failed: %w", err)
 	}
 
-	fmt.Println("  Connected")
+	fmt.Println(connectedLine(conn.ConnectionType()))
 
 	// 7. Receive files
 	statsURL := flagServer

--- a/cli/cmd/floe/main_test.go
+++ b/cli/cmd/floe/main_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestConnectedLine pins the three shapes the status line can take. The bare
+// word is the fail-open shape: other tooling matches it as a prefix, so an
+// unreadable or unknown route must never produce anything else.
+func TestConnectedLine(t *testing.T) {
+	tests := []struct {
+		name string
+		ct   string
+		err  error
+		want string
+	}{
+		{"direct", "direct", nil, "  Connected (direct)"},
+		{"relay", "relay", nil, "  Connected (relay)"},
+		{"an error wins over a route", "direct", errors.New("no candidate pair selected"), "  Connected"},
+		{"empty route", "", nil, "  Connected"},
+		{"unknown route", "srflx", nil, "  Connected"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := connectedLine(tc.ct, tc.err); got != tc.want {
+				t.Errorf("connectedLine(%q, %v) = %q, want %q", tc.ct, tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// sharedFlagNames are the persistent flags these tests type or read. --iface
+// is left out on purpose: its default renders as "[]", which pflag would parse
+// back as a one-element slice.
+var sharedFlagNames = []string{"server", "no-relay", "relay-only", "web"}
+
+// resetSharedFlags returns each shared flag, and the variable bound to it, to
+// its compiled default. Cobra keeps flag state on the package-level rootCmd
+// between Execute calls, so without this a flag typed in one test would still
+// read as Changed in the next. It also blanks the FLOE_* variables for the
+// duration of the test so a developer's shell cannot leak into a case.
+func resetSharedFlags(t *testing.T) {
+	t.Helper()
+	for _, name := range sharedFlagNames {
+		f := rootCmd.PersistentFlags().Lookup(name)
+		if f == nil {
+			t.Fatalf("flag --%s is not registered on the root command", name)
+		}
+		if err := f.Value.Set(f.DefValue); err != nil {
+			t.Fatalf("reset --%s to %q: %v", name, f.DefValue, err)
+		}
+		f.Changed = false
+	}
+	for _, k := range []string{"FLOE_SERVER", "FLOE_WEB", "FLOE_RELAY_ONLY"} {
+		t.Setenv(k, "")
+	}
+}
+
+// TestApplyEnvPrecedence drives the env-to-flag step directly, with a fake
+// environment, over the real flag definitions: a typed flag beats its
+// variable, an unset variable leaves the default alone, and a typed --no-relay
+// beats FLOE_RELAY_ONLY because the pair can never both be on.
+func TestApplyEnvPrecedence(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		env           map[string]string
+		wantServer    string
+		wantWeb       string
+		wantRelayOnly bool
+		wantNoRelay   bool
+	}{
+		{
+			name:       "nothing typed, nothing set: compiled defaults",
+			wantServer: "https://api.floe.one",
+		},
+		{
+			name:       "FLOE_SERVER and FLOE_WEB fill in untyped flags",
+			env:        map[string]string{"FLOE_SERVER": "https://floe.example.com", "FLOE_WEB": "https://app.example.com"},
+			wantServer: "https://floe.example.com",
+			wantWeb:    "https://app.example.com",
+		},
+		{
+			name:       "a typed --server beats FLOE_SERVER",
+			args:       []string{"--server", "http://localhost:3001"},
+			env:        map[string]string{"FLOE_SERVER": "https://floe.example.com"},
+			wantServer: "http://localhost:3001",
+		},
+		{
+			name:          "FLOE_RELAY_ONLY=1 turns the flag on",
+			env:           map[string]string{"FLOE_RELAY_ONLY": "1"},
+			wantServer:    "https://api.floe.one",
+			wantRelayOnly: true,
+		},
+		{
+			name:       "FLOE_RELAY_ONLY must be exactly 1",
+			env:        map[string]string{"FLOE_RELAY_ONLY": "true"},
+			wantServer: "https://api.floe.one",
+		},
+		{
+			name:          "a typed --relay-only with the variable set stays on",
+			args:          []string{"--relay-only"},
+			env:           map[string]string{"FLOE_RELAY_ONLY": "1"},
+			wantServer:    "https://api.floe.one",
+			wantRelayOnly: true,
+		},
+		{
+			name:        "a typed --no-relay beats FLOE_RELAY_ONLY",
+			args:        []string{"--no-relay"},
+			env:         map[string]string{"FLOE_RELAY_ONLY": "1"},
+			wantServer:  "https://api.floe.one",
+			wantNoRelay: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resetSharedFlags(t)
+			if err := rootCmd.ParseFlags(tc.args); err != nil {
+				t.Fatalf("ParseFlags(%v): %v", tc.args, err)
+			}
+			applyEnv(rootCmd, func(k string) string { return tc.env[k] })
+
+			if flagServer != tc.wantServer {
+				t.Errorf("flagServer = %q, want %q", flagServer, tc.wantServer)
+			}
+			if flagWebURL != tc.wantWeb {
+				t.Errorf("flagWebURL = %q, want %q", flagWebURL, tc.wantWeb)
+			}
+			if flagRelayOnly != tc.wantRelayOnly {
+				t.Errorf("flagRelayOnly = %v, want %v", flagRelayOnly, tc.wantRelayOnly)
+			}
+			if flagNoRelay != tc.wantNoRelay {
+				t.Errorf("flagNoRelay = %v, want %v", flagNoRelay, tc.wantNoRelay)
+			}
+		})
+	}
+}
+
+// runRoot executes the real command tree the way main does, through cobra, so
+// the root PersistentPreRunE and the flag-group validation both run. The
+// arguments follow the `help` subcommand, the cheapest command that still
+// passes through both. Output is discarded.
+func runRoot(t *testing.T, env map[string]string, args ...string) error {
+	t.Helper()
+	resetSharedFlags(t)
+	for k, v := range env {
+		t.Setenv(k, v)
+	}
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+	rootCmd.SetArgs(append([]string{"help"}, args...))
+	return rootCmd.Execute()
+}
+
+// TestRelayOnlyAndNoRelayAreMutuallyExclusive proves the pair is refused by
+// cobra's own group validation when both are typed, on the real command tree.
+func TestRelayOnlyAndNoRelayAreMutuallyExclusive(t *testing.T) {
+	err := runRoot(t, nil, "--relay-only", "--no-relay")
+	if err == nil {
+		t.Fatal("--relay-only --no-relay was accepted, want cobra's mutual-exclusion error")
+	}
+	for _, want := range []string{"relay-only", "no-relay", "none of the others can be"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+// TestRelayOnlyThroughTheCommandTree proves the wiring, not the logic: the
+// flag and the variable each reach flagRelayOnly through the real hook, and a
+// variable-set relay-only next to a typed --no-relay is resolved in favor of
+// the typed flag rather than tripping the group validation.
+func TestRelayOnlyThroughTheCommandTree(t *testing.T) {
+	tests := []struct {
+		name          string
+		env           map[string]string
+		args          []string
+		wantRelayOnly bool
+		wantNoRelay   bool
+	}{
+		{"flag alone", nil, []string{"--relay-only"}, true, false},
+		{"variable alone", map[string]string{"FLOE_RELAY_ONLY": "1"}, nil, true, false},
+		{"neither", nil, nil, false, false},
+		{"variable set, --no-relay typed", map[string]string{"FLOE_RELAY_ONLY": "1"}, []string{"--no-relay"}, false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := runRoot(t, tc.env, tc.args...); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+			if flagRelayOnly != tc.wantRelayOnly {
+				t.Errorf("flagRelayOnly = %v, want %v", flagRelayOnly, tc.wantRelayOnly)
+			}
+			if flagNoRelay != tc.wantNoRelay {
+				t.Errorf("flagNoRelay = %v, want %v", flagNoRelay, tc.wantNoRelay)
+			}
+		})
+	}
+}

--- a/cli/engine/peer/connection_test.go
+++ b/cli/engine/peer/connection_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jannskiee/floe/cli/engine/signaling"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -58,5 +59,35 @@ func TestConnectionTypeUnconnected(t *testing.T) {
 	conn := &Connection{pc: pc}
 	if _, err := conn.ConnectionType(); err == nil {
 		t.Fatal("expected an error before a candidate pair is selected, got nil")
+	}
+}
+
+// TestWithRelayOnlySetsRelayPolicy verifies the option lands on the peer
+// connection as ICE transport policy "relay", which is what makes pion gather
+// and pair relay candidates only. Without the option the policy stays "all".
+func TestWithRelayOnlySetsRelayPolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []Option
+		want webrtc.ICETransportPolicy
+	}{
+		{"default gathers every path", nil, webrtc.ICETransportPolicyAll},
+		{"WithRelayOnly restricts to relay", []Option{WithRelayOnly()}, webrtc.ICETransportPolicyRelay},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// A zero-value signaling client is enough: New only reads it from
+			// goroutines that block on its channels, and nothing here starts
+			// ICE gathering, which is the only path that writes to it.
+			conn, err := New(nil, &signaling.Client{}, tc.opts...)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			defer conn.Close()
+
+			if got := conn.pc.GetConfiguration().ICETransportPolicy; got != tc.want {
+				t.Errorf("ICETransportPolicy = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -43,6 +43,15 @@ Floe ships on two version lines. `vX.Y.Z` releases floe.one, the `floe` CLI, and
 
 Each entry lists the parts it changed. Filter on the right to see only the ones you use.
 
+<Update label="Unreleased" tags={["CLI"]}>
+  **The CLI can hide your IP address by forcing the relay, and says which route each transfer took**
+
+  - A new `--relay-only` flag on `floe send` and `floe receive` routes the whole transfer through the TURN relay and never tries a direct path, so the other side sees the relay's address instead of yours. It is the command-line twin of Floe Desktop's **Hide my IP address** setting, applies to your side only, and can be kept on with `FLOE_RELAY_ONLY=1`. While it is on, the 2 GB relay cap applies to every transfer. It cannot be combined with `--no-relay`, and a typed `--no-relay` overrides the variable for that one command.
+  - Once the connection is up, the `Connected` line names the route: `Connected (direct)` when the two devices talk to each other, `Connected (relay)` when the transfer runs through the TURN relay. If the route cannot be read, the line stays `Connected` and the transfer proceeds as before.
+  - Against a server that offers no TURN relay, `--relay-only` has nowhere to go and fails after about 30 seconds with `timed out establishing a connection`, the same generic timeout `--no-relay` produces when no direct path exists.
+  - The wire protocol is unchanged, so this still transfers with older CLI, desktop, and browser peers in both directions.
+</Update>
+
 <Update label="desktop-v0.2.8" description="2026-08-27" tags={["Desktop"]}>
   **A file name chosen by the other side can no longer disguise its extension in the incoming preview, and an impossible file size no longer closes the app**
 

--- a/docs/choosing-floe.mdx
+++ b/docs/choosing-floe.mdx
@@ -65,7 +65,7 @@ right-click menu.
 | Folder structure on arrival | Flattened when saved one at a time, rebuilt inside **Download ZIP** | Rebuilt | Rebuilt |
 | Confirm before receiving | No, it starts on its own | No, it starts on its own | Yes, unless you pass `-y` |
 | Refuse the relay | Yes, the **Network relay fallback** checkbox | No | Yes, `--no-relay` |
-| Force the relay to hide your IP | No | Yes, **Hide my IP address** | No |
+| Force the relay to hide your IP | No | Yes, **Hide my IP address** | Yes, `--relay-only` |
 | Transfer history | No | The last 50, stored on your device | No |
 | File Explorer right-click entry | No | Yes, on the build from GitHub | No |
 | Point at a self-hosted server | Automatic, it is served by that instance | **Settings**, then **Server address** | `--server` or `FLOE_SERVER` |

--- a/docs/cli/flags.mdx
+++ b/docs/cli/flags.mdx
@@ -7,16 +7,17 @@ keywords: ["flags", "options", "environment variables", "exit codes", "timeouts"
 
 ## Global flags
 
-Every command accepts these, but only `send` and `receive` act on them. `floe version` and `floe update` parse them and then ignore them, so `floe version --server https://floe.example.com` is accepted and changes nothing.
+Every command accepts these, but only `send` and `receive` act on them. `floe version` and `floe update` parse them and then ignore them, so `floe version --server https://floe.example.com` is accepted and changes nothing. The one exception is the pair `--relay-only` and `--no-relay`, which every command refuses together.
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--server <url>` | `https://api.floe.one` | Signaling server URL. Use `http://localhost:3001` for local testing or your self-hosted server URL. |
 | `--no-relay` | `false` | Drop every TURN entry from **your** ICE list, so you offer nothing relayed. It is one-sided: the peer can still offer a relay, and if that path wins the CLI proceeds over it, so pass the flag on **both** ends when it has to be a guarantee. When no path forms at all the failure is a generic connection error after about 30 seconds, never a message about the relay. |
+| `--relay-only` | `false` | Route everything through the TURN relay and never try a direct path, so the other side sees the relay's address instead of yours. It is the command-line twin of the desktop app's **Hide my IP address** switch, and it applies to your side only. While it is on, the 2 GB relay cap applies to every transfer, even on a network that could have connected directly; see [File size limits](/how-it-works/2gb-limit). It needs a relay to exist: against a server that offers STUN only, the connection fails after about 30 seconds with `timed out establishing a connection`. Cannot be combined with `--no-relay`. Also settable with `FLOE_RELAY_ONLY=1`. |
 | `--web <url>` | _(auto-detected)_ | Web app URL included in the browser link printed by `floe send`. Auto-detected from `--server`: `https://api.floe.one` maps to `https://floe.one`, `http://localhost:3001` maps to `http://localhost:3000`, and any other server maps to itself, on the assumption that one origin serves both the API and the web app. Set `--web` only when your web app has its own hostname. |
 | `--iface <name>` | _(all interfaces)_ | Restrict WebRTC to network interfaces whose name contains this value (case-insensitive). Repeat the flag or separate names with commas, so `--iface Ethernet --iface Wi-Fi` and `--iface Ethernet,Wi-Fi` do the same thing. Use it when a VPN or virtual-machine adapter (Tailscale, VMware, WSL, Hyper-V) slows connection setup. See [Troubleshooting](/troubleshooting). |
 
-The desktop app has equivalents for two of these. `--server` and `--web` are **Server address** and **Share link address**, under Advanced in **Settings**. `--no-relay` has no desktop equivalent: the **Hide my IP address** toggle does the opposite, forcing every transfer through the relay rather than refusing it. See [Desktop app settings](/desktop/settings).
+The desktop app has equivalents for three of these. `--server` and `--web` are **Server address** and **Share link address**, under Advanced in **Settings**, and `--relay-only` is the **Hide my IP address** toggle under Privacy. `--no-relay` has no desktop equivalent: Floe Desktop can require the relay but never refuse it. See [Desktop app settings](/desktop/settings).
 
 ## Help and version flags
 
@@ -31,12 +32,13 @@ These come from the CLI framework rather than from Floe itself.
 
 ## Environment variables
 
-Floe reads four environment variables. If you run your own signaling server, set it once in your environment instead of passing `--server` on every command.
+Floe reads five environment variables. If you run your own signaling server, set it once in your environment instead of passing `--server` on every command.
 
 | Variable | Equivalent flag | Description |
 |----------|-----------------|-------------|
 | `FLOE_SERVER` | `--server` | Signaling server URL, used by every command. |
 | `FLOE_WEB` | `--web` | Web app URL used for the browser link printed by `floe send`. |
+| `FLOE_RELAY_ONLY` | `--relay-only` | Set to `1` to route every transfer through the relay, hiding your IP address from the other side. A typed `--no-relay` overrides it for that one command, since the two can never both be on. |
 | `FLOE_NO_STATS` | `--no-report` | Set to `1` to never report byte counts. Applies to `floe receive`. See [Opting out of the global counter](#opting-out-of-the-global-counter). |
 | `FLOE_NO_UPDATE_CHECK` | _(no flag)_ | Set to `1` to suppress the "Update available" hint that `floe version` prints. It does not affect transfers or `floe update` itself. |
 
@@ -140,6 +142,12 @@ Disable relay fallback (direct connections only):
 
 ```bash Terminal
 floe send photo.jpg --no-relay
+```
+
+Hide your IP address from the other side by forcing the relay (the 2 GB cap applies):
+
+```bash Terminal
+floe send photo.jpg --relay-only
 ```
 
 Point the browser link at a custom web client:

--- a/docs/cli/receive.mdx
+++ b/docs/cli/receive.mdx
@@ -43,7 +43,7 @@ Running `floe receive olive-tiger-castle -o ~/Downloads`:
 
 ```text Output
   Connecting to sender...
-  Connected
+  Connected (direct)
 
   ─────────────────────────────────────────────────
   Incoming   2 files · 2.3 MB
@@ -61,6 +61,8 @@ Running `floe receive olive-tiger-castle -o ~/Downloads`:
 ```
 
 With no `-o` flag, files save to the current directory.
+
+The `Connected` line names the route: `(direct)` when the two devices talk to each other, `(relay)` when the transfer runs through the TURN relay. It reads `Connected` alone only when the route could not be determined, and the transfer proceeds either way.
 
 ## Confirmation prompt
 
@@ -88,7 +90,7 @@ Pass `-y` to skip this prompt and accept automatically.
 | `--yes` | `-y` | `false` | Accept incoming files without the confirmation prompt. |
 | `--no-report` | | `false` | Do not report the transferred byte count to Floe's public global counter. Set `FLOE_NO_STATS=1` to opt out permanently. |
 
-See [CLI flags reference](/cli/flags) for the global flags that matter here (`--server`, `--no-relay`, `--iface`) and full opt-out documentation.
+See [CLI flags reference](/cli/flags) for the global flags that matter here (`--server`, `--no-relay`, `--relay-only`, `--iface`) and full opt-out documentation.
 
 ## Notes
 

--- a/docs/cli/send.mdx
+++ b/docs/cli/send.mdx
@@ -49,7 +49,7 @@ Once the recipient connects, Floe negotiates the WebRTC connection and streams e
 
 ```text Output
   Connecting...
-  Connected
+  Connected (direct)
 
   [1/3] report.pdf 100% [███████████████] (1.4 MB/s)
   [2/3] photo.jpg 100% [███████████████] (2.1 MB/s)
@@ -60,6 +60,8 @@ Once the recipient connects, Floe negotiates the WebRTC connection and streams e
   Time   8s · avg 1.4 MB/s
   ─────────────────────────────────────────────────
 ```
+
+The `Connected` line names the route ICE settled on: `(direct)` when the two devices talk to each other, `(relay)` when the transfer runs through the TURN relay, where the 2 GB cap applies (see [File size limits](/how-it-works/2gb-limit)). It is read once, as the connection comes up. On the rare occasion the route cannot be read, the line is `Connected` alone and the transfer proceeds.
 
 While a file is still in flight its line also carries elapsed and remaining time, for example `  [1/3] report.pdf  85% [██████████░░░░░] (1.4 MB/s) [6s:1s]`. Those brackets disappear once the line reaches 100%. The bar stretches to the width of your terminal, so the number of blocks varies with your window, and names longer than 30 characters are truncated. The rate in parentheses uses base-1000 units (`kB`, `MB`), while the summary rows below it use base-1024 units, so the two do not always agree to the decimal.
 
@@ -91,11 +93,11 @@ and fails to read. Copy what you mean to send, or send the target path directly.
 
 ## Flags
 
-See [CLI flags reference](/cli/flags) for `--server`, `--no-relay`, `--web`, and `--iface`.
+See [CLI flags reference](/cli/flags) for `--server`, `--no-relay`, `--relay-only`, `--web`, and `--iface`.
 
 ## Notes
 
-- Relayed transfers are capped at 2 GB per session; direct connections have no size limit. When the selected route runs through the TURN relay and the queued files total more than 2 GB, `floe send` blocks the transfer before any file data moves. See [File size limits](/how-it-works/2gb-limit).
+- Relayed transfers are capped at 2 GB per session; direct connections have no size limit. When the selected route runs through the TURN relay and the queued files total more than 2 GB, `floe send` blocks the transfer before any file data moves. With `--relay-only` every transfer is relayed, so the cap always applies. See [File size limits](/how-it-works/2gb-limit).
 - Press `Ctrl+C` at any time to cancel the transfer and close the session.
 - If the short code cannot be registered (for example, the signaling server is unreachable), Floe prints a warning and continues with the link only.
 - Files are streamed in the order they are listed. For multiple files, progress is shown per file.

--- a/docs/desktop/settings.mdx
+++ b/docs/desktop/settings.mdx
@@ -48,7 +48,9 @@ path is impossible, so it does not single you out.
 
 This is not the web app's **Network relay fallback** checkbox, despite the similar subject. That
 one lets you turn the relay **off**. This one makes the relay the **only** path. The desktop app
-has no direct-only mode, and the browser has no relay-only mode.
+has no direct-only mode, and the browser has no relay-only mode. On the command line the same
+switch is `--relay-only` on `floe send` or `floe receive`, and `FLOE_RELAY_ONLY=1` keeps it on.
+See the [CLI flags reference](/cli/flags).
 
 <Warning>
   **Hide my IP needs a relay to exist.** On Floe's own server there is always one. If you point
@@ -56,7 +58,7 @@ has no direct-only mode, and the browser has no relay-only mode.
   connection has nowhere to go, and the transfer fails with a generic connection error rather
   than a message explaining why. If transfers stop working right after you switch servers, turn
   Hide my IP off and try again. To keep using it, add a relay to your instance. See
-  [TURN relay](/self-hosting/turn-relay).
+  [TURN relay](/self-hosting/turn-relay). The CLI's `--relay-only` fails the same way.
 </Warning>
 
 ### Contribute to global stats

--- a/docs/how-it-works/2gb-limit.mdx
+++ b/docs/how-it-works/2gb-limit.mdx
@@ -58,10 +58,10 @@ setting is what forced the relay.
 
 ## One case that catches people out
 
-Floe Desktop's [Hide my IP address](/desktop/settings#hide-my-ip-address) setting routes every
-transfer through the relay on purpose, so the other person never sees your address. While it is
-on, **the 2 GB cap applies to every transfer**, even on a network that could easily have connected
-directly. Turn it off to send more.
+Floe Desktop's [Hide my IP address](/desktop/settings#hide-my-ip-address) setting, and the CLI's
+`--relay-only` flag, route every transfer through the relay on purpose, so the other person never
+sees your address. While either is on, **the 2 GB cap applies to every transfer**, even on a
+network that could easily have connected directly. Turn it off, or drop the flag, to send more.
 
 You never need to turn relay fallback off to send something large. The cap applies only when the
 connection actually ends up relayed, so leaving fallback on costs a direct transfer nothing and

--- a/docs/how-it-works/known-limitations.mdx
+++ b/docs/how-it-works/known-limitations.mdx
@@ -47,8 +47,8 @@ does the same thing.
 
 **What you can do:** Floe Desktop has a [Hide my IP address](/desktop/settings#hide-my-ip-address)
 switch that forces every transfer through the relay, so the other side sees the relay's address
-instead of yours. The web app and the CLI have no equivalent. The trade is speed and the 2 GB
-session cap.
+instead of yours, and the CLI's `--relay-only` flag does the same. The web app has no
+equivalent. The trade is speed and the 2 GB session cap.
 
 ## The relay sees more than the signaling server does
 

--- a/docs/how-it-works/relay-connection.mdx
+++ b/docs/how-it-works/relay-connection.mdx
@@ -22,7 +22,7 @@ where it needs to go and cannot open it.
 | Who pays for the bandwidth | Nobody | Floe, or you, if you self-host |
 | Encryption | End to end | End to end, unchanged |
 | Typical networks | Home Wi-Fi, hotspots, most mobile | Corporate, university, carrier-grade NAT |
-| Badge | **Direct**, green | **Relay**, amber |
+| Badge | **Direct**, green; `Connected (direct)` in the CLI | **Relay**, amber; `Connected (relay)` in the CLI |
 
 The encryption row is the important one. Relaying changes the route, not the protection. Your
 files are encrypted before they reach the relay and decrypted only on the other device, so the
@@ -55,13 +55,22 @@ receiving and a transfer will not start, this is the sender's setting to check.
 floe send photo.jpg --no-relay
 ```
 
-**Floe Desktop has no relay-fallback switch at all**, so the relay is always available there. Its
-[Hide my IP address](/desktop/settings#hide-my-ip-address) setting is the opposite control: it
-makes the relay the **only** path, so the other person sees the relay's address rather than yours.
-That means every transfer is relayed and every transfer is capped at 2 GB while it is on.
+The CLI also has the opposite switch. `--relay-only` makes the relay the **only** path, so the
+other person sees the relay's address rather than yours, and every transfer is capped at 2 GB while
+it is on. Set `FLOE_RELAY_ONLY=1` to keep it on. The two flags cannot be combined.
 
-Nothing in Floe offers a direct-only mode in the desktop app, and nothing offers a relay-only mode
-in the browser or the CLI.
+```bash Terminal
+floe receive olive-tiger-castle --relay-only
+```
+
+**Floe Desktop has no relay-fallback switch at all**, so the relay is always available there. Its
+[Hide my IP address](/desktop/settings#hide-my-ip-address) setting is the same control as
+`--relay-only`: it makes the relay the **only** path, so the other person sees the relay's address
+rather than yours. That means every transfer is relayed and every transfer is capped at 2 GB while
+it is on.
+
+Nothing in Floe offers a direct-only mode in the desktop app, and the browser has no relay-only
+mode.
 
 <Accordion title="How the route is chosen, and how Floe knows which it got">
   ICE tries the candidate pairs it gathered and nominates one that works. Traffic is relayed when
@@ -77,10 +86,11 @@ in the browser or the CLI.
   offer a relay" rather than as a guarantee.
 
   The browser re-reads the connection statistics every five seconds and flips the badge to amber
-  when the nominated pair is relayed. Floe Desktop reads it once, when the connection is
-  established, so its badge is a snapshot rather than a live reading. The CLI never reads it at
-  all and shows no direct-or-relay indicator; it only consults the route when deciding whether the
-  size cap applies.
+  when the nominated pair is relayed. Floe Desktop and the CLI each read it once, when the
+  connection is established, so their indicators are a snapshot rather than a live reading: the
+  desktop badge, and the CLI's `Connected (direct)` or `Connected (relay)` line. When the CLI
+  cannot read the route it prints `Connected` alone and carries on. The sender consults the route
+  a second time only to decide whether the size cap applies.
 
   On floe.one the signaling server hands out three endpoints and no more: a STUN URL, a TURN URL
   over UDP, and a TURN URL over TLS on port 443, which looks like ordinary HTTPS to a network that

--- a/docs/security-privacy.mdx
+++ b/docs/security-privacy.mdx
@@ -53,7 +53,8 @@ Routing through a relay also changes who learns your IP address. On a direct con
 devices learn each other's, which is how any peer-to-peer connection works. If you would rather
 not reveal yours, Floe Desktop's
 [Hide my IP address](/desktop/settings#hide-my-ip-address) forces the relay path so the other
-person sees the relay instead. The browser and the CLI have no equivalent.
+person sees the relay instead, and the CLI's `--relay-only` flag does the same. The browser has
+no equivalent.
 
 ## The room secret stays out of every server log
 

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -136,6 +136,13 @@ If you passed `--no-relay`, this is what that looks like when no direct path exi
 removes the relay from the address list, so there is nothing else to try and the failure is this
 generic timeout rather than a message about the relay.
 
+`--relay-only` fails the same way when the server offers no TURN relay. With only STUN in the
+list, a relay-only connection has nowhere to go, and after thirty seconds the command ends with
+`WebRTC setup failed: timed out establishing a connection` and exit code 1. The other side ends
+with the same line at the same moment, since no pair of addresses could ever form. On Floe's own
+server there is always a relay, so this points at a self-hosted server without one: drop the
+flag, or add a relay to the instance. See [TURN relay](/self-hosting/turn-relay).
+
 ### `connected, but no data arrived from the sender within 30s`
 
 You reached the sender and they never started sending. Ask them to try again.


### PR DESCRIPTION
## Summary

- `floe send --relay-only` and `floe receive --relay-only` (env `FLOE_RELAY_ONLY=1`, a typed flag beats the env, mutually exclusive with `--no-relay`) pin ICE to the TURN relay through the engine's existing `peer.WithRelayOnly()`, the twin of the desktop app's Hide my IP switch. The 2 GB relay cap applies, as it does on the desktop.
- Both commands now print the path they got after WebRTC setup, from the selected ICE candidate pair the engine already reads for the relay gate: `  Connected (direct)` or `  Connected (relay)`, with the plain `  Connected` as the fail-open fallback. The prefix is unchanged and nothing in `client/e2e` matches the full line.
- Docs: flags table and env table (five variables now), send and receive output examples, the relay page (the CLI reads the route once and offers relay-only; the browser still does neither), desktop settings, choosing-floe, known-limitations, security-privacy, the 2 GB page, troubleshooting (the measured failure when a server serves no TURN), the docs-verify claim map, and a changelog entry under `Unreleased` tagged `["CLI"]`.

## Test plan

- [x] `go vet ./...` clean; `go test -count=1 ./...` in `cli/` all 9 packages ok. New tests: `connectedLine` table, env precedence through the real flag set, the mutual exclusion and the flag through the command tree, `WithRelayOnly` setting `ICETransportPolicyRelay`. An independent reviewer mutation-tested them: dropping the exclusion, the env guard, the fail-open, the engine option, or the `"1"` check each fails a test.
- [x] Live on the local stack (STUN only, stats sentinel, receiver with `--no-report`): a 1 MiB direct transfer prints `  Connected (direct)` on both sides, sha256 matches; `--relay-only` on either side against a server without TURN ends both sides with `Error: WebRTC setup failed: timed out establishing a connection`, exit 1, about 30 s after `Connecting...`; `--relay-only --no-relay` is refused by cobra before any network on `send`, `receive`, `version` and `help`.
- [x] `docs-check.mjs all`: 0 hard, 41 notes (the same 41 as main). Byte scan of every changed file: no em or en dashes.
- [x] `grep Connected client/e2e`: 0 matches.

Not in this PR: an up-front warning when `--relay-only` meets an ICE list without TURN (the generic 30 s timeout is documented instead); the pre-existing gofmt drift in `main.go`'s header comment and the em dash in `rootCmd.Short`.
