### PR TITLE
fix(client): guard both byte formatters, key files by id, and stop naming a CLI command

### DIFF
--- a/client/components/FileIcon.tsx
+++ b/client/components/FileIcon.tsx
@@ -17,7 +17,9 @@ export const FileIcon = ({
     fileName,
     className = 'h-4 w-4 text-zinc-200',
 }: FileIconProps) => {
-    const ext = fileName.split('.').pop()?.toLowerCase();
+    // Requires a real dot: split('.') on an extensionless name returns the
+    // whole name, so a file called "PNG" or "zip" used to get a type icon.
+    const ext = fileName.includes('.') ? fileName.split('.').pop()?.toLowerCase() : '';
 
     if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'bmp'].includes(ext || ''))
         return <FileImage className={className} />;
@@ -38,6 +40,7 @@ export const FileIcon = ({
             'tsx',
             'jsx',
             'py',
+            'go',
             'html',
             'css',
             'json',

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -1020,7 +1020,7 @@ export function P2PTransfer() {
                                                 </span>
                                                 <span className={`text-right font-mono text-[10px] uppercase tracking-[0.2em] ${showRelayLimitNotice ? 'text-amber-500' : 'text-zinc-600'
                                                     }`}>
-                                                    {files.length} · {formatBytes(totalBytes)}{connectionType === 'relay' || relayBlocked ? ' / 2.0 GB' : ''}
+                                                    {files.length} · {formatBytes(totalBytes)}{connectionType === 'relay' || relayBlocked ? ` / ${formatBytes(RELAY_SIZE_LIMIT)}` : ''}
                                                 </span>
                                             </div>
                                         )}

--- a/client/components/SelectedFilesList.tsx
+++ b/client/components/SelectedFilesList.tsx
@@ -37,7 +37,7 @@ export function SelectedFilesList({
         >
             {files.map((item, i) => (
                 <div
-                    key={i}
+                    key={item.id}
                     className="flex items-center gap-3 bg-white/[0.02] p-2 rounded-lg border border-white/[0.06]"
                 >
                     <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/[0.04] ring-1 ring-inset ring-white/10">

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -164,7 +164,11 @@ export function compatErrorMessage(
     if (localTooOld) {
         return `Cannot transfer: your browser is running an older version of Floe.\nYou: ${localStr}  Peer: ${remoteStr}\nRefresh the page to get the latest version.`;
     }
-    return `Cannot transfer: peer's floe is too old.\nYou: ${localStr}  Peer: ${remoteStr}\nAsk the other side to run \`floe update\`.`;
+    // Not "run `floe update`": the peer may be a browser or the desktop app,
+    // and only the CLI has that command. Go passes an updateHint for exactly
+    // this; the browser has no way to know which surface it is talking to, so
+    // it says the thing that is true of all three.
+    return `Cannot transfer: peer's floe is too old.\nYou: ${localStr}  Peer: ${remoteStr}\nAsk the other side to update Floe.`;
 }
 
 // --- Control message classifier ---

--- a/client/lib/utils.test.ts
+++ b/client/lib/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { formatBytes } from './utils';
+import { formatBytes, splitBytes } from './utils';
+import { RELAY_SIZE_LIMIT } from './relay';
 
 describe('formatBytes', () => {
     it('returns "0 Bytes" for 0', () => expect(formatBytes(0)).toBe('0 Bytes'));
@@ -13,4 +14,29 @@ describe('formatBytes', () => {
     it('formats fractional MB', () => expect(formatBytes(1.5 * 1024 * 1024)).toBe('1.5 MB'));
 
     it('formats GB', () => expect(formatBytes(1024 ** 3)).toBe('1 GB'));
+});
+
+// The guards both formatters were missing one half of. Math.log of a negative
+// is NaN; BYTE_UNITS[NaN] and BYTE_UNITS[Math.min(NaN, 4)] are both undefined,
+// so formatBytes printed "NaN undefined" and splitBytes returned an undefined
+// unit. formatBytes also had no top clamp, so a petabyte printed
+// "1 undefined". cli/engine/transfer/format.go carries the post-mortem for the
+// same bug on the Go side, where it was fixed and the browser was not.
+describe('byte formatter guards', () => {
+    const bad = [-1, -1024, NaN, Infinity, -Infinity];
+
+    it('formatBytes never emits an undefined unit', () => {
+        for (const n of bad) expect(formatBytes(n)).toBe('0 Bytes');
+        expect(formatBytes(1024 ** 5)).toBe('1024 TB');
+        expect(formatBytes(1024 ** 6)).toBe('1048576 TB');
+    });
+
+    it('splitBytes never emits an undefined unit', () => {
+        for (const n of bad) expect(splitBytes(n)).toEqual({ value: 0, unit: 'Bytes' });
+        expect(splitBytes(1024 ** 5)).toEqual({ value: 1024, unit: 'TB' });
+    });
+
+    it('renders the relay cap the way every other copy of the string spells it', () => {
+        expect(formatBytes(RELAY_SIZE_LIMIT)).toBe('2 GB');
+    });
 });

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -5,23 +5,31 @@ export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs));
 }
 
+// unitIndex is the shared guard both formatters were missing one half of.
+// Math.log of a negative is NaN, and both sizes[NaN] and
+// sizes[Math.min(NaN, 4)] are undefined, so formatBytes(-1) printed
+// "NaN undefined" and splitBytes(-1) returned an undefined unit. The top
+// clamp matters too: formatBytes(1024**5) printed "1 undefined".
+// cli/engine/transfer/format.go carries the post-mortem for the same bug.
+const BYTE_UNITS = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+const unitIndex = (bytes: number) => {
+    if (!Number.isFinite(bytes) || bytes <= 0) return 0;
+    return Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), BYTE_UNITS.length - 1);
+};
+
 export const formatBytes = (bytes: number) => {
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024;
-    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+    if (!Number.isFinite(bytes) || bytes <= 0) return '0 Bytes';
+    const i = unitIndex(bytes);
+    return parseFloat((bytes / Math.pow(1024, i)).toFixed(2)) + ' ' + BYTE_UNITS[i];
 };
 
 // splitBytes returns the numeric value and unit separately so NumberFlow can
 // animate the number while keeping the unit stable as a suffix.
 export const splitBytes = (bytes: number): { value: number; unit: string } => {
-    if (bytes === 0) return { value: 0, unit: 'Bytes' };
-    const k = 1024;
-    const units = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), units.length - 1);
+    if (!Number.isFinite(bytes) || bytes <= 0) return { value: 0, unit: 'Bytes' };
+    const i = unitIndex(bytes);
     return {
-        value: parseFloat((bytes / Math.pow(k, i)).toFixed(2)),
-        unit: units[i],
+        value: parseFloat((bytes / Math.pow(1024, i)).toFixed(2)),
+        unit: BYTE_UNITS[i],
     };
 };


### PR DESCRIPTION
## Summary

**Both formatters in `utils.ts` were half-guarded, in opposite halves.** `formatBytes` had neither a top clamp nor a non-positive guard, so `formatBytes(-1)` printed `NaN undefined` and `formatBytes(1024**5)` printed `1 undefined`. `splitBytes` *has* the clamp but no negative guard — and `Math.min(NaN, 4)` is `NaN`, so it was equally broken there. They now share one `unitIndex` that has both.

`cli/engine/transfer/format.go` carries the post-mortem for this exact failure on the Go side, where it was fixed and the browser was not.

**`SelectedFilesList` keyed rows by array index** while every item carries a stable `id` — used two lines below for the delete itself. Removing the first of three made React mutate every surviving row instead of unmounting one.

**`FileIcon` gained `go` and a dot guard.** The desktop's copy has had `go` all along and its header claims to mirror this file, so `main.go` got a code icon there and a generic one here. The dot guard is the desktop's too: `split('.')` on a name with no dot returns the whole name, so a file literally called `PNG` or `zip` picked up a type icon.

**The relay cap in the file-count row was the literal `' / 2.0 GB'`** — the one place the number is spelled differently from the six other copies that say "2 GB", and the only one sitting next to a live `formatBytes` call. It now derives from `RELAY_SIZE_LIMIT`.

**And the browser stopped telling people to run a command they may not have.** `compatErrorMessage` said "Ask the other side to run \`floe update\`" when the peer is too old — but the peer may be a browser or the desktop app. Go solved this with an `updateHint` parameter; the browser cannot know which surface it is talking to, so it says the thing that is true of all three.

## Test plan

- `pnpm test` — 20 files, 252 tests pass.
- **The two new guard tests were checked against the unfixed `utils.ts`:**
  ```
  × formatBytes never emits an undefined unit
      expected 'NaN undefined' to be '0 Bytes'
  × splitBytes never emits an undefined unit
      expected { value: NaN, unit: undefined } to deeply equal { value: +0, unit: 'Bytes' }
  ```
  which is also the correction: `splitBytes` was not the good sibling it looked like.
- A third test pins `formatBytes(RELAY_SIZE_LIMIT) === '2 GB'`, so the derived string matches the six hand-written ones.
- `pnpm lint` — 0 errors. `pnpm build` — compiles.
- `pnpm exec playwright test transfer responsive` — 10 passed locally, including the 50 MB SHA-256 transfer and the sender-flow viewport checks that render the file rows this touches.
- CI arbitrates all three e2e legs and back-compat.
