### PR TITLE
chore(client): point the download links at desktop-v0.2.9

### DIFF
--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.8';
-export const DESKTOP_RELEASE_DATE = 'Aug 27, 2026';
+export const DESKTOP_VERSION = '0.2.9';
+export const DESKTOP_RELEASE_DATE = 'Sep 4, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
## Summary

The release-phase pin bump, deliberately separate from the prep PR (#398).

CI's "Check desktop release assets" step resolves `DESKTOP_VERSION` against
the GitHub release and fails a pin whose assets do not exist yet, so this
could only land after `desktop-release.yml` finished. It has.

Every download link on the site derives from these two constants, so this is
what actually points `/download`, the landing page and the desktop section at
`desktop-v0.2.9`.

## Test plan

- `pnpm test`: 255 pass, including `desktopRelease.test.ts`, which rejects a
  `DESKTOP_RELEASE_DATE` in the runner's UTC future. Today is `2026-09-04` UTC.
- `check-version-pins --cli v1.10.7 --desktop desktop-v0.2.9 --phase follow-up`:
  0 tracked findings.
- All three assets plus the tag page verified 200 after redirects with
  `curl.exe -sIL` before this was written:
  `floe-desktop-setup-0.2.9.exe`, `floe-desktop-0.2.9-windows-amd64.zip`,
  `SHA256SUMS.txt`.
