### PR TITLE
ci(desktop-release): vet, assert the Wails pin, retry NSIS, serialize the tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,9 +290,12 @@ jobs:
     # the tag-triggered desktop-release.yml, which is how the plated Store
     # icon (#250) survived every PR and shipped through a full certification
     # cycle; these steps make packaging breakage a PR-time failure instead.
-    # The steps mirror desktop-release.yml by hand (that workflow stays
-    # untouched on purpose; keep the two in sync), the app builds as version
-    # "dev", and nothing is uploaded or published.
+    # The steps mirror desktop-release.yml by hand and the two must be kept in
+    # sync; the app builds as version "dev", and nothing is uploaded or
+    # published. The mirroring is no longer one-way: the vet step, the Wails
+    # pin assertion and the NSIS retry below were copied INTO
+    # desktop-release.yml, because the tag path is the one that cannot be
+    # re-run cheaply and it had been the weaker of the two.
     runs-on: windows-latest
     timeout-minutes: 15
     needs: [changes]

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -29,6 +29,15 @@ on:
 # needs, and any job added later starts from zero permissions.
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Never cancel a publish, for the same reason images.yml does not: this
+  # workflow creates a GitHub Release and uploads assets to it. A two-tag push
+  # once fired every tag workflow twice and the duplicates raced the published
+  # release, so a second run on the same ref queues behind the first instead
+  # of running beside it.
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build & publish (windows)
@@ -37,6 +46,10 @@ jobs:
     permissions:
       # Create the GitHub Release and upload its assets (tag path only).
       contents: write
+    env:
+      # Must match desktop/go.mod (asserted in the install step below) and
+      # ci.yml's desktop job; bump all three together.
+      WAILS_VERSION: v2.12.0
 
     steps:
       - name: Checkout
@@ -104,6 +117,12 @@ jobs:
           npm test
           npm run build
 
+      - name: Vet
+        # ci.yml vets desktop/ on every code PR; the release path did not, so a
+        # vet-clean main could still ship from a tag that was not.
+        working-directory: desktop
+        run: go vet ./...
+
       - name: Go tests
         # A release must not outrun its tests. The workspace (go.work) resolves
         # the ../cli engine inside this checkout.
@@ -112,14 +131,27 @@ jobs:
 
       - name: Install Wails CLI
         shell: bash
-        # Pinned to the version in desktop/go.mod. GOWORK=off so `go install`
-        # of an external tool is never influenced by this repo's workspace.
-        run: GOWORK=off go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
+        # Pinned to the version desktop/go.mod links against; the grep fails
+        # the job if the two drift (the CLI embeds runtime assets that must
+        # match the library, and this repo has eaten one version drift
+        # already, #262). The comment here used to claim the pin without
+        # enforcing it: the version was a literal in this run: string, so a
+        # go.mod bump would have shipped a mismatched CLI with a green build.
+        # GOWORK=off so `go install` of an external tool is never influenced
+        # by this repo's workspace.
+        run: |
+          grep -q "github.com/wailsapp/wails/v2 ${WAILS_VERSION}\$" desktop/go.mod \
+            || { echo "WAILS_VERSION ${WAILS_VERSION} does not match desktop/go.mod" >&2; exit 1; }
+          GOWORK=off go install "github.com/wailsapp/wails/v2/cmd/wails@${WAILS_VERSION}"
 
       - name: Install NSIS
         shell: bash
+        # One retry, as in ci.yml. This is the path where a transient
+        # chocolatey blip costs a failed tag run, which cannot be re-cut
+        # cheaply, so it matters more here than on a PR.
         run: |
-          choco install nsis -y --no-progress
+          choco install nsis -y --no-progress \
+            || { echo "choco install failed once; retrying" >&2; sleep 10; choco install nsis -y --no-progress; }
           # wails build -nsis silently skips the installer when makensis is
           # missing (it warns and returns success), so resolve it now or fail.
           export PATH="$PATH:/c/Program Files (x86)/NSIS"


### PR DESCRIPTION
## Summary

Four gaps between the release path and the PR path, all closed by copying
lines that already run on every code PR. The direction is deliberate: **the
tag path is the one that cannot be re-run cheaply**, and it was the weaker of
the two.

**The Wails pin is the one with an incident behind it.**
`desktop-release.yml` said *"Pinned to the version in `desktop/go.mod`"* and
then hardcoded `@v2.12.0` as a literal in its `run:` string — so the comment
claimed an invariant that nothing enforced. A `go.mod` bump without a matching
edit here would have installed a mismatched Wails CLI and **shipped it, with a
green build**. `ci.yml` has greped `go.mod` for exactly this since #262, the
drift that already cost this repo once. Same env var, same grep, same failure
message.

**`go vet` did not run on the release path at all**, so a vet-clean `main`
could still ship from a tag that was not.

**The NSIS install had no retry.** On a PR a transient chocolatey failure
costs a re-run; on a tag it costs a failed release.

**The `concurrency` block** is the one thing *not* copied from `ci.yml`,
because `ci.yml` cancels superseded runs and a publishing workflow must not.
It matches `images.yml` instead. A two-tag push in a previous release fired
every tag workflow twice and the duplicates raced the published release; a
second run on the same ref now queues behind the first.

`ci.yml`'s comment said `desktop-release.yml` "stays untouched on purpose",
which is no longer true, so it now says what is.

## Test plan

- **`actionlint` on both files: clean, exit 0.**
- The new assertion verified against the tree it will run on:
  `grep -q "github.com/wailsapp/wails/v2 v2.12.0$" desktop/go.mod` passes.
- Nothing changes build behavior: `vet` is additive, the Wails install
  resolves the same version, and the NSIS retry only runs after a first
  failure.
- The release path cannot be exercised without pushing a tag, so this is
  verified by actionlint plus a line-for-line comparison against the `ci.yml`
  steps it copies — which pass on every PR, including this one.
