### PR TITLE
fix(client): scrub the room link from Sentry performance traces and honor Do Not Track

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -94,13 +94,19 @@ export default function RootLayout({
                         defer
                         src="https://cloud.umami.is/script.js"
                         data-website-id={process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID}
-                        // BOTH of these are load-bearing privacy settings, not tidiness.
+                        // The two exclude flags are load-bearing privacy settings, not tidiness.
                         // The tracker reports location.href and only strips the fragment
                         // when exclude-hash is set, so without this a receiver opening
                         // /?s=nonce#room=<uuid> would POST the room secret to Umami, which
                         // is exactly what the privacy page promises never happens.
                         data-exclude-hash="true"
                         data-exclude-search="true"
+                        // Honor the browser's Do Not Track signal: with this set the
+                        // tracker sends nothing at all for that visitor. The live
+                        // cloud.umami.is script reads data-do-not-track and checks
+                        // navigator.doNotTrack, msDoNotTrack and window.doNotTrack
+                        // (verified 2026-09-05); the privacy page states this.
+                        data-do-not-track="true"
                         strategy="afterInteractive"
                     />
                 )}

--- a/client/lib/scrubUrl.test.ts
+++ b/client/lib/scrubUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scrubUrl } from './scrubUrl';
+import { scrubSpanJson, scrubTransactionEvent, scrubUrl } from './scrubUrl';
 
 describe('scrubUrl', () => {
     it('strips the room id from a fragment (new-style links)', () => {
@@ -46,5 +46,54 @@ describe('scrubUrl', () => {
         );
         // The dummy-base strip itself still works for relative inputs.
         expect(scrubUrl('/path?room=secret-uuid')).toBe('/path?room=redacted');
+    });
+});
+
+describe('scrubTransactionEvent', () => {
+    const LINK = 'https://www.floe.one/?s=abcd1234#room=secret-uuid';
+
+    it('strips the room id from the transaction request url', () => {
+        const event = { type: 'transaction', request: { url: LINK } };
+        expect(scrubTransactionEvent(event).request.url).toBe('https://www.floe.one/?s=abcd1234');
+    });
+
+    it('scrubs the trace context and every span attribute the SDK writes', () => {
+        const event = {
+            contexts: { trace: { data: { 'url.full': LINK, 'sentry.op': 'pageload' } } },
+            spans: [
+                {
+                    data: {
+                        'url.full': LINK,
+                        'http.url': LINK,
+                        'http.query': '?room=secret-uuid&x=1',
+                        'http.fragment': '#room=secret-uuid',
+                    },
+                },
+                { data: { 'sentry.op': 'ui.react.render', 'http.query': '' } },
+            ],
+        };
+        const out = scrubTransactionEvent(event);
+        expect(JSON.stringify(out)).not.toContain('secret-uuid');
+        expect(out.contexts.trace.data['url.full']).toBe('https://www.floe.one/?s=abcd1234');
+        expect(out.contexts.trace.data['sentry.op']).toBe('pageload');
+        expect(out.spans[0].data['http.url']).toBe('https://www.floe.one/?s=abcd1234');
+        expect(out.spans[0].data['http.query']).toBe('?room=redacted&x=1');
+        expect(out.spans[0].data).not.toHaveProperty('http.fragment');
+        expect(out.spans[1].data).toEqual({ 'sentry.op': 'ui.react.render', 'http.query': '' });
+    });
+
+    it('returns the same object, tolerates a bare event, and leaves non-strings alone', () => {
+        const bare = {};
+        expect(scrubTransactionEvent(bare)).toBe(bare);
+        const odd = { spans: [{ data: { 'url.full': 42 } }] };
+        expect(scrubTransactionEvent(odd).spans[0].data['url.full']).toBe(42);
+    });
+});
+
+describe('scrubSpanJson', () => {
+    it('scrubs a standalone span in place', () => {
+        const span = { data: { 'url.full': 'https://www.floe.one/#room=secret-uuid' } };
+        expect(scrubSpanJson(span)).toBe(span);
+        expect(span.data['url.full']).toBe('https://www.floe.one/');
     });
 });

--- a/client/lib/scrubUrl.ts
+++ b/client/lib/scrubUrl.ts
@@ -31,3 +31,70 @@ export function scrubUrl(url: string | undefined | null): string | undefined {
             .replace(/([?&])room=[^&]*/i, '$1room=redacted');
     }
 }
+
+// The URL-bearing attributes the SDK writes onto spans: url.full and http.url
+// on http.client spans and on the segment span (the HttpContext integration
+// backfills url.full there from location.href), plus the http.query and
+// http.fragment the fetch and XHR instrumentation split out of a request URL.
+const URL_ATTRIBUTES = ['url.full', 'http.url', 'http.query', 'http.fragment'] as const;
+
+// Structural shapes for Sentry's TransactionEvent and SpanJSON, declared here
+// rather than imported so this module and its vitest never load the SDK.
+export interface ScrubbableSpan {
+    data?: Record<string, unknown>;
+}
+
+export interface ScrubbableTransaction {
+    request?: { url?: string };
+    contexts?: { trace?: { data?: Record<string, unknown> } };
+    spans?: ScrubbableSpan[];
+}
+
+// Scrubs the room secret out of one span's URL attributes, in place. Standalone
+// spans reach beforeSendSpan; spans inside a transaction event go through
+// scrubTransactionEvent below.
+export function scrubSpanJson<T extends ScrubbableSpan>(span: T): T {
+    scrubAttributes(span.data);
+    return span;
+}
+
+// Scrubs the room secret out of a performance transaction, in place.
+//
+// beforeSend never sees a transaction: the SDK routes error events through
+// beforeSend and transaction events through beforeSendTransaction, so the
+// scrubbing that protects error reports covered no trace. Meanwhile the
+// browser SDK's HttpContext integration stamps location.href, fragment
+// included, onto every event's request.url and onto the segment span's
+// url.full. On a receiver page that is the whole share link, and with
+// tracesSampleRate 0.1 one page load in ten was sending it.
+export function scrubTransactionEvent<T extends ScrubbableTransaction>(event: T): T {
+    if (event.request?.url) event.request.url = scrubUrl(event.request.url);
+    scrubAttributes(event.contexts?.trace?.data);
+    for (const span of event.spans ?? []) scrubAttributes(span.data);
+    return event;
+}
+
+function scrubAttributes(data: Record<string, unknown> | undefined): void {
+    if (!data) return;
+    for (const key of URL_ATTRIBUTES) {
+        const value = data[key];
+        if (typeof value !== 'string' || value === '') continue;
+        if (key === 'http.fragment') {
+            // A fragment is never useful telemetry, and it is where every
+            // current link keeps the room id.
+            delete data[key];
+        } else if (key === 'http.query') {
+            data[key] = scrubQuery(value);
+        } else {
+            data[key] = scrubUrl(value);
+        }
+    }
+}
+
+// http.query holds the bare search string ("?room=x&foo=1"). Run it through
+// scrubUrl on a dummy path and hand back only the search part.
+function scrubQuery(query: string): string {
+    const scrubbed = scrubUrl('/' + (query.startsWith('?') ? query : '?' + query)) ?? '';
+    const i = scrubbed.indexOf('?');
+    return i >= 0 ? scrubbed.slice(i) : '';
+}

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 import { BROWSER_EXTENSION_URL_PATTERNS } from './lib/browserExtensions';
 import { isStaleBundleError } from './lib/staleBundle';
-import { scrubUrl } from './lib/scrubUrl';
+import { scrubSpanJson, scrubTransactionEvent, scrubUrl } from './lib/scrubUrl';
 
 Sentry.init({
     // Set NEXT_PUBLIC_SENTRY_DSN in your environment to enable error tracking.
@@ -79,6 +79,22 @@ Sentry.init({
         return breadcrumb;
     },
 
+    // Transactions never pass through beforeSend: the SDK routes them here
+    // instead, and the HttpContext integration stamps the full page URL,
+    // fragment included, onto every event's request.url and onto the segment
+    // span's url.full. On a receiver page that is the whole share link, so
+    // until this hook existed one trace-sampled page load in ten sent it.
+    beforeSendTransaction(event) {
+        return scrubTransactionEvent(event);
+    },
+
+    // Standalone spans (the span-streaming lifecycle) bypass
+    // beforeSendTransaction. Scrub their URL attributes the same way so a
+    // future SDK default cannot reopen the gap.
+    beforeSendSpan(span) {
+        return scrubSpanJson(span);
+    },
+
     // Session Replay is deliberately absent, and must not be added back.
     //
     // A replay envelope reports the page URL in `request.url`, and on a receiver
@@ -101,8 +117,9 @@ Sentry.init({
     // rates at 0 or absent, initializeSampling() returns before attaching any
     // listener.
     //
-    // Error and performance monitoring are unaffected and keep their scrubbing
-    // through beforeSend and beforeBreadcrumb above.
+    // Error reports keep their scrubbing through beforeSend and
+    // beforeBreadcrumb above; performance traces get theirs through
+    // beforeSendTransaction and beforeSendSpan.
 
     debug: false,
 });

--- a/client/sentry.edge.config.ts
+++ b/client/sentry.edge.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
-import { scrubUrl } from './lib/scrubUrl';
+import { scrubTransactionEvent, scrubUrl } from './lib/scrubUrl';
 
 Sentry.init({
     // Set SENTRY_DSN in your environment to enable edge-side error tracking.
@@ -15,5 +15,11 @@ Sentry.init({
             event.request.url = scrubUrl(event.request.url);
         }
         return event;
+    },
+    // Transactions skip beforeSend, and a traced request carries its URL in
+    // the trace context and span attributes just as an error carries it in
+    // request.url. Same scrub, same reason.
+    beforeSendTransaction(event) {
+        return scrubTransactionEvent(event);
     },
 });

--- a/client/sentry.server.config.ts
+++ b/client/sentry.server.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs';
-import { scrubUrl } from './lib/scrubUrl';
+import { scrubTransactionEvent, scrubUrl } from './lib/scrubUrl';
 
 Sentry.init({
     // Set SENTRY_DSN in your environment to enable server-side error tracking.
@@ -17,5 +17,11 @@ Sentry.init({
             event.request.url = scrubUrl(event.request.url);
         }
         return event;
+    },
+    // Transactions skip beforeSend, and a traced request carries its URL in
+    // the trace context and span attributes just as an error carries it in
+    // request.url. Same scrub, same reason.
+    beforeSendTransaction(event) {
+        return scrubTransactionEvent(event);
     },
 });


### PR DESCRIPTION
## Summary

Two privacy fixes for floe.one that the legal-pages audit surfaced, landing ahead of the page rewrite so the pages can state them as live.

- **Sentry performance traces leaked the room link.** `beforeSend` only runs for error events; transactions go through `beforeSendTransaction`, which was never set, while the SDK's HttpContext integration stamps `location.href` (fragment included) onto every event. With `tracesSampleRate: 0.1`, one trace-sampled receiver page load in ten sent `/?s=<nonce>#room=<id>` to Sentry. Same class as the Session Replay leak #242 removed, and that PR's claim that performance kept its scrubbing through `beforeSend` was wrong. New `scrubTransactionEvent` / `scrubSpanJson` in `lib/scrubUrl.ts`, wired into `beforeSendTransaction` and `beforeSendSpan` (client) and `beforeSendTransaction` (server, edge).
- **Umami now honors Do Not Track** via `data-do-not-track="true"` on the script tag. The site's analytics had no opt-out at all until now.

## Test plan

- [x] `corepack pnpm test`: 11 scrubUrl tests pass (4 new: request.url, trace context, every span URL attribute the SDK writes, non-string values untouched)
- [x] `npx tsc --noEmit`, `corepack pnpm lint` (0 errors; the 2 Navbar warnings predate this)
- [x] `next build` with a local-sink DSN, then `node scripts/check-titles.mjs`
- [x] Real-bundle A/B on `/?s=abcd1234#room=<uuid>`: hook bypassed, the transaction envelope's `request.url` carries `#room=`; real hook, no `room=` anywhere in the envelope, the `http.fragment` attribute is dropped, and error events are still scrubbed
- [x] Do Not Track: the live `cloud.umami.is/script.js` pointed at a local sink host with `navigator.doNotTrack = '1'`: with the attribute, zero `/api/send` requests across two loads; without it, one pageview POST
- [ ] CI `CI green`
