### PR TITLE
refactor(engine): fold three verbatim duplicates, and stop two comments lying

### DIFF
--- a/cli/engine/transfer/format.go
+++ b/cli/engine/transfer/format.go
@@ -14,7 +14,7 @@ import (
 // here touches the on-disk name (safeJoin owns that, and its lack of a cap is
 // a compatibility surface) or anything on the wire.
 const (
-	maxDisplayName   = 200 // the browser's MAX_SEGMENT, so both surfaces agree
+	maxDisplayName   = 200 // the browser's MAX_SEGMENT: the two agree on DISPLAY
 	maxDisplayVer    = 64  // real values look like "v1.2.3", "desktop-v0.1.2", "dev"
 	maxDisplayReason = 300 // a current peer's reason is three short lines
 )

--- a/cli/engine/transfer/partial.go
+++ b/cli/engine/transfer/partial.go
@@ -43,6 +43,27 @@ func unregisterPartial(f *os.File) {
 	delete(partialFiles, f)
 }
 
+// discardPart drops a staging file the receive loop is giving up on.
+//
+// The order is the whole correctness argument and it is why this is one
+// function rather than three copies. Unregister FIRST, so a concurrent
+// AbandonPartials cannot pick the handle up after we have decided to drop it.
+// Then use our own Close as the ownership test: it succeeding means abandon
+// never touched this file and the path is still ours to remove; it failing
+// means abandon owned the endgame and has already removed it, so removing by
+// path here would delete whatever now sits at that name. A torture test
+// proved exactly that theft when the code trusted the path string alone.
+//
+// There were three verbatim copies of this before, which is three places to
+// get an ordering this subtle wrong.
+func discardPart(f *os.File) {
+	name := f.Name()
+	unregisterPartial(f)
+	if f.Close() == nil {
+		_ = os.Remove(name)
+	}
+}
+
 // AbandonPartials best-effort removes every in-flight staging file. Close
 // comes first: Go opens files on Windows without FILE_SHARE_DELETE, so
 // removing a file the receive loop still holds open fails with a sharing

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -175,21 +175,10 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 	// in place.
 	defer func() {
 		if currentFile != nil {
-			// Unregister first, then let the owner's own Close arbitrate
-			// ownership of the PATH. AbandonPartials closes registered files
-			// from another goroutine and then removes their paths; once that
-			// has happened, the path may already belong to a brand-new
-			// transfer's staging file, so removing by path would destroy
-			// someone else's bytes (a torture test proved exactly that
-			// theft). Abandon always closes before removing, so the arbiter
-			// is exact: our Close succeeding means abandon never touched the
-			// file and the path is still ours to remove; our Close failing
-			// means abandon owned the endgame and already removed it.
-			name := currentFile.Name()
-			unregisterPartial(currentFile)
-			if currentFile.Close() == nil {
-				_ = os.Remove(name)
-			}
+			// discardPart, not a Close and Remove here: the unregister-then-Close
+			// ordering is what keeps this from deleting another transfer's file,
+			// and it is argued once, on the function.
+			discardPart(currentFile)
 		}
 	}()
 
@@ -225,34 +214,14 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 				// with no completed files is never success: the sender cancelled
 				// or was blocked (for example by its relay size cap), so report
 				// it instead of returning a false "saved" outcome.
-				if currentFile != nil {
-					return fmt.Errorf("connection closed mid-transfer: %s (%d of %d bytes)",
-						currentDisplayName, bytesReceived, currentInfo.FileSize)
-				}
-				if filesReceived == 0 {
-					return fmt.Errorf("connection closed before any file arrived (the sender canceled, or the transfer was blocked)")
-				}
-				if currentInfo.Total > 0 && filesReceived < currentInfo.Total {
-					return fmt.Errorf("connection closed after %d of %d files", filesReceived, currentInfo.Total)
-				}
-				return nil
+				return closedError(currentFile, currentDisplayName, bytesReceived, currentInfo, filesReceived)
 			case <-stallTimer.C:
 				// If the close raced the timer, report the close: it is the
 				// more precise diagnosis, and it keeps behavior identical to
 				// the done case above.
 				select {
 				case <-done:
-					if currentFile != nil {
-						return fmt.Errorf("connection closed mid-transfer: %s (%d of %d bytes)",
-							currentDisplayName, bytesReceived, currentInfo.FileSize)
-					}
-					if filesReceived == 0 {
-						return fmt.Errorf("connection closed before any file arrived (the sender canceled, or the transfer was blocked)")
-					}
-					if currentInfo.Total > 0 && filesReceived < currentInfo.Total {
-						return fmt.Errorf("connection closed after %d of %d files", filesReceived, currentInfo.Total)
-					}
-					return nil
+					return closedError(currentFile, currentDisplayName, bytesReceived, currentInfo, filesReceived)
 				default:
 				}
 				// Phase-aware stall errors. Deliberately no protocol or
@@ -310,13 +279,7 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 				// handle leaks and the abandoned staging file lingers, keeping
 				// its claimed final name blocked.
 				if currentFile != nil {
-					// Unregister, then Close-as-ownership-test; see the
-					// deferred cleanup above.
-					name := currentFile.Name()
-					unregisterPartial(currentFile)
-					if currentFile.Close() == nil {
-						_ = os.Remove(name)
-					}
+					discardPart(currentFile)
 					currentFile = nil
 				}
 				currentInfo = info
@@ -415,11 +378,9 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 				// open and writable, and refusing on a stat hiccup would break a
 				// transfer that would otherwise succeed.
 				if st, statErr := currentFile.Stat(); statErr == nil && !st.Mode().IsRegular() {
+					// Read the name before discarding: discardPart closes the handle.
 					name := currentFile.Name()
-					unregisterPartial(currentFile)
-					if currentFile.Close() == nil {
-						_ = os.Remove(name)
-					}
+					discardPart(currentFile)
 					currentFile = nil
 					return fmt.Errorf("refusing to write %s: not a regular file (%s)",
 						name, st.Mode())
@@ -618,6 +579,25 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 			})
 		}
 	}
+}
+
+// closedError judges a closed connection: nil when everything the sender
+// announced actually arrived, and the most specific diagnosis otherwise.
+// Two verbatim copies of this ladder lived twenty lines apart, one in the
+// done case and one in the stall timer's race-with-close check, which is two
+// places to get "was this a clean finish?" wrong.
+func closedError(currentFile *os.File, displayName string, bytesReceived int64, info FileInfo, filesReceived int) error {
+	if currentFile != nil {
+		return fmt.Errorf("connection closed mid-transfer: %s (%d of %d bytes)",
+			displayName, bytesReceived, info.FileSize)
+	}
+	if filesReceived == 0 {
+		return fmt.Errorf("connection closed before any file arrived (the sender canceled, or the transfer was blocked)")
+	}
+	if info.Total > 0 && filesReceived < info.Total {
+		return fmt.Errorf("connection closed after %d of %d files", filesReceived, info.Total)
+	}
+	return nil
 }
 
 // rejectDescription tells the sender why its file description was refused, in

--- a/cli/engine/transfer/sender.go
+++ b/cli/engine/transfer/sender.go
@@ -43,7 +43,13 @@ const (
 // It caps at maxChunkSize and never exceeds the negotiated ceiling, so dc.Send
 // can never return ErrOutboundPacketTooLarge (pion/sctp enforces the limit on
 // send). A zero sctpMax (capabilities not yet available) falls back to the
-// proven default. Mirrors chunkSize() in client/lib/transfer/protocol.ts.
+// proven default.
+//
+// The ADAPTIVE half mirrors chunkSize() in client/lib/transfer/protocol.ts:
+// both cap at 256 KB and both send exactly the negotiated ceiling below it.
+// The FALLBACK does not. This is 16 KB and the browser's DEFAULT_CHUNK is
+// 64 KB, and both are deliberate: it applies only when the SCTP ceiling is
+// unknown, which is exactly when the conservative number is wanted here.
 func chunkSizeFor(sctpMax uint32) int {
 	if sctpMax == 0 {
 		return defaultChunkSize
@@ -100,6 +106,20 @@ type ackMsg struct {
 // endMsg is sent after the last chunk of each file.
 type endMsg struct {
 	Type string `json:"type"`
+}
+
+// isReceived reports whether raw is the receiver's delivery confirmation.
+// The size bound is the same one the ack loop applies: a frame larger than a
+// control message is file data and must never be JSON-parsed. Two verbatim
+// copies of this lived fourteen lines apart in the drain handshake.
+func isReceived(raw []byte) bool {
+	if len(raw) > controlMsgMax {
+		return false
+	}
+	var msg struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(raw, &msg) == nil && msg.Type == "received"
 }
 
 // SendOptions carries optional behavior for GUI clients. The zero value is
@@ -269,10 +289,7 @@ drainLoop:
 			if len(raw) > controlMsgMax {
 				continue // same bound as the ack loop in sendFile
 			}
-			var msg struct {
-				Type string `json:"type"`
-			}
-			if json.Unmarshal(raw, &msg) == nil && msg.Type == "received" {
+			if isReceived(raw) {
 				break drainLoop
 			}
 		case <-drainTick.C:
@@ -293,10 +310,7 @@ drainLoop:
 					if len(raw) > controlMsgMax {
 						continue
 					}
-					var msg struct {
-						Type string `json:"type"`
-					}
-					if json.Unmarshal(raw, &msg) == nil && msg.Type == "received" {
+					if isReceived(raw) {
 						break drainLoop
 					}
 				default:


### PR DESCRIPTION
## Summary

Three blocks of code existed in more than one copy, and each copy was of a sequence subtle enough to have its own written argument.

**`discardPart`**, from three copies in `receiver.go`. The order *is* the argument: unregister first, so a concurrent `AbandonPartials` cannot pick the handle up after we have decided to drop it, then use our own `Close` as the ownership test for the path. A torture test in this package proved the theft that happens when the code trusts the path string instead. Three copies is three places to get that wrong; the ten-line rationale now lives on the function, beside the registry it depends on.

**`closedError`**, from two copies twenty lines apart — one in the `done` case, one in the stall timer's race-with-close check. Two places to answer "was this a clean finish?" differently.

**`isReceived`**, from two copies fourteen lines apart in the drain handshake. The size bound moves into the helper with it, so the guard cannot be forgotten at a future third call site.

### Two comments that asserted a parity the code does not have

Worse than duplication, because they stop the next reader from checking.

- `sender.go` said `chunkSizeFor` "Mirrors chunkSize() in client/lib/transfer/protocol.ts". The adaptive half does; the fallback is 16 KB against the browser's 64 KB. Both are deliberate — the fallback applies only when the SCTP ceiling is unknown, which is exactly when the conservative number is wanted — so **the comment was wrong, not the constant**.
- `format.go` said `maxDisplayName` is "the browser's MAX_SEGMENT, so both surfaces agree". They agree on *display*. On disk the browser caps a segment at 200 and `safeJoin` deliberately does not, which the const block's own header already says two lines above.

No behavior change.

## Test plan

- `go vet ./...` and `go test -count=1 ./...` in `cli/` and `desktop/` — all pass, including the `.part` torture test that governs `discardPart`'s ordering.
- **Symbol proof:** `go doc -all -u ./engine/transfer` against a worktree at `origin/main` differs by exactly three added functions (`closedError`, `discardPart`, `isReceived`) plus the two reworded comments. Nothing removed, no signature changed.
- CI arbitrates the other two OS legs, the three e2e legs and back-compat.
