### PR TITLE
fix(engine): stop the signaling read loop wedging on a repeated frame

### DIFF
--- a/cli/engine/signaling/client.go
+++ b/cli/engine/signaling/client.go
@@ -152,11 +152,26 @@ func (c *Client) readLoop() {
 		}
 
 		switch msg.Type {
+		// Non-blocking, like every other case below. Both channels are buffered
+		// to 1 and every consumer reads them exactly once, so a second frame can
+		// only arrive when nobody is waiting for it. The server re-sends
+		// user-connected to the room's first peer on every second-peer join and
+		// keeps the surviving seat across a one-sided drop, so a receiver that
+		// dropped and rejoined twice filled the buffer and then wedged this loop
+		// for good. readLoop is the only reader of the socket, so a wedge here
+		// silently stops trickle ICE and the transfer dies at the 30s connect
+		// timeout with nothing to diagnose from.
 		case "room-joined":
-			c.Role <- msg.Role
+			select {
+			case c.Role <- msg.Role:
+			default:
+			}
 
 		case "user-connected":
-			c.PeerConnected <- msg.ID
+			select {
+			case c.PeerConnected <- msg.ID:
+			default:
+			}
 
 		case "signal":
 			if len(msg.Signal) > 0 {

--- a/cli/engine/signaling/client_test.go
+++ b/cli/engine/signaling/client_test.go
@@ -1,0 +1,183 @@
+package signaling
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestToWSScheme(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"https://api.floe.one", "wss://api.floe.one"},
+		{"http://localhost:3001", "ws://localhost:3001"},
+		{"wss://api.floe.one", "wss://api.floe.one"},
+		{"ws://localhost:3001", "ws://localhost:3001"},
+		// Not a URL at all: passed through rather than guessed at, so the dial
+		// fails with the string the user typed instead of a mangled one.
+		{"api.floe.one", "api.floe.one"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := toWSScheme(c.in); got != c.want {
+			t.Errorf("toWSScheme(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestOriginFromServer(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// The two known deployments map to their web app, not to themselves.
+		{"https://api.floe.one", "https://floe.one"},
+		{"http://localhost:3001", "http://localhost:3000"},
+		// Everything else keeps its own origin, so a self-hosted server is not
+		// misrepresented as floe.one to its own CORS check.
+		{"https://floe.example.com", "https://floe.example.com"},
+		{"https://floe.example.com/", "https://floe.example.com"},
+		{"https://floe.example.com/signal", "https://floe.example.com"},
+		{"https://floe.example.com:8443/x/y", "https://floe.example.com:8443"},
+		{"api.floe.one", "api.floe.one"},
+	}
+	for _, c := range cases {
+		if got := originFromServer(c.in); got != c.want {
+			t.Errorf("originFromServer(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// testServer upgrades one connection and hands the raw socket to write, so a
+// test can push exactly the frame sequence it wants to reproduce.
+func testServer(t *testing.T, write func(*websocket.Conn)) *httptest.Server {
+	t.Helper()
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ws" {
+			http.NotFound(w, r)
+			return
+		}
+		conn, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		write(conn)
+		// Hold the connection open so readLoop is not torn down by the close
+		// before the test has read what it is waiting for.
+		time.Sleep(2 * time.Second)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func dial(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	c, err := Connect(strings.Replace(srv.URL, "http://", "ws://", 1))
+	if err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	t.Cleanup(c.Close)
+	return c
+}
+
+// The regression this package exists to prevent. Role and PeerConnected are
+// buffered to 1 and every consumer reads them exactly once, so a repeated
+// user-connected has nobody waiting for it. The server re-sends user-connected
+// to the room's first peer on every second-peer join and keeps the surviving
+// seat across a one-sided drop, so a receiver that drops and rejoins twice
+// produces exactly this sequence. With a blocking send, the third frame parks
+// readLoop forever; readLoop is the only reader of the socket, so every later
+// signal frame is lost and the peer dies at the connect timeout with a generic
+// message.
+func TestReadLoopSurvivesRepeatedUserConnected(t *testing.T) {
+	srv := testServer(t, func(conn *websocket.Conn) {
+		for i := 0; i < 3; i++ {
+			_ = conn.WriteJSON(map[string]string{"type": "user-connected", "id": "peer"})
+		}
+		_ = conn.WriteJSON(map[string]any{
+			"type":   "signal",
+			"signal": map[string]string{"type": "offer", "sdp": "v=0"},
+		})
+	})
+	c := dial(t, srv)
+
+	select {
+	case <-c.PeerConnected:
+	case <-time.After(3 * time.Second):
+		t.Fatal("no user-connected delivered")
+	}
+
+	// The assertion: dispatch is still running after the surplus frames.
+	select {
+	case raw := <-c.Signal:
+		var got struct{ Type string }
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("signal payload: %v", err)
+		}
+		if got.Type != "offer" {
+			t.Fatalf("signal type = %q, want offer", got.Type)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("signal never arrived: readLoop wedged on a surplus user-connected")
+	}
+}
+
+// Same shape for room-joined. Unreachable today (both the CLI and the desktop
+// call JoinRoom once per Connect), but it is one added rejoin away and the
+// blocking form has the same consequence.
+func TestReadLoopSurvivesRepeatedRoomJoined(t *testing.T) {
+	srv := testServer(t, func(conn *websocket.Conn) {
+		for i := 0; i < 3; i++ {
+			_ = conn.WriteJSON(map[string]string{"type": "room-joined", "role": "sender"})
+		}
+		_ = conn.WriteJSON(map[string]string{"type": "error", "message": "after"})
+	})
+	c := dial(t, srv)
+
+	select {
+	case role := <-c.Role:
+		if role != "sender" {
+			t.Fatalf("role = %q, want sender", role)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("no room-joined delivered")
+	}
+
+	select {
+	case <-c.Errors:
+	case <-time.After(3 * time.Second):
+		t.Fatal("error frame never arrived: readLoop wedged on a surplus room-joined")
+	}
+}
+
+// A closed socket must release anything waiting on PeerLeft rather than
+// leaving a caller blocked with no connection behind it.
+func TestReadLoopSignalsPeerLeftOnClose(t *testing.T) {
+	srv := testServer(t, func(conn *websocket.Conn) { _ = conn.Close() })
+	c := dial(t, srv)
+
+	select {
+	case <-c.PeerLeft:
+	case <-time.After(3 * time.Second):
+		t.Fatal("PeerLeft not signalled after the connection closed")
+	}
+}
+
+// Malformed JSON is skipped, not fatal: one bad frame from a misbehaving proxy
+// must not cost the rest of the session.
+func TestReadLoopSkipsMalformedFrames(t *testing.T) {
+	srv := testServer(t, func(conn *websocket.Conn) {
+		_ = conn.WriteMessage(websocket.TextMessage, []byte("{not json"))
+		_ = conn.WriteJSON(map[string]string{"type": "room-full"})
+	})
+	c := dial(t, srv)
+
+	select {
+	case <-c.RoomFull:
+	case <-time.After(3 * time.Second):
+		t.Fatal("room-full never arrived after a malformed frame")
+	}
+}


### PR DESCRIPTION
## Summary

`readLoop` dispatched four of its six cases through a non-blocking `select` and two — `room-joined` and `user-connected` — through a bare channel send. Both channels are buffered to 1 and every consumer reads them exactly once, so a second frame arrives with nobody waiting for it and a third blocks the send forever.

**The sequence is reachable.** `server.js` sends `user-connected` to the room's first peer on *every* second-peer join, and `handleDisconnect` deliberately keeps the surviving peer's seat so the room survives a one-sided drop. A receiver that drops and rejoins twice therefore produces three `user-connected` frames against a slot the sender read once.

`readLoop` is the only reader of the socket, so once it parks, every later `signal` frame is dropped: trickle ICE stops mid-setup and the peer dies at the 30 s connect timeout with `timed out establishing a connection` and nothing to diagnose from.

Both sends now match the four around them. Dropping a duplicate is strictly better than wedging the loop that delivers everything else, and the first frame — the one anybody actually waits for — is always the one in the buffer.

This is also **the package's first test file**. `engine/signaling` was the only package in `cli/` with zero coverage, and it owns the highest-complexity function in its own package.

## Test plan

- `go test ./engine/signaling` — 6 tests pass (two pure-string tables, the two regression tests, a close-releases-PeerLeft case, and a malformed-frame case).
- **Proved the regression tests fail without the fix.** Restoring the old `client.go` and rerunning:
  ```
  --- FAIL: TestReadLoopSurvivesRepeatedUserConnected (3.00s)
      signal never arrived: readLoop wedged on a surplus user-connected
  --- FAIL: TestReadLoopSurvivesRepeatedRoomJoined (3.00s)
      error frame never arrived: readLoop wedged on a surplus room-joined
  ```
- `go vet ./...` and `go test -count=1 ./...` in `cli/` — every package passes, including the pion loopback and hostile-peer suites.
- `go vet ./...` and `go test -count=1 ./...` in `desktop/` — pass.
- CI arbitrates the other two OS legs, the three e2e legs and back-compat.
