### PR TITLE
fix(client): seal the file set when Create is clicked, not when the link renders

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -88,6 +88,13 @@ export function P2PTransfer() {
     const [isSender, setIsSender] = useState<boolean | null>(null);
     const [status, setStatus] = useState('Idle');
     const [generatedLink, setGeneratedLink] = useState('');
+    // Set the instant Create is clicked. Everything that can change the file
+    // set is gated on this rather than on generatedLink, because the link is
+    // not rendered until the room-joined ack (or the 3s fallback), and
+    // onUserConnected captures the files array at click time. A file dropped
+    // in that window was counted in the header and shown with a green tick by
+    // SelectedFilesList, and never sent.
+    const [linkPending, setLinkPending] = useState(false);
     const [currentFileIndex, setCurrentFileIndex] = useState(0);
     const [progress, setProgress] = useState(0);
     const [receivedFiles, setReceivedFiles] = useState<ReceivedFile[]>([]);
@@ -128,6 +135,8 @@ export function P2PTransfer() {
     const { relayEnabled, setRelayEnabled } = useRelayConfiguration();
 
     const [relayBlocked, setRelayBlocked] = useState(false);
+    // The staged set is sealed once Create is clicked and stays sealed.
+    const filesLocked = linkPending || generatedLink !== '';
     // Live check, used before the transfer is blocked. It derives from
     // connectionType, which peer.destroy() resets to null, so the blocked state
     // below is latched separately or tearing the connection down would also
@@ -524,6 +533,7 @@ export function P2PTransfer() {
     }, [isConnected, connectionType]);
 
     const handleCreateLink = () => {
+        setLinkPending(true);
         const newRoomId = uuidv4();
         // A unique per-link nonce in the query string (not the fragment) makes
         // every transfer link a distinct document. Without it, two links differ
@@ -864,7 +874,7 @@ export function P2PTransfer() {
                                 />
                             )}
 
-                            {isSender && !generatedLink && files.length === 0 && (
+                            {isSender && !filesLocked && files.length === 0 && (
                                 <div
                                     onDragOver={handleDragOver}
                                     onDragLeave={handleDragLeave}
@@ -906,7 +916,7 @@ export function P2PTransfer() {
                                 </div>
                             )}
 
-                            {isSender && !generatedLink && files.length > 0 && (
+                            {isSender && !filesLocked && files.length > 0 && (
                                 <div
                                     onDragOver={handleDragOver}
                                     onDragLeave={handleDragLeave}
@@ -963,13 +973,13 @@ export function P2PTransfer() {
                                             files={files}
                                             currentFileIndex={currentFileIndex}
                                             progress={progress}
-                                            generatedLink={generatedLink}
+                                            filesLocked={filesLocked}
                                             status={status}
                                             onDeleteFile={handleDeleteFile}
                                             listRef={fileListRef}
                                         />
 
-                                        {files.length > 0 && !generatedLink && (
+                                        {files.length > 0 && !filesLocked && (
                                             <div className="mt-4 space-y-4">
                                                 <RelayFallbackToggle relayEnabled={relayEnabled} onChange={setRelayEnabled} />
 

--- a/client/components/SelectedFilesList.tsx
+++ b/client/components/SelectedFilesList.tsx
@@ -8,15 +8,16 @@ interface SelectedFilesListProps {
     files: FileWithId[];
     currentFileIndex: number;
     progress: number;
-    generatedLink: string;
+    filesLocked: boolean;
     status: string;
     onDeleteFile: (id: string) => void;
     listRef: RefObject<HTMLDivElement | null>;
 }
 
 /**
- * Sender-side scrollable list of the files queued for transfer. Before the link
- * exists each row has a delete button; during/after transfer it shows a
+ * Sender-side scrollable list of the files queued for transfer. While the set
+ * is still editable each row has a delete button; once it is sealed (Create
+ * clicked) it shows a
  * per-file checkmark or spinner. Purely presentational; the file state and the
  * scroll ref live in P2PTransfer.
  */
@@ -24,7 +25,7 @@ export function SelectedFilesList({
     files,
     currentFileIndex,
     progress,
-    generatedLink,
+    filesLocked,
     status,
     onDeleteFile,
     listRef,
@@ -64,7 +65,7 @@ export function SelectedFilesList({
                         </span>
                     </div>
                     <div className="ml-auto flex items-center gap-2">
-                        {!generatedLink ? (
+                        {!filesLocked ? (
                             <button
                                 onClick={() => onDeleteFile(item.id)}
                                 className="relative before:absolute before:-inset-2 p-1.5 rounded-md hover:bg-red-500/20 text-zinc-500 hover:text-red-400 transition-all"


### PR DESCRIPTION
## Summary

`handleCreateLink` registers `onUserConnected` once, and `useSignaling` registers it with an `off`-then-`on`, so the handler is **frozen at click time**. It closes over the `files` array as it stood then, and `sendAllFiles` walks that frozen array.

Everything that can change the file set was gated on `!generatedLink` — and `generatedLink` is not set until the `room-joined` ack arrives, or until the 3 s fallback timer fires on a lossy path. **So for up to three seconds after the click, both dropzones, both file inputs and every row's delete button were still live.**

A file dropped in that window was counted everywhere the user could see it: the header reads `files.length`, `TransferProgressBar` gets `filesCount`, and `SelectedFilesList` paints a green `CheckCircle2` on *every* row once `status` is `All Files Sent!`. It was never sent. Six files reported delivered, three actually transferred, no error anywhere.

The fix seals the set at the click instead of at the ack: a `linkPending` flag set as the first statement of `handleCreateLink`, and a `filesLocked` derived from it.

**The alternative was rejected deliberately.** Routing `files` through a ref so the frozen closure reads the live array would desynchronize the relay gate (which reads the frozen `files` for its size check) from the amber banner (which already reads live `totalBytes`), so the 2 GB block could fire on a size the banner never showed. Sealing is smaller and it preserves the invariant the UI already encodes.

`SelectedFilesList`'s prop changes from `generatedLink: string` to `filesLocked: boolean`, which is what it was always testing for.

**Noted while here, not changed:** the relay-limit banner says "Remove files to proceed", but it requires `connectionType === 'relay'`, which cannot be true before a peer connects — by which point the delete buttons are hidden. That mismatch predates this change and is unaffected by it.

## Test plan

- `pnpm lint` — 0 errors (2 pre-existing warnings).
- `pnpm build` — compiles; `tsc` covers the prop rename across both files.
- `pnpm test` — 19 files, 249 tests pass.
- CI's three e2e legs prove the sender flow end to end with SHA-256.
- The window itself is not deterministically e2e-testable (it is one RTT locally), so it is verified by reading plus a manual check on the local stack.
