### PR TITLE
test(desktop): mount the receive and history views for the first time

### DIFF
--- a/desktop/frontend/src/test/app.test.tsx
+++ b/desktop/frontend/src/test/app.test.tsx
@@ -259,3 +259,60 @@ describe('the progress label', () => {
         }
     });
 });
+
+/**
+ * Smoke renders for the two views nothing has ever mounted.
+ *
+ * Every existing test in this file leaves `mode` at its 'send' default, so the
+ * receive console and the history console have no render coverage of any kind.
+ * That matters because they are next in line to be extracted into top-level
+ * components, and a JSX move that silently dropped a branch would take the
+ * whole suite green with it.
+ *
+ * These are deliberately shallow. They assert that each view mounts and shows
+ * the controls that make it that view, which is what a bad extraction breaks;
+ * they do not try to cover behavior the views do not have tests for today.
+ */
+describe('the views no other test mounts', () => {
+    it('renders the receive console when the Receive tab is chosen', async () => {
+        mount();
+        await settled();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Receive'}));
+
+        // The code field is the view: placeholder, not label, because the
+        // Eyebrow above it is not associated with the input.
+        expect(
+            screen.getByPlaceholderText('amber-otter-cloud')
+        ).toBeInstanceOf(HTMLInputElement);
+        // And the save-folder field, which is the half that reads a real path.
+        expect(screen.getByPlaceholderText('Downloads (default)')).toBeTruthy();
+    });
+
+    it('renders the history console, empty and populated', async () => {
+        localStorage.setItem(
+            'floe:history',
+            JSON.stringify([
+                {kind: 'recv', names: ['report.pdf'], count: 1, at: Date.now(), bytes: 1024},
+            ])
+        );
+        mount();
+        await settled();
+
+        await userEvent.click(screen.getByRole('button', {name: 'History'}));
+
+        // A seeded row must actually reach the list. Asserting only the empty
+        // state would pass against a view that renders nothing at all.
+        expect(await screen.findByText('report.pdf')).toBeTruthy();
+        expect(screen.queryByText('No transfers yet.')).toBeNull();
+    });
+
+    it('shows the empty state when there is no history', async () => {
+        mount();
+        await settled();
+
+        await userEvent.click(screen.getByRole('button', {name: 'History'}));
+
+        expect(await screen.findByText('No transfers yet.')).toBeTruthy();
+    });
+});


### PR DESCRIPTION
## Summary

`app.test.tsx` has nine tests and **not one of them ever switches `mode`**. It stays at the `'send'` default (`setup.ts` clears `localStorage`), so the receive console and the history console have never been rendered by any test in this repo.

That is precisely the half of `App.tsx` still queued for extraction into top-level view components. A JSX move that silently dropped a conditional would take the entire suite green with it, because `tsc` cannot see a branch that stopped being reachable.

## What it adds

Three smoke renders, deliberately shallow. They assert each view mounts and shows the controls that make it that view, which is what a bad extraction breaks. They do not try to cover behavior these views have no tests for today.

- **Receive**: the code field (`amber-otter-cloud`) and the save-folder field
- **History, populated**: a seeded `floe:history` row actually reaches the list
- **History, empty**: `No transfers yet.`

The seeded row matters more than it looks. Asserting only the empty state would pass against a view that renders **nothing at all**.

## Proof it catches what it is for

Disconnecting the receive branch from its mode check (`: mode === 'receive' ? (` becomes a condition that is never true):

```
npx tsc --noEmit                                              clean
x renders the receive console when the Receive tab is chosen
```

`tsc` is completely happy with the view gone. The test is not.

## Test plan

`npm test` in `desktop/frontend`: **135 passed** (132 before, +3).

**Zero source diff.** This PR cannot break the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnqqWsyK1FWQxU52qy8SqN