### PR TITLE
fix(desktop): match the web and CLI on transfer speed and ETA

### DIFF
--- a/client/lib/transferUtils.test.ts
+++ b/client/lib/transferUtils.test.ts
@@ -24,12 +24,20 @@ describe('formatETA', () => {
     it('formats seconds', () => {
         expect(formatETA(0)).toBe('0s');
         expect(formatETA(30)).toBe('30s');
-        expect(formatETA(59.9)).toBe('60s');
     });
 
     it('formats minutes and seconds', () => {
         expect(formatETA(90)).toBe('1m 30s');
-        expect(formatETA(3599)).toBe('59m 59s'); // Math.ceil(3599 % 60) = ceil(59) = 59
+        expect(formatETA(3599)).toBe('59m 59s');
+    });
+
+    // The carry. Rounding the remainder instead of the whole value let the
+    // seconds field reach 60, so these three read "60s", "1m 60s" and
+    // "2m 60s". The Go twin truncates and never had it.
+    it('never prints a seconds field of 60', () => {
+        expect(formatETA(59.9)).toBe('1m 0s');
+        expect(formatETA(119.5)).toBe('2m 0s');
+        expect(formatETA(179.1)).toBe('3m 0s');
     });
 
     it('formats hours and minutes', () => {

--- a/client/lib/transferUtils.ts
+++ b/client/lib/transferUtils.ts
@@ -12,11 +12,11 @@ export function formatSpeed(bytesPerSec: number): string {
 
 export function formatETA(etaSeconds: number): string {
     if (!Number.isFinite(etaSeconds) || etaSeconds < 0) return '';
-    if (etaSeconds < 60) {
-        return `${Math.ceil(etaSeconds)}s`;
-    } else if (etaSeconds < 3600) {
-        return `${Math.floor(etaSeconds / 60)}m ${Math.ceil(etaSeconds % 60)}s`;
-    } else {
-        return `${Math.floor(etaSeconds / 3600)}h ${Math.floor((etaSeconds % 3600) / 60)}m`;
-    }
+    // Round to whole seconds FIRST. Applying Math.ceil to the remainder
+    // instead let it reach 60, so 119.5s printed "1m 60s" and 59.9s printed
+    // "60s". The Go twin truncates and never had either.
+    const s = Math.ceil(etaSeconds);
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+    return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -121,15 +121,28 @@ interface Prog {
 
 type Marker = {t: number; bytes: number} | null;
 
+// Both mirror client/lib/transferUtils.ts, which mirrors
+// cli/engine/transfer/format.go. The web and the CLI already agreed; the
+// desktop was the outlier on both counts, so the desktop is what moves.
 function fmtSpeed(bps: number): string {
     if (!isFinite(bps) || bps <= 0) return '';
-    return bps >= 1024 * 1024 ? (bps / 1048576).toFixed(1) + ' MB/s' : (bps / 1024).toFixed(0) + ' KB/s';
+    // One decimal on BOTH branches. toFixed(0) on the KB branch printed
+    // "0 KB/s" while bytes were still moving, and lost a significant digit
+    // at every rate under a megabyte.
+    return bps >= 1024 * 1024
+        ? (bps / 1048576).toFixed(1) + ' MB/s'
+        : (bps / 1024).toFixed(1) + ' KB/s';
 }
 
 function fmtEta(sec: number): string {
     if (!isFinite(sec) || sec < 0) return '';
-    if (sec < 60) return `${Math.ceil(sec)}s`;
-    return `${Math.floor(sec / 60)}m ${Math.ceil(sec % 60)}s`;
+    // Three branches, not two. Without the hours branch a 20 GB transfer on a
+    // slow link read "166m 40s" where the web and the CLI both said "2h 46m".
+    // Rounding first is what keeps the minutes branch from printing "1m 60s".
+    const s = Math.ceil(sec);
+    if (s < 60) return `${s}s`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;
+    return `${Math.floor(s / 3600)}h ${Math.floor((s % 3600) / 60)}m`;
 }
 
 // track computes percent, speed, and ETA for a progress event. It uses an

--- a/desktop/frontend/src/test/app.test.tsx
+++ b/desktop/frontend/src/test/app.test.tsx
@@ -12,7 +12,7 @@
 import {StrictMode, act} from 'react';
 import {render, screen, waitFor, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {describe, expect, it} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import App from '../App';
 
 // main.tsx wraps App in StrictMode, so the tests do too. Not ceremony:
@@ -215,5 +215,47 @@ describe('the history store', () => {
         // bytes. The store is documented as user-editable, so they were
         // recoverable right up until that ran.
         expect(localStorage.getItem('floe:history')).toBe('{not json');
+    });
+});
+
+describe('the progress label', () => {
+    // Drives the real send:progress path, so it covers track() as well as the
+    // two formatters. Date.now is stubbed rather than the timers faked: track
+    // derives speed from Date.now deltas, and faking timers would also stall
+    // testing-library's waitFor.
+    it('matches the web and CLI on sub-megabyte speed and multi-hour ETA', async () => {
+        let now = 1_700_000_000_000;
+        const clock = vi.spyOn(Date, 'now').mockImplementation(() => now);
+        try {
+            mount();
+            await settled();
+
+            const prog = (totalBytes: number) => ({
+                fileName: 'big.bin',
+                fileIndex: 1,
+                fileCount: 1,
+                fileBytes: totalBytes,
+                fileSize: 20_000_000,
+                totalBytes,
+                grandTotal: 20_000_000,
+                savedName: '',
+            });
+
+            // The first event sets the marker; no rate is known yet.
+            act(() => wails.emit('send:progress', prog(0)));
+            // 5000 bytes in 10s is 500 B/s, and the 19,995,000 left at that rate
+            // is 39,990s.
+            now += 10_000;
+            act(() => wails.emit('send:progress', prog(5000)));
+
+            const label = await screen.findByText(/big\.bin/);
+            // toFixed(0) on the KB branch printed "0 KB/s" here, while bytes
+            // were still moving. The web and the CLI both print one decimal.
+            expect(label.textContent).toContain('0.5 KB/s');
+            // Without the hours branch this read "666m 30s".
+            expect(label.textContent).toContain('ETA 11h 6m');
+        } finally {
+            clock.mockRestore();
+        }
     });
 });


### PR DESCRIPTION
## Summary

Three surfaces, one product, two answers. The web and the CLI already agreed on both of these, so **the desktop is what moves**.

**`fmtSpeed` used `toFixed(0)` on the KB/s branch** where `client/lib/transferUtils.ts` and `cli/engine/transfer/format.go` both use one decimal. At 500 B/s the desktop printed `0 KB/s` while bytes were still moving, and it lost a significant digit at every rate under a megabyte.

**`fmtEta` had two branches instead of three.** A 20 GB transfer over a slow relay read `166m 40s` where the web and the CLI both said `2h 46m`.

**And the carry, on both TS surfaces** since they share the formula: `Math.ceil` applied to the seconds *remainder* can reach 60, so 119.5 s printed `1m 60s` and 59.9 s printed `60s`. Rounding the whole value first fixes both. Go truncates and never had it. The client test that pinned `formatETA(59.9) === '60s'` was documenting the bug; it is replaced by three cases asserting the seconds field can never be 60.

### Deliberately not changed: `fmtBytes`

The desktop prints `0 B` and `1.0 MB` where the other two print `0 Bytes` and `1 MB`, and that is not an accident: `App.tsx` builds the progress label as `<n> / <total>` and `app.go` throttles `send:progress` to about 10 per second, so `toFixed(i ? 1 : 0)` holds the digit count steady where `parseFloat(toFixed(2))` would make a 10 Hz line jitter horizontally. The divergence is now documented instead of silently inconsistent.

## Test plan

- `npm test` in `desktop/frontend` — 7 files, 92 tests pass.
- **The new render test drives the real `send:progress` path**, so it covers `track()` as well as both formatters. `Date.now` is stubbed rather than the timers faked, because faking timers stalls testing-library's `waitFor`. Checked against the unfixed `App.tsx`:
  ```
  AssertionError: expected 'big.bin - 0%  (4.9 KB / 19.1 MB), 0 K…' to contain '0.5 KB/s'
  ```
  which is the bug in one line — and the same output shows `fmtBytes` deliberately unchanged.
- `pnpm test` in `client/` — 20 files, 252 tests pass.
- `npm run build`, `pnpm lint` — clean.
- CI arbitrates the Wails packaging path and the three e2e legs.
