### PR TITLE
fix(engine): bound the HTTP calls, fold code case, and stop two silent hangs

### DIFF
--- a/cli/cmd/floe/main.go
+++ b/cli/cmd/floe/main.go
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jannskiee/floe/cli/engine/code"
@@ -33,6 +34,11 @@ import (
 // Build-time version — set by goreleaser: -ldflags "-X main.version=1.0.0"
 // (GoReleaser's {{ .Version }} strips the tag's leading v.)
 var version = "dev"
+
+// roleAssignTimeout bounds the wait for the server to answer join-room. The
+// desktop copy of the role select has always had it; without it a server that
+// accepts the socket and then goes quiet hangs the command indefinitely.
+const roleAssignTimeout = 20 * time.Second
 
 // Shared flags
 var (
@@ -217,6 +223,9 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to join room: %w", err)
 	}
 
+	// PeerLeft and the deadline are what the desktop copy of this block has
+	// carried all along. Without them a server that accepts the socket and then
+	// goes quiet hangs the command with no output and no way out but Ctrl+C.
 	select {
 	case role := <-sc.Role:
 		if role != "sender" {
@@ -226,6 +235,10 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("room is full")
 	case errMsg := <-sc.Errors:
 		return fmt.Errorf("server error: %s", errMsg)
+	case <-sc.PeerLeft:
+		return fmt.Errorf("connection closed before the server assigned a role")
+	case <-time.After(roleAssignTimeout):
+		return fmt.Errorf("timed out waiting for the server to assign a role")
 	}
 
 	// 5. Register a short code phrase for this room
@@ -372,6 +385,9 @@ func runReceive(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to join room: %w", err)
 	}
 
+	// PeerLeft and the deadline are what the desktop copy of this block has
+	// carried all along. Without them a server that accepts the socket and then
+	// goes quiet hangs the command with no output and no way out but Ctrl+C.
 	select {
 	case role := <-sc.Role:
 		if role != "receiver" {
@@ -385,6 +401,10 @@ func runReceive(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("room is full (someone else may already be receiving)")
 	case errMsg := <-sc.Errors:
 		return fmt.Errorf("server error: %s", errMsg)
+	case <-sc.PeerLeft:
+		return fmt.Errorf("connection closed before the server assigned a role")
+	case <-time.After(roleAssignTimeout):
+		return fmt.Errorf("timed out waiting for the server to assign a role")
 	}
 
 	fmt.Println("  Connecting to sender...")

--- a/cli/engine/code/client.go
+++ b/cli/engine/code/client.go
@@ -10,13 +10,19 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
+
+// client bounds both calls. http.DefaultClient has no timeout, and Resolve's
+// error is fatal to `floe receive`, so this is generous: a slow link that
+// resolves today must keep resolving.
+var client = &http.Client{Timeout: 30 * time.Second}
 
 // Register calls POST /api/code on the signaling server to get a short code
 // that resolves to the given roomId. Returns the code phrase e.g. "olive-tiger-castle".
 func Register(serverURL, roomId string) (string, error) {
 	body, _ := json.Marshal(map[string]string{"roomId": roomId})
-	resp, err := http.Post(serverURL+"/api/code", "application/json", bytes.NewReader(body))
+	resp, err := client.Post(serverURL+"/api/code", "application/json", bytes.NewReader(body))
 	if err != nil {
 		return "", fmt.Errorf("could not register code: %w", err)
 	}
@@ -62,8 +68,12 @@ func Resolve(serverURL, input string) (string, error) {
 		return roomId, nil
 	}
 
-	// Otherwise treat it as a word code and resolve via the server
-	resp, err := http.Get(serverURL + "/api/code/" + url.PathEscape(input))
+	// Otherwise treat it as a word code and resolve via the server. Fold case
+	// first: every entry in the server's words.json is lowercase ASCII and the
+	// lookup is a plain Map.get, so "Olive-Tiger-Castle" (what a phone keyboard
+	// autocapitalizes to) used to be a hard 404 reading "code not found or
+	// expired".
+	resp, err := client.Get(serverURL + "/api/code/" + url.PathEscape(strings.ToLower(input)))
 	if err != nil {
 		return "", fmt.Errorf("could not reach signaling server: %w", err)
 	}

--- a/cli/engine/code/client_test.go
+++ b/cli/engine/code/client_test.go
@@ -1,6 +1,11 @@
 package code
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
 
 // Resolve must accept both the new fragment links (#room=) and the older query
 // links (?room=) so that a link from either the browser or the CLI works in
@@ -35,5 +40,41 @@ func TestResolveURL(t *testing.T) {
 func TestResolveURLWithoutRoom(t *testing.T) {
 	if _, err := Resolve("", "https://floe.one/about"); err == nil {
 		t.Fatal("expected an error for a URL with no room id, got nil")
+	}
+}
+
+// The server keys codeToRoom by the lowercase words in words.json and does a
+// plain Map.get, and nothing on any surface folded case. A phone keyboard
+// autocapitalizes the first letter of a typed code, so "Olive-Tiger-Castle"
+// was a hard 404 reading "code not found or expired".
+func TestResolveFoldsCaseBeforeLookup(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = strings.TrimPrefix(r.URL.Path, "/api/code/")
+		_, _ = w.Write([]byte(`{"roomId":"room-1"}`))
+	}))
+	defer srv.Close()
+
+	roomID, err := Resolve(srv.URL, "Olive-Tiger-Castle")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if roomID != "room-1" {
+		t.Fatalf("roomId = %q, want room-1", roomID)
+	}
+	if got != "olive-tiger-castle" {
+		t.Fatalf("server saw %q, want olive-tiger-castle", got)
+	}
+}
+
+// A URL is not a code phrase: the fragment carries a room id whose case is
+// significant, so the URL branch must not fold it.
+func TestResolveDoesNotFoldRoomIdsInLinks(t *testing.T) {
+	got, err := Resolve("", "https://floe.one/#room=6F207790-92A6-4662-BB68-4C4059F75139")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "6F207790-92A6-4662-BB68-4C4059F75139" {
+		t.Fatalf("Resolve folded a room id in a link: got %q", got)
 	}
 }

--- a/cli/engine/ice/credentials.go
+++ b/cli/engine/ice/credentials.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/pion/webrtc/v4"
 )
@@ -111,14 +112,31 @@ type iceServerJSON struct {
 
 // Fetch fetches ICE server credentials from serverURL/api/turn-credentials.
 // Falls back to Google STUN if the endpoint is unreachable or misconfigured.
+// client bounds the fetch. http.DefaultClient has no timeout at all, so a
+// server that accepts the TCP connection and then never answers used to hang
+// `floe send` at step 2 forever. Generous on purpose: falling back to STUN
+// costs a relay, so a slow-but-working server should still win.
+var client = &http.Client{Timeout: 30 * time.Second}
+
 func Fetch(serverURL string) ([]webrtc.ICEServer, error) {
-	resp, err := http.Get(serverURL + "/api/turn-credentials")
+	resp, err := client.Get(serverURL + "/api/turn-credentials")
 	if err != nil {
 		// Server unreachable — use public Google STUN as fallback
 		fmt.Println("  Warning: could not reach signaling server for TURN credentials. Using STUN only.")
 		return defaults(), nil
 	}
 	defer resp.Body.Close()
+
+	// An HTTP error used to be silent: the body is not a JSON array, Decode
+	// fails, and the STUN-only fallback below returns with nothing printed.
+	// serverurl.go documents the consequence, that a relayed transfer dies with
+	// no message. Say so, but still fall back rather than erroring: both callers
+	// treat a Fetch error as fatal, and a 429 from the TURN limiter is a
+	// documented degrade that today completes over direct STUN.
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("  Warning: signaling server returned %d for TURN credentials. Using STUN only.\n", resp.StatusCode)
+		return defaults(), nil
+	}
 
 	var raw []iceServerJSON
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil || len(raw) == 0 {

--- a/cli/engine/ice/credentials_test.go
+++ b/cli/engine/ice/credentials_test.go
@@ -1,6 +1,8 @@
 package ice
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
@@ -113,5 +115,38 @@ func TestIceURLClass(t *testing.T) {
 		if got := iceURLClass(u); got != want {
 			t.Errorf("iceURLClass(%q) = %q, want %q", u, got, want)
 		}
+	}
+}
+
+// Fetch must never return an error: both callers in cmd/floe treat one as
+// fatal, and a 429 from the server's TURN limiter is a documented degrade that
+// still completes over direct STUN. It must, however, say something. The
+// silent version of this fallback is what serverurl.go's own comment blames
+// for "a relayed transfer dies with no message".
+func TestFetchFallsBackWithoutErroringOnHTTPError(t *testing.T) {
+	for _, status := range []int{429, 500, 404} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"error":"nope"}`))
+		}))
+
+		servers, err := Fetch(srv.URL)
+		srv.Close()
+
+		if err != nil {
+			t.Fatalf("status %d: Fetch returned an error (%v); both callers abort the transfer on one", status, err)
+		}
+		if len(servers) == 0 {
+			t.Fatalf("status %d: Fetch returned no ICE servers; the STUN fallback is what keeps a direct transfer working", status)
+		}
+	}
+}
+
+// A server that accepts the connection and never answers must not hang the
+// command forever. The budget is 30s, so this only proves the client is bounded
+// at all, not the exact number.
+func TestFetchClientHasATimeout(t *testing.T) {
+	if client.Timeout <= 0 {
+		t.Fatal("ice.Fetch runs on a client with no timeout; a black-holing server hangs `floe send` at step 2 indefinitely")
 	}
 }

--- a/cli/internal/selfupdate/selfupdate.go
+++ b/cli/internal/selfupdate/selfupdate.go
@@ -253,7 +253,11 @@ func fromCache() (string, bool) {
 	if err := json.Unmarshal(data, &c); err != nil {
 		return "", false
 	}
-	if time.Since(c.CheckedAt) > cacheTTL {
+	// A negative age (the clock moved backwards since the write, or the file was
+	// hand-edited) is a miss too. Without this a future checked_at never expires
+	// and the update check is pinned off for good. desktop/updatecheck.go has
+	// carried this guard; this is its twin.
+	if age := time.Since(c.CheckedAt); age < 0 || age > cacheTTL {
 		return "", false
 	}
 	return c.Latest, true

--- a/cli/internal/selfupdate/selfupdate_test.go
+++ b/cli/internal/selfupdate/selfupdate_test.go
@@ -1,10 +1,12 @@
 package selfupdate
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 func TestCompareVersions(t *testing.T) {
@@ -164,5 +166,44 @@ func TestCopyFileSetsMode(t *testing.T) {
 		if info.Mode().Perm() != 0o755 {
 			t.Errorf("mode = %v, want 0755", info.Mode().Perm())
 		}
+	}
+}
+
+// A future checked_at must be a miss. Without the guard time.Since is negative,
+// the "> cacheTTL" test is false, and the entry never expires: the update check
+// stays off until wall time catches up to whatever was written. The desktop's
+// twin in desktop/updatecheck.go has always had this.
+func TestFromCacheRejectsAFutureTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	if runtime.GOOS == "windows" {
+		t.Setenv("AppData", dir)
+	}
+	p := cacheFilePath()
+	if p == "" {
+		t.Skip("no user config dir on this machine")
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	write := func(at time.Time) {
+		b, err := json.Marshal(cacheEntry{CheckedAt: at, Latest: "v9.9.9"})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := os.WriteFile(p, b, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	write(time.Now().Add(-time.Minute))
+	if got, ok := fromCache(); !ok || got != "v9.9.9" {
+		t.Fatalf("a fresh entry should hit: got %q ok=%v", got, ok)
+	}
+
+	write(time.Now().Add(72 * time.Hour))
+	if _, ok := fromCache(); ok {
+		t.Fatal("a future checked_at was treated as a hit; the update check would stay pinned off")
 	}
 }


### PR DESCRIPTION
## Summary

Four small defects that all end the same way: the command sits there.

**HTTP budgets.** `ice.Fetch`, `code.Register` and `code.Resolve` all ran on `http.DefaultClient`, whose `Timeout` is zero. A server that accepts the TCP connection and then never answers hung `floe send` at step 2 with a blank line and no way out but Ctrl+C. Every other HTTP call in the repo already sets a budget (5 s, 10 s, 30 s, 5 min). 30 s here on purpose: `Resolve`'s error is fatal to `floe receive`, so a slow-but-working link must keep working.

**`ice.Fetch` reports an HTTP error instead of swallowing it.** On a non-200 the body is not a JSON array, `Decode` fails, and the STUN-only fallback returned with nothing printed. `serverurl.go`'s own comment blames exactly this for "a relayed transfer dies with no message". It still *falls back* rather than erroring: both callers in `cmd/floe` treat a `Fetch` error as fatal, and a 429 from the server's TURN limiter is a documented degrade that completes fine over direct STUN. Returning an error there would abort transfers that work today.

**The role select gains `PeerLeft` and a 20 s deadline** in `runSend` and `runReceive` — the two cases the desktop's byte-identical copy of the same block has always had. Without them a server that accepts the socket and then goes quiet hangs the command with no output.

**`code.Resolve` folds case before the lookup.** The server keys `codeToRoom` by the lowercase words in `words.json` and does a plain `Map.get`, and no surface folded case, so `Olive-Tiger-Castle` — what a phone keyboard autocapitalizes to — was a hard 404 reading "code not found or expired". The URL branch is untouched: a room id in a link is case-significant, and there is a test pinning that.

**`selfupdate`'s cache gains the negative-age guard its desktop twin has.** A future `checked_at` made `time.Since` negative, so the `> cacheTTL` test never fired and the update check stayed pinned off until wall time caught up.

## Test plan

- `go vet ./...` and `go test -count=1 ./...` in `cli/` and `desktop/` — all pass.
- Each new test was checked against the unfixed code:
  - `TestResolveFoldsCaseBeforeLookup` — FAIL before, pass after.
  - `TestFromCacheRejectsAFutureTimestamp` — FAIL before, pass after.
  - `TestFetchFallsBackWithoutErroringOnHTTPError` is **a guard, not a bug proof**, and the PR says so: the old code also returned `(defaults, nil)`. It locks in the property this change could most easily have broken — that `Fetch` never errors. The warning it now prints shows up in `-v`:
    ```
    Warning: signaling server returned 429 for TURN credentials. Using STUN only.
    ```
- `TestResolveDoesNotFoldRoomIdsInLinks` pins the URL branch against the fold.
- CI arbitrates the other two OS legs, the three e2e legs and back-compat.
