### PR TITLE
fix(client): neutral white dropzone hover instead of the ice accent

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -876,12 +876,12 @@ export function P2PTransfer() {
                                     // It wraps below about 430px, which is most phones.
                                     className={`group relative mt-2 flex flex-col items-center justify-center rounded-xl border border-dashed p-10 text-center transition-all sm:p-14 ${isDragging
                                         ? 'border-ice bg-ice/[0.04]'
-                                        : 'border-white/15 hover:border-ice/40 hover:bg-white/[0.02]'
+                                        : 'border-white/15 hover:border-white/35 hover:bg-white/[0.02]'
                                         }`}
                                 >
                                     <div className={`mb-4 flex h-12 w-12 items-center justify-center rounded-full border transition ${isDragging
                                         ? 'border-ice/60 bg-ice/10'
-                                        : 'border-white/10 bg-white/[0.03] group-hover:border-ice/30'
+                                        : 'border-white/10 bg-white/[0.03] group-hover:border-white/25'
                                         }`}>
                                         <UploadCloud className={`h-5 w-5 transition ${isDragging ? 'text-ice' : 'text-zinc-400 group-hover:text-zinc-200'
                                             }`} />
@@ -913,7 +913,7 @@ export function P2PTransfer() {
                                     onDrop={handleDrop}
                                     className={`group relative mt-2 flex items-center justify-center gap-2 rounded-lg border border-dashed py-3 transition-all ${isDragging
                                         ? 'border-ice bg-ice/[0.04]'
-                                        : 'border-white/15 hover:border-ice/40 hover:bg-white/[0.02]'
+                                        : 'border-white/15 hover:border-white/35 hover:bg-white/[0.02]'
                                         }`}
                                 >
                                     <Plus className={`h-3.5 w-3.5 transition ${isDragging ? 'text-ice' : 'text-zinc-500 group-hover:text-zinc-300'}`} />


### PR DESCRIPTION
## Summary

Hovering the file dropzone tinted its dashed border ice blue. It now goes neutral white. Hue only: no geometry, spacing, copy, or idle-state changes.

Three class tokens in `client/components/P2PTransfer.tsx`:

| Line | Element | From | To |
|---|---|---|---|
| 879 | large zone container | `hover:border-ice/40` | `hover:border-white/35` |
| 916 | slim "Add more files" container | `hover:border-ice/40` | `hover:border-white/35` |
| 884 | icon chip | `group-hover:border-ice/30` | `group-hover:border-white/25` |

Why this and not something else:

- **It was the client's only ice hover on a surface.** Of the 17 hover-triggered ice tokens in `client/`, 14 are text (`hover:text-ice` on links and their arrows). These three were the only non-text ones, so after this every hover-triggered ice token in the client is a text link.
- **Desktop already shipped this exact change.** `76562ea` ("feat(desktop): calm dropzone borders and one-control history rows", #299) took the byte-identical strings in `desktop/frontend/src/App.tsx` off ice. `group-hover:border-white/25` is that commit's own value for a chip with an identical `border-white/10 bg-white/[0.03]` rest state, not a number invented here.
- **`white/35`, not a straight alpha carry-over.** Composited on `bg-zinc-950`, `ice/40` lands at `#4C5E65` and `white/35` at `#5F5F60`, so the hover changes hue without changing weight. An exact luminance match is ~`/33`; a chromatic edge reads brighter than an achromatic one of equal luminance, so this sits just above it. Straight `/40` would have been +42% luminance, a louder hover than before.
- **`isDragging` deliberately keeps ice** (`border-ice bg-ice/[0.04]`, `text-ice`). Hover and drag now differ by hue rather than by two strengths of the same blue. That is the split the desktop app ships (`desktop/frontend/src/globals.css:143-146`) and the same "ice marks the engaged state" grammar as the active install tab (`InstallTabs.tsx:48`).

Idle `border-white/15` and `hover:bg-white/[0.02]` are untouched, which is also what keeps `docs/images/web/01-send-staged.png` valid.

## Test plan

Nothing in CI can see a colour: no vitest or Playwright test asserts these class names, and `client/e2e/screenshot-matrix.mjs` captures the un-hovered state only. Verified by hand against a local stack.

- `pnpm lint` - 0 errors (2 pre-existing `window.location.href` warnings, untouched here)
- `pnpm test` - 254 passed, 20 files
- `pnpm build` - clean; the production CSS bundle contains `.hover\:border-white\/35` and `border-white\/25`, both inside `@media (hover: hover)`
- Live hover, measured with `getComputedStyle` while genuinely hovering (`:hover` matched):
  - large zone -> `oklab(0.999994 0.0000456 0.0000201 / 0.35)`, composited `rgb(95, 95, 96)` = `#5F5F60`. Chroma is ~4e-5, i.e. neutral.
  - slim zone -> identical, `rgb(95, 95, 96)`. Both zones agree.
  - icon chip -> white at alpha 0.25 under `group-hover`.
- Drag-active still ice: dispatching a real `dragover` swaps the copy to "Release to add files" and the border composites to `rgb(177, 221, 235)` = `#B1DDEB`, the ice token. Confirmed after the 0.15s transition settles.
- Touch is unaffected by construction, since Tailwind v4 emits `hover:` inside `@media (hover: hover)`.

Left to CI: the E2E matrix, back-compat, the Wails/MSIX packaging steps, and the Docker stack, none of which this change can reach.
