### PR TITLE
docs: say what is actually true about Prettier in this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,8 @@ Even with the overlay this is a production build with no hot reload, so use it t
 ## Code Style
 
 - TypeScript for all new client code
-- Match the formatting of the surrounding code (Prettier is configured repo-wide), and lint before pushing: `pnpm lint` (in `client/`)
+- Match the formatting of the surrounding code, and lint before pushing: `pnpm lint` (in `client/`)
+- There is a root `.prettierrc`, but no CI job runs it and almost nothing in the repo is formatted to it. Measured on 2026-09-05: of 320 tracked files Prettier will parse, 315 are unformatted, and the 5 it accepts are lockfiles and generated JSON. The config leaves `printWidth` at the default 80 against a codebase written to about 120, so `npm run format` would reflow essentially every file in the repository. Do not run it. Formatting a file you are already editing is fine; reformatting one you are not is a diff nobody can review.
 - Keep components focused and readable
 
 ---


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` told contributors "Prettier is configured repo-wide". Literally true, practically misleading: acting on it produces a diff nobody can review.

**Measured 2026-09-05**, tracked files only, after normalising path separators:

| | count |
| --- | --- |
| tracked files Prettier will parse | 320 |
| **unformatted** | **315** |
| already clean | 5 |

The five clean ones are `client/pnpm-lock.yaml`, `server/package-lock.json`, `desktop/frontend/package-lock.json`, `desktop/build/windows/info.json` and `desktop/build/README.md`. Every hand-written file in the repository is drifted.

The cause is that `.prettierrc` sets no `printWidth`, so the default 80 applies to a codebase written to about 120. Formatting `App.tsx` alone rewrites roughly 6,900 lines against a 2,900-line file.

`CLAUDE.md` already words this honestly ("root Prettier *can* format it, but nothing checks"). This lines the contributor-facing copy up with it.

**Not adopting Prettier here either way.** That is its own project, and the shape it would need is: a `printWidth` the codebase already lives at, a scope of one directory (`server/` is 5 files and the obvious candidate), a CI `--check` limited to that path, and a `.git-blame-ignore-revs` in the same commit as the reformat. Doing it as the tail of a refactor program would collide head-on with the PRs that decompose `App.tsx`, and would trade away `git blame` in a repo whose real documentation is 16-line comments explaining why a line exists.

## Test plan

Docs-only in content, but `CONTRIBUTING.md` is outside `docs/`, so the `changes` classifier marks it as code and the full matrix runs. That is the fail-closed behaviour working as designed, not something to route around.

No em dash or en dash introduced (checked: 0 in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnqqWsyK1FWQxU52qy8SqN