### PR TITLE
fix(client): correct the transfer lifecycle refs and clear what outlived unmount

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -162,10 +162,42 @@ export function P2PTransfer() {
     const progressRef = useRef(0);
     const fileListRef = useRef<HTMLDivElement>(null);
 
+    // A latest-ref for the once-registered handlers, the same idiom and for the
+    // same reason as useSignaling's cbRef: onUserConnected and
+    // joinRoomAsReceiver both capture their closure before any peer exists, so
+    // reading the state directly reported connection: "unknown" for every
+    // transfer on both roles. Written in an effect rather than during render,
+    // because react-hooks forbids the render-time assignment and because these
+    // reads all happen on a transfer boundary, long after the commit.
+    const connectionTypeRef = useRef<string | null>(null);
+    // What the sender announced, from the first metadata. 0 until then.
+    const expectedFilesRef = useRef(0);
+    // Timers the unmount cleanup has to reach.
+    const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const iceProbeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const iceServersRef = useRef<RTCIceServer[]>([
         { urls: 'stun:stun.l.google.com:19302' },
         { urls: 'stun:stun1.l.google.com:19302' },
     ]);
+
+    // What to say when a receive ends. transferCompleteRef is set after EVERY
+    // file, not after the last one, so a receiver that got 1 of 3 and then lost
+    // the sender was told "Transfer complete". The ref and every guard that
+    // reads it stay exactly as they are: they also gate the reconnect path, and
+    // re-pointing them at an all-files meaning would turn a usable partial
+    // receive into a permanent reconnect spinner. Only the sentence changes.
+    const receiveOutcome = () => {
+        const got = receivedFilesRef.current.length;
+        const want = expectedFilesRef.current;
+        if (want > 0 && got < want) {
+            return `Sender disconnected. ${got} of ${want} files received`;
+        }
+        return 'Transfer complete';
+    };
+
+    useEffect(() => {
+        connectionTypeRef.current = connectionType;
+    });
 
     const { requestWakeLock, releaseWakeLock } = useWakeLock();
 
@@ -209,7 +241,7 @@ export function P2PTransfer() {
         },
         onPeerDisconnected: () => {
             if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
-                setStatus('Transfer complete');
+                setStatus(receiveOutcome());
             } else {
                 setStatus('Peer disconnected. Waiting for reconnection');
             }
@@ -218,7 +250,7 @@ export function P2PTransfer() {
         },
         onDisconnect: () => {
             if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
-                setStatus('Transfer complete');
+                setStatus(receiveOutcome());
             }
         },
         onConnectError: (err) => {
@@ -304,7 +336,8 @@ export function P2PTransfer() {
             document.body.removeChild(textarea);
         }
         setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (copyResetRef.current) clearTimeout(copyResetRef.current);
+        copyResetRef.current = setTimeout(() => setCopied(false), 2000);
     };
 
     const handleShare = async () => {
@@ -414,11 +447,18 @@ export function P2PTransfer() {
         const rx = createReceiver({
             send: (d) => peer.send(d),
             onFileStart: (index, total) => {
+                expectedFilesRef.current = total;
                 setTransferSpeed('');
                 setEstimatedTime('');
                 setStatus(`Receiving file ${index} of ${total}`);
             },
-            onProgress: (pct) => setProgress(pct),
+            onProgress: (pct) => {
+                // Written on both roles now. It was sender-only, and the
+                // receiver error scope reads it, so every receiver failure
+                // reached Sentry as 0% however far it had actually got.
+                progressRef.current = pct;
+                setProgress(pct);
+            },
             onSpeed: (bps, eta) => {
                 setTransferSpeed(formatSpeed(bps));
                 setEstimatedTime(formatETA(eta));
@@ -446,7 +486,7 @@ export function P2PTransfer() {
                 track('transfer-received', {
                     files: fileCount,
                     bytes: totalBytes,
-                    connection: connectionType ?? 'unknown',
+                    connection: connectionTypeRef.current ?? 'unknown',
                     role: 'receiver',
                 });
                 reportBytes(totalBytes);
@@ -462,6 +502,7 @@ export function P2PTransfer() {
     };
 
     useEffect(() => {
+        let cancelled = false;
         const roomFromUrl = getRoomFromUrl();
 
         if (roomFromUrl) {
@@ -477,16 +518,31 @@ export function P2PTransfer() {
                 setStatus('Access Denied');
                 return;
             }
-            fetchIceServers().then(() => joinRoomAsReceiver(roomFromUrl));
+            // The credentials fetch is a round trip, and unmounting during it
+            // used to leave the .then to build a SimplePeer, register
+            // onRoomFull, emit join-room and assign peerRef, with no cleanup
+            // left to tear any of it down. useSignaling already does exactly
+            // this one file away.
+            fetchIceServers().then(() => {
+                if (cancelled) return;
+                joinRoomAsReceiver(roomFromUrl);
+            });
         } else {
             fetchIceServers();
         }
 
         return () => {
+            cancelled = true;
             stopConnectionTypePolling();
             releaseWakeLock();
             peerRef.current?.destroy();
             receivedFilesRef.current.forEach((f) => URL.revokeObjectURL(f.downloadUrl));
+            // Three timers that outlived the component: the link-ack fallback
+            // would setGeneratedLink post-unmount, the ICE probe would getStats
+            // a destroyed peer, and the copy reset would setCopied on nothing.
+            if (linkAckFallbackRef.current) clearTimeout(linkAckFallbackRef.current);
+            if (iceProbeRef.current) clearTimeout(iceProbeRef.current);
+            if (copyResetRef.current) clearTimeout(copyResetRef.current);
         };
         // joinRoomAsReceiver is intentionally excluded: this effect must run once on mount only.
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -600,7 +656,7 @@ export function P2PTransfer() {
                     data: { relayEnabled, filesCount: files.length, totalBytes },
                 });
 
-                setTimeout(async () => {
+                iceProbeRef.current = setTimeout(async () => {
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any
                     const pc = (peer as any)._pc as RTCPeerConnection | undefined;
                     let isRelay = false;
@@ -769,7 +825,7 @@ export function P2PTransfer() {
                     track('transfer-complete', {
                         files: fileList.length,
                         bytes: fileList.reduce((s, f) => s + f.file.size, 0),
-                        connection: connectionType ?? 'unknown',
+                        connection: connectionTypeRef.current ?? 'unknown',
                         role: 'sender',
                     });
                 },


### PR DESCRIPTION
## Summary

Five defects around the same seam: handlers registered once that then read values which have moved on, and timers that outlive the component.

**`connectionType` reached both analytics calls as a value captured before any peer existed**, so `transfer-complete` and `transfer-received` have reported `connection: "unknown"` for *every* transfer on *both* roles. It now goes through a latest-ref — the same idiom and for the same reason as `useSignaling`'s `cbRef`. Assigned in an effect rather than during render: `react-hooks` forbids the render-time assignment, and every read happens on a transfer boundary, long after the commit. Worth a release note, since it splits a series that has been 100% `unknown` for receivers into direct and relay.

**`progressRef` was written only on the sender path but read in the *receiver's* Sentry scope**, so a receive that failed at 90% was indistinguishable from one that failed at 0%. Now written on both.

**A receive that ended partway said "Transfer complete".** `transferCompleteRef` is set after *every* file, not after the last one, so 1 of 3 received and then a lost sender read as a finished transfer.

Only the **sentence** changes here, on purpose: that ref also gates the reconnect path at three other sites, and re-pointing it at an all-files meaning would turn a usable partial receive into a permanent reconnect spinner. The receiver now records what the sender announced (from `onFileStart`'s `total`) and says `Sender disconnected. N of M files received` when they disagree.

**Three timers outlived the component.** The 3 s link-ack fallback called `setGeneratedLink` post-unmount, the 2 s ICE probe ran `getStats` on a destroyed peer, and the copy reset called `setCopied` on nothing. All three are now reachable from the cleanup.

**And the mount effect's credentials fetch is a round trip.** Unmounting during it left the `.then` to build a `SimplePeer`, register `onRoomFull`, emit `join-room` and assign `peerRef` — with no cleanup left to tear any of it down. It gets the `cancelled` flag `useSignaling` already uses one file away.

## Test plan

- `pnpm lint` — 0 errors (2 pre-existing warnings). The first attempt assigned the ref during render and lint caught it, which is why it is an effect.
- `pnpm build` — compiles.
- `pnpm test` — 19 files, 249 tests pass.
- `pnpm exec playwright test transfer reconnect invalid-room` — **7 passed locally**, including a 50 MB SHA-256-verified browser transfer and both reconnect cases, which are the specs that exercise this seam.
- CI arbitrates all three e2e legs, back-compat and the Docker stack.
