### PR TITLE
fix(skills): read directory currency from the tree object, not a capped compare

### DIFF
--- a/.claude/skills/transfer-audit/scripts/lib/cli.test.mjs
+++ b/.claude/skills/transfer-audit/scripts/lib/cli.test.mjs
@@ -53,6 +53,12 @@ const FIXTURES = fileURLToPath(new URL('./tests/fixtures/', import.meta.url));
 const SEND_FIXTURE = join(FIXTURES, 'send-1.10.5.stdout.txt');
 const RECEIVE_FIXTURE = join(FIXTURES, 'receive-1.10.5.stdout.txt');
 const HELP_FIXTURE = join(FIXTURES, 'send-help-1.10.5.txt');
+/**
+ * Fixture text with line endings normalized. git checks these files out
+ * CRLF on Windows (core.autocrlf), and a test that matches against a \n
+ * string would silently stop matching on a fresh clone.
+ */
+const fixture = (p) => readFileSync(p, 'utf8').replace(/\r\n/g, '\n');
 const INFRA = { server: 'http://localhost:3001', web: 'http://localhost:3000' };
 const made = [];
 
@@ -269,7 +275,7 @@ test('parseVersion and parseHelpFlags', () => {
     assert.equal(parseVersion('floe dev\n'), 'dev');
     assert.equal(parseVersion('floe head-abc1234\r\n'), 'head-abc1234');
     assert.equal(parseVersion('nope'), null);
-    const help = readFileSync(HELP_FIXTURE, 'utf8');
+    const help = fixture(HELP_FIXTURE);
     const flags = parseHelpFlags(help);
     for (const f of ['--help', '--iface', '--no-relay', '--server', '--web'])
         assert.ok(flags.includes(f), f);
@@ -282,7 +288,7 @@ test('parseVersion and parseHelpFlags', () => {
 });
 
 test('parseCode, parseLink and parseSummary on the shipped 1.10.5 sender transcript', () => {
-    const out = readFileSync(SEND_FIXTURE, 'utf8');
+    const out = fixture(SEND_FIXTURE);
     assert.match(parseCode(out), /^[a-z]+(-[a-z]+){2,3}$/);
     assert.equal(
         parseLink(out),
@@ -305,7 +311,7 @@ test('parseCode, parseLink and parseSummary on the shipped 1.10.5 sender transcr
 });
 
 test('parseSummary on the shipped 1.10.5 receiver transcript', () => {
-    const out = readFileSync(RECEIVE_FIXTURE, 'utf8');
+    const out = fixture(RECEIVE_FIXTURE);
     const s = parseSummary(out);
     assert.equal(s.complete, true);
     assert.equal(s.files, 1);

--- a/.claude/skills/transfer-audit/scripts/lib/versions.mjs
+++ b/.claude/skills/transfer-audit/scripts/lib/versions.mjs
@@ -343,15 +343,54 @@ export function mainSha({ gh }) {
 }
 
 /** true, false, or null on a 4xx compare (unknown sha, unrelated). */
+/**
+ * The compare API caps its `files` array at this many entries, with no
+ * truncation flag. Measured 2026-08-30: `5dedc94...7590ddb` (119 commits)
+ * returned exactly 300 filenames and not one of them under `server/`,
+ * although five commits in the range change it. Read as "not touched", that
+ * turned a STALE server row CURRENT.
+ */
+export const COMPARE_FILES_CAP = 300;
+
+/** The tree object id of one top-level directory at a ref, or null. */
+export function treeShaFor({ gh, ref, dir }) {
+    const json = gh([
+        'api',
+        `repos/${REPO}/git/trees/${ref}`,
+        '--jq',
+        `[.tree[] | select(.path == "${dir}") | .sha]`,
+    ]);
+    const list = JSON.parse(json);
+    return Array.isArray(list) && list.length ? String(list[0]) : null;
+}
+
+/**
+ * Whether `dir` differs between two commits. Tree objects first: two calls
+ * whatever the range, immune to the file cap, and they answer the question
+ * the report actually asks (does the deployed code differ) rather than
+ * whether some commit touched the path. compare stays as the fallback and
+ * refuses to answer once it is at the cap, so a truncated answer can never
+ * read as CURRENT.
+ */
 export function compareTouches({ gh, base, head, dir }) {
+    try {
+        const b = treeShaFor({ gh, ref: base, dir });
+        const h = treeShaFor({ gh, ref: head, dir });
+        if (b && h) return b !== h;
+    } catch {
+        // The tree call is the preferred oracle, not a required one.
+    }
     try {
         const json = gh([
             'api',
             `repos/${REPO}/compare/${base}...${head}`,
             '--jq',
-            '[.files[].filename]',
+            '{ n: (.files | length), f: [.files[].filename] }',
         ]);
-        return touchesDir(JSON.parse(json), dir);
+        const r = JSON.parse(json);
+        if (!r || !Array.isArray(r.f)) return null;
+        if (r.n >= COMPARE_FILES_CAP) return null;
+        return touchesDir(r.f, dir);
     } catch {
         return null;
     }

--- a/.claude/skills/transfer-audit/scripts/lib/versions.test.mjs
+++ b/.claude/skills/transfer-audit/scripts/lib/versions.test.mjs
@@ -10,7 +10,9 @@ import {
     cliUnderTestOracle,
     collectVersions,
     commitCurrency,
+    COMPARE_FILES_CAP,
     compareQuad,
+    compareTouches,
     compareVersions,
     gatingDrift,
     identityVersion,
@@ -23,6 +25,7 @@ import {
     pickLatestDesktop,
     protocolParity,
     touchesDir,
+    treeShaFor,
     versionStatus,
 } from './versions.mjs';
 
@@ -227,8 +230,12 @@ test('collectVersions with injected gh, exec and fetch', async () => {
             ]);
         if (key.startsWith('api repos/jannskiee/floe/commits/main'))
             return 'ffffffffffffffffffffffffffffffffffffffff';
+        // The tree oracle answers first: the same tree id at both refs
+        // means the directory is identical, so the row is CURRENT.
+        if (key.startsWith('api repos/jannskiee/floe/git/trees/'))
+            return JSON.stringify(['same-tree-object']);
         if (key.startsWith('api repos/jannskiee/floe/compare/'))
-            return JSON.stringify(['docs/changelog.mdx']);
+            return JSON.stringify({ n: 1, f: ['docs/changelog.mdx'] });
         throw new Error(`unexpected gh ${key}`);
     };
     const exec = (cmd, args, opts) => {
@@ -307,7 +314,17 @@ test('collectVersions with injected gh, exec and fetch', async () => {
     assert.equal(by2['Web floe.one'].status, 'CURRENT');
     assert.equal(by2['Server api.floe.one'].status, 'CURRENT');
     assert.equal(by2['Server api.floe.one'].gate, true);
-    assert.ok(calls.some((c) => /compare\/1234567\.\.\./.test(c)));
+    // The directory tree object is the currency oracle now: the compare
+    // endpoint caps its file list at 300 and cannot be trusted to say a
+    // directory was untouched.
+    assert.ok(
+        calls.some((c) => c.includes('git/trees/1234567')),
+        'the deployed ref tree is read'
+    );
+    assert.ok(
+        !calls.some((c) => c.includes('compare/1234567')),
+        'compare is not needed when the trees answer'
+    );
 
     // gh failure degrades to UNKNOWN with the auth hint, never a throw.
     const v3 = await collectVersions({
@@ -352,4 +369,108 @@ test('parseAppx picks the highest Version when several packages match', () => {
     assert.equal(compareQuad('1.2.10.0', '1.2.9.0'), 1);
     assert.equal(compareQuad('1.2.8', '1.2.8.0'), 0);
     assert.equal(compareQuad('0.9.9.9', '1.0.0.0'), -1);
+});
+
+test('compareTouches reads the directory tree, and a capped compare never reads as CURRENT', () => {
+    // 2026-08-30, found by the skill auditing its own report: the compare
+    // API caps .files at 300 with no truncation flag, so a 119-commit range
+    // came back with 300 filenames and not one under server/, which read as
+    // "not touched" and printed CURRENT for a server five commits behind.
+    const calls = [];
+    const treeGh = (args) => {
+        calls.push(args.join(' '));
+        const url = args[1];
+        if (/git\/trees\/base/.test(url)) return JSON.stringify(['tree-old']);
+        if (/git\/trees\/head/.test(url)) return JSON.stringify(['tree-new']);
+        throw new Error('unexpected ' + url);
+    };
+    assert.equal(
+        compareTouches({
+            gh: treeGh,
+            base: 'base',
+            head: 'head',
+            dir: 'server',
+        }),
+        true,
+        'different trees mean the deployed directory differs'
+    );
+    assert.ok(
+        calls.every((c) => !/compare/.test(c)),
+        'the compare endpoint is not consulted when trees answer'
+    );
+    assert.match(calls[0], /git\/trees\/base/);
+    assert.match(calls[0], /select\(\.path == "server"\)/);
+    assert.equal(
+        treeShaFor({ gh: treeGh, ref: 'head', dir: 'server' }),
+        'tree-new'
+    );
+
+    assert.equal(
+        compareTouches({
+            gh: () => JSON.stringify(['same']),
+            base: 'a',
+            head: 'b',
+            dir: 'server',
+        }),
+        false,
+        'the same tree is current whatever happened in between'
+    );
+
+    // No tree entry for the directory: fall back to compare.
+    const viaCompare = (n, names) => (args) =>
+        /git\/trees/.test(args[1])
+            ? JSON.stringify([])
+            : JSON.stringify({ n, f: names });
+    assert.equal(
+        compareTouches({
+            gh: viaCompare(2, ['server/server.js', 'README.md']),
+            base: 'a',
+            head: 'b',
+            dir: 'server',
+        }),
+        true
+    );
+    assert.equal(
+        compareTouches({
+            gh: viaCompare(2, ['client/page.tsx', 'README.md']),
+            base: 'a',
+            head: 'b',
+            dir: 'server',
+        }),
+        false
+    );
+
+    // At the cap the answer is unknown, never false.
+    const capped = viaCompare(
+        COMPARE_FILES_CAP,
+        Array.from(
+            { length: COMPARE_FILES_CAP },
+            (_, i) => 'docs/f' + i + '.mdx'
+        )
+    );
+    assert.equal(
+        compareTouches({ gh: capped, base: 'a', head: 'b', dir: 'server' }),
+        null
+    );
+    assert.equal(
+        commitCurrency({ deployed: 'a', main: 'b', touched: null }),
+        'UNKNOWN',
+        'so the row reads UNKNOWN, not CURRENT'
+    );
+    assert.equal(
+        commitCurrency({ deployed: 'a', main: 'b', touched: true }),
+        'STALE'
+    );
+    assert.equal(
+        compareTouches({
+            gh: () => {
+                throw new Error('gh missing');
+            },
+            base: 'a',
+            head: 'b',
+            dir: 'server',
+        }),
+        null,
+        'a broken gh is unknown, not current'
+    );
 });


### PR DESCRIPTION
## Summary

The `transfer-audit` Versions table called `api.floe.one` CURRENT while it was running five `server/`-touching commits behind. The skill found this on its own first run from `main`: the row had read STALE all day, then flipped the moment the skill itself landed and pushed the diff over an API limit.

`GET /repos/{repo}/compare/{base}...{head}` caps its `files` array at 300 entries and gives no truncation flag. Measured 2026-08-30: `5dedc94...7590ddb` (119 commits) returns exactly 300 filenames, not one of them under `server/`, although five commits in that range change it. `compareTouches` read that as "the directory did not change" and `commitCurrency` printed CURRENT.

- Currency now compares the directory's **tree object**: two calls whatever the range, immune to the cap, and it answers what the report actually asks (does the deployed code differ) rather than whether some commit touched the path and reverted it. On the same pair: `server` tree `8eff2f3` deployed against `c4d26fd` on main, which is the STALE the row should have shown.
- The compare endpoint stays as a fallback for a ref whose tree cannot be read, and refuses to answer once it is at the cap, so a truncated diff can never read as CURRENT again (`commitCurrency` turns the null into UNKNOWN).
- The CLI transcript fixtures are read line-ending normalized. git checks them out CRLF on Windows, the only platform this skill runs on, so `parseVersion and parseHelpFlags` failed on a fresh clone once its `\n` search string stopped matching. The parsers under test split on `\r\n`, `\r` or `\n` regardless.

## Test plan

- [x] `node --test` over the skill: 293 tests, 290 pass, 3 skipped (all opt-in behind `LTA_LIVE=1`), 0 fail.
- [x] New regression test: different trees give `true`, identical trees `false`, a missing tree entry falls back to compare, a 300-file compare gives `null`, and `commitCurrency` turns that null into UNKNOWN rather than CURRENT. A throwing `gh` is UNKNOWN too.
- [x] The `collectVersions` fake now answers the tree endpoint and asserts compare is not consulted when trees answer.
- [x] `audit.mjs --self-test` 9 checks; `desktop-uia.ps1 -SelfTest` 81 checks; Prettier clean on the three changed files.
- [x] Verified against the live deployment: `ssh floe-azure "git -C ~/floe rev-parse HEAD"` is `5dedc94`, and `git log 5dedc94..HEAD -- server/` lists five commits, so STALE is the correct verdict.
