### PR TITLE
docs: stop telling API callers a capitalized code cannot resolve

### DIFF
--- a/docs/reference/http-api.mdx
+++ b/docs/reference/http-api.mdx
@@ -171,8 +171,9 @@ entries once a minute, so the count can briefly include codes that have already 
 Resolves a code back to its room. Called by `floe receive` and by Floe Desktop's **Receive** tab.
 
 <ParamField path="code" type="string" required>
-  The phrase, matched **exactly**. Codes are always lowercase, so `Olive-Tiger-Castle` does not
-  resolve. Surrounding whitespace is trimmed by the clients, not by the server.
+  The phrase, matched **exactly**: the server looks up the code exactly as it arrives. `floe
+  receive` and Floe Desktop lowercase and trim what you type before calling this, so
+  `Olive-Tiger-Castle` resolves from either of them. A direct caller has to send lowercase itself.
 </ParamField>
 
 ```json 200 OK

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -114,8 +114,8 @@ The code was mistyped, or it has passed its ten minutes.
 
 Codes are lowercase words joined by hyphens, but capitalization does not matter: `floe receive`
 and Floe Desktop lowercase what you type before the lookup, so `Olive-Tiger-Castle` resolves the
-same as `olive-tiger-castle`. Surrounding spaces are trimmed for you; nothing else is. Ask the
-sender to start a new session for a fresh code.
+same as `olive-tiger-castle`. Surrounding spaces are trimmed and capitalization is folded for
+you; nothing else is. Ask the sender to start a new session for a fresh code.
 
 ### `this code is no longer active; ask for a new one`
 


### PR DESCRIPTION
## Summary

`v1.10.7` and `desktop-v0.2.9` fold case before the code lookup. That makes
`docs/reference/http-api.mdx` say the opposite of `docs/troubleshooting.mdx`
about the same behavior:

- `http-api.mdx` (before): "Codes are always lowercase, so `Olive-Tiger-Castle`
  does not resolve."
- `troubleshooting.mdx` (already merged in #393): "`Olive-Tiger-Castle`
  resolves the same as `olive-tiger-castle`."

Both pages now describe the same two-part behavior: the server matches the
code exactly as it arrives, and the two shipped clients lowercase and trim
before they send. A direct API caller still has to send lowercase itself,
which is the part `http-api.mdx` is actually responsible for documenting.

`troubleshooting.mdx` also said "surrounding spaces are trimmed for you;
nothing else is" two sentences after saying capitalization is folded for you.

**This is the one docs inaccuracy the release does not fix by shipping.**
Every other claim added in #393 becomes true the moment both tags land.
`http-api.mdx:174` gets *worse*, because it will then contradict a true
statement on the troubleshooting page.

## Test plan

- `docs-check.mjs`: 0 hard, 43 notes, unchanged from the baseline.
- No em dash or en dash in either file (Vale's rule for `docs/`).
- No added line over 100 columns.
- Docs-only, so the `changes` job skips the heavy matrix and `CI green`
  reports in under a minute.
