### PR TITLE
fix(client): give the badge and the relay gate one verdict, not two

### DIFF
--- a/client/hooks/useConnectionType.ts
+++ b/client/hooks/useConnectionType.ts
@@ -1,12 +1,19 @@
 import { useState, useRef } from 'react';
 import type { Instance as PeerInstance } from 'simple-peer';
-import { isRelayPair } from '@/lib/relay';
+import { readConnectionType } from '@/lib/relay';
 
 /**
  * Detects and tracks whether the active WebRTC connection is direct or routed
  * through a TURN relay, by polling the peer's ICE candidate-pair stats every 5s.
  * Pure connection-quality detection: it only drives the "Direct/Relay" badge and
  * has no effect on the transfer itself.
+ *
+ * The reading comes from lib/relay.ts, which is also what the relay-size gate
+ * in P2PTransfer uses. It used to be a second, subtly different copy of the
+ * same scan: this one wrote a verdict per nominated pair, so the LAST pair the
+ * stats iterator yielded won, while the gate latched on any relay pair. With
+ * more than one nominated pair (an ICE restart, or several m-lines) the badge
+ * could read Direct on a connection the gate was blocking as relay.
  */
 export function useConnectionType() {
     const [connectionType, setConnectionType] = useState<'direct' | 'relay' | null>(null);
@@ -17,18 +24,11 @@ export function useConnectionType() {
         const pc = (peer as any)._pc as RTCPeerConnection | undefined;
         if (!pc) return;
         try {
-            const stats = await pc.getStats();
-            stats.forEach((report) => {
-                if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
-                    const localCandidate = stats.get(report.localCandidateId);
-                    const remoteCandidate = stats.get(report.remoteCandidateId);
-                    const isRelay = isRelayPair(
-                        localCandidate?.candidateType,
-                        remoteCandidate?.candidateType
-                    );
-                    setConnectionType(isRelay ? 'relay' : 'direct');
-                }
-            });
+            // null means ICE has not nominated a pair yet. Leave the badge as
+            // it was rather than guessing: the poll starts the moment the peer
+            // connects, so this is the normal state for the first tick or two.
+            const next = readConnectionType(await pc.getStats());
+            if (next) setConnectionType(next);
         } catch { }
     };
 

--- a/client/lib/relay.test.ts
+++ b/client/lib/relay.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate, isRelayPair, probeIsRelay } from './relay';
+import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate, isRelayPair, probeIsRelay, readConnectionType } from './relay';
 
 const STUN: RTCIceServer = { urls: 'stun:stun.l.google.com:19302' };
 const TURN: RTCIceServer = { urls: 'turn:turn.example.com:3478' };
@@ -151,5 +151,57 @@ describe('probeIsRelay', () => {
                 })
             )
         ).toBe(false);
+    });
+});
+
+describe('readConnectionType', () => {
+    const report = (entries: Record<string, unknown>) =>
+        new Map(Object.entries(entries)) as unknown as RTCStatsReport;
+
+    const pair = (id: string, local: string, remote: string, over: Record<string, unknown> = {}) => ({
+        [`p-${id}`]: {
+            type: 'candidate-pair',
+            state: 'succeeded',
+            nominated: true,
+            localCandidateId: `l-${id}`,
+            remoteCandidateId: `r-${id}`,
+            ...over,
+        },
+        [`l-${id}`]: { type: 'local-candidate', candidateType: local },
+        [`r-${id}`]: { type: 'remote-candidate', candidateType: remote },
+    });
+
+    it('answers null until ICE has nominated something', () => {
+        // The badge polls from the moment the peer connects. probeIsRelay says
+        // false here, which is right for the gate and wrong for the badge:
+        // reporting "direct" now would flash the wrong route on a connection
+        // that turns out to be relayed.
+        expect(readConnectionType(report({}))).toBeNull();
+        expect(readConnectionType(report(pair('a', 'relay', 'host', { nominated: false })))).toBeNull();
+        expect(readConnectionType(report(pair('a', 'host', 'host', { state: 'failed' })))).toBeNull();
+    });
+
+    it('agrees with the gate once a pair is nominated', () => {
+        const direct = report(pair('a', 'host', 'srflx'));
+        expect(readConnectionType(direct)).toBe('direct');
+        expect(probeIsRelay(direct)).toBe(false);
+
+        const relayed = report(pair('a', 'relay', 'host'));
+        expect(readConnectionType(relayed)).toBe('relay');
+        expect(probeIsRelay(relayed)).toBe(true);
+    });
+
+    it('cannot disagree with the gate on a mixed multi-pair report', () => {
+        // This is the whole bug: the badge used to take the last pair the
+        // iterator yielded, so it could read direct while the gate blocked as
+        // relay. Both readings now come from one scan.
+        for (const entries of [
+            { ...pair('d', 'host', 'host'), ...pair('r', 'relay', 'host') },
+            { ...pair('r', 'relay', 'host'), ...pair('d', 'host', 'host') },
+        ]) {
+            const stats = report(entries);
+            expect(readConnectionType(stats)).toBe('relay');
+            expect(probeIsRelay(stats)).toBe(true);
+        }
     });
 });

--- a/client/lib/relay.ts
+++ b/client/lib/relay.ts
@@ -69,15 +69,38 @@ export function evaluateRelayGate(opts: {
  *  transfer start on the relay, while the reverse only shows a cap that does
  *  not bind. */
 export function probeIsRelay(stats: RTCStatsReport): boolean {
-    let isRelay = false;
+    return scanPairs(stats).relay;
+}
+
+/** readConnectionType is the badge's reading of the same scan, and it is a
+ *  different question from probeIsRelay's: it must be able to answer "I do not
+ *  know yet".
+ *
+ *  The badge polls from the moment the peer connects, so it runs before ICE has
+ *  nominated anything. probeIsRelay answers false there, which is right for the
+ *  gate (no evidence of a relay, so do not block) and wrong for the badge,
+ *  which would flash "Direct" on a connection that turns out to be relayed.
+ *  null means not yet decided, and the badge renders nothing. */
+export function readConnectionType(stats: RTCStatsReport): 'direct' | 'relay' | null {
+    const { nominated, relay } = scanPairs(stats);
+    if (!nominated) return null;
+    return relay ? 'relay' : 'direct';
+}
+
+/** One scan, two questions. `nominated` is whether ICE has settled on anything
+ *  at all; `relay` LATCHES across every nominated succeeded pair. */
+function scanPairs(stats: RTCStatsReport): { nominated: boolean; relay: boolean } {
+    let nominated = false;
+    let relay = false;
     stats.forEach((report) => {
         if (report.type === 'candidate-pair' && report.state === 'succeeded' && report.nominated) {
+            nominated = true;
             const local = stats.get(report.localCandidateId);
             const remote = stats.get(report.remoteCandidateId);
             if (isRelayPair(local?.candidateType, remote?.candidateType)) {
-                isRelay = true;
+                relay = true;
             }
         }
     });
-    return isRelay;
+    return { nominated, relay };
 }


### PR DESCRIPTION
## Summary

The connection route was read **twice**, by two scans of the same
`RTCStatsReport` that disagreed with each other.

The **gate** in `P2PTransfer` latched: any nominated succeeded pair that is
relay made the whole connection relay. The **badge** in `useConnectionType`
wrote a verdict *per pair inside the `forEach`*, so whichever pair the stats
iterator yielded **last** won. WebRTC normally nominates one pair, but more
than one can be nominated during an ICE restart or across m-lines — and then
the two answers differ by iteration order alone.

Reproduced against one report holding a direct pair and a relay pair:

```
relay listed last : gate=relay  badge=relay   agree
relay listed first: gate=relay  badge=direct  DISAGREE
```

So the badge could read **Direct** on a connection the gate was blocking as
**relay** — and the amber "capped at 2 GB" banner, the byte counter and the
dropzone hint all follow the badge.

## The fix

Both readings now come from `lib/relay.ts`, which #411 moved the gate's scan
into. **Latching is the direction kept**, because the reading gates the 2 GB
relay cap: calling a relayed connection direct would let an oversized transfer
start on the relay, while the reverse only shows a cap that does not bind.

## Why `readConnectionType` is a separate export

The badge asks a different question and **must be able to answer "not yet"**.
It polls from the moment the peer connects, before ICE has nominated anything;
`probeIsRelay` answers `false` there, which is right for the gate and wrong for
the badge, which would flash **Direct** on a connection that turns out to be
relayed. `null` means undecided and the badge is left alone.

The old code got this right by accident, because it only ever wrote from
inside the loop. That behavior is preserved **deliberately** rather than
inherited — a naive swap to `probeIsRelay` would have regressed it.

## Test plan

- `pnpm test`: **277 pass**, up from 274. `pnpm lint` 0 errors, `pnpm build`
  clean.
- The new tests assert both readings **agree on a mixed multi-pair report in
  both insertion orders** — the case that used to break — and that
  `readConnectionType` returns `null` for an empty report, an un-nominated pair
  and a failed pair, which is the regression the naive fix would have
  introduced.
- The disagreement above was reproduced by running **both original scans,
  copied verbatim**, against the same report.
