### PR TITLE
fix(desktop): clear the route on completion, drop dead work, guard the history store

### DIFF
--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -46,7 +46,7 @@ cli/
     ice/               STUN/TURN credential fetch
     code/              short room-code register and resolve
     serverurl/         normalizes user-supplied server URLs
-    verify/            short authentication string from DTLS fingerprints
+    verify/            short authentication string from DTLS fingerprints (retained, unwired)
   internal/
     selfupdate/        CLI-only self updater (stays private)
 desktop/               Wails app: imports cli/engine/...
@@ -119,6 +119,12 @@ verify the connection independently of the server.
       `engine/verify` + `verify.ts` stay (tested, zero cost). PAKE (3b) is the
       intended replacement: it does the same MITM check automatically, so the
       human compare never comes back.
+- [x] The last CALLERS went with the UI. Until then `desktop/app.go` still
+      ran `Fingerprints()` + `verify.Code()` per transfer and emitted
+      `send:verify` / `recv:verify`, which no frontend has listened for
+      since 2026-07-04, so "zero cost" was true of the browser and not of
+      the desktop. `engine/verify` and `Connection.Fingerprints()` are now
+      retained but UNWIRED: tested, called by nothing, and waiting for 3b.
 
 **3b - PAKE auto-verification (removes the human compare)**
 - [ ] PAKE (CPace or SPAKE2) keyed by the room code, bound to the DTLS fingerprints,

--- a/cli/engine/peer/connection.go
+++ b/cli/engine/peer/connection.go
@@ -450,7 +450,9 @@ func (conn *Connection) Close() {
 // Fingerprints returns the local and remote DTLS certificate fingerprints from
 // the negotiated SDPs (e.g. "sha-256 AB:CD:..."). Call after the data channel is
 // open, when both descriptions are set. These feed the connection verification
-// code (see engine/verify) so peers can detect a man-in-the-middle.
+// code (see engine/verify) so peers can detect a man-in-the-middle. Retained
+// but unwired: no surface calls this today, and PAKE (DESKTOP.md 3b) is the
+// intended consumer.
 func (conn *Connection) Fingerprints() (local, remote string, err error) {
 	ld := conn.pc.LocalDescription()
 	rd := conn.pc.RemoteDescription()

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jannskiee/floe/cli/engine/serverurl"
 	"github.com/jannskiee/floe/cli/engine/signaling"
 	"github.com/jannskiee/floe/cli/engine/transfer"
-	"github.com/jannskiee/floe/cli/engine/verify"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 )
@@ -902,10 +901,6 @@ func (a *App) runSend(g uint64, paths []string, hideIP bool) {
 		return
 	}
 
-	if local, remote, fErr := conn.Fingerprints(); fErr == nil {
-		vc := verify.Code(local, remote)
-		go emit("send:verify", vc) // off the transfer critical path
-	}
 	if ct, ctErr := conn.ConnectionType(); ctErr == nil {
 		emit("send:route", ct) // "direct" or "relay", best-effort
 	}
@@ -1060,10 +1055,6 @@ func (a *App) receiveByCode(g uint64, codeOrLink string, outputDir string, hideI
 		return "", fmt.Errorf("WebRTC setup failed: %w", err)
 	}
 
-	if local, remote, fErr := conn.Fingerprints(); fErr == nil {
-		vc := verify.Code(local, remote)
-		go emit("recv:verify", vc) // off the transfer critical path
-	}
 	if ct, ctErr := conn.ConnectionType(); ctErr == nil {
 		emit("recv:route", ct) // "direct" or "relay", best-effort
 	}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1096,6 +1096,10 @@ function App() {
             if (sendCancel.current) return;
             setSendProg(null);
             setSending(false);
+            // route is cleared on every terminal path, not just on cancel and
+            // Start over. relayTone reads it while idle, so a finished relayed
+            // transfer left an amber dot next to the word Ready.
+            setRoute('');
             setSendDone(true);
             setSendStatus('');
             // Record what went out, so Start over can tell the note that was
@@ -1109,6 +1113,7 @@ function App() {
         });
         EventsOn('send:error', (msg: string) => {
             if (sendCancel.current) return;
+            setRoute('');
             setSendStatus(friendlyError(msg) + serverNote());
             setSending(false);
             // The progress row goes with the transfer. Left behind it froze
@@ -1246,14 +1251,33 @@ function App() {
                 const rep = localStorage.getItem('floe:report-stats') !== '0';
                 setHideIP(hip);
                 setReportStats(rep);
-                void SetSettings(c.server || '', c.web || '', hip, rep);
+                // .catch, not void: this is inside a .then callback, so the
+                // chain's own .catch below never sees its rejection. It is the
+                // one bridge call in the file that had none, and it rejects for
+                // real when os.UserConfigDir fails, on every launch.
+                SetSettings(c.server || '', c.web || '', hip, rep).catch(() => {});
             })
             .catch(() => {});
     }, []);
 
     // Persist only the transfer tabs; relaunching into History would be odd.
     useEffect(() => { if (mode !== 'history') localStorage.setItem('floe:mode', mode); }, [mode]);
-    useEffect(() => { localStorage.setItem('floe:history', JSON.stringify(history)); }, [history]);
+    // Persists only what the app changed. loadHistory swallows a parse error
+    // and returns [], and this effect used to fire on mount, so a corrupt or
+    // hand-edited store was overwritten with "[]" before anything could report
+    // a problem. The store is documented as user-editable, so those bytes were
+    // recoverable right up until this ran.
+    //
+    // The guard is IDENTITY, not a run counter: a ref flag set on the first
+    // run is still set on the second, and StrictMode double-invokes effects in
+    // development, so the counter version still wrote the fallback back under
+    // `wails dev`. loadHistory runs once as a lazy initializer, so the array it
+    // produced keeps its identity until setHistory makes a new one.
+    const loadedHistory = useRef(history);
+    useEffect(() => {
+        if (history === loadedHistory.current) return;
+        localStorage.setItem('floe:history', JSON.stringify(history));
+    }, [history]);
     useEffect(() => { localStorage.setItem('floe:saveDir', output); }, [output]);
 
     // Per-visit settings-screen state, forgotten when Settings closes by ANY route.
@@ -1738,6 +1762,9 @@ function App() {
         } finally {
             if (recvAttempt.current !== attempt) return;
             setReceiving(false);
+            // Inside the generation guard on purpose: outside it, a stale
+            // attempt returning late would clear a newer attempt's route.
+            setRoute('');
             // Every exit clears the progress row, not just the successful one.
             // On failure it used to stay frozen on screen and keep Start over
             // convinced a transfer was still running, which showed the cancel

--- a/desktop/frontend/src/test/app.test.tsx
+++ b/desktop/frontend/src/test/app.test.tsx
@@ -177,3 +177,43 @@ describe('the once-registered handlers', () => {
         expect(await screen.findByText('Peer connected. Sending...')).toBeTruthy();
     });
 });
+
+describe('the route badge', () => {
+    it('goes back to green when a relayed send finishes', async () => {
+        const {container} = mount();
+        await settled();
+
+        // StatusDot renders two spans; the solid one is h-1.5 w-1.5. Matching
+        // on rounded-full alone also picks up the left rail's ambient glow.
+        const dot = () => container.querySelector('span.h-1\\.5.w-1\\.5.rounded-full');
+        act(() => {
+            wails.emit('send:route', 'relay');
+        });
+        await waitFor(() => expect(dot()?.className).toContain('bg-amber-500'));
+
+        act(() => {
+            wails.emit('send:done');
+        });
+
+        // relayTone reads route while idle, so a finished relayed transfer used
+        // to leave an amber dot beside the word Ready.
+        await waitFor(() => expect(dot()?.className).toContain('bg-green-500'));
+        expect(dot()?.className).not.toContain('bg-amber-500');
+    });
+});
+
+describe('the history store', () => {
+    it('does not overwrite a corrupt store on mount', async () => {
+        localStorage.setItem('floe:history', '{not json');
+        mount();
+        await settled();
+        // Let every mount effect, including the persist one, run.
+        await waitFor(() => expect(wails.calls).toContain('GetPendingFiles'));
+
+        // loadHistory swallows the parse error and returns [], and the persist
+        // effect used to fire on mount and write that [] straight back over the
+        // bytes. The store is documented as user-editable, so they were
+        // recoverable right up until that ran.
+        expect(localStorage.getItem('floe:history')).toBe('{not json');
+    });
+});


### PR DESCRIPTION
## Summary

Four defects. The first two are the ones a user sees.

**`route` was cleared on Start over and on cancel but on no terminal path**, so it outlived the transfer that set it. `relayTone` reads it while idle, which left an amber relay dot sitting next to the word "Ready" and the tooltip "Ready for a transfer" after every completed relayed transfer. It is now cleared on `send:done`, on `send:error`, and in `receive`'s `finally`. The receive one goes *inside* the generation guard on purpose: outside it, a stale attempt returning late would clear a newer attempt's route.

**A corrupt `floe:history` was destroyed on the next launch.** `loadHistory` swallows the parse error and returns `[]`, and the persist effect fired on mount and wrote that `[]` straight back. `history.ts` documents the store as loaded verbatim and user-editable, so those bytes were recoverable right up until this ran.

The guard is **identity, not a run counter**, and that distinction is the reason the render harness went in first: a `useRef` flag set on the effect's first run is still set on the second, and StrictMode double-invokes effects in development, so the counter version still wrote the fallback back under `wails dev`. `loadHistory` runs once as a lazy initializer, so the array it produced keeps its identity until `setHistory` makes a new one. **The test caught the counter version.**

**`send:verify` and `recv:verify` were emitted to nobody.** The frontend registers exactly 11 `EventsOn` names and neither has been among them since the verify UI was removed on 2026-07-04, so every transfer paid for an SDP fingerprint parse and a `verify.Code` for an event with no listener.

Removing the emit removes the last callers of `engine/verify` and `Connection.Fingerprints()`, so `DESKTOP.md` and the `Fingerprints` doc comment now say "retained, unwired" rather than implying they are live. The package and the method stay: they are tested, they now genuinely cost nothing, and PAKE (DESKTOP.md 3b) is their intended consumer. **The verify UI is not being restored.**

**And the one bridge call in `App.tsx` with no `.catch`.** `void SetSettings(...)` sits inside a `.then` callback, so the chain's own `.catch` never sees its rejection — and it rejects for real when `os.UserConfigDir` fails: `config.go` returns "cannot locate the user configuration directory", on every launch of that profile.

## Test plan

- `npm test` in `desktop/frontend` — 8 files, 99 tests pass (91 pure + 8 render).
- **Both new render tests were checked against the unfixed `App.tsx`:**
  ```
  × goes back to green when a relayed send finishes   -> stayed amber
  × does not overwrite a corrupt store on mount        -> got "[]"
  ```
  The six characterization tests from #386 still pass, which is what says the mount contract survived.
- `npm run build` — `tsc` + `vite build` succeed.
- `go vet ./...` and `go test -count=1 ./...` in `desktop/` — pass.
- `go vet ./...` and `go test ./engine/peer ./engine/verify` in `cli/` — pass. The verify package keeps its own tests; only its callers went.
- CI arbitrates the Wails packaging path and the MSIX pack.
