### PR TITLE
fix(client): show the link being created, and drop the stale ICE probe

### DIFF
--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -364,6 +364,12 @@ export function P2PTransfer() {
         setStatus('Connecting');
 
         onRoomFull(() => {
+            // Deliberately not receiveOutcome(): this branch is unreachable and
+            // its string is never rendered. A room-full answer only follows a
+            // join-room, and the reconnect path returns before re-joining once
+            // a file has landed (see the guard in the socket reconnect
+            // handler), so the condition below is false on every real path.
+            // The receiver renders status only under includes('Receiving').
             if (receivedFilesRef.current.length > 0 || transferCompleteRef.current) {
                 setStatus('Transfer complete');
                 return;
@@ -624,6 +630,13 @@ export function P2PTransfer() {
             if (peerRef.current && !peerRef.current.destroyed) {
                 peerRef.current.destroy();
             }
+            // The destroyed peer's ICE probe goes with it. simple-peer nulls
+            // _pc on destroy, so the orphan cannot reach getStats(); what it
+            // does instead is record a false "ICE resolved: direct" breadcrumb
+            // against a dead peer. Clear at the event that invalidates the
+            // probe, not when the next peer connects: a replacement that never
+            // connects would otherwise leave the stale one armed.
+            if (iceProbeRef.current) clearTimeout(iceProbeRef.current);
             // Clear the previous verdict. A blocked transfer tears its peer down,
             // so the next receiver to join arrives here; without this the amber
             // "capped at 2 GB" banner would still be up during a transfer that
@@ -1046,6 +1059,13 @@ export function P2PTransfer() {
                                                     Create secure link ({files.length} {files.length === 1 ? 'file' : 'files'})
                                                     <ArrowRight className="w-3.5 h-3.5 sm:w-4 sm:h-4 ml-1.5 sm:ml-2 shrink-0" />
                                                 </Button>
+                                            </div>
+                                        )}
+
+                                        {files.length > 0 && filesLocked && !generatedLink && (
+                                            <div className="mt-4 flex w-full items-center justify-center gap-2 py-2.5 text-xs text-zinc-400">
+                                                <Loader2 className="h-3 w-3 shrink-0 animate-spin" />
+                                                <span>Creating secure link...</span>
                                             </div>
                                         )}
 

--- a/client/e2e/pending-link.spec.ts
+++ b/client/e2e/pending-link.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+import { createFixture } from './helpers';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// The sender seals its file set the moment "Create secure link" is clicked, but
+// the link itself is not rendered until the server acknowledges the join (or a
+// 3s fallback fires, whichever comes first). That gap used to render nothing at
+// all: no button, no link, no spinner, on a card the user had just acted on.
+//
+// Blocking Socket.IO is what makes the gap deterministic. Without an ack the
+// fallback governs the whole window, so the pending state is observable for a
+// full three seconds instead of one loopback round trip.
+const FIXTURE_DIR = join(tmpdir(), 'floe-e2e-pending');
+
+test.describe('sender card while the link is being created', () => {
+    test('shows a pending affordance until the link arrives', async ({ page }) => {
+        const { path } = createFixture(FIXTURE_DIR, 1024);
+
+        await page.route('**/socket.io/**', (route) => route.abort());
+        await page.goto('/');
+        await page.locator('input[type="file"]').setInputFiles(path);
+
+        const createButton = page.locator('button', { hasText: /create secure link/i });
+        await expect(createButton).toBeVisible();
+        await createButton.click();
+
+        // The regression: between the click and the link, this is the only
+        // thing on the card that says anything is happening.
+        const pending = page.getByText('Creating secure link...');
+        await expect(pending).toBeVisible({ timeout: 2_000 });
+
+        // ...and it is a genuine intermediate state, not a duplicate of either
+        // neighbour. Both of those are gated on the same two flags.
+        await expect(createButton).toBeHidden();
+        await expect(page.locator('code').filter({ hasText: '#room=' })).toHaveCount(0);
+
+        // The 3s fallback resolves it even though no ack ever arrives.
+        await expect(page.locator('code').filter({ hasText: '#room=' })).toBeVisible({
+            timeout: 10_000,
+        });
+        await expect(pending).toBeHidden();
+    });
+
+    test('never leaves the card with no button, no link and no affordance', async ({ page }) => {
+        const { path } = createFixture(FIXTURE_DIR, 1024);
+
+        await page.route('**/socket.io/**', (route) => route.abort());
+        await page.goto('/');
+        await page.locator('input[type="file"]').setInputFiles(path);
+
+        // Sample the card across the whole pending window. Polling rather than a
+        // MutationObserver because the dead state was a steady render, not a
+        // transient one: any sample inside the window would have caught it.
+        await page.locator('button', { hasText: /create secure link/i }).click();
+
+        const deadFrames: string[] = [];
+        for (let i = 0; i < 12; i++) {
+            const state = await page.evaluate(() => {
+                const text = document.body.innerText;
+                return {
+                    button: /create secure link/i.test(text),
+                    link: text.includes('#room='),
+                    affordance: text.includes('Creating secure link'),
+                };
+            });
+            if (!state.button && !state.link && !state.affordance) {
+                deadFrames.push(`sample ${i}: ${JSON.stringify(state)}`);
+            }
+            await page.waitForTimeout(250);
+        }
+
+        expect(deadFrames, `card had nothing to show at: ${deadFrames.join('; ')}`).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

Two follow-ups to #385 and #387, found by re-reading the merged result rather
than the PRs, plus one comment that records a dead end so nobody walks it twice.

**The sender card had a dead window.** #385 sealed the file set at click
instead of at the room-joined ack, which was right, but it hid the Create
button a moment before anything replaced it. The link renders on the ack or on
the 3s fallback, so between those two points the card showed a file list, no
button, no link and no spinner. It now shows a spinner reading `Creating
secure link...`, which is also the first feedback that the ack round-trip is
happening at all.

**A stale ICE probe survived its peer.** `onUserConnected` armed a fresh probe
without dropping the previous one. The clear goes next to the peer teardown
that invalidates it, not in the next peer's connect handler: a replacement
peer that never connects is the common field case, and arming the clear there
would leave the stale probe running straight through it. The orphan cannot
crash (simple-peer nulls `_pc` on destroy, so it never reaches `getStats`);
what it does is record a false `ICE resolved: direct` breadcrumb against a
dead peer, which is worse than a crash because it is silent.

**One comment, no code.** A receive ends in three places and #387 converted
two, so the room-full handler looks like an oversight. It is not reachable: a
room-full answer only follows a `join-room`, and the reconnect path returns
before re-joining once a file has landed, so its partial-receive condition is
false on every path. The receiver also renders `status` only under
`includes('Receiving')`, so the string never reaches a user. I wrote that
"fix", proved it was a no-op, and backed it out. The comment records the proof
at the site.

## Test plan

- New e2e spec `client/e2e/pending-link.spec.ts`. It blocks Socket.IO, which
  makes the window deterministic: with no ack the 3s fallback governs it, so
  the pending state lasts three seconds instead of one loopback round trip.
  **Both tests fail against the code before this PR.** The second is the
  useful record; it samples the card twelve times across the window, and on
  the old code all twelve report no button, no link and no affordance. The
  dead card was a steady three-second render, not a transient frame between
  two good ones.
- `pnpm lint` 0 errors (2 pre-existing warnings, both on untouched lines),
  `pnpm test` 255 pass, `pnpm build` clean.
- `go vet` and `go test` clean in `cli/` and `desktop/`; server 51 pass;
  desktop frontend 100 pass; the skills suites 399 pass.
- `transfer-audit run --profile head --desktop none --relaxed` against this
  tree: 4/4 executable cells PASS (W2W, W2C, C2W, C2C, 12 MiB each,
  byte-exact, direct route proven).

The ICE probe change has no automated test, and the PR does not pretend
otherwise: reproducing it needs a second joiner whose replacement peer never
connects, which the harness cannot stage today. It is read-verified, reviewed
and exercised by the audit.
