### PR TITLE
test(server): call handleSignal with the arity it actually has

### DIFF
--- a/server/server.test.js
+++ b/server/server.test.js
@@ -176,14 +176,14 @@ describe('handleSignal', () => {
         pA.msgs.length = 0;
         pB.msgs.length = 0;
 
-        handleSignal(pA, { type: 'offer' }, 'peer-B', null);
+        handleSignal(pA, { type: 'offer' }, 'peer-B');
 
         assert.equal(pB.msgs.length, 1);
         assert.equal(pB.msgs[0].type, 'signal');
         assert.equal(pA.msgs.length, 0, 'sender should not receive its own signal');
     });
 
-    it('routes signal by roomId when no targetId is given', () => {
+    it('routes to the other peer in the room the server recorded for the sender', () => {
         const pA = makePeer('peer-A');
         const pB = makePeer('peer-B');
         handleJoinRoom(pA, ROOM_ID);
@@ -191,13 +191,13 @@ describe('handleSignal', () => {
         pA.msgs.length = 0;
         pB.msgs.length = 0;
 
-        handleSignal(pA, { type: 'candidate' }, null, ROOM_ID);
+        handleSignal(pA, { type: 'candidate' }, null);
 
         assert.equal(pB.msgs.length, 1);
         assert.equal(pB.msgs[0].type, 'signal');
     });
 
-    it('falls back to sender.roomId when neither targetId nor explicit roomId is given', () => {
+    it('routes by sender.roomId with an explicit null targetId', () => {
         const pA = makePeer('peer-A');
         const pB = makePeer('peer-B');
         handleJoinRoom(pA, ROOM_ID);
@@ -205,7 +205,7 @@ describe('handleSignal', () => {
         pA.msgs.length = 0;
         pB.msgs.length = 0;
 
-        handleSignal(pA, { type: 'candidate' }, null, null);
+        handleSignal(pA, { type: 'candidate' }, null);
 
         assert.equal(pB.msgs.length, 1);
     });
@@ -216,7 +216,7 @@ describe('handleSignal', () => {
         pA.msgs.length = 0;
 
         // Should not throw.
-        handleSignal(pA, { type: 'offer' }, 'nonexistent-id', null);
+        handleSignal(pA, { type: 'offer' }, 'nonexistent-id');
         assert.equal(pA.msgs.length, 0);
     });
 
@@ -227,7 +227,7 @@ describe('handleSignal', () => {
         handleJoinRoom(pB, ROOM_ID);
         pB.msgs.length = 0;
 
-        handleSignal(pA, null, 'peer-B', null);
+        handleSignal(pA, null, 'peer-B');
         assert.equal(pB.msgs.length, 0);
     });
 


### PR DESCRIPTION
## Summary

`handleSignal(senderPeer, signal, targetId)` takes three parameters and takes the room from `senderPeer.roomId`. **Five call sites in the suite passed a fourth**, and one test was *named* for it: `routes signal by roomId when no targetId is given` passed `ROOM_ID` as that phantom argument, so it read as proof of a routing mode the function has not had since the server started tracking the room itself.

JavaScript discards the extra argument silently, so every one of them passed while asserting nothing about it.

Both tests in that pair are renamed to say what actually distinguishes them: one routes to the other peer in the room the server recorded for the sender, the other does the same with an explicit `null` targetId.

Test-only. No server behavior changes — and this lands **before** the server split so the fiction is not carried into a new module's docstring.

## Test plan

- `npm test` in `server/` — 51 pass, 0 fail. Same count as before; what changed is what the calls and the names say, not how many run.
