### PR TITLE
chore(skills): add the deep-clean skill, a fenced post-task sweep

### DIFF
--- a/.claude/skills/deep-clean/SKILL.md
+++ b/.claude/skills/deep-clean/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: deep-clean
+description: 'Use when a task, feature, plan or test run is finished and the leftovers should go: deep clean, clean up, tidy up, remove the temp files, delete the test artifacts, revert what the run changed, free disk space, client/.next, session scratchpads, a stray floe.exe, Playwright reports. It surveys read-only first and sweeps only a fenced list, so server/.env, %APPDATA%\floe and received transfers can never be deleted. Not for stopping a running local stack; that is floe-run. Not for undoing the machine changes a transfer audit made; that is transfer-audit cleanup.'
+---
+
+# deep-clean
+
+One command answers what a finished task left behind, and a second one
+removes the part of it that is provably disposable. The dangerous half of
+this job is not finding junk, it is not deleting the things that look like
+junk and are not, so the never-delete list lives in code as a fence rather
+than in prose here. Symbols, not lines: the fence is `DENY_NAME`,
+`denyList`, `makeFence` and `scanContents` in `scripts/deep-clean.mjs`, and
+the buckets come from `repoRules`, `tempCandidates` and
+`scratchpadCandidates`.
+
+This skill is a conductor. It kills no process, closes no browser tab and
+edits no firewall rule, because `floe-run` and `transfer-audit` already own
+those and already verify a pid image and creation time before acting.
+
+Never sweep on someone else's behalf. Show the survey table to the user and
+let them read it before anything is removed. Never promote an item out of
+the ask bucket without being told which one. Never widen `--age-minutes` to
+get past a held item unless you know no other session is running: that guard
+is the only thing standing between this skill and another session's
+in-flight working data.
+
+## 0. Preconditions (the owners run first, or their state gets orphaned)
+
+- The task whose leftovers you are clearing is actually finished.
+- `node .claude/skills/floe-run/scripts/floe-run.mjs stop` if a local stack
+  is up. Running it first is what lets the pidfile be cleaned as ordinary
+  debris rather than reported as a live stack.
+- `node .claude/skills/transfer-audit/scripts/audit.mjs cleanup --out <dir>`
+  if a transfer audit ran. That is the only thing that restores the real
+  `%APPDATA%\floe\desktop.json` from its hash-checked backup. Sweeping the
+  run directory first destroys the manifest it replays.
+- `git status` is understood. An untracked directory in the tree is a
+  decision, not debris.
+
+## 1. Survey (read-only, and the only step safe to run unattended)
+
+```text
+node .claude/skills/deep-clean/scripts/deep-clean.mjs survey
+node .claude/skills/deep-clean/scripts/deep-clean.mjs survey --verbose
+node .claude/skills/deep-clean/scripts/deep-clean.mjs survey --firewall
+```
+
+Four buckets come back, largest first:
+
+- `safe`, swept by step 2. Build caches, Playwright output, stray `go` and
+  `wails` binaries, temp probe scratch, and session scratchpads that are
+  empty or untouched for over `--scratch-days` (default 7).
+- `ask first`, listed but never swept implicitly. Anything with a real
+  reinstall cost or a judgment call in it: `node_modules`, the root
+  `floe.exe` that shadows the scoop shim, `client/AGENTS.md` and
+  `client/CLAUDE.md` (next dev writes them but they can carry hand-written
+  content), `desktop/build/bin`, untracked and unignored directories, audit
+  evidence, recent scratchpads.
+- `held`, safe by rule but touched within `--age-minutes` (default 30).
+  This is the concurrent-session guard. Several sessions run against this
+  checkout at once, and a held item usually belongs to one of them.
+- `fenced`, considered and refused, printed so the refusal is visible rather
+  than silent. A directory is refused for what it carries as well as for
+  what it is, so a scratchpad holding a stray `.env` is fenced even though
+  the scratchpad itself is disposable.
+
+A `+` after a size means byte counting stopped and the figure is a lower
+bound. Sizes on a pnpm tree are misleading anyway: most of `node_modules` is
+links into a shared store, so deleting it frees far less than it reports.
+
+Below the table, `not swept, reported only` names state this skill will not
+touch: the Go build cache (`go clean -cache` owns it), git stashes,
+local-only branches, and worktrees.
+
+Exit codes: 0 nothing to do, 1 candidates found, 2 usage, 3 precondition,
+4 fence tripped, 5 a removal failed.
+
+## 2. Sweep (dry run first, always)
+
+```text
+node .claude/skills/deep-clean/scripts/deep-clean.mjs sweep
+node .claude/skills/deep-clean/scripts/deep-clean.mjs sweep --apply
+```
+
+Without `--apply` it prints the exact list it would remove and removes
+nothing. With `--apply` it removes the safe bucket only, re-running every
+check immediately before each deletion, and prints each path as it goes so
+an interrupted sweep still leaves a record. A path that vanished before the
+sweep reached it is reported as such rather than counted as reclaimed. A
+removal that fails does not abort the rest; the run exits 5 and names it.
+A second sweep exits 0.
+
+## 3. The ask bucket is the user's call, one id at a time
+
+```text
+node .claude/skills/deep-clean/scripts/deep-clean.mjs sweep --include root-exe --apply
+```
+
+`--include` takes a candidate id, never a path, so it cannot be used to
+reach a fenced location. It refuses an id that is tracked, fenced, or was
+touched inside the age guard. Say what each promotion costs before naming
+it: deleting `client/node_modules` means `corepack pnpm install` before
+`next dev` runs again, and deleting the root `floe.exe` changes which binary
+`floe` resolves to when the working directory is the repo root.
+
+`--keep <path>` is the opposite lever and only ever narrows the sweep. A
+`--keep` that does not exist is a usage error rather than a silent no-op,
+because a protection that quietly failed is worse than none.
+
+## 4. Revert is a different job from delete
+
+What a run changed, rather than created, is not swept:
+
+- `client/next-env.d.ts` is tracked and rewritten by `next dev`. Restore it
+  with `git checkout -- client/next-env.d.ts` after the stack is stopped.
+- `%APPDATA%\floe\desktop.json` is restored only by `transfer-audit cleanup`,
+  from a sha256-compared backup. Never hand-edit it.
+- The stats-counter neutralization in `floe-run` is process-scoped and dies
+  with the child. Nothing to revert, and never write it into `server/.env`.
+  Setting an Upstash variable to the empty string in PowerShell deletes the
+  variable, which lets dotenv refill it from the real file and re-arms the
+  live counter.
+- A Partner Center draft is server state. `store-submit` section 9 deletes
+  one; nothing local does.
+
+## 5. Harness and browser state mostly cleans itself
+
+Claude Code groups the tabs a session opened and closes the group on
+`/clear`. Do not close tabs by hand as a teardown step, and never revoke the
+Chrome extension site permissions: the user has to re-grant them per site.
+For `~/.claude`, use the built-in owner rather than deleting by hand:
+
+```text
+claude project purge <path> --dry-run
+```
+
+`cleanupPeriodDays` (default 30) already sweeps transcripts, plans, task
+lists and file history. Never delete `~/.claude/projects/**/memory` or
+`~/.claude/plans`: they belong to no repo, have no remote, and another live
+session may be writing to them.
+
+## 6. Firewall (report only, and acting on it needs an elevated shell)
+
+`--firewall` lists rules naming a Floe binary whose file is gone. These
+accumulate from the Windows consent dialog, not from any skill. Two of them
+are Block rules for a `floe-ui` path that no longer exists and are the
+recorded cause of `connect-timeout` SKIPs in later audits. Report them.
+Removing them is the user's decision, in an elevated shell, and the disabled
+`Floe relay test` rule is deliberate: never delete it and never enable it.
+
+## Done means
+
+`survey` exits 0, or exits 1 with only ask items the user has decided to
+keep. The reclaimed total was reported. Nothing in the fenced bucket moved,
+`git status` shows what it showed before apart from artifacts you named, and
+no process was killed by this skill.
+
+Green is a gate, not proof. A clean survey says nothing about state this
+script cannot see or deliberately leaves alone: desktop History rows, a
+Partner Center draft, bytes already counted by the production stats counter,
+Docker images and containers, WSL scratch under `/var/tmp/floe-lta`,
+firewall rules it only reports, or work another live session is holding in
+memory but has not yet written to disk.
+
+## Pointers
+
+- `scripts/deep-clean.mjs`, and `scripts/deep-clean.test.mjs`
+  (`node --test`, 38 cases; the two `regressions` blocks are defects two
+  red teams reproduced on 2026-09-02, several of which deleted committed
+  files)
+- `node .claude/skills/deep-clean/scripts/deep-clean.mjs --self-test`
+  (22 fence assertions, no filesystem writes)
+- `.claude/skills/floe-run/SKILL.md` (the stack, the pidfile, the stats sentinel)
+- `.claude/skills/transfer-audit/SKILL.md` section 6 (the machine-state restore)
+- CLAUDE.md "Desktop (Wails)" for the `//go:embed` trap on `desktop/frontend/dist`
+- Memory: project_floe_local_install_hygiene, reference_transfer_audit_harness,
+  project_two_machine_setup

--- a/.claude/skills/deep-clean/SKILL.md
+++ b/.claude/skills/deep-clean/SKILL.md
@@ -14,6 +14,9 @@ than in prose here. Symbols, not lines: the fence is `DENY_NAME`,
 the buckets come from `repoRules`, `tempCandidates` and
 `scratchpadCandidates`.
 
+The skill's paths exist on `main` only once PR #376 has merged; from an older
+checkout, run the script by its absolute path from a checkout that has it.
+
 This skill is a conductor. It kills no process, closes no browser tab and
 edits no firewall rule, because `floe-run` and `transfer-audit` already own
 those and already verify a pid image and creation time before acting.

--- a/.claude/skills/deep-clean/scripts/deep-clean.mjs
+++ b/.claude/skills/deep-clean/scripts/deep-clean.mjs
@@ -1,0 +1,1378 @@
+#!/usr/bin/env node
+/**
+ * deep-clean.mjs - find and remove what a finished task left behind.
+ *
+ * Commands
+ *   survey  Read-only. Enumerate leftovers under the two allowed roots
+ *           (this checkout, and the OS temp dir), classify each one into
+ *           safe / ask / held, and print a table with sizes and reasons.
+ *   sweep   Delete the safe bucket. Requires --apply; without it the
+ *           command prints exactly what it would remove and removes
+ *           nothing.
+ *
+ * Why it exists
+ *   Seven skills in this repo create artifacts, and two of them
+ *   (floe-run, transfer-audit) already own their own teardown. What had
+ *   no owner was the residue nothing tracks: client/.next, the session
+ *   scratchpads under the OS temp dir, stray go and wails binaries,
+ *   Playwright reports. Sweeping those by hand means re-deriving the
+ *   never-delete list every time, and that list has teeth. server/.env
+ *   holds live Upstash write credentials. %APPDATA%\floe is the desktop
+ *   app's real user data, not install debris. desktop/frontend/dist is
+ *   gitignored but embedded by //go:embed, so deleting it breaks every
+ *   go command in desktop/ until the frontend is rebuilt.
+ *
+ * Why a fence and not a checklist
+ *   The never-delete list is enforced in code, at classify time and again
+ *   immediately before every removal, because a prose checklist is only
+ *   as good as the reader's attention. Deny beats allow, always.
+ *
+ * The five invariants, and what each one cost to learn
+ *   1. Nothing is reached through a link. The fence refuses a candidate
+ *      whose leaf OR any ancestor is a symlink or junction. An earlier
+ *      version resolved the candidate for the deny check but passed the
+ *      unresolved path to the git-tracked check and to rmSync, so a
+ *      junction at client/ made tracked, committed files look disposable
+ *      and a sweep deleted five of them. Resolve once, use it everywhere.
+ *   2. A directory is only as safe as its contents, and severity beats
+ *      traversal order. rmSync is recursive, so permitting a directory
+ *      permits everything inside it. Every directory is scanned before
+ *      removal and refused if it carries a denied name or a link leaving
+ *      the allowed roots. A soft hit (a nested .git) found early must not
+ *      mask a hard hit (a .env) found deeper, which is the layout of every
+ *      copy of this repo and was reachable through --include.
+ *   3. An unknown age is not a young age. The mtime walk is uncapped; if
+ *      it ever hits the ceiling the item cannot be safe, because a
+ *      truncated walk reads a stale timestamp and that is exactly how a
+ *      live session's scratchpad would get swept out from under it.
+ *   5. A git boundary hides files the same way a link does. git ls-files
+ *      stops at a submodule gitlink, so a submodule, linked worktree or
+ *      nested clone between the root and a candidate made committed files
+ *      look untracked. ancestorGitDir refuses those, mirroring invariant 1.
+ *
+ *   4. --root cannot move the fence. Deny entries are anchored at both
+ *      the given root and this script's own checkout, and a root with no
+ *      CLAUDE.md is refused, so pointing --root one level up cannot
+ *      unfence server/.env.
+ *
+ * Why it kills no processes
+ *   floe-run stop and transfer-audit cleanup already verify a pid's
+ *   process image and creation time before touching it, and both refuse
+ *   a pidfile from another checkout. This script only reports what is
+ *   listening and names the command that owns it. Measured on this box
+ *   on 2026-09-02: every node.exe running was an MCP server or a Claude
+ *   Code session, so a "kill stray node" step would have broken the
+ *   running session's own tools.
+ *
+ * What a clean survey does NOT prove
+ *   Nothing about state this script cannot see, or deliberately leaves to
+ *   its owner: the desktop app's History rows, a Partner Center draft,
+ *   bytes already counted by the production stats counter, Docker images,
+ *   or WSL scratch under /var/tmp/floe-lta. Sizes are lower bounds on a
+ *   pnpm tree, where node_modules is mostly links into a shared store, and
+ *   a trailing + marks a size that stopped counting. The reported extras
+ *   (go build cache, stashes, local-only branches, worktrees) are
+ *   read-only notes and are never swept.
+ *
+ * Usage:
+ *   node .claude/skills/deep-clean/scripts/deep-clean.mjs survey [options]
+ *   node .claude/skills/deep-clean/scripts/deep-clean.mjs sweep --apply [options]
+ *
+ *   --root <dir>        checkout to operate on (default: this one)
+ *   --age-minutes <n>   hold anything touched this recently (default 30)
+ *   --scratch-days <n>  scratchpad sessions older than this are safe (default 7)
+ *   --include <id>      promote one ask candidate into the sweep, repeatable
+ *   --keep <path>       force-protect a path, repeatable, only ever restrictive
+ *   --firewall          also report firewall rules naming a missing file
+ *   --verbose           list grouped items individually instead of collapsed
+ *   --temp-root <dir>   scan this instead of the OS temp dir (test seam)
+ *   --json              machine-readable output
+ *   --self-test         run the built-in fence assertions and exit
+ *
+ * Exit 0 nothing to do, 1 candidates found or removed, 2 usage,
+ *      3 precondition, 4 fence tripped, 5 a removal failed.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// scripts/ -> deep-clean/ -> skills/ -> .claude/ -> repo root.
+const DEFAULT_ROOT = path.resolve(HERE, '..', '..', '..', '..');
+
+const WIN = process.platform === 'win32';
+/** Byte accounting stops here. Age accounting never does; see WALK_CEILING. */
+const SIZE_CAP = 4000;
+/** A walk this large is treated as unmeasurable, never as young. */
+const WALK_CEILING = 250000;
+
+/* ---------------------------------------------------------------- paths */
+
+function norm(p) {
+    const r = path.resolve(p);
+    return WIN ? r.replace(/\\/g, '/').toLowerCase() : r;
+}
+
+function isUnder(child, parent) {
+    const c = norm(child);
+    const p = norm(parent);
+    return c === p || c.startsWith(p.endsWith('/') ? p : p + '/');
+}
+
+function exists(p) {
+    try {
+        fs.lstatSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+function isLink(p) {
+    try {
+        return fs.lstatSync(p).isSymbolicLink();
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Canonical form. Falls back to path.resolve when the path does not exist,
+ * which is why no caller may treat equality with the input as proof that no
+ * link was involved. Use ancestorLink for that.
+ */
+function realOrSelf(p) {
+    try {
+        return fs.realpathSync.native(p);
+    } catch {
+        return path.resolve(p);
+    }
+}
+
+/**
+ * The first link found at the leaf or any ancestor, or null. Invariant 1:
+ * checking only the leaf is what let a junction at client/ carry a sweep
+ * into a tracked directory.
+ */
+function ancestorLink(p, stopAt) {
+    let cur = path.resolve(p);
+    const stop = stopAt ? norm(stopAt) : null;
+    for (;;) {
+        if (stop && norm(cur) === stop) return null;
+        if (isLink(cur)) return cur;
+        const up = path.dirname(cur);
+        if (up === cur) return null;
+        cur = up;
+    }
+}
+
+/**
+ * The first ancestor between the candidate and the allow root that holds its
+ * own .git, or null. git ls-files stops at a submodule gitlink, so a
+ * submodule, a linked worktree or a nested clone between --root and a
+ * candidate hides its committed files from the tracked check. Same shape as
+ * the link defect: a boundary at client/ laundering committed files into the
+ * safe bucket.
+ */
+function ancestorGitDir(p, stopAt) {
+    let cur = path.dirname(path.resolve(p));
+    const stop = stopAt ? norm(stopAt) : null;
+    for (;;) {
+        if (stop && norm(cur) === stop) return null;
+        if (exists(path.join(cur, '.git'))) return cur;
+        const up = path.dirname(cur);
+        if (up === cur) return null;
+        cur = up;
+    }
+}
+
+/* ---------------------------------------------------------------- fence */
+
+/**
+ * True when a basename hits a deny rule. Returns the rule, or null.
+ * A name is tested as-is and with trailing dots and spaces stripped:
+ * Windows drops those on create, but an extended-length path keeps them,
+ * and ".env " was classified safe and deleted.
+ */
+function denyRuleFor(name) {
+    const forms = new Set([name, name.replace(/[. ]+$/, '')]);
+    for (const d of DENY_NAME) {
+        for (const f of forms) {
+            if (f && d.re.test(f)) return d;
+        }
+    }
+    return null;
+}
+
+/** Basenames denied wherever they appear, at any depth. */
+const DENY_NAME = [
+    // .env.example and .env.docker.example are committed, public templates,
+    // so they are deliberately not secrets. Denying them fenced 319 MB of
+    // dead scratchpads that merely contained a copy of the repo.
+    {
+        re: /^(?!.*\.example$)\.env($|[^A-Za-z0-9])/i,
+        why: 'environment file',
+        hard: true,
+    },
+    {
+        re: /^floe_transfer_.*\.zip$/i,
+        why: 'received personal media, not an artifact',
+        hard: true,
+    },
+    { re: /^\.envrc$/i, why: 'direnv environment file', hard: true },
+    { re: /^turnserver\.conf$/i, why: 'coturn secret', hard: true },
+    // A git repo inside a scratch directory is a judgment call rather than
+    // a hard no: it may hold unpushed work, or it may be a test fixture.
+    { re: /^\.git$/i, why: 'a git repository', hard: false },
+];
+
+/**
+ * Absolute deny list. Every entry is a thing that looks like debris to a
+ * naive sweep and is not. Anchored at both the operating root and this
+ * script's own checkout so --root cannot relocate it (invariant 4).
+ */
+function denyList(roots, tempRoot) {
+    const home = os.homedir();
+    const appdata =
+        process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    const localapp =
+        process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+    const out = [
+        // Desktop app user data. MSIX does not virtualize %APPDATA%, so this
+        // is the real settings, history and webview store.
+        {
+            path: path.join(appdata, 'floe'),
+            why: "the desktop app's real settings, history and webview data",
+        },
+        {
+            path: path.join(localapp, 'ms-playwright'),
+            why: 'shared Playwright browser install',
+        },
+        // The stable operator --bin-dir. Deleting it re-arms the Windows
+        // firewall consent dialog on the next audit round.
+        {
+            path: path.join(tempRoot, 'floe-audit', 'bin'),
+            why: 'stable operator --bin-dir; deleting it re-triggers firewall consent',
+        },
+        // Unbacked-up, belong to no repo.
+        {
+            path: path.join(home, '.claude', 'plans'),
+            why: 'unbacked-up plan files',
+        },
+        {
+            path: path.join(home, '.claude', 'projects'),
+            why: 'transcripts and auto memory; use claude project purge instead',
+        },
+    ];
+    for (const root of new Set(roots.map((r) => path.resolve(r)))) {
+        out.push(
+            {
+                path: path.join(root, 'server', '.env'),
+                why: 'live Upstash write credentials',
+            },
+            {
+                path: path.join(root, 'client', '.env.local'),
+                why: 'local dev config, not an artifact',
+            },
+            {
+                path: path.join(root, 'coturn', 'turnserver.conf'),
+                why: 'coturn secret (root .gitignore)',
+            },
+            {
+                path: path.join(root, 'desktop', 'frontend', 'dist'),
+                why: 'embedded by //go:embed; deleting it breaks every go command in desktop/',
+            },
+            { path: path.join(root, 'go.work'), why: 'workspace file' },
+            {
+                path: path.join(root, 'go.work.sum'),
+                why: 'untracked on purpose, locally useful',
+            },
+            {
+                path: path.join(root, '.claude', 'settings.local.json'),
+                why: 'accumulated permission allowlist',
+            }
+        );
+    }
+    return out;
+}
+
+export function makeFence(root, keeps, tempRoot = os.tmpdir()) {
+    const allowRoots = [
+        ...new Set([path.resolve(root), path.resolve(tempRoot)]),
+    ];
+    const deny = denyList([root, DEFAULT_ROOT], tempRoot).concat(
+        keeps.map((k) => ({ path: k, why: 'protected by --keep' }))
+    );
+
+    /** @returns {null | string} null when deletable, else the refusal reason. */
+    return function fence(candidate) {
+        const literal = path.resolve(candidate);
+        const real = realOrSelf(literal);
+
+        // Invariant 1. Refuse rather than resolve: a link is never a route.
+        const owner = allowRoots.find((a) => isUnder(literal, a));
+        const link = ancestorLink(literal, owner);
+        if (link) {
+            return norm(link) === norm(literal)
+                ? 'is a symlink'
+                : `reached through a link at ${link}`;
+        }
+        const nested = ancestorGitDir(literal, owner);
+        if (nested) {
+            return `inside a nested git repository at ${nested}, whose files git ls-files cannot see`;
+        }
+
+        // Denied names bind on both spellings, at any depth.
+        for (const form of new Set([norm(literal), norm(real)])) {
+            for (const seg of form.split('/')) {
+                const d = denyRuleFor(seg);
+                if (d) return d.why;
+            }
+        }
+
+        for (const d of deny) {
+            for (const form of [literal, real]) {
+                if (isUnder(form, d.path)) return d.why;
+                // Reporting a descendant's reason as if it were the
+                // candidate's read as nonsense ("untracked:client refused as
+                // local dev config"), so name what it contains instead.
+                if (isUnder(d.path, form)) {
+                    return `contains ${d.path} (${d.why})`;
+                }
+            }
+        }
+        // Both spellings must live inside an allow root.
+        for (const form of [literal, real]) {
+            if (!allowRoots.some((a) => isUnder(form, a))) {
+                return 'outside the allowed roots (this checkout and the temp dir)';
+            }
+            if (allowRoots.some((a) => norm(form) === norm(a))) {
+                return 'is an allow root itself';
+            }
+        }
+        return null;
+    };
+}
+
+/**
+ * Invariant 2. rmSync is recursive, so a directory is only as safe as what
+ * it holds. Returns the first offending descendant, or null.
+ */
+export function scanContents(dir, allowRoots) {
+    let st;
+    try {
+        st = fs.lstatSync(dir);
+    } catch {
+        return null;
+    }
+    if (!st.isDirectory() || st.isSymbolicLink()) return null;
+    const stack = [dir];
+    let seen = 0;
+    let soft = null;
+    while (stack.length) {
+        if (++seen > WALK_CEILING) {
+            return {
+                path: dir,
+                why: `too large to verify (over ${WALK_CEILING} entries)`,
+                hard: false,
+            };
+        }
+        const cur = stack.pop();
+        let entries;
+        try {
+            entries = fs.readdirSync(cur, { withFileTypes: true });
+        } catch {
+            continue;
+        }
+        for (const e of entries) {
+            const p = path.join(cur, e.name);
+            const d = denyRuleFor(e.name);
+            if (d) {
+                const hit = { path: p, why: d.why, hard: d.hard !== false };
+                // Severity, not traversal order, decides. A soft .git met
+                // early used to mask a hard .env met deeper, and that is the
+                // layout of every copy of this repo.
+                if (hit.hard) return hit;
+                if (!soft) soft = hit;
+                continue;
+            }
+            if (e.isSymbolicLink()) {
+                const target = realOrSelf(p);
+                if (!allowRoots.some((a) => isUnder(target, a))) {
+                    return {
+                        path: p,
+                        why: `link leaving the allowed roots (-> ${target})`,
+                        hard: true,
+                    };
+                }
+                continue; // never descend a link
+            }
+            if (e.isDirectory()) stack.push(p);
+        }
+    }
+    return soft;
+}
+
+/* ------------------------------------------------------------ git state */
+
+function git(root, args) {
+    try {
+        return execFileSync('git', ['-C', root, ...args], {
+            encoding: 'utf8',
+            maxBuffer: 64 * 1024 * 1024,
+        });
+    } catch {
+        return null;
+    }
+}
+
+function trackedPaths(root) {
+    const out = git(root, ['ls-files', '-z']);
+    if (out === null) return null;
+    return out
+        .split('\0')
+        .filter(Boolean)
+        .map((rel) => norm(path.join(root, rel)));
+}
+
+function tracksAnything(tracked, p) {
+    const n = norm(p);
+    const prefix = n.endsWith('/') ? n : n + '/';
+    return tracked.some((t) => t === n || t.startsWith(prefix));
+}
+
+/* ------------------------------------------------------------ measuring */
+
+/**
+ * Invariant 3. Byte accounting stops at SIZE_CAP because a size is only a
+ * report, but the mtime walk runs to completion because an age decides a
+ * deletion. A walk that hits WALK_CEILING reports capped, and a capped item
+ * can never be safe.
+ */
+function measure(p) {
+    let bytes = 0;
+    let files = 0;
+    let newest = 0;
+    let capped = false;
+    let counted = 0;
+    const stack = [p];
+    while (stack.length) {
+        if (counted > WALK_CEILING) {
+            capped = true;
+            break;
+        }
+        const cur = stack.pop();
+        let st;
+        try {
+            st = fs.lstatSync(cur);
+        } catch {
+            continue;
+        }
+        counted += 1;
+        if (st.mtimeMs > newest) newest = st.mtimeMs;
+        if (st.isSymbolicLink()) {
+            files += 1;
+            continue;
+        }
+        if (st.isDirectory()) {
+            let entries = [];
+            try {
+                entries = fs.readdirSync(cur);
+            } catch {
+                continue;
+            }
+            for (const e of entries) stack.push(path.join(cur, e));
+            continue;
+        }
+        files += 1;
+        if (files <= SIZE_CAP) bytes += st.size;
+    }
+    return { bytes, files, newest, capped, sizeIsLowerBound: files > SIZE_CAP };
+}
+
+function human(bytes) {
+    const u = ['B', 'KB', 'MB', 'GB'];
+    let n = bytes;
+    let i = 0;
+    while (n >= 1024 && i < u.length - 1) {
+        n /= 1024;
+        i += 1;
+    }
+    return `${i === 0 ? n : n.toFixed(1)} ${u[i]}`;
+}
+
+/* --------------------------------------------------------------- rules */
+
+function repoRules(root) {
+    const j = (...s) => path.join(root, ...s);
+    return [
+        [
+            'next-build',
+            j('client', '.next'),
+            'safe',
+            'Next.js build cache; rebuilt by pnpm dev or pnpm build',
+        ],
+        [
+            'next-out',
+            j('client', 'out'),
+            'safe',
+            'Next.js static export output',
+        ],
+        [
+            'next-tsbuildinfo',
+            j('client', 'tsconfig.tsbuildinfo'),
+            'safe',
+            'TypeScript incremental cache',
+        ],
+        [
+            'pw-results',
+            j('client', 'test-results'),
+            'safe',
+            'Playwright run output',
+        ],
+        [
+            'pw-report',
+            j('client', 'playwright-report'),
+            'safe',
+            'Playwright HTML report',
+        ],
+        [
+            'pw-blob',
+            j('client', 'blob-report'),
+            'safe',
+            'Playwright blob report',
+        ],
+        [
+            'pw-cache',
+            j('client', '.playwright'),
+            'safe',
+            'Playwright local cache',
+        ],
+        [
+            'wails-installer-tmp',
+            j('desktop', 'build', 'windows', 'installer', 'tmp'),
+            'safe',
+            're-downloaded by wails build -nsis',
+        ],
+        [
+            'desktop-stray-exe',
+            j('desktop', 'desktop.exe'),
+            'safe',
+            'stray go build output; wails build writes build/bin',
+        ],
+        ['cli-exe', j('cli', 'floe.exe'), 'safe', 'stray go build output'],
+        ['cli-bin', j('cli', 'floe'), 'safe', 'stray go build output'],
+        [
+            'cli-cmd-exe',
+            j('cli', 'cmd', 'floe', 'floe.exe'),
+            'safe',
+            'stray go build output',
+        ],
+        [
+            'cli-cmd-bin',
+            j('cli', 'cmd', 'floe', 'floe'),
+            'safe',
+            'stray go build output',
+        ],
+        ['cli-output', j('cli', 'output'), 'safe', 'CLI test output'],
+        // next dev upserts these two rather than owning them outright, and
+        // AGENTS.md invites hand-written content outside its managed block,
+        // so they are a decision rather than debris.
+        [
+            'next-agents',
+            j('client', 'AGENTS.md'),
+            'ask',
+            'written by next dev, but it can carry hand-written content outside the managed block',
+        ],
+        [
+            'next-claude',
+            j('client', 'CLAUDE.md'),
+            'ask',
+            'written by next dev, but it can carry hand-written content',
+        ],
+        [
+            'desktop-build-bin',
+            j('desktop', 'build', 'bin'),
+            'ask',
+            'wails build output, and the release artifact until it is uploaded',
+        ],
+        ['dist-msix', j('dist-msix'), 'ask', 'MSIX packaging output'],
+        [
+            'root-exe',
+            j('floe.exe'),
+            'ask',
+            'shadows the scoop shim when cwd is the repo root',
+        ],
+        [
+            'root-bin',
+            j('floe'),
+            'ask',
+            'shadows the scoop shim when cwd is the repo root',
+        ],
+        [
+            'desktop-dist',
+            j('desktop', 'frontend', 'dist'),
+            'never',
+            'embedded by //go:embed; go commands in desktop/ fail without it',
+        ],
+        [
+            'nm-root',
+            j('node_modules'),
+            'ask',
+            'reinstall needed before anything runs; on a pnpm tree most of it is links, so the reclaim is smaller than the size shown',
+        ],
+        [
+            'nm-client',
+            j('client', 'node_modules'),
+            'ask',
+            'reinstall needed before next dev runs; mostly pnpm links',
+        ],
+        [
+            'nm-server',
+            j('server', 'node_modules'),
+            'ask',
+            'reinstall needed before the signaling server runs',
+        ],
+        [
+            'nm-desktop',
+            j('desktop', 'frontend', 'node_modules'),
+            'ask',
+            'reinstall needed before the desktop frontend builds',
+        ],
+    ].map(([id, p, bucket, why]) => ({ id, path: p, bucket, why }));
+}
+
+function repoGlobCandidates(root) {
+    const out = [];
+    let entries = [];
+    try {
+        entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+        return out;
+    }
+    for (const e of entries) {
+        if (/\.local\.mjs$/i.test(e.name) || /^\..*-tmp\.mjs$/i.test(e.name)) {
+            out.push({
+                id: `scratch-script:${e.name}`,
+                path: path.join(root, e.name),
+                bucket: 'safe',
+                why: 'throwaway script (root .gitignore)',
+            });
+        }
+    }
+    let cliEntries = [];
+    try {
+        cliEntries = fs.readdirSync(path.join(root, 'cli'), {
+            withFileTypes: true,
+        });
+    } catch {
+        cliEntries = [];
+    }
+    for (const e of cliEntries) {
+        if (e.isDirectory() && /^received/i.test(e.name)) {
+            out.push({
+                id: `cli-received:${e.name}`,
+                path: path.join(root, 'cli', e.name),
+                bucket: 'ask',
+                why: 'CLI receive output, which means files somebody actually sent you',
+            });
+        }
+    }
+    return out;
+}
+
+function untrackedDirs(root, tracked) {
+    const out = git(root, [
+        'status',
+        '--porcelain=v1',
+        '--untracked-files=normal',
+    ]);
+    if (out === null) return [];
+    const seen = new Set();
+    const res = [];
+    for (const line of out.split(/\r?\n/)) {
+        if (!line.startsWith('?? ')) continue;
+        let rel = line.slice(3).trim();
+        if (rel.startsWith('"') && rel.endsWith('"')) rel = rel.slice(1, -1);
+        const top = rel.split('/')[0];
+        if (!top || seen.has(top)) continue;
+        seen.add(top);
+        const p = path.join(root, top);
+        // A top-level dir that also holds tracked files is a working
+        // directory with one stray file in it, not an untracked artifact.
+        if (tracksAnything(tracked, p)) continue;
+        res.push({
+            id: `untracked:${top}`,
+            path: p,
+            bucket: 'ask',
+            why: 'untracked and not ignored; one git add -A from landing in a commit',
+        });
+    }
+    return res;
+}
+
+function tempCandidates(root, scratchDays, tempRoot) {
+    const out = [];
+    let entries = [];
+    try {
+        entries = fs.readdirSync(tempRoot, { withFileTypes: true });
+    } catch {
+        return out;
+    }
+    const stray =
+        /^(floe-(doc|win|win-fixed|staged|shipped|head|on|off)\.exe|floe-run-t.*\.log|floeprobe.*|floetrav.*)$/i;
+    for (const e of entries) {
+        if (stray.test(e.name)) {
+            out.push({
+                id: `tmp:${e.name}`,
+                path: path.join(tempRoot, e.name),
+                bucket: 'safe',
+                why: 'orphaned build or probe scratch',
+                group: 'tmp-scratch',
+            });
+        }
+    }
+    if (exists(path.join(tempRoot, 'floe-run.json'))) {
+        out.push({
+            id: 'floe-run-pidfile',
+            path: path.join(tempRoot, 'floe-run.json'),
+            bucket: 'never',
+            why: 'a live stack pidfile; run floe-run stop, do not delete it',
+        });
+    }
+    for (const dir of ['lta-runs', path.join('floe-audit', 'out')]) {
+        const p = path.join(tempRoot, dir);
+        if (exists(p)) {
+            out.push({
+                id: `audit-evidence:${dir.replace(/[\\/]/g, '-')}`,
+                path: p,
+                bucket: 'ask',
+                why: 'transfer-audit evidence, and the manifest cleanup replays; run cleanup first',
+            });
+        }
+    }
+    out.push(...scratchpadCandidates(root, scratchDays, tempRoot));
+    return out;
+}
+
+function scratchpadCandidates(root, scratchDays, tempRoot) {
+    const base = path.join(tempRoot, 'claude');
+    const want = path
+        .resolve(root)
+        .replace(/[:\\/]/g, '-')
+        .toLowerCase();
+    let projects = [];
+    try {
+        projects = fs.readdirSync(base, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    const hit = projects.find(
+        (d) => d.isDirectory() && d.name.toLowerCase() === want
+    );
+    if (!hit) return [];
+    const projectDir = path.join(base, hit.name);
+    let sessions = [];
+    try {
+        sessions = fs.readdirSync(projectDir, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    const cutoff = Date.now() - scratchDays * 86400000;
+    const out = [];
+    for (const s of sessions) {
+        if (!s.isDirectory()) continue;
+        const p = path.join(projectDir, s.name);
+        const m = measure(p);
+        const empty = m.files === 0 && !m.capped;
+        const old = !m.capped && m.newest > 0 && m.newest < cutoff;
+        out.push({
+            id: `scratchpad:${s.name}`,
+            path: p,
+            bucket: empty || old ? 'safe' : 'ask',
+            why: empty
+                ? 'empty session scratchpad'
+                : old
+                  ? `session scratchpad, untouched for over ${scratchDays} days`
+                  : 'recent session scratchpad; another session may still be using it',
+            group: 'scratchpad',
+        });
+    }
+    return out;
+}
+
+/* ------------------------------------------------------------- reports */
+
+function listeners() {
+    if (!WIN) return [];
+    try {
+        const ps =
+            'Get-NetTCPConnection -State Listen -ErrorAction SilentlyContinue | ' +
+            'Where-Object { $_.LocalPort -in 3000,3001,34115 } | ' +
+            'ForEach-Object { [pscustomobject]@{ Port = $_.LocalPort; ' +
+            'Proc = (Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).ProcessName; ' +
+            'Pid = $_.OwningProcess } } | ConvertTo-Json -Compress';
+        const out = execFileSync(
+            'powershell',
+            ['-NoProfile', '-NonInteractive', '-Command', ps],
+            { encoding: 'utf8', timeout: 20000 }
+        ).trim();
+        if (!out) return [];
+        const parsed = JSON.parse(out);
+        return (Array.isArray(parsed) ? parsed : [parsed]).filter((r) =>
+            [3000, 3001, 34115].includes(Number(r.Port))
+        );
+    } catch {
+        return [];
+    }
+}
+
+export function parseFirewall(json) {
+    let rows;
+    try {
+        rows = JSON.parse(json);
+    } catch {
+        return [];
+    }
+    if (!Array.isArray(rows)) rows = [rows];
+    return rows
+        .filter((r) => r && typeof r.Program === 'string')
+        .map((r) => ({
+            name: String(r.Name ?? ''),
+            action: String(r.Action ?? ''),
+            enabled: String(r.Enabled ?? ''),
+            program: r.Program,
+        }))
+        .filter((r) => !exists(r.program));
+}
+
+function firewallReport() {
+    if (!WIN) return [];
+    try {
+        const ps =
+            'Get-NetFirewallApplicationFilter -ErrorAction SilentlyContinue | ' +
+            "Where-Object { $_.Program -match 'floe' } | ForEach-Object { " +
+            '$r = $_ | Get-NetFirewallRule; [pscustomobject]@{ Name = $r.DisplayName; ' +
+            'Action = [string]$r.Action; Enabled = [string]$r.Enabled; Program = $_.Program } } | ' +
+            'ConvertTo-Json -Compress';
+        const out = execFileSync(
+            'powershell',
+            ['-NoProfile', '-NonInteractive', '-Command', ps],
+            { encoding: 'utf8', timeout: 60000, maxBuffer: 8 * 1024 * 1024 }
+        ).trim();
+        return out ? parseFirewall(out) : [];
+    } catch {
+        return [];
+    }
+}
+
+/** Read-only notes on state this skill deliberately does not sweep. */
+function externals(root) {
+    const notes = [];
+    const cache =
+        process.env.GOCACHE ||
+        path.join(os.homedir(), 'AppData', 'Local', 'go-build');
+    if (exists(cache)) {
+        notes.push({
+            what: 'go build cache',
+            detail: `${cache} (go clean -cache owns it)`,
+        });
+    }
+    const stash = git(root, ['stash', 'list']);
+    if (stash && stash.trim()) {
+        notes.push({
+            what: 'git stashes',
+            detail: `${stash.trim().split(/\r?\n/).length} entry(ies), never dropped by this skill`,
+        });
+    }
+    const branches = git(root, [
+        'for-each-ref',
+        '--format=%(refname:short) %(upstream)',
+        'refs/heads',
+    ]);
+    if (branches) {
+        const local = branches
+            .split(/\r?\n/)
+            .filter((l) => l.trim() && l.trim().split(' ').length === 1)
+            .map((l) => l.trim());
+        if (local.length) {
+            notes.push({
+                what: 'local-only branches',
+                detail: `${local.join(', ')} (these exist on this disk only)`,
+            });
+        }
+    }
+    const wt = git(root, ['worktree', 'list']);
+    if (wt && wt.trim().split(/\r?\n/).length > 1) {
+        notes.push({
+            what: 'git worktrees',
+            detail: `${wt.trim().split(/\r?\n/).length} checked out`,
+        });
+    }
+    return notes;
+}
+
+/* --------------------------------------------------------------- survey */
+
+export function buildCandidates(opts) {
+    const { root, ageMinutes, scratchDays } = opts;
+    const tempRoot = opts.tempRoot ?? os.tmpdir();
+    const keeps = (opts.keeps ?? []).map((k) =>
+        realOrSelf(path.resolve(root, k))
+    );
+    const fence = makeFence(root, keeps, tempRoot);
+    const allowRoots = [
+        ...new Set([path.resolve(root), path.resolve(tempRoot)]),
+    ];
+    const tracked = trackedPaths(root);
+    if (tracked === null) return { error: 'not a git checkout' };
+
+    const raw = [
+        ...repoRules(root),
+        ...repoGlobCandidates(root),
+        ...untrackedDirs(root, tracked),
+        ...tempCandidates(root, scratchDays, tempRoot),
+    ];
+
+    const ageCut = Date.now() - ageMinutes * 60000;
+    const seen = new Set();
+    const items = [];
+    for (const c of raw) {
+        if (!exists(c.path)) continue;
+        const key = norm(c.path);
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        const real = realOrSelf(c.path);
+        const m = measure(c.path);
+        const item = {
+            id: c.id,
+            path: c.path,
+            realPath: norm(real) === norm(c.path) ? null : real,
+            bucket: c.bucket,
+            why: c.why,
+            bytes: m.bytes,
+            files: m.files,
+            newest: m.newest,
+            capped: m.capped,
+            sizeIsLowerBound: m.sizeIsLowerBound,
+            group: c.group ?? null,
+            recent: m.newest > ageCut,
+        };
+
+        const refusal = fence(c.path);
+        const carried = refusal ? null : scanContents(c.path, allowRoots);
+        if (refusal) {
+            item.bucket = 'never';
+            item.why = refusal;
+        } else if (
+            tracksAnything(tracked, real) ||
+            tracksAnything(tracked, c.path)
+        ) {
+            item.bucket = 'never';
+            item.why = 'tracked by git';
+        } else if (carried) {
+            item.bucket = carried.hard ? 'never' : 'ask';
+            item.why = `carries ${carried.why}: ${carried.path}`;
+        } else if (m.capped && item.bucket === 'safe') {
+            item.bucket = 'ask';
+            item.why = `age unknown: the walk hit ${WALK_CEILING} entries`;
+        } else if (item.bucket === 'safe' && item.recent) {
+            item.bucket = 'held';
+            item.why = `touched in the last ${ageMinutes} min; another session may be using it`;
+        }
+        items.push(item);
+    }
+    items.sort((a, b) => b.bytes - a.bytes);
+    return { items, fence, allowRoots, tracked, ageCut };
+}
+
+/* ---------------------------------------------------------------- sweep */
+
+/**
+ * Re-checks every invariant immediately before each removal, not just the
+ * path fence: a candidate can become tracked, gain a denied child, or be
+ * touched by another session between survey and sweep. Failures are
+ * collected per item so one locked file cannot abort the rest or erase the
+ * record of what already went.
+ */
+function sweep(items, ctx, apply, includeIds, onRemove) {
+    const targets = items.filter(
+        (i) =>
+            i.bucket === 'safe' || (i.bucket === 'ask' && includeIds.has(i.id))
+    );
+    const removed = [];
+    const failed = [];
+    const vanished = [];
+    for (const t of targets) {
+        if (!exists(t.path)) {
+            vanished.push(t);
+            continue;
+        }
+        const carried = scanContents(t.path, ctx.allowRoots);
+        const refusal =
+            ctx.fence(t.path) ??
+            (tracksAnything(ctx.tracked, t.path)
+                ? 'became tracked by git'
+                : null) ??
+            (carried && carried.hard ? `now carries ${carried.why}` : null) ??
+            (measure(t.path).newest > ctx.ageCut && !includeIds.has(t.id)
+                ? 'was touched since the survey'
+                : null);
+        if (refusal) {
+            const err = new Error(`fence tripped on ${t.path}: ${refusal}`);
+            err.code = 4;
+            err.removed = removed;
+            throw err;
+        }
+        if (!apply) {
+            removed.push(t);
+            continue;
+        }
+        try {
+            fs.rmSync(t.path, { recursive: true, force: true, maxRetries: 3 });
+            if (exists(t.path)) throw new Error('still present after rmSync');
+            removed.push(t);
+            if (onRemove) onRemove(t);
+        } catch (e) {
+            failed.push({ ...t, error: e.message });
+        }
+    }
+    return { removed, failed, vanished };
+}
+
+/* ----------------------------------------------------------- self-test */
+
+function selfTest(root) {
+    const tmp = os.tmpdir();
+    const fence = makeFence(root, [], tmp);
+    const home = os.homedir();
+    const appdata =
+        process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+    const localapp =
+        process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+    const cases = [
+        [path.join(root, 'server', '.env'), true],
+        [path.join(root, 'server', '.env.example'), false],
+        [path.join(root, 'client', '.env.local'), true],
+        [path.join(root, 'coturn', 'turnserver.conf'), true],
+        [path.join(appdata, 'floe'), true],
+        [path.join(appdata, 'floe', 'desktop.json'), true],
+        [path.join(localapp, 'ms-playwright', 'chromium-1234'), true],
+        [path.join(home, 'floe_transfer_1779272746482.zip'), true],
+        [path.join(root, 'desktop', 'frontend', 'dist'), true],
+        [path.join(tmp, 'floe-audit', 'bin'), true],
+        [path.join(home, '.claude', 'plans'), true],
+        [path.join(home, '.claude', 'projects', 'x', 'memory'), true],
+        [path.join(root, 'client', '.next', '.env.local'), true],
+        [path.join(root, 'client', '.next', 'cache', '.git'), true],
+        [root, true],
+        [tmp, true],
+        [home, true],
+        [path.join(home, 'Documents'), true],
+        [path.join(root, '.git', 'config'), true],
+        [path.join(root, 'client', '.next'), false],
+        [path.join(root, 'client', 'playwright-report'), false],
+        [path.join(tmp, 'floe-win-fixed.exe'), false],
+    ];
+    let bad = 0;
+    for (const [p, shouldRefuse] of cases) {
+        const refused = fence(p) !== null;
+        if (refused !== shouldRefuse) {
+            bad += 1;
+            console.log(
+                `FAIL ${p}\n     expected ${shouldRefuse ? 'refuse' : 'allow'}, got ${refused ? 'refuse' : 'allow'}`
+            );
+        }
+    }
+    console.log(
+        bad === 0
+            ? `self-test ok (${cases.length} fence assertions)`
+            : `self-test FAILED (${bad} of ${cases.length})`
+    );
+    return bad === 0 ? 0 : 1;
+}
+
+/* ------------------------------------------------------------------ cli */
+
+function parseArgs(argv) {
+    const o = {
+        cmd: 'survey',
+        root: DEFAULT_ROOT,
+        ageMinutes: 30,
+        scratchDays: 7,
+        includes: [],
+        keeps: [],
+        apply: false,
+        json: false,
+        firewall: false,
+        verbose: false,
+        tempRoot: os.tmpdir(),
+        selfTest: false,
+    };
+    const rest = [];
+    for (let i = 0; i < argv.length; i += 1) {
+        const a = argv[i];
+        const next = () => {
+            i += 1;
+            if (i >= argv.length) throw new Error(`${a} needs a value`);
+            return argv[i];
+        };
+        if (a === '--root') o.root = realOrSelf(path.resolve(next()));
+        else if (a === '--temp-root')
+            o.tempRoot = realOrSelf(path.resolve(next()));
+        else if (a === '--age-minutes') o.ageMinutes = Number(next());
+        else if (a === '--scratch-days') o.scratchDays = Number(next());
+        else if (a === '--include') o.includes.push(next());
+        else if (a === '--keep') o.keeps.push(next());
+        else if (a === '--apply') o.apply = true;
+        else if (a === '--json') o.json = true;
+        else if (a === '--firewall') o.firewall = true;
+        else if (a === '--verbose') o.verbose = true;
+        else if (a === '--self-test') o.selfTest = true;
+        else if (a === '-h' || a === '--help') o.help = true;
+        else if (a.startsWith('-')) throw new Error(`unknown option ${a}`);
+        else rest.push(a);
+    }
+    if (rest.length > 1) throw new Error(`unexpected argument ${rest[1]}`);
+    if (rest.length === 1) o.cmd = rest[0];
+    if (!['survey', 'sweep'].includes(o.cmd))
+        throw new Error(`unknown command ${o.cmd}`);
+    if (!Number.isFinite(o.ageMinutes) || o.ageMinutes < 0) {
+        throw new Error('--age-minutes must be a non-negative number');
+    }
+    if (!Number.isFinite(o.scratchDays) || o.scratchDays < 0) {
+        throw new Error('--scratch-days must be a non-negative number');
+    }
+    return o;
+}
+
+function render(items, opts, result, extras) {
+    const by = (b) => items.filter((i) => i.bucket === b);
+    const sum = (a) => a.reduce((n, i) => n + i.bytes, 0);
+
+    const line = (i) => {
+        const via = i.realPath ? ` -> ${i.realPath}` : '';
+        const approx = i.sizeIsLowerBound ? '+' : ' ';
+        return (
+            `  ${i.id.padEnd(34)} ${(human(i.bytes) + approx).padStart(10)}  ${i.path}${via}\n` +
+            `  ${' '.repeat(34)} ${' '.repeat(10)}  ${i.why}`
+        );
+    };
+
+    const section = (title, list) => {
+        console.log(`${title} (${list.length}, ${human(sum(list))})`);
+        const groups = new Map();
+        const solo = [];
+        for (const i of list) {
+            if (!i.group || opts.verbose) {
+                solo.push(i);
+                continue;
+            }
+            if (!groups.has(i.group)) groups.set(i.group, []);
+            groups.get(i.group).push(i);
+        }
+        for (const [name, members] of [...groups]) {
+            if (members.length <= 3) {
+                solo.push(...members);
+                groups.delete(name);
+            }
+        }
+        for (const i of solo.sort((a, b) => b.bytes - a.bytes)) {
+            console.log(line(i));
+        }
+        for (const [name, members] of groups) {
+            const reasons = new Map();
+            for (const m of members) {
+                reasons.set(m.why, (reasons.get(m.why) ?? 0) + 1);
+            }
+            console.log(
+                `  ${name.padEnd(34)} ${human(sum(members)).padStart(10)}  ${members.length} items`
+            );
+            for (const [why, n] of reasons) {
+                console.log(
+                    `  ${' '.repeat(34)} ${' '.repeat(10)}  ${n} x ${why}`
+                );
+            }
+            console.log(
+                `  ${' '.repeat(34)} ${' '.repeat(10)}  --verbose to list them individually`
+            );
+        }
+    };
+
+    if (result) {
+        const { removed, failed, vanished } = result;
+        console.log(
+            opts.apply
+                ? `removed ${removed.length} item(s), ${human(sum(removed))} reclaimed`
+                : `would remove ${removed.length} item(s), ${human(sum(removed))} (dry run, pass --apply)`
+        );
+        for (const i of removed) console.log(`  ${i.path}`);
+        for (const i of vanished) {
+            console.log(`  gone before the sweep reached it: ${i.path}`);
+        }
+        for (const i of failed) console.log(`  FAILED ${i.path}: ${i.error}`);
+        console.log('');
+    }
+
+    section('safe', by('safe'));
+    console.log('');
+    section('ask first', by('ask'));
+    console.log('');
+    section('held', by('held'));
+    console.log(`\nfenced (${by('never').length}) - considered and refused`);
+    for (const i of by('never')) console.log(`  ${i.id.padEnd(34)} ${i.why}`);
+
+    if (extras.listeners.length) {
+        console.log('\nlisteners (this skill never kills anything)');
+        for (const l of extras.listeners) {
+            console.log(`  :${l.Port} ${l.Proc ?? '?'} pid ${l.Pid}`);
+        }
+        console.log(
+            '  owner: node .claude/skills/floe-run/scripts/floe-run.mjs stop'
+        );
+    }
+    if (extras.externals.length) {
+        console.log('\nnot swept, reported only');
+        for (const n of extras.externals) {
+            console.log(`  ${n.what.padEnd(22)} ${n.detail}`);
+        }
+    }
+    if (opts.firewall) {
+        console.log(
+            `\nfirewall rules naming a missing file (${extras.firewall.length})`
+        );
+        for (const f of extras.firewall) {
+            console.log(
+                `  ${f.action.padEnd(5)} ${f.enabled.padEnd(5)} ${f.program}`
+            );
+        }
+        if (extras.firewall.length) {
+            console.log(
+                '  removing these needs an elevated shell and is your call.'
+            );
+        }
+    }
+}
+
+function main() {
+    let opts;
+    try {
+        opts = parseArgs(process.argv.slice(2));
+    } catch (e) {
+        console.error(`usage error: ${e.message}`);
+        return 2;
+    }
+    if (opts.help) {
+        console.log(
+            'usage: deep-clean.mjs [survey|sweep] [--apply] [--root dir]\n' +
+                '       [--age-minutes n] [--scratch-days n] [--include id]\n' +
+                '       [--keep path] [--firewall] [--verbose] [--json] [--self-test]'
+        );
+        return 0;
+    }
+    if (opts.selfTest) return selfTest(opts.root);
+
+    // Invariant 4: a root that is not a Floe checkout cannot move the fence.
+    if (!exists(path.join(opts.root, '.git'))) {
+        console.error(`precondition: ${opts.root} is not a git checkout`);
+        return 3;
+    }
+    if (!exists(path.join(opts.root, 'CLAUDE.md'))) {
+        console.error(
+            `precondition: ${opts.root} has no CLAUDE.md, so it does not look like a Floe checkout.\n` +
+                '  Refusing, because --root also decides where the deny list is anchored.'
+        );
+        return 3;
+    }
+    for (const k of opts.keeps) {
+        const resolved = path.resolve(opts.root, k);
+        if (!exists(resolved)) {
+            console.error(
+                `usage error: --keep ${k} does not exist (resolved to ${resolved})`
+            );
+            return 2;
+        }
+    }
+
+    const built = buildCandidates(opts);
+    if (built.error) {
+        console.error(`precondition: ${built.error}`);
+        return 3;
+    }
+    const { items } = built;
+
+    const includeIds = new Set(opts.includes);
+    for (const id of includeIds) {
+        const hit = items.find((i) => i.id === id);
+        if (!hit) {
+            console.error(`usage error: --include ${id} matches no candidate`);
+            return 2;
+        }
+        if (hit.bucket !== 'ask') {
+            console.error(
+                `usage error: --include ${id} is in the ${hit.bucket} bucket, only ask items can be promoted`
+            );
+            return 2;
+        }
+        if (hit.recent) {
+            console.error(
+                `usage error: --include ${id} was touched in the last ${opts.ageMinutes} min.\n` +
+                    '  Another session may be writing to it. Wait, or re-run with an explicit\n' +
+                    '  --age-minutes if you are certain nothing else is using it.'
+            );
+            return 2;
+        }
+    }
+
+    let result = null;
+    if (opts.cmd === 'sweep') {
+        try {
+            result = sweep(items, built, opts.apply, includeIds, (t) =>
+                console.log(`removed ${t.path}`)
+            );
+        } catch (e) {
+            console.error(e.message);
+            for (const r of e.removed ?? []) {
+                console.error(`  already removed: ${r.path}`);
+            }
+            return Number.isInteger(e.code) ? e.code : 1;
+        }
+        if (opts.apply) {
+            const gone = new Set(result.removed.map((i) => i.id));
+            for (const i of items) if (gone.has(i.id)) i.bucket = 'swept';
+        }
+    }
+
+    const extras = {
+        listeners: listeners(),
+        externals: externals(opts.root),
+        firewall: opts.firewall ? firewallReport() : [],
+    };
+
+    if (opts.json) {
+        console.log(
+            JSON.stringify({ root: opts.root, items, result, extras }, null, 2)
+        );
+    } else {
+        render(items, opts, result, extras);
+    }
+
+    if (opts.cmd === 'sweep') {
+        if (result.failed.length) return 5;
+        return result.removed.length ? 1 : 0;
+    }
+    return items.filter((i) => i.bucket === 'safe' || i.bucket === 'ask').length
+        ? 1
+        : 0;
+}
+
+if (
+    import.meta.url === `file://${process.argv[1]}` ||
+    process.argv[1] === fileURLToPath(import.meta.url)
+) {
+    process.exit(main());
+}

--- a/.claude/skills/deep-clean/scripts/deep-clean.test.mjs
+++ b/.claude/skills/deep-clean/scripts/deep-clean.test.mjs
@@ -1,0 +1,826 @@
+#!/usr/bin/env node
+/**
+ * Tests for deep-clean.mjs.
+ *
+ * The suite builds a synthetic checkout and a synthetic temp dir, both
+ * seeded with decoys: files that look exactly like debris and must never
+ * be swept. Every assertion that matters is of the form "this decoy still
+ * exists after sweep --apply", because the failure this script must never
+ * have is deleting something precious, not missing some junk.
+ *
+ * The fixture is a real git repo (git init plus git add, no commit) so the
+ * tracked-file check is exercised for real rather than mocked.
+ *
+ * The "regressions" block is the important one. Every case in it is a
+ * defect a red-team agent actually reproduced against an earlier version
+ * of this script on 2026-09-02, most of them ending in real deletion of
+ * committed files. They are written as tests so they cannot come back.
+ *
+ * Run: node --test .claude/skills/deep-clean/scripts/deep-clean.test.mjs
+ */
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { makeFence, parseFirewall, scanContents } from './deep-clean.mjs';
+
+const SCRIPT = fileURLToPath(new URL('./deep-clean.mjs', import.meta.url));
+const DAY = 86400000;
+
+let BASE;
+let REPO;
+let TEMP;
+let LINK;
+let DECOYS;
+
+function w(p, body = 'x') {
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, body);
+    return p;
+}
+
+function walk(p) {
+    const out = [];
+    let st;
+    try {
+        st = fs.lstatSync(p);
+    } catch {
+        return out;
+    }
+    if (!st.isDirectory() || st.isSymbolicLink()) return out;
+    for (const e of fs.readdirSync(p)) {
+        const c = path.join(p, e);
+        out.push(c, ...walk(c));
+    }
+    return out;
+}
+
+function age(p, days) {
+    const t = new Date(Date.now() - days * DAY);
+    for (const f of [...walk(p), p]) {
+        try {
+            fs.utimesSync(f, t, t);
+        } catch {
+            /* best effort */
+        }
+    }
+}
+
+/** Try to make a directory link. Returns the path, or null if unprivileged. */
+function tryLink(target, linkPath) {
+    try {
+        fs.symlinkSync(target, linkPath, 'junction');
+        return linkPath;
+    } catch {
+        try {
+            fs.symlinkSync(target, linkPath, 'dir');
+            return linkPath;
+        } catch {
+            return null;
+        }
+    }
+}
+
+/** Run the script. Never throws on a non-zero exit. */
+function run(args) {
+    try {
+        const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+            encoding: 'utf8',
+            maxBuffer: 64 * 1024 * 1024,
+        });
+        return { code: 0, stdout, stderr: '' };
+    } catch (e) {
+        return {
+            code: e.status ?? -1,
+            stdout: e.stdout ?? '',
+            stderr: e.stderr ?? '',
+        };
+    }
+}
+
+function inRepo(repo, temp, args) {
+    return run([...args, '--root', repo, '--temp-root', temp]);
+}
+
+function survey(extra = []) {
+    const r = inRepo(REPO, TEMP, [
+        'survey',
+        '--json',
+        '--age-minutes',
+        '0',
+        ...extra,
+    ]);
+    return { code: r.code, data: JSON.parse(r.stdout) };
+}
+
+function bucketOf(data, id) {
+    return data.items.find((i) => i.id === id)?.bucket ?? '(absent)';
+}
+
+/** A minimal repo that passes the --root marker check. */
+function newRepo(base, name) {
+    const repo = path.join(base, name);
+    fs.mkdirSync(repo, { recursive: true });
+    execFileSync('git', ['init', '-q'], { cwd: repo });
+    w(path.join(repo, 'CLAUDE.md'), '# marker');
+    execFileSync('git', ['add', 'CLAUDE.md'], { cwd: repo });
+    return repo;
+}
+
+/* ------------------------------------------------------------- fixture */
+
+function build() {
+    BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'deep-clean-test-'));
+    REPO = newRepo(BASE, 'repo');
+    TEMP = path.join(BASE, 'temp');
+    fs.mkdirSync(TEMP, { recursive: true });
+
+    const tracked = w(path.join(REPO, 'keeper.txt'), 'tracked');
+    const trackedDecoy = w(
+        path.join(REPO, 'client', 'tsconfig.tsbuildinfo'),
+        'tracked'
+    );
+    execFileSync('git', ['add', 'keeper.txt', 'client/tsconfig.tsbuildinfo'], {
+        cwd: REPO,
+    });
+
+    // Fenced decoys.
+    const env = w(path.join(REPO, 'server', '.env'), 'UPSTASH_TOKEN=live');
+    const envLocal = w(path.join(REPO, 'client', '.env.local'), 'x');
+    const turn = w(path.join(REPO, 'coturn', 'turnserver.conf'), 'secret');
+    const dist = w(
+        path.join(REPO, 'desktop', 'frontend', 'dist', 'index.html')
+    );
+    const goWorkSum = w(path.join(REPO, 'go.work.sum'), 'x');
+    const auditBin = w(path.join(TEMP, 'floe-audit', 'bin', 'floe.exe'));
+
+    // A denied file buried inside an otherwise safe directory. rmSync is
+    // recursive, so this is the one that used to die silently.
+    const buriedEnv = w(
+        path.join(REPO, 'client', '.next', 'cache', '.env.production'),
+        'SECRET=1'
+    );
+    const buriedZip = w(
+        path.join(REPO, 'client', 'playwright-report', 'floe_transfer_9.zip'),
+        'media'
+    );
+
+    // Safe artifacts.
+    w(path.join(REPO, 'client', '.next', 'build.bin'), 'z'.repeat(4096));
+    w(path.join(REPO, 'client', 'test-results', '.last-run.json'));
+    w(path.join(REPO, 'desktop', 'desktop.exe'));
+    w(path.join(TEMP, 'floe-win-fixed.exe'));
+
+    // Ask items.
+    w(path.join(REPO, 'floe.exe'));
+    w(path.join(REPO, '.refactor-audit', 'notes.md'));
+    w(path.join(TEMP, 'floe-audit', 'out', 'report.md'));
+    w(path.join(REPO, 'node_modules', 'pkg', 'index.js'));
+
+    // Scratchpads: empty, stale, fresh.
+    const slug = path.resolve(REPO).replace(/[:\\/]/g, '-');
+    const scratch = path.join(TEMP, 'claude', slug);
+    fs.mkdirSync(path.join(scratch, 'empty-session'), { recursive: true });
+    const stale = path.join(scratch, 'stale-session');
+    w(path.join(stale, 'old.bin'), 'y'.repeat(2048));
+    age(stale, 30);
+    const fresh = path.join(scratch, 'fresh-session');
+    w(path.join(fresh, 'live.bin'), 'y'.repeat(2048));
+
+    LINK = tryLink(
+        path.join(REPO, 'server'),
+        path.join(TEMP, 'floeprobe_link')
+    );
+
+    DECOYS = [
+        tracked,
+        trackedDecoy,
+        env,
+        envLocal,
+        turn,
+        dist,
+        goWorkSum,
+        auditBin,
+        buriedEnv,
+        buriedZip,
+        path.join(fresh, 'live.bin'),
+    ];
+}
+
+before(build);
+
+after(() => {
+    try {
+        fs.rmSync(BASE, { recursive: true, force: true, maxRetries: 5 });
+    } catch {
+        /* windows may hold a handle briefly; the temp dir is disposable */
+    }
+});
+
+/* --------------------------------------------------------------- tests */
+
+describe('fence', () => {
+    it('refuses every never-touch path', () => {
+        const fence = makeFence(REPO, [], TEMP);
+        const home = os.homedir();
+        const appdata =
+            process.env.APPDATA || path.join(home, 'AppData', 'Roaming');
+        const localapp =
+            process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local');
+        for (const p of [
+            path.join(REPO, 'server', '.env'),
+            path.join(REPO, 'client', '.env.local'),
+            path.join(REPO, 'coturn', 'turnserver.conf'),
+            path.join(REPO, 'desktop', 'frontend', 'dist'),
+            path.join(REPO, 'go.work'),
+            path.join(REPO, 'go.work.sum'),
+            path.join(REPO, '.claude', 'settings.local.json'),
+            path.join(REPO, '.git', 'config'),
+            path.join(REPO, 'client', '.next', 'x', '.env.local'),
+            path.join(appdata, 'floe'),
+            path.join(appdata, 'floe', 'desktop.json'),
+            path.join(localapp, 'ms-playwright', 'chromium-1234'),
+            path.join(home, 'floe_transfer_1779272746482.zip'),
+            path.join(home, '.claude', 'plans'),
+            path.join(home, '.claude', 'projects', 'p', 'memory'),
+            path.join(TEMP, 'floe-audit', 'bin'),
+            path.join(TEMP, 'floe-audit', 'bin', 'floe.exe'),
+            REPO,
+            TEMP,
+            home,
+            path.join(home, 'Documents'),
+            'C:\\Windows\\System32',
+            '/etc/passwd',
+        ]) {
+            assert.notEqual(fence(p), null, `fence should refuse ${p}`);
+        }
+    });
+
+    it('allows genuine artifacts', () => {
+        const fence = makeFence(REPO, [], TEMP);
+        for (const p of [
+            path.join(REPO, 'client', '.next'),
+            path.join(REPO, 'client', 'playwright-report'),
+            path.join(TEMP, 'floe-win-fixed.exe'),
+        ]) {
+            assert.equal(fence(p), null, `fence should allow ${p}`);
+        }
+    });
+
+    /**
+     * .env.example and .env.docker.example are committed public templates,
+     * so the deny-by-name rule deliberately exempts them. Denying them
+     * fenced 319 MB of dead scratchpads that held nothing but a copy of the
+     * repo. The tracked-file check is what protects the real ones.
+     */
+    it('exempts .env.example from the environment-file rule', () => {
+        const fence = makeFence(REPO, [], TEMP);
+        assert.equal(fence(path.join(REPO, 'x', '.env.example')), null);
+        assert.equal(fence(path.join(REPO, 'x', '.env.docker.example')), null);
+        assert.notEqual(fence(path.join(REPO, 'x', '.env')), null);
+        assert.notEqual(fence(path.join(REPO, 'x', '.env.production')), null);
+        // and a name that merely starts with the same letters is not a match
+        assert.equal(fence(path.join(REPO, 'x', '.environment')), null);
+    });
+
+    it('refuses a link at the leaf', () => {
+        if (!LINK) return;
+        assert.notEqual(makeFence(REPO, [], TEMP)(LINK), null);
+    });
+
+    it('honours --keep, which is only ever restrictive', () => {
+        const target = path.join(REPO, 'client', '.next');
+        assert.equal(makeFence(REPO, [], TEMP)(target), null);
+        assert.notEqual(makeFence(REPO, [target], TEMP)(target), null);
+    });
+});
+
+describe('scanContents', () => {
+    it('finds a denied name at any depth', () => {
+        const hit = scanContents(path.join(REPO, 'client', '.next'), [
+            REPO,
+            TEMP,
+        ]);
+        assert.ok(hit, 'a buried .env must be found');
+        assert.match(hit.path, /\.env\.production$/);
+    });
+
+    it('passes a clean directory', () => {
+        assert.equal(
+            scanContents(path.join(REPO, 'client', 'test-results'), [
+                REPO,
+                TEMP,
+            ]),
+            null
+        );
+    });
+
+    it('marks a secret hard and a nested git repo soft', () => {
+        const hard = scanContents(path.join(REPO, 'client', '.next'), [
+            REPO,
+            TEMP,
+        ]);
+        assert.equal(hard.hard, true, 'a buried .env is a hard refusal');
+
+        const dir = path.join(TEMP, 'carrier');
+        w(path.join(dir, 'sub', '.git', 'HEAD'), 'ref');
+        const soft = scanContents(dir, [REPO, TEMP]);
+        assert.ok(soft);
+        assert.equal(soft.hard, false, 'a nested git repo is a judgment call');
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+});
+
+describe('survey', () => {
+    it('classifies artifacts as safe', () => {
+        const { data } = survey();
+        for (const id of ['pw-results', 'desktop-stray-exe']) {
+            assert.equal(bucketOf(data, id), 'safe', id);
+        }
+        assert.equal(bucketOf(data, 'tmp:floe-win-fixed.exe'), 'safe');
+    });
+
+    it('never puts a tracked file in the safe bucket', () => {
+        const hit = survey().data.items.find(
+            (i) => i.id === 'next-tsbuildinfo'
+        );
+        assert.equal(hit.bucket, 'never');
+        assert.equal(hit.why, 'tracked by git');
+    });
+
+    it('fences the embedded desktop dist', () => {
+        assert.equal(bucketOf(survey().data, 'desktop-dist'), 'never');
+    });
+
+    it('refuses a safe directory that carries a denied file', () => {
+        const { data } = survey();
+        for (const id of ['next-build', 'pw-report']) {
+            const hit = data.items.find((i) => i.id === id);
+            assert.equal(hit.bucket, 'never', id);
+            assert.match(hit.why, /^carries /);
+        }
+    });
+
+    it('puts reinstall-cost and ambiguous items in ask', () => {
+        const { data } = survey();
+        for (const id of [
+            'nm-root',
+            'root-exe',
+            'untracked:.refactor-audit',
+            'next-agents',
+            'next-claude',
+        ]) {
+            if (bucketOf(data, id) === '(absent)') continue;
+            assert.equal(bucketOf(data, id), 'ask', id);
+        }
+    });
+
+    it('sorts scratchpads by age, not by name', () => {
+        const { data } = survey();
+        assert.equal(bucketOf(data, 'scratchpad:empty-session'), 'safe');
+        assert.equal(bucketOf(data, 'scratchpad:stale-session'), 'safe');
+        assert.equal(bucketOf(data, 'scratchpad:fresh-session'), 'ask');
+    });
+
+    it('holds a recently touched artifact when the age guard is armed', () => {
+        const r = inRepo(REPO, TEMP, [
+            'survey',
+            '--json',
+            '--age-minutes',
+            '600',
+        ]);
+        const data = JSON.parse(r.stdout);
+        assert.equal(bucketOf(data, 'pw-results'), 'held');
+    });
+
+    it('exits 1 when there is something to do', () => {
+        assert.equal(survey().code, 1);
+    });
+});
+
+describe('sweep', () => {
+    it('deletes nothing without --apply', () => {
+        const r = inRepo(REPO, TEMP, ['sweep', '--age-minutes', '0']);
+        assert.equal(r.code, 1);
+        assert.ok(fs.existsSync(path.join(REPO, 'desktop', 'desktop.exe')));
+        assert.match(r.stdout, /dry run/);
+    });
+
+    it('refuses to promote a fenced or tracked id', () => {
+        for (const id of ['desktop-dist', 'next-tsbuildinfo', 'next-build']) {
+            const r = inRepo(REPO, TEMP, [
+                'sweep',
+                '--age-minutes',
+                '0',
+                '--include',
+                id,
+                '--apply',
+            ]);
+            assert.equal(r.code, 2, `--include ${id} must be a usage error`);
+        }
+    });
+
+    it('refuses to promote an item another session may be writing', () => {
+        const r = inRepo(REPO, TEMP, [
+            'sweep',
+            '--age-minutes',
+            '600',
+            '--include',
+            'scratchpad:fresh-session',
+            '--apply',
+        ]);
+        assert.equal(r.code, 2);
+        assert.match(r.stderr, /touched in the last/);
+    });
+
+    it('removes the safe bucket and nothing else', () => {
+        const r = inRepo(REPO, TEMP, [
+            'sweep',
+            '--age-minutes',
+            '0',
+            '--apply',
+        ]);
+        assert.equal(r.code, 1);
+        for (const p of [
+            path.join(REPO, 'client', 'test-results'),
+            path.join(REPO, 'desktop', 'desktop.exe'),
+            path.join(TEMP, 'floe-win-fixed.exe'),
+        ]) {
+            assert.ok(!fs.existsSync(p), `${p} should have been swept`);
+        }
+        for (const p of DECOYS) {
+            assert.ok(fs.existsSync(p), `DECOY DESTROYED: ${p}`);
+        }
+        for (const p of [
+            path.join(REPO, 'floe.exe'),
+            path.join(REPO, '.refactor-audit', 'notes.md'),
+            path.join(REPO, 'node_modules', 'pkg', 'index.js'),
+            path.join(TEMP, 'floe-audit', 'out', 'report.md'),
+        ]) {
+            assert.ok(fs.existsSync(p), `${p} is ask, it must survive`);
+        }
+    });
+
+    it('is idempotent', () => {
+        const r = inRepo(REPO, TEMP, [
+            'sweep',
+            '--age-minutes',
+            '0',
+            '--apply',
+        ]);
+        assert.equal(r.code, 0, 'a second sweep has nothing left to do');
+    });
+
+    it('promotes a single ask item by id when told to', () => {
+        const target = path.join(REPO, 'floe.exe');
+        assert.ok(fs.existsSync(target));
+        const r = inRepo(REPO, TEMP, [
+            'sweep',
+            '--age-minutes',
+            '0',
+            '--include',
+            'root-exe',
+            '--apply',
+        ]);
+        assert.equal(r.code, 1);
+        assert.ok(!fs.existsSync(target));
+        assert.ok(
+            fs.existsSync(path.join(REPO, 'node_modules', 'pkg', 'index.js'))
+        );
+        for (const p of DECOYS) assert.ok(fs.existsSync(p), `DECOY: ${p}`);
+    });
+});
+
+describe('regressions (each one was a real, reproduced deletion)', () => {
+    /**
+     * An ancestor junction at client/ used to make tracked, committed files
+     * classify as safe, because the fence resolved the path but the git
+     * check and rmSync did not. Five committed files died.
+     */
+    it('an ancestor link cannot launder a tracked path into the safe bucket', () => {
+        const base = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-anc-'));
+        try {
+            const repo = newRepo(base, 'repo');
+            const temp = path.join(base, 'temp');
+            fs.mkdirSync(temp, { recursive: true });
+            w(
+                path.join(repo, 'apps', 'web', 'test-results', 'baseline.png'),
+                'p'
+            );
+            execFileSync('git', ['add', '-A'], { cwd: repo });
+            const linked = tryLink(
+                path.join(repo, 'apps', 'web'),
+                path.join(repo, 'client')
+            );
+            if (!linked) return; // unprivileged box, nothing to assert
+
+            const r = run([
+                'survey',
+                '--root',
+                repo,
+                '--temp-root',
+                temp,
+                '--json',
+                '--age-minutes',
+                '0',
+            ]);
+            const data = JSON.parse(r.stdout);
+            const hit = data.items.find((i) => i.id === 'pw-results');
+            if (hit) {
+                assert.equal(
+                    hit.bucket,
+                    'never',
+                    'must not be swept via a link'
+                );
+                assert.match(hit.why, /link|tracked/);
+            }
+            run([
+                'sweep',
+                '--root',
+                repo,
+                '--temp-root',
+                temp,
+                '--age-minutes',
+                '0',
+                '--apply',
+            ]);
+            assert.ok(
+                fs.existsSync(
+                    path.join(
+                        repo,
+                        'apps',
+                        'web',
+                        'test-results',
+                        'baseline.png'
+                    )
+                ),
+                'the committed file behind the link must survive'
+            );
+        } finally {
+            fs.rmSync(base, { recursive: true, force: true, maxRetries: 5 });
+        }
+    });
+
+    /** --root one level up used to widen the allow root and move the deny list. */
+    it('refuses a --root that is not a Floe checkout', () => {
+        const base = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-root-'));
+        try {
+            execFileSync('git', ['init', '-q'], { cwd: base });
+            w(path.join(base, 'server', '.env'), 'SECRET');
+            const r = run(['sweep', '--root', base, '--apply']);
+            assert.equal(r.code, 3, 'no CLAUDE.md means refuse');
+            assert.match(r.stderr, /does not look like a Floe checkout/);
+            assert.ok(fs.existsSync(path.join(base, 'server', '.env')));
+        } finally {
+            fs.rmSync(base, { recursive: true, force: true, maxRetries: 5 });
+        }
+    });
+
+    /** --keep used to be matched as a raw string against canonical paths. */
+    it('--keep protects across equivalent spellings', () => {
+        const target = path.join(REPO, 'client', 'blob-report');
+        w(path.join(target, 'x.json'));
+        const spellings = [
+            target,
+            target.replace(/\\/g, '/'),
+            path.join(REPO, 'client', '..', 'client', 'blob-report'),
+            'client/blob-report',
+        ];
+        for (const s of spellings) {
+            const r = inRepo(REPO, TEMP, [
+                'sweep',
+                '--age-minutes',
+                '0',
+                '--keep',
+                s,
+                '--apply',
+            ]);
+            assert.notEqual(r.code, 2, `--keep ${s} should be accepted`);
+            assert.ok(fs.existsSync(target), `--keep ${s} failed to protect`);
+        }
+        fs.rmSync(target, { recursive: true, force: true });
+    });
+
+    it('rejects a --keep that does not exist rather than silently ignoring it', () => {
+        const r = inRepo(REPO, TEMP, ['survey', '--keep', 'no/such/path']);
+        assert.equal(r.code, 2);
+        assert.match(r.stderr, /does not exist/);
+    });
+
+    /** A vanished candidate used to be counted as reclaimed bytes. */
+    it('reports a vanished candidate honestly instead of claiming it', () => {
+        const base = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-van-'));
+        try {
+            const repo = newRepo(base, 'repo');
+            const temp = path.join(base, 'temp');
+            fs.mkdirSync(temp, { recursive: true });
+            w(path.join(repo, 'client', 'test-results', 'a.json'));
+            const r = run([
+                'sweep',
+                '--root',
+                repo,
+                '--temp-root',
+                temp,
+                '--age-minutes',
+                '0',
+                '--apply',
+            ]);
+            assert.equal(r.code, 1);
+            assert.match(r.stdout, /removed 1 item/);
+        } finally {
+            fs.rmSync(base, { recursive: true, force: true, maxRetries: 5 });
+        }
+    });
+});
+
+describe('regressions found by the second red team', () => {
+    /**
+     * scanContents returned the FIRST deny hit, so a soft .git met early
+     * masked a hard .env met deeper. That is the layout of every copy of
+     * this repo, and it downgraded never to ask, after which the documented
+     * --include promotion deleted the secret.
+     */
+    it('severity, not traversal order, decides a carried refusal', () => {
+        const dir = path.join(TEMP, 'masker');
+        w(path.join(dir, '.git', 'HEAD'), 'ref');
+        w(path.join(dir, 'sub', 'server', '.env'), 'SECRET');
+        const hit = scanContents(dir, [REPO, TEMP]);
+        assert.ok(hit, 'something must be found');
+        assert.equal(hit.hard, true, 'the .env must win over the .git');
+        assert.match(hit.path, /\.env$/);
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('a masked secret keeps its directory out of the sweep entirely', () => {
+        const base = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-mask-'));
+        try {
+            const repo = newRepo(base, 'repo');
+            const temp = path.join(base, 'temp');
+            const slug = path.resolve(repo).replace(/[:\/]/g, '-');
+            const sess = path.join(temp, 'claude', slug, 'old-session');
+            w(path.join(sess, '.git', 'HEAD'), 'ref');
+            const secret = w(
+                path.join(sess, 'fixture', 'server', '.env'),
+                'LIVE'
+            );
+            age(sess, 30);
+            const r = run([
+                'sweep',
+                '--root',
+                repo,
+                '--temp-root',
+                temp,
+                '--age-minutes',
+                '0',
+                '--include',
+                `scratchpad:old-session`,
+                '--apply',
+            ]);
+            assert.notEqual(r.code, 1, 'must not report a successful removal');
+            assert.ok(fs.existsSync(secret), 'SECRET DESTROYED via the mask');
+        } finally {
+            fs.rmSync(base, { recursive: true, force: true, maxRetries: 5 });
+        }
+    });
+
+    /** ".env " and ".env~" were classified safe and deleted. */
+    it('catches editor backups and trailing-space spellings of .env', () => {
+        const fence = makeFence(REPO, [], TEMP);
+        for (const n of ['.env~', '.env.', '.env.swp', '.env.bak', '.envrc']) {
+            assert.notEqual(
+                fence(path.join(REPO, 'x', n)),
+                null,
+                `${n} must be refused`
+            );
+        }
+        for (const n of [
+            '.env.example',
+            '.env.docker.example',
+            '.environment',
+        ]) {
+            assert.equal(fence(path.join(REPO, 'x', n)), null, `${n} is fine`);
+        }
+    });
+
+    /**
+     * git ls-files stops at a submodule gitlink, so committed files under a
+     * nested repo at client/ classified as safe. Four of them were deleted.
+     */
+    it('refuses a candidate inside a nested git repository', () => {
+        const base = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-sub-'));
+        try {
+            const repo = newRepo(base, 'repo');
+            const temp = path.join(base, 'temp');
+            fs.mkdirSync(temp, { recursive: true });
+            const inner = path.join(repo, 'client');
+            fs.mkdirSync(inner, { recursive: true });
+            execFileSync('git', ['init', '-q'], { cwd: inner });
+            const committed = w(
+                path.join(inner, 'test-results', 'baseline.png'),
+                'PNG'
+            );
+            execFileSync('git', ['add', '-A'], { cwd: inner });
+
+            const r = run([
+                'survey',
+                '--root',
+                repo,
+                '--temp-root',
+                temp,
+                '--json',
+                '--age-minutes',
+                '0',
+            ]);
+            const hit = JSON.parse(r.stdout).items.find(
+                (i) => i.id === 'pw-results'
+            );
+            if (hit) {
+                assert.equal(hit.bucket, 'never');
+                assert.match(hit.why, /nested git repository/);
+            }
+            run([
+                'sweep',
+                '--root',
+                repo,
+                '--temp-root',
+                temp,
+                '--age-minutes',
+                '0',
+                '--apply',
+            ]);
+            assert.ok(
+                fs.existsSync(committed),
+                'a file committed to the nested repo must survive'
+            );
+        } finally {
+            fs.rmSync(base, { recursive: true, force: true, maxRetries: 5 });
+        }
+    });
+
+    /** Invariant 2 leans on rmSync never following a link. Assert it. */
+    it('rmSync unlinks a link without following it', () => {
+        const base = fs.mkdtempSync(path.join(os.tmpdir(), 'dc-rm-'));
+        try {
+            const victim = path.join(base, 'victim');
+            const payload = w(path.join(victim, 'keep.txt'), 'KEEP');
+            const holder = path.join(base, 'holder');
+            fs.mkdirSync(holder);
+            const link = tryLink(victim, path.join(holder, 'link'));
+            if (!link) return;
+            fs.rmSync(holder, { recursive: true, force: true });
+            assert.ok(!fs.existsSync(holder), 'the holder is gone');
+            assert.ok(fs.existsSync(payload), 'the link target must survive');
+        } finally {
+            fs.rmSync(base, { recursive: true, force: true, maxRetries: 5 });
+        }
+    });
+});
+
+describe('preconditions and usage', () => {
+    it('exits 3 outside a git checkout', () => {
+        assert.equal(inRepo(BASE, TEMP, ['survey']).code, 3);
+    });
+
+    it('exits 2 on an unknown command or option', () => {
+        assert.equal(run(['scrub', '--root', REPO]).code, 2);
+        assert.equal(run(['survey', '--root', REPO, '--wat']).code, 2);
+    });
+
+    it('exits 2 when --include names nothing', () => {
+        const r = inRepo(REPO, TEMP, ['sweep', '--include', 'nope', '--apply']);
+        assert.equal(r.code, 2);
+    });
+
+    it('self-test passes', () => {
+        const r = run(['--self-test']);
+        assert.equal(r.code, 0);
+        assert.match(r.stdout, /self-test ok/);
+    });
+});
+
+describe('parseFirewall', () => {
+    it('keeps only rules whose program is gone', () => {
+        const present = SCRIPT.replace(/\\/g, '\\\\');
+        const rows = parseFirewall(`[
+            {"Name":"gone","Action":"Block","Enabled":"False","Program":"C:\\\\nope\\\\floe.exe"},
+            {"Name":"here","Action":"Allow","Enabled":"True","Program":"${present}"}
+        ]`);
+        assert.equal(rows.length, 1);
+        assert.equal(rows[0].name, 'gone');
+        assert.equal(rows[0].action, 'Block');
+    });
+
+    it('tolerates a single object and malformed input', () => {
+        assert.deepEqual(parseFirewall('not json'), []);
+        assert.equal(
+            parseFirewall('{"Name":"x","Program":"C:\\\\nope\\\\a.exe"}')
+                .length,
+            1
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Adds `deep-clean`, an eighth project skill: post-task teardown for the residue
that no existing skill owns.

`floe-run` and `transfer-audit` already tear down what they start, and they do
it carefully (pid image matching, creation-time checks, a sha256-compared
`desktop.json` restore). What had no owner was everything in between. Measured
on one developer box: 440 MB in `client/.next`, 1.8 GB across 190 session
scratchpads (120 of them empty), ~48 MB of stray `go` and `wails` binaries, plus
Playwright reports.

`survey` is read-only and classifies into four buckets. `sweep` removes only the
safe one, and only behind `--apply`.

The skill is a conductor, not a competitor. It kills no process, closes no
browser tab and edits no firewall rule, because the skills that create those
already know how to undo them safely, and because on a developer box most
`node.exe` processes are MCP servers rather than dev leftovers.

### The fence is code, not a checklist

A cleanup tool's only real failure mode is deleting something precious, so the
never-delete list is enforced at classify time and again immediately before
every removal. Deny beats allow. Five invariants, each one the residue of a
defect a red team reproduced against an earlier draft of this branch:

1. **Nothing is reached through a link.** An ancestor junction at `client/` made
   tracked, committed files classify as `safe`; a sweep deleted five of them.
   The fence now refuses a candidate whose leaf or any ancestor is a link.
2. **A directory is only as safe as its contents, and severity beats traversal
   order.** `rmSync` is recursive. A soft nested `.git` found early masked a hard
   `.env` found deeper, which is the layout of every copy of this repo, and
   `--include` could then delete the secret.
3. **An unknown age is not a young age.** A capped walk read a stale mtime and
   classified a live session's scratchpad as `safe`. The mtime walk is now
   uncapped and a capped measurement can never be `safe`.
4. **`--root` cannot move the fence.** It is anchored at both the given root and
   this checkout, and a root with no `CLAUDE.md` is refused.
5. **A git boundary hides files the way a link does.** `git ls-files` stops at a
   submodule gitlink, so a nested repo laundered committed files into `safe`.

Protected in code: `server/.env` and every `.env` spelling (including `.env~`
and trailing-space variants, but not the committed `.env.example` templates),
`coturn/turnserver.conf`, `%APPDATA%\floe`, `floe_transfer_*.zip`,
`desktop/frontend/dist` (gitignored but consumed by `//go:embed`), the operator
`--bin-dir`, the shared Playwright install, and `~/.claude/plans` and
`~/.claude/projects`.

The 30-minute age guard exists because several Claude Code sessions run against
one checkout at a time; it is what stops one session sweeping another's
in-flight work.

## Test plan

- `node .claude/skills/deep-clean/scripts/deep-clean.mjs --self-test` passes
  (22 fence assertions, no filesystem writes).
- `node --test .claude/skills/deep-clean/scripts/deep-clean.test.mjs` passes
  (38 cases). The assertions that matter are decoy survival after
  `sweep --apply`, not junk removal. Two `regressions` blocks cover every defect
  the two red-team rounds reproduced, including the ancestor-link case that
  deleted committed files and the severity-masking case that reached a secret.
- Live read-only `survey` against this checkout: buckets correct, `client/.next`
  correctly `held` while another session was building it, three scratchpads
  correctly fenced for carrying a stray `.env`.
- The original critical attack replayed against the merged version: previously
  5 committed files deleted, now 0.
- Prettier clean; zero em dashes or en dashes.
- Left to CI: the full matrix. Nothing outside `.claude/skills/deep-clean/`
  changed, and no CI job runs skill test suites, so a green run here proves the
  existing suite is unaffected rather than that this skill works. The evidence
  for the skill itself is the runs listed above.
