### PR TITLE
chore(deps): bump brace-expansion from 5.0.7 to 5.0.9 in /server

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -150,16 +150,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {


### PR DESCRIPTION
## Summary

Lockfile-only bump of `brace-expansion` 5.0.7 to 5.0.9 in `server/`, the one finding `npm audit`
still reported after #381. It is a development-scope transitive (`nodemon` to `minimatch` to
`brace-expansion`), so it never reaches the production image (`npm ci --omit=dev`) or api.floe.one.
GitHub auto-dismissed the two alerts for exactly that reason (101 and 103), which is why Dependabot
never opened a PR, but `npm audit` keeps flagging them as high:

- `GHSA-mh99-v99m-4gvg`: DoS via unbounded expansion length (out-of-memory crash).
- `GHSA-rgw5-rvv9-x895`: DoS via unbounded intermediate arrays, bypassing the first fix.

Both first patched in 5.0.9, which `minimatch`'s `^5.0.5` range already admits, so `package.json`
is untouched. `engines` moves from `18 || 20 || >=22` to `20 || >=22`; CI and the image run Node 24.
`client/` already resolves 5.0.9 and 1.1.18, and `desktop/frontend/` has no copy.

## Test plan

Clean clone on main (4c259e8): `npm update brace-expansion` produced this 8-line diff, `npm ci`
reinstalls it cleanly (117 packages), `npm ls brace-expansion` shows the single 5.0.9 under
nodemon, `npm audit` reports 0 vulnerabilities, `npm test` 51/51. Nothing at runtime imports it.
