### PR TITLE
chore(ci): stop dependabot reopening the unmergeable plugin-react major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,23 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    # @vitejs/plugin-react 6 peers on vite "^8.0.0" exclusively (the other three
+    # peers it declares are optional). vite 8 is itself under a live
+    # `@dependabot ignore this major version`, set when #359 was closed because
+    # @vitejs/plugin-react 4.7.0 caps vite at ^7.0.0. So a plugin-react major can
+    # never resolve here until vite 8 is taken by hand, and Dependabot re-opens an
+    # unmergeable PR on every new 6.x release: #371 was that PR, and seven 6.x
+    # releases shipped in the five months after 6.0.0. Scoped with update-types so
+    # 4.x minors and patches still arrive and so a plugin-react advisory can still
+    # open its own security PR ("update-types only affects version updates, not
+    # security updates"). A bare dependency-name would have silenced that too.
+    # One update-type, following the node ignore below rather than the wails one:
+    # only the major is unwanted. Lift this together with the vite 8 ignore when
+    # vite 8 and plugin-react 6 are taken as one hand-built pair.
+    ignore:
+      - dependency-name: "@vitejs/plugin-react"
+        update-types:
+          - "version-update:semver-major"
     groups:
       # Minor and patch only: a single incompatible major inside a 20-update
       # group PR blocks every other update in it (day one: the TypeScript


### PR DESCRIPTION
## Summary

#371 (`@vitejs/plugin-react` 4.7.0 to 6.1.1) could not merge in any order and was closed. The 6.x
line declares peer `vite: "^8.0.0"` and nothing else, so `npm ci` fails with ERESOLVE against this
tree, and #369 only reached vite 7.3.6. Peer ranges, from the registry:

| version | peer `vite` |
| --- | --- |
| 4.7.0 (current) | `^4.2.0 \|\| ^5.0.0 \|\| ^6.0.0 \|\| ^7.0.0` |
| 5.2.0 | `^4.2.0 \|\| ^5.0.0 \|\| ^6.0.0 \|\| ^7.0.0 \|\| ^8.0.0` |
| 6.0.0 and 6.1.1 | `^8.0.0` |

Without an ignore the same red PR returns on every new 6.x release, and seven shipped in the five
months after 6.0.0.

Scoped with `update-types` rather than a bare `dependency-name`, for the reason already written out
on the gomod entry: an ignore covers security updates too, and `update-types` narrows it to version
updates, so a plugin-react advisory can still open its own PR. One update-type, following the `node`
ignore rather than the `wails` one, because 4.x minors and patches are still wanted here.

Worth recording in the file, because it is otherwise invisible: the vite `>= 8` ignore this
interacts with lives only in Dependabot's per-repo state, set by the `@dependabot ignore this major
version` comment that closed #359. That is why Dependabot proposed vite **7** in #369 rather than 8.
Both ignores should be lifted together whenever vite 8 and plugin-react 6 are taken as one
hand-built pair.

## Test plan

- `.github/dependabot.yml` parses: `yaml.safe_load` succeeds, and the npm entry now carries exactly
  one ignore (`@vitejs/plugin-react`, one update-type), alongside the existing gomod `wails` ignore
  (three update-types) and docker `node` ignore (one).
- Nothing under `.github/workflows/` or `.github/scripts/` is touched, so `Lint workflows` correctly
  skips; the rest of the suite runs as a normal code lane.
- Dependabot config changes are not validated by CI at all, here or upstream. The real feedback loop
  is the dynamic "Dependabot Updates" workflow after merge; the observable next month is that no
  `@vitejs/plugin-react` major PR opens while 4.x minors and patches still do.
