### PR TITLE
fix(client): one clipboard path, and it reports what actually happened

### DIFF
--- a/client/components/InAppBrowserGuard.tsx
+++ b/client/components/InAppBrowserGuard.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { ExternalLink, Copy, Check, SquareArrowOutUpRight } from 'lucide-react';
+import { copyText } from '@/lib/clipboard';
 
 interface UmamiWindow extends Window {
     umami?: {
@@ -37,21 +38,6 @@ function isAndroid(ua: string): boolean {
     return /Android/i.test(ua);
 }
 
-function copyLinkFallback(url: string) {
-    try {
-        const textarea = document.createElement('textarea');
-        textarea.value = url;
-        textarea.style.position = 'fixed';
-        textarea.style.opacity = '0';
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textarea);
-    } catch {
-        // URL is visible on screen so user can copy manually
-    }
-}
-
 interface Props {
     children: React.ReactNode;
 }
@@ -83,12 +69,12 @@ export function InAppBrowserGuard({ children }: Props) {
         }
     }, []);
 
+    // This component only ever renders inside a Facebook, Instagram, TikTok
+    // or WeChat webview, which is the environment most likely to block the
+    // async clipboard API, so it was the worst place to claim "Link copied"
+    // unconditionally. The URL stays on screen for a manual copy either way.
     const handleCopy = async () => {
-        try {
-            await navigator.clipboard.writeText(currentUrl);
-        } catch {
-            copyLinkFallback(currentUrl);
-        }
+        if (!(await copyText(currentUrl))) return;
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);
     };

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -26,6 +26,7 @@ import { useRelayConfiguration } from '@/hooks/useRelayConfiguration';
 import { RELAY_SIZE_LIMIT, filterIceServers, evaluateRelayGate, probeIsRelay } from '@/lib/relay';
 import { buildShareLink, getRoomFromUrl, isValidRoomId } from '@/lib/roomLink';
 import { classifyPeerError } from '@/lib/peerErrors';
+import { copyText } from '@/lib/clipboard';
 import { resolveSocketUrl } from '@/lib/socketUrl';
 
 import {
@@ -297,19 +298,12 @@ export function P2PTransfer() {
         isSender,
     ]);
 
+    // Nothing is shown when the copy fails. The link is on screen right
+    // above this button, so a silent no-op leaves the user with the one thing
+    // that still works, where the green "Copied" it used to show regardless
+    // told them to stop looking at it.
     const handleCopy = async () => {
-        try {
-            await navigator.clipboard.writeText(generatedLink);
-        } catch {
-            const textarea = document.createElement('textarea');
-            textarea.value = generatedLink;
-            textarea.style.position = 'fixed';
-            textarea.style.opacity = '0';
-            document.body.appendChild(textarea);
-            textarea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textarea);
-        }
+        if (!(await copyText(generatedLink))) return;
         setCopied(true);
         if (copyResetRef.current) clearTimeout(copyResetRef.current);
         copyResetRef.current = setTimeout(() => setCopied(false), 2000);

--- a/client/components/landing/InstallTabs.tsx
+++ b/client/components/landing/InstallTabs.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { Check, Copy } from 'lucide-react';
+import { copyText } from '@/lib/clipboard';
 
 // Install commands are copied verbatim from README.md; keep them in sync.
 //
@@ -20,14 +21,13 @@ export function InstallTabs() {
     const [active, setActive] = useState(0);
     const [copied, setCopied] = useState(false);
 
+    // This site was already honest, and gains the textarea fallback it never
+    // had. Clipboard still unavailable (permissions or insecure context) and
+    // the command stays selectable.
     const copy = async () => {
-        try {
-            await navigator.clipboard.writeText(CLI_INSTALL_TABS[active].command);
-            setCopied(true);
-            setTimeout(() => setCopied(false), 2000);
-        } catch {
-            // Clipboard unavailable (permissions or insecure context); the command stays selectable.
-        }
+        if (!(await copyText(CLI_INSTALL_TABS[active].command))) return;
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
     };
 
     return (

--- a/client/lib/clipboard.test.ts
+++ b/client/lib/clipboard.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { copyText } from './clipboard';
+
+/**
+ * There is no DOM here: client/vitest.config.ts runs environment 'node' and no
+ * jsdom is installed. So these fakes prove the branch selection and the
+ * no-node-left-behind invariant, and they cannot prove that execCommand puts
+ * anything on a real clipboard. The PR body says the same thing rather than
+ * implying coverage this does not have.
+ */
+
+/** A document.body stand-in that records what is attached to it. */
+function stubDom(opts: {
+    exec?: () => boolean;
+    onAppend?: () => void;
+    onCreate?: () => void;
+}) {
+    const attached: unknown[] = [];
+    const body = {
+        appendChild(node: { parent: unknown }) {
+            opts.onAppend?.();
+            node.parent = body;
+            attached.push(node);
+        },
+    };
+    vi.stubGlobal('document', {
+        createElement() {
+            opts.onCreate?.();
+            const node = {
+                value: '',
+                style: {} as Record<string, string>,
+                parent: null as unknown,
+                select() {},
+                remove() {
+                    const i = attached.indexOf(node);
+                    if (i !== -1) attached.splice(i, 1);
+                },
+            };
+            return node;
+        },
+        body,
+        execCommand: opts.exec ?? (() => true),
+    });
+    return attached;
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('copyText, async clipboard path', () => {
+    it('returns true and writes the exact string', async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        vi.stubGlobal('navigator', { clipboard: { writeText } });
+        expect(await copyText('hello')).toBe(true);
+        expect(writeText).toHaveBeenCalledWith('hello');
+    });
+
+    it('falls back when writeText rejects', async () => {
+        vi.stubGlobal('navigator', {
+            clipboard: { writeText: vi.fn().mockRejectedValue(new Error('denied')) },
+        });
+        const attached = stubDom({ exec: () => true });
+        expect(await copyText('x')).toBe(true);
+        expect(attached).toEqual([]);
+    });
+
+    it('falls back when the page has no clipboard API at all', async () => {
+        // The insecure-context case, and the one InstallTabs hit with no
+        // fallback of its own.
+        vi.stubGlobal('navigator', {});
+        stubDom({ exec: () => true });
+        expect(await copyText('x')).toBe(true);
+    });
+});
+
+describe('copyText, fallback honesty', () => {
+    it('returns false when execCommand returns false', async () => {
+        // The bug all three sites shared: the return value was discarded and
+        // every one of them reported success anyway.
+        vi.stubGlobal('navigator', {});
+        stubDom({ exec: () => false });
+        expect(await copyText('x')).toBe(false);
+    });
+
+    it('returns false when execCommand throws', async () => {
+        vi.stubGlobal('navigator', {});
+        stubDom({
+            exec: () => {
+                throw new Error('SecurityError');
+            },
+        });
+        expect(await copyText('x')).toBe(false);
+    });
+
+    it('returns false when there is no document (server render)', async () => {
+        vi.stubGlobal('navigator', {});
+        vi.stubGlobal('document', undefined);
+        expect(await copyText('x')).toBe(false);
+    });
+
+    it('never rejects, whatever fails', async () => {
+        vi.stubGlobal('navigator', {
+            clipboard: {
+                get writeText(): never {
+                    throw new Error('blocked getter');
+                },
+            },
+        });
+        stubDom({
+            onCreate: () => {
+                throw new Error('createElement blew up');
+            },
+        });
+        await expect(copyText('x')).resolves.toBe(false);
+    });
+});
+
+describe('copyText leaves no node behind', () => {
+    // rmSync-style invariant: whatever happens, document.body holds exactly
+    // what it held on entry. Both implementations this replaces removed the
+    // textarea on the success line only, so both leaked on a throw.
+    const paths: Array<[string, Parameters<typeof stubDom>[0]]> = [
+        ['execCommand true', { exec: () => true }],
+        ['execCommand false', { exec: () => false }],
+        [
+            'execCommand throws',
+            {
+                exec: () => {
+                    throw new Error('boom');
+                },
+            },
+        ],
+        [
+            'appendChild throws',
+            {
+                onAppend: () => {
+                    throw new Error('detached body');
+                },
+            },
+        ],
+    ];
+
+    for (const [name, opts] of paths) {
+        it(name, async () => {
+            vi.stubGlobal('navigator', {});
+            const attached = stubDom(opts);
+            await copyText('x');
+            expect(attached).toEqual([]);
+        });
+    }
+});

--- a/client/lib/clipboard.ts
+++ b/client/lib/clipboard.ts
@@ -1,0 +1,66 @@
+// One copy path for the three buttons that had three. The point of the module
+// is not that copying is hard, it is that FAILING to copy was reported three
+// different ways: P2PTransfer let an execCommand throw escape as an unhandled
+// rejection and leaked the textarea it had appended, InAppBrowserGuard
+// swallowed the same throw and then said "Link copied" anyway, and InstallTabs
+// had no fallback at all. A caller cannot render an honest label off a helper
+// that does not tell it what happened, so this one returns a boolean and never
+// throws.
+
+/**
+ * Writes `text` to the system clipboard and reports whether it actually landed
+ * there. Never throws and never rejects: every failure is a `false`, so a
+ * caller cannot show "Copied" for a copy that did not happen.
+ *
+ * The caller keeps its own copied flag and its own reset timer. This helper
+ * owns no UI state on purpose, because the three call sites label and time
+ * their feedback differently and unifying that too would be a redesign.
+ */
+export async function copyText(text: string): Promise<boolean> {
+    // Read the globals inside the body rather than at module scope. A test
+    // stubs them after this module is imported, and a module-scope capture
+    // would hold the pre-stub value forever.
+    //
+    // The property reads sit INSIDE the try, not just the call. Optional
+    // chaining keeps a missing clipboard API an ordinary branch rather than a
+    // caught TypeError, which is what makes the insecure-context case
+    // assertable; it does not help when the property itself is a throwing
+    // getter, and a helper whose contract is "never throws" has to survive
+    // that too.
+    try {
+        const clip = globalThis.navigator?.clipboard;
+        if (clip && typeof clip.writeText === 'function') {
+            await clip.writeText(text);
+            return true;
+        }
+    } catch {
+        // Denied by permissions policy, or the document was not focused.
+        // Both are recoverable by the textarea path below.
+    }
+
+    if (typeof document === 'undefined' || !document.body) return false;
+
+    let textarea: HTMLTextAreaElement | null = null;
+    try {
+        textarea = document.createElement('textarea');
+        textarea.value = text;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        // The return value is the whole reason this module exists. Both copies
+        // this replaces discarded it and then reported success regardless.
+        return document.execCommand('copy') === true;
+    } catch {
+        return false;
+    } finally {
+        // remove(), not document.body.removeChild(). removeChild throws
+        // NotFoundError when appendChild is the call that threw, which would
+        // turn a failed copy into a second exception; remove() on a node with
+        // no parent is a specified no-op. In a finally so that no path, including
+        // a throw from createElement, select or execCommand, can leave the
+        // node attached. Both replaced copies removed it on the happy line
+        // only, which is exactly why both leaked.
+        textarea?.remove();
+    }
+}


### PR DESCRIPTION
## Summary

Three copy buttons, three implementations, three different answers to "what if the copy failed".

| Site | fallback | reports honestly | leaks a node on throw |
| --- | --- | --- | --- |
| `P2PTransfer.tsx` | textarea, unguarded | no | **yes**, plus an unhandled rejection |
| `InAppBrowserGuard.tsx` | textarea, bare catch | no | **yes**, silently |
| `landing/InstallTabs.tsx` | **none** | yes | n/a |

`InAppBrowserGuard` is the worst of the three: it set `Copied` outside the try/catch, and it only ever renders inside a Facebook, Instagram, TikTok or WeChat webview, which is precisely where the async clipboard API is most likely to be blocked. The button claimed success in the one environment most likely to fail.

## What changed

All three now call `copyText(text): Promise<boolean>`, which never throws.

Two **visible behavior changes**, named because this is a fix and not a refactor:

- A failed copy no longer shows "Copied" / "Link copied". Nothing is shown. The link or command is on screen in all three cases, so a silent no-op leaves the user with the thing that still works, where the green tick told them to stop looking at it.
- `InstallTabs` gains the textarea fallback the other two already had.

Three details that are the actual content of the fix:

1. **The `execCommand` return value is captured.** All three copies discarded it and reported success regardless.
2. **The node is removed in a `finally`, via `remove()`.** `document.body.removeChild()` throws `NotFoundError` when `appendChild` is the call that threw, turning a failed copy into a second exception; `remove()` on an unparented node is a specified no-op. Both replaced copies removed on the happy line only, which is exactly why both leaked.
3. **The property reads sit inside the `try`, not just the call.** Optional chaining keeps a missing clipboard API an ordinary branch (what makes the insecure-context case assertable), but it does nothing for a throwing getter. My own "never rejects" test caught this and it was a real hole in the first draft.

## Test plan

`client/lib/clipboard.test.ts`, 11 cases, all green:

- async path: resolves, writes the exact string; falls back when it rejects; falls back when there is no clipboard API at all
- **returns `false` when `execCommand` returns `false`** (the bug all three shared)
- returns `false` when `execCommand` throws, when `document` is undefined, and when the `writeText` getter itself throws
- **no-node-left-behind across all four paths** (`execCommand` true / false / throws, `appendChild` throws), asserted against a recording `document.body` stub

Gates: `pnpm lint` 0 errors (2 pre-existing `window.location.href` warnings, untouched), `pnpm test` 288 passed, `pnpm build` clean.

**What this does not prove.** `client/vitest.config.ts` is `environment: 'node'` with no jsdom, so the fakes prove branch selection and the node invariant and cannot prove `execCommand` reaches a real clipboard. `client/e2e/` has no copy-button interaction at all (`responsive.spec.ts` asserts the button is visible and never clicks it), so nothing end-to-end defends this. Worth filling, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnqqWsyK1FWQxU52qy8SqN