### PR TITLE
fix(client): stop the sender leaking a wait that never settles and an ack timer

### DIFF
--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -282,16 +282,33 @@ async function sendSingleFile(
 
     let offset = ackResult.offset;
 
+    // Waits for the buffer to fall below LOW_WATER, or for the peer to go
+    // away. The escape is destroyed(), never a deadline: a time-based one
+    // would let a truncated file fall through to the unconditional end marker
+    // below and return true, which is exactly the failure the slab read guard
+    // further down records having already been fixed once.
+    //
+    // Without any escape at all, a receiver that closed its tab while the
+    // buffer sat above HIGH_WATER left this promise unsettled for the life of
+    // the page: sendSingleFile never returned, so sendFiles never reached its
+    // finally, and the 500ms progress ticker and the 4 MB slab stayed
+    // reachable. emitView early-returns on destroyed(), so it was invisible.
     const waitForBuffer = () =>
         new Promise<void>((r) => {
-            const onLow = () => {
+            let poll: ReturnType<typeof setInterval> | null = null;
+            const finish = () => {
                 channel.removeEventListener('bufferedamountlow', onLow);
+                if (poll) clearInterval(poll);
                 r();
             };
-            if (channel.bufferedAmount < LOW_WATER) {
+            const onLow = () => finish();
+            if (channel.bufferedAmount < LOW_WATER || destroyed()) {
                 r();
             } else {
                 channel.addEventListener('bufferedamountlow', onLow);
+                poll = setInterval(() => {
+                    if (destroyed() || channel.bufferedAmount < LOW_WATER) finish();
+                }, 200);
             }
         });
 
@@ -362,22 +379,35 @@ function waitForAck(
     onData: (handler: (data: Uint8Array | ArrayBuffer) => void) => () => void,
     fileId: string
 ): Promise<AckResult> {
+    // Both arms of the race clean up after the other wins. The listener used
+    // to survive a timeout (and the timeout aborts the transfer, so it stayed
+    // on a live peer), and the 120s timer used to survive an ack, so an
+    // N-file transfer left N pending timers each retaining its closure.
+    let off: (() => void) | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const done = (r: AckResult): AckResult => {
+        off?.();
+        off = null;
+        if (timer) clearTimeout(timer);
+        timer = null;
+        return r;
+    };
     return Promise.race([
         new Promise<AckResult>((resolve) => {
-            const off = onData((raw) => {
+            off = onData((raw) => {
                 const buf = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
                 const msg = classifyControl(buf);
                 if (!msg) return;
                 if (msg.type === 'ack' && (msg as Ack).id === fileId) {
-                    off();
                     const ack = msg as Ack;
                     resolve({ type: 'ack', offset: ack.offset, pv: ack.pv, pvMin: ack.pvMin, ver: ack.ver });
                 } else if (msg.type === 'incompatible') {
-                    off();
                     resolve({ type: 'incompatible', reason: (msg as Incompatible).reason });
                 }
             });
         }),
-        new Promise<AckResult>((resolve) => setTimeout(() => resolve({ type: 'timeout' }), ACK_TIMEOUT_MS)),
-    ]);
+        new Promise<AckResult>((resolve) => {
+            timer = setTimeout(() => resolve({ type: 'timeout' }), ACK_TIMEOUT_MS);
+        }),
+    ]).then(done);
 }

--- a/client/lib/transfer/senderLeaks.test.ts
+++ b/client/lib/transfer/senderLeaks.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { sendFiles, type SenderDeps } from './sender';
+import { ackMessage, HIGH_WATER } from './protocol';
+// HIGH_WATER is 8 MB; the fixture below must exceed it or the send loop finishes
+// without ever reaching waitForBuffer, and the test passes against the bug.
+const OVER_HIGH_WATER = HIGH_WATER + 4 * 1024 * 1024;
+
+const enc = new TextEncoder();
+
+/**
+ * A channel that starts empty, fills as the sender writes, and never drains.
+ * That is what a receiver whose tab has closed looks like from this side: the
+ * buffer climbs past HIGH_WATER and bufferedamountlow never fires again.
+ *
+ * Starting empty matters. Starting it already full parks the metadata
+ * drainBelow instead, which has always had a destroyed() escape, so the test
+ * would pass against the unfixed code without ever reaching the chunk loop.
+ */
+function makeFillingChannel() {
+    return {
+        bufferedAmount: 0,
+        bufferedAmountLowThreshold: 0,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+    };
+}
+
+function makeDeps(channel: { bufferedAmount: number } & SenderDeps['channel'], fill = false) {
+    let handler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+    const deps: SenderDeps = {
+        send: (d) => {
+            if (fill) channel.bufferedAmount += (d as Uint8Array).byteLength ?? 0;
+        },
+        onData: (h) => {
+            handler = h;
+            return () => {
+                handler = null;
+            };
+        },
+        channel,
+        sctpMaxMessageSize: null,
+    };
+    return { deps, deliverAck: (id: string) => handler?.(enc.encode(ackMessage(id, 0))) };
+}
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('sender teardown', () => {
+    // A receiver that closes its tab while the buffer sits above HIGH_WATER used
+    // to strand the send for the life of the page: waitForBuffer awaited a
+    // bufferedamountlow that a closed channel never fires, so sendSingleFile
+    // never returned, sendFiles never reached its finally, and the 500ms
+    // progress ticker plus the 4 MB read slab stayed reachable. emitView
+    // early-returns on isDestroyed, so nothing showed.
+    it('resolves the buffer wait when the peer is destroyed above the high-water mark', async () => {
+        vi.useFakeTimers();
+        const channel = makeFillingChannel();
+        const { deps, deliverAck } = makeDeps(channel, true);
+
+        let destroyed = false;
+        const onAllSent = vi.fn();
+        const file = new File([new Uint8Array(OVER_HIGH_WATER)], 'big.bin');
+
+        let settled = false;
+        const p = sendFiles(deps, [{ id: 'id-stuck', file }], {
+            isDestroyed: () => destroyed,
+            onAllSent,
+        }).then(() => {
+            settled = true;
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        deliverAck('id-stuck');
+        // Let the loop reach the point where the buffer is over the mark.
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(settled).toBe(false);
+
+        destroyed = true;
+        // The poll is what notices; the event never fires on a dead channel.
+        await vi.advanceTimersByTimeAsync(500);
+        await p;
+
+        expect(settled).toBe(true);
+        // And it must not claim success for a file that stopped short.
+        expect(onAllSent).not.toHaveBeenCalled();
+    });
+
+    // The ack path used to leave its 120s timer pending, so an N-file transfer
+    // held N timers each retaining its closure. Timer count is the only
+    // observable: the leak has no user-visible symptom, which is why it lasted.
+    it('clears the ack deadline once the ack wins the race', async () => {
+        vi.useFakeTimers();
+        const channel = {
+            bufferedAmount: 0,
+            bufferedAmountLowThreshold: 0,
+            addEventListener: () => {},
+            removeEventListener: () => {},
+        };
+        const { deps, deliverAck } = makeDeps(channel);
+
+        const file = new File([new Uint8Array(8)], 'x.bin');
+        const p = sendFiles(deps, [{ id: 'id-ack', file }], {});
+        await vi.advanceTimersByTimeAsync(0);
+
+        deliverAck('id-ack');
+        await vi.advanceTimersByTimeAsync(0);
+        await p;
+
+        // Nothing may be left waiting to fire. Before the fix the 120s deadline
+        // sat here for every file in the batch.
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

**`waitForBuffer` parked on `bufferedamountlow` with no escape.** A receiver that closes its tab while the buffer sits above `HIGH_WATER` never fires that event again, so the promise stayed unsettled for the life of the page: `sendSingleFile` never returned, `sendFiles` never reached its `finally`, and the 500 ms progress ticker and the 4 MB read slab stayed reachable. `emitView` early-returns on `isDestroyed`, which is why nothing on screen ever showed it.

It now has exactly the shape `drainBelow` — its sibling twenty lines up — has always had: the same event plus a 200 ms poll, and the poll's predicate is `destroyed()`.

**Deliberately not a deadline.** A time-based escape would let a truncated file fall through to the unconditional end marker and return `true`, which is the precise regression the slab read guard in the same function records having already been fixed once.

**`waitForAck` leaked both arms of its race.** On the ack path the 120 s timer was never cleared, so an N-file transfer left N pending timers each retaining its closure; on the timeout path `off()` was never called, so the data listener stayed on a live peer. Both arms now clean up after the other wins.

## Test plan

- `pnpm test` — 20 files, 251 tests pass.
- `pnpm lint` — 0 errors.
- **Both new tests were checked against the unfixed sender:**
  ```
  × resolves the buffer wait when the peer is destroyed above the high-water mark
      Error: Test timed out in 5000ms          <- the hang itself
  × clears the ack deadline once the ack wins the race
      expected 1 to be +0                      <- the surviving timer
  ```
- Worth recording how the fixture had to be built: it must exceed `HIGH_WATER`, and the channel must **start empty and fill as the sender writes**. An already-full channel parks the metadata `drainBelow` instead, which has always had the escape, and the test then passes against the bug. The first draft did exactly that, which is why the before/after check is in this list rather than assumed.
- CI arbitrates the three e2e legs and back-compat.
