### PR TITLE
fix(engine): release the peer connection's two goroutines on Close

### DIFF
--- a/cli/engine/peer/connection.go
+++ b/cli/engine/peer/connection.go
@@ -98,6 +98,14 @@ type Connection struct {
 	// early is the data channel's message pump, wired the instant the channel
 	// exists rather than when the transfer layer gets around to it. See attach.
 	early *Early
+
+	// done is closed exactly once by Close and is the only thing that stops
+	// dispatchSignals and handleCandidates. Neither sc.Signal nor candidates
+	// is ever closed: dispatchSignals SENDS into candidates, so closing that
+	// channel would race a live send into a panic, and sc.Signal belongs to
+	// the signaling client, whose Close shuts the socket without closing it.
+	closeOnce sync.Once
+	done      chan struct{}
 }
 
 // Early carries a data channel's incoming messages and its close signal.
@@ -235,6 +243,7 @@ func New(iceServers []webrtc.ICEServer, sc *signaling.Client, opts ...Option) (*
 		answers:    make(chan webrtc.SessionDescription, 1),
 		candidates: make(chan webrtc.ICECandidateInit, 64),
 		connected:  make(chan error, 1),
+		done:       make(chan struct{}),
 	}
 
 	// When pion discovers a local ICE candidate, forward it to the remote peer.
@@ -430,8 +439,11 @@ func (conn *Connection) WaitConnected() error {
 	return <-conn.connected
 }
 
-// Close tears down the peer connection.
+// Close tears down the peer connection and releases the two goroutines New
+// started. Idempotent: the CLI defers this once, but the desktop builds a
+// fresh Connection per transfer, so a leak here is unbounded over a session.
 func (conn *Connection) Close() {
+	conn.closeOnce.Do(func() { close(conn.done) })
 	conn.pc.Close()
 }
 
@@ -529,7 +541,18 @@ func (conn *Connection) addRemoteCandidate(c webrtc.ICECandidateInit) {
 // dispatchSignals runs in a goroutine. It reads raw JSON from the signaling
 // channel and routes each message to the offers, answers, or candidates channel.
 func (conn *Connection) dispatchSignals() {
-	for rawSignal := range conn.sc.Signal {
+	for {
+		var rawSignal json.RawMessage
+		select {
+		case <-conn.done:
+			return
+		case raw, ok := <-conn.sc.Signal:
+			if !ok {
+				return
+			}
+			rawSignal = raw
+		}
+
 		var payload signalPayload
 		if err := json.Unmarshal(rawSignal, &payload); err != nil {
 			continue
@@ -557,8 +580,16 @@ func (conn *Connection) dispatchSignals() {
 // handleCandidates runs in a goroutine. It drains the candidates channel and
 // adds each remote ICE candidate (or buffers it if remote desc not yet set).
 func (conn *Connection) handleCandidates() {
-	for c := range conn.candidates {
-		conn.addRemoteCandidate(c)
+	for {
+		select {
+		case <-conn.done:
+			return
+		case c, ok := <-conn.candidates:
+			if !ok {
+				return
+			}
+			conn.addRemoteCandidate(c)
+		}
 	}
 }
 

--- a/cli/engine/peer/connection_test.go
+++ b/cli/engine/peer/connection_test.go
@@ -1,8 +1,10 @@
 package peer
 
 import (
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jannskiee/floe/cli/engine/signaling"
 	"github.com/pion/webrtc/v4"
@@ -90,4 +92,65 @@ func TestWithRelayOnlySetsRelayPolicy(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCloseReleasesGoroutines is the regression test for the leak the desktop
+// pays for. New starts dispatchSignals and handleCandidates; before Close
+// closed conn.done, dispatchSignals ranged over conn.sc.Signal and
+// handleCandidates over conn.candidates, and neither channel is ever closed by
+// anyone. Connection.Close called only pc.Close, so both goroutines parked
+// forever holding a closed *webrtc.PeerConnection alive.
+//
+// It costs nothing in the CLI (one Connection per process, then exit) and is
+// unbounded on the desktop, which builds a fresh Connection for every send and
+// every receive.
+//
+// The count is sampled rather than asserted exactly: pion starts its own
+// goroutines and the runtime keeps some of them briefly after Close. What
+// matters is that the delta does not scale with the number of connections,
+// which is what a per-Connection leak looks like.
+func TestCloseReleasesGoroutines(t *testing.T) {
+	settle := func() int {
+		for i := 0; i < 50; i++ {
+			runtime.GC()
+			time.Sleep(20 * time.Millisecond)
+		}
+		return runtime.NumGoroutine()
+	}
+
+	before := settle()
+
+	const rounds = 20
+	for i := 0; i < rounds; i++ {
+		// A zero-value signaling client leaves sc.Signal nil, so the dispatcher
+		// can never be released by a channel close. done is the only exit, which
+		// is exactly the property under test.
+		conn, err := New(nil, &signaling.Client{})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		conn.Close()
+	}
+
+	after := settle()
+
+	// Two goroutines per Connection would be 40 here. Anything under one per
+	// round means they are being released; the slack absorbs pion's own.
+	if leaked := after - before; leaked >= rounds {
+		t.Fatalf("goroutines grew by %d across %d connections (before %d, after %d): "+
+			"dispatchSignals or handleCandidates is not exiting on Close",
+			leaked, rounds, before, after)
+	}
+}
+
+// Close is called from more than one defer on some paths, and the desktop's
+// cancel path can race it. Closing conn.done twice would panic.
+func TestCloseIsIdempotent(t *testing.T) {
+	conn, err := New(nil, &signaling.Client{})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	conn.Close()
+	conn.Close()
+	conn.Close()
 }


### PR DESCRIPTION
## Summary

`New` starts `dispatchSignals` and `handleCandidates`. `dispatchSignals` ranged over `conn.sc.Signal` and `handleCandidates` over `conn.candidates`, and **neither channel is ever closed by anyone**: `signaling.Client.Close` shuts the socket without closing `Signal`, and nothing closes `candidates` at all. `Connection.Close` called only `pc.Close`, so both goroutines parked forever, each holding a closed `*webrtc.PeerConnection` alive.

It costs nothing in the CLI, which builds one `Connection` per process and then exits. **On the desktop it is unbounded**: `app.go` builds a fresh `Connection` for every send and every receive, so a long session accumulates two parked goroutines and one retained peer connection per transfer.

The fix is a `done` channel closed exactly once by `Close`, which both loops select on.

**Deliberately not closing `conn.candidates`**, which is the obvious-looking alternative: `dispatchSignals` *sends* into that channel, so a close would race a live trickle-ICE candidate into `panic: send on closed channel`. The CLI's defer order makes that window real rather than theoretical — `sc.Close` is deferred first and therefore runs last, so `conn.Close` fires while the socket is still open and `readLoop` is still feeding `Signal`.

`Close` is now idempotent (`sync.Once`), since more than one path defers it and the desktop's cancel can race it.

## Test plan

- `go test ./engine/peer` — `TestCloseReleasesGoroutines` and `TestCloseIsIdempotent` pass.
- **Proved the leak test fails without the fix.** Restoring the old `connection.go`:
  ```
  --- FAIL: TestCloseReleasesGoroutines (2.11s)
      goroutines grew by 40 across 20 connections (before 2, after 42)
  ```
  40 for 20 connections is exactly the two per `Connection` this fixes.
- `go vet ./...` and `go test -count=1 ./...` in `cli/` — all pass, including the pion loopback suite that exercises real `Connection`s end to end.
- `go vet ./...` and `go test -count=1 ./...` in `desktop/` — pass.
- CI arbitrates the other two OS legs, the three e2e legs and back-compat.
