### PR TITLE
feat(client): redesign the privacy and terms pages and correct their content

### DIFF
--- a/client/app/privacy/page.tsx
+++ b/client/app/privacy/page.tsx
@@ -3,9 +3,12 @@ import type { Metadata } from 'next';
 import {
     InlineCode,
     LegalCallout,
+    LegalLedger,
+    LegalLink,
     LegalList,
     LegalSection,
     LegalShell,
+    sectionIndex,
 } from '@/components/legal/LegalShell';
 import { sharedOpenGraph, sharedTwitter } from '@/lib/socialMetadata';
 
@@ -23,6 +26,10 @@ export const metadata: Metadata = {
     twitter: { ...sharedTwitter, title: 'Floe Privacy Policy' },
 };
 
+// Every sentence below was checked against the code it describes on
+// 2026-09-05 (server/server.js, server/turn.js, client/sentry.*.config.ts,
+// client/app/layout.tsx, cli/, desktop/) and against docs/security-privacy.mdx.
+// When a flag, label, hostname or number changes, this page changes with it.
 const toc = [
     { id: 'transfer', label: 'How the transfer works' },
     { id: 'collect', label: 'Information we collect' },
@@ -30,265 +37,542 @@ const toc = [
     { id: 'relay', label: 'Relay server' },
     { id: 'errors', label: 'Error monitoring' },
     { id: 'analytics', label: 'Usage analytics' },
+    { id: 'browser', label: 'The web app on your device' },
     { id: 'desktop', label: 'The desktop app' },
-    { id: 'contact', label: 'Contact & abuse reports' },
+    { id: 'cli', label: 'The CLI' },
+    { id: 'contact', label: 'Contact & reports' },
 ];
 
 export default function PrivacyPolicy() {
     return (
         <LegalShell
-            eyebrow="Legal"
+            document="privacy"
             title="Privacy policy"
-            updated="Last updated: August 2026"
+            dates={[{ label: 'Last updated', iso: '2026-09', text: 'September 2026' }]}
+            historyHref="https://github.com/jannskiee/floe/commits/main/client/app/privacy/page.tsx"
             toc={toc}
             intro={
-                <LegalCallout label="The short version" tone="positive">
+                <LegalCallout label="The short version" tone="summary">
                     <p>
-                        Floe is a <strong className="font-semibold text-zinc-200">peer-to-peer</strong>{' '}
-                        file transfer service. Your files stream directly from the sender&apos;s device
-                        to the receiver&apos;s device whenever possible.
+                        Floe is a <strong>peer-to-peer</strong> file transfer service. Your files
+                        stream directly from the sender&apos;s device to the receiver&apos;s device
+                        whenever possible, encrypted from end to end.
                     </p>
                     <p>
-                        <strong className="font-semibold text-zinc-200">
-                            We do not store, view, or process your files.
-                        </strong>{' '}
-                        In direct connections, files never touch our servers. In relay connections,
-                        encrypted file data passes through our TURN server in transit but is never
-                        stored or inspected. The only tally we keep is one anonymous number: the
-                        running total of bytes transferred across all users, shown by the counter on
-                        our homepage. You can opt out of contributing to it at any time. The
-                        cookieless, aggregate analytics and error monitoring we use are described
-                        below.
+                        <strong>We do not store, view, or process your files.</strong> In direct
+                        connections, files never touch our servers. In relay connections, encrypted
+                        file data passes through a TURN relay in transit (on floe.one, Cloudflare&apos;s
+                        network) but is never stored or inspected. The only tally we keep is one
+                        anonymous number: the running total of bytes transferred across all users,
+                        shown by the counter on our homepage, and you can opt out of contributing to
+                        it. The cookieless, aggregate analytics and the error monitoring the website
+                        uses are described below.
+                    </p>
+                    <p>
+                        This policy describes floe.one and the servers we run for it. Floe is open
+                        source, and an instance someone else hosts is theirs to run, under their own
+                        policy.
                     </p>
                 </LegalCallout>
             }
         >
-            <LegalSection id="transfer" index="01" title="How the transfer works">
+            <LegalSection id="transfer" index={sectionIndex(toc, 'transfer')} title="How the transfer works">
                 <p>
-                    When you send a file, we use{' '}
-                    <strong className="font-semibold text-zinc-200">WebRTC</strong> to establish a
-                    connection between you and the recipient. Our signaling server introduces the two
-                    devices and then steps aside. In most cases, data flows directly between browsers.
-                    When a direct path is not available, our TURN relay server bridges the connection.
-                    Even through the relay, files remain encrypted and are never stored.
+                    When you send a file, we use <strong>WebRTC</strong> to open a connection between
+                    you and the recipient. Our signaling server introduces the two devices and then
+                    steps aside. In most cases, data then flows directly between the two devices,
+                    whether each one is a browser, Floe Desktop, or the CLI. When a direct path is not
+                    available, a TURN relay (on floe.one, Cloudflare&apos;s network) bridges the
+                    connection. Even through the relay, files remain encrypted and are never stored.
+                </p>
+                <p>
+                    The encryption is WebRTC&apos;s own (DTLS), with keys that exist only on the two
+                    devices for that one transfer. The certificate fingerprints the two devices use to
+                    agree on those keys pass through our signaling server, so that server is trusted
+                    to introduce you honestly, and no Floe client shows a verification code to check
+                    it today. This is true of every WebRTC application; the full list of what Floe
+                    does not protect against is in{' '}
+                    <LegalLink href="https://www.floe.one/docs/how-it-works/known-limitations">
+                        Known limitations
+                    </LegalLink>
+                    .
+                </p>
+                <p>
+                    Peer-to-peer means the two devices connect to each other, so on a direct
+                    connection each learns the other&apos;s IP address, in the same way a video call
+                    does. A receiver page joins the room as soon as the link opens, with no click, and
+                    your browser begins exchanging its network addresses with the sender at that
+                    point. If you would rather not reveal your address to the other person, Floe
+                    Desktop&apos;s &quot;Hide my IP address&quot; setting and the CLI&apos;s{' '}
+                    <InlineCode>--relay-only</InlineCode> flag (or{' '}
+                    <InlineCode>FLOE_RELAY_ONLY=1</InlineCode>) route your side through the relay
+                    instead, so the other person sees the relay&apos;s address; relayed transfers are
+                    slower and capped at 2 GB. The web app has no equivalent: its &quot;Network relay
+                    fallback&quot; checkbox does the opposite, turning the relay off so only a direct
+                    connection is attempted.
                 </p>
             </LegalSection>
 
-            <LegalSection id="collect" index="02" title="Information we collect">
-                <LegalList
-                    marker={null}
-                    items={[
-                        <>
-                            <strong className="font-semibold text-zinc-200">Files.</strong> We do not
-                            collect or store any files.
-                        </>,
-                        <>
-                            <strong className="font-semibold text-zinc-200">Metadata.</strong>{' '}
-                            Filenames and sizes travel directly between the two devices over the
-                            encrypted data channel so the receiver can see what is arriving. They
-                            never pass through, and are never stored on, our servers.
-                        </>,
-                        <>
-                            <strong className="font-semibold text-zinc-200">
-                                Aggregate transfer total.
-                            </strong>{' '}
-                            When a transfer completes, the receiving side reports only the number of
-                            bytes it received. We add this to one shared, all-time counter of total
-                            bytes transferred, shown on our homepage. The sender never reports. We do
-                            not store file names, file contents, or any link between this number and
-                            you. You can opt out of this report: uncheck
-                            &quot;Contribute to global stats&quot; on the receiver view in the browser or in
-                            Floe Desktop&apos;s Settings, or use <InlineCode>--no-report</InlineCode> (or set{' '}
-                            <InlineCode>FLOE_NO_STATS=1</InlineCode>) when using the CLI.
-                        </>,
-                        <>
-                            <strong className="font-semibold text-zinc-200">IP addresses.</strong> Like
-                            all web servers, our hosting provider may log connection request IP
-                            addresses for security and abuse prevention. We do not link this to your
-                            identity.
-                        </>,
+            <LegalSection id="collect" index={sectionIndex(toc, 'collect')} title="Information we collect">
+                <LegalLedger
+                    rows={[
+                        {
+                            term: 'Files',
+                            body: <p>We do not collect or store any files.</p>,
+                        },
+                        {
+                            term: 'Connection setup',
+                            body: (
+                                <p>
+                                    To pair two devices, our signaling server receives the room id and
+                                    relays the WebRTC connection messages (offers, answers, and ICE
+                                    candidates, which carry each device&apos;s network addresses)
+                                    between them. It forwards them from memory, unread, and keeps
+                                    nothing once the room closes. When the sender uses the CLI or Floe
+                                    Desktop, the server also maps a random three-word code to the room
+                                    id for ten minutes.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'Metadata',
+                            body: (
+                                <p>
+                                    Filenames and sizes travel between the two devices over the
+                                    encrypted data channel so the receiver can see what is arriving.
+                                    They never reach our signaling server. On a relayed transfer they
+                                    pass through the relay in the same encrypted stream as the file
+                                    data, which the relay cannot read.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'Byte total',
+                            body: (
+                                <>
+                                    <p>
+                                        When a transfer completes, the receiving side reports only the
+                                        number of bytes it received. We add this to one shared,
+                                        all-time counter of total bytes transferred, shown on our
+                                        homepage and stored as a single number in a hosted Redis
+                                        database (Upstash). The sender never reports. We do not store
+                                        file names, file contents, or any link between this number and
+                                        you.
+                                    </p>
+                                    <p>
+                                        You can opt out: uncheck &quot;Contribute to global stats&quot;
+                                        on the receiver view in the browser or in Floe Desktop&apos;s
+                                        Settings, or use <InlineCode>--no-report</InlineCode> (or set{' '}
+                                        <InlineCode>FLOE_NO_STATS=1</InlineCode>) with the CLI. This
+                                        switch covers the public counter and nothing else: on floe.one
+                                        the site analytics described under Usage analytics record a
+                                        transfer&apos;s outcome separately, and the desktop app and the
+                                        CLI send no such event.
+                                    </p>
+                                </>
+                            ),
+                        },
+                        {
+                            term: 'IP addresses',
+                            body: (
+                                <p>
+                                    Our signaling server keeps your IP address in memory only long
+                                    enough to rate-limit abuse (at most about two minutes after your
+                                    last request), and the server itself writes no log of it. Like all
+                                    web servers, the reverse proxy in front of it and the providers
+                                    that host us may log connection request IP addresses for security
+                                    and abuse prevention. We do not link any of this to your identity.
+                                    Who else sees your IP address, and how to hide it from the other
+                                    person, is under How the transfer works.
+                                </p>
+                            ),
+                        },
                     ]}
                 />
             </LegalSection>
 
-            <LegalSection id="third-parties" index="03" title="Third-party services">
+            <LegalSection id="third-parties" index={sectionIndex(toc, 'third-parties')} title="Third-party services">
                 <p>
-                    Floe uses third-party infrastructure providers for hosting and network relay
-                    services. The web app is hosted on Vercel, the signaling server runs on Microsoft
-                    Azure, and when a relay is needed, encrypted file data passes through
-                    Cloudflare&apos;s TURN network. For usage analytics we use only Umami, which is
-                    cookieless and does not track you across sites, and we optionally use Sentry for
-                    error monitoring. The link you share carries its room id in the URL fragment (the
-                    part after the <InlineCode>#</InlineCode>). Browsers never include the fragment in
-                    HTTP requests, so it stays out of hosting logs, referrer headers, and analytics.
-                    Our signaling server receives the room id only when your app joins the room to be
-                    paired with your peer; it is held in memory for the life of the session and never
-                    logged. Please refer to each provider&apos;s privacy policy regarding data
-                    handling.
+                    Floe uses third-party infrastructure providers for hosting and connection setup.
+                    The web app is hosted on Vercel and the signaling server runs on Microsoft Azure.
+                    Connection setup uses Cloudflare on every transfer, direct or relayed, and relayed
+                    file data passes through Cloudflare&apos;s TURN network; Relay server below says
+                    exactly what it sees. If your app cannot get relay credentials from our signaling
+                    server, because the server is unreachable, has rate limited you, or has none to
+                    hand out at that moment, it falls back to Google&apos;s public STUN servers (
+                    <InlineCode>stun.l.google.com</InlineCode>) to learn its own public address.
+                    Google then sees your IP address and nothing about the transfer; STUN carries no
+                    file data.
+                </p>
+                <p>
+                    The running total behind the homepage counter is stored in a hosted Redis database
+                    (Upstash); the only thing ever written there is that single number, by our server,
+                    never by your device. Floe Desktop and the CLI contact GitHub only to check for or
+                    download updates: Floe Desktop&apos;s GitHub build once a day unless you turn the
+                    check off (Microsoft Store builds never check), and the CLI only when you run{' '}
+                    <InlineCode>floe version</InlineCode>, <InlineCode>floe update</InlineCode>, or{' '}
+                    <InlineCode>floe update --check</InlineCode>. Both are described in their own
+                    sections below. The documentation at floe.one/docs is served by Mintlify, a
+                    third-party documentation host: requests to those pages reach Mintlify, its pages
+                    load Mintlify&apos;s own scripts, and Mintlify may collect page-view data there.
+                </p>
+                <p>
+                    For usage analytics we use only Umami, which is cookieless and does not track you
+                    across sites, and for error monitoring we use Sentry. Both apply to the floe.one
+                    website only and are described below; the desktop app and the CLI have neither,
+                    and a self-hosted copy of Floe ships with both turned off.
+                </p>
+                <p>
+                    The link you share carries its room id in the URL fragment (the part after the{' '}
+                    <InlineCode>#</InlineCode>). Browsers never include the fragment in HTTP requests,
+                    so it stays out of hosting logs and referrer headers, and our analytics script is
+                    configured to drop it as well; what our error monitoring receives is described
+                    under Error monitoring. Links from the web app and Floe Desktop also carry a short
+                    random marker before the <InlineCode>#</InlineCode> (the{' '}
+                    <InlineCode>?s=</InlineCode> part); it exists only so each link opens as a
+                    distinct page, it says nothing about you or the room, and links printed by the CLI
+                    do not carry one. Our signaling server receives the room id when your app joins
+                    the room to be paired with your peer, and, for a transfer started from the CLI or
+                    Floe Desktop, when it registers the three-word code that stands in for the link.
+                    Both are held in memory only: the room is dropped when the last device leaves it,
+                    and a code&apos;s mapping to its room id expires ten minutes after the code was
+                    made. Neither is written to a log.
+                </p>
+                <p>
+                    Please refer to each provider&apos;s privacy policy regarding data handling:{' '}
+                    <LegalLink href="https://vercel.com/legal/privacy-notice">Vercel</LegalLink>,{' '}
+                    <LegalLink href="https://www.microsoft.com/privacy/privacystatement">
+                        Microsoft
+                    </LegalLink>
+                    , <LegalLink href="https://www.cloudflare.com/privacypolicy/">Cloudflare</LegalLink>
+                    , <LegalLink href="https://mintlify.com/legal/privacy">Mintlify</LegalLink>, and the
+                    Sentry and Umami policies linked in the sections below.
                 </p>
             </LegalSection>
 
-            <LegalSection id="relay" index="04" title="Relay server">
+            <LegalSection id="relay" index={sectionIndex(toc, 'relay')} title="Relay server">
                 <p>
                     When a direct connection cannot be established, file data is routed through
-                    Cloudflare&apos;s TURN relay network (<InlineCode>turn.cloudflare.com</InlineCode>).
-                    The relay processes encrypted data packets in transit and does not store, decrypt,
-                    or inspect any file contents. Relay sessions are limited to 2 GB per session.
-                    Connection metadata (timestamps, IP addresses) may be logged by the infrastructure
-                    provider for security purposes.
+                    Cloudflare&apos;s TURN relay network (<InlineCode>turn.cloudflare.com</InlineCode>
+                    ). The relay forwards encrypted packets it cannot decrypt: the keys exist only on
+                    the two devices. It does not store or inspect file contents. Relay sessions are
+                    limited to 2 GB per session.
+                </p>
+                <p>
+                    Cloudflare is involved before the route is decided, not only when a relay is
+                    needed. To find a working path, your app asks Cloudflare&apos;s STUN server (
+                    <InlineCode>stun.cloudflare.com</InlineCode>) for its own public address and,
+                    unless you turned relay fallback off in the browser or passed{' '}
+                    <InlineCode>--no-relay</InlineCode> to the CLI, opens a standby relay allocation
+                    on <InlineCode>turn.cloudflare.com</InlineCode>. That happens on every transfer,
+                    whichever route wins, so Cloudflare sees your IP address and the timing of the
+                    connection attempt on every transfer. File data crosses Cloudflare only when the
+                    relay is the route that wins.
+                </p>
+                <p>
+                    Before connecting, your app fetches relay credentials from our signaling server.
+                    On floe.one these are one shared credential set, minted from Cloudflare and valid
+                    for 24 hours, served to every client until we refresh it. They are not tied to
+                    you, your device, or an account.
+                </p>
+                <p>
+                    The relay is a hop both devices connect to, so Cloudflare sees both IP addresses
+                    and the timing and amount of data it forwards, and may log that for its own
+                    security purposes. See{' '}
+                    <LegalLink href="https://www.cloudflare.com/privacypolicy/">
+                        Cloudflare&apos;s privacy policy
+                    </LegalLink>{' '}
+                    for its handling of that data.
                 </p>
             </LegalSection>
 
-            <LegalSection id="errors" index="05" title="Error monitoring">
+            <LegalSection id="errors" index={sectionIndex(toc, 'errors')} title="Error monitoring">
                 <p>
-                    The <strong className="font-semibold text-zinc-200">web app</strong> uses Sentry
-                    to monitor application errors and performance. This applies to floe.one in the
-                    browser only; the desktop app and the CLI contain no error monitoring. Sentry may
+                    The <strong>web app</strong> uses Sentry to monitor application errors and a 10%
+                    sample of page performance traces. This applies to the floe.one website only; the
+                    desktop app and the CLI contain no error monitoring. Sentry is configured to attach
+                    no cookies and no IP address to what it sends; each report does carry the page
+                    address, your browser&apos;s user agent, and the page that referred you. It may
                     capture:
                 </p>
                 <LegalList
                     items={[
-                        'Error stack traces and browser metadata (browser version, OS, device type)',
+                        'Error stack traces and browser metadata (browser version, OS, device type, language, and time zone)',
                         'Connection type (direct or relay), transfer progress, file count, and total size at the time of an error',
                     ]}
                 />
                 <p>
-                    Session replay is{' '}
-                    <strong className="font-semibold text-zinc-200">not</strong> enabled. Floe used to
-                    record a sample of browser sessions. A recording reported the page address, and on
-                    a receiver page that address contains the room link, so replay was removed rather
-                    than kept: the room link is the only thing protecting a transfer.
+                    Session replay is <strong>not</strong> enabled. Floe used to record a sample of
+                    browser sessions. A recording reported the page address, and on a receiver page
+                    that address contains the room link, so replay was removed rather than kept: the
+                    room link is the only thing protecting a transfer.
                 </p>
                 <p>
-                    Sentry does <strong className="font-semibold text-zinc-200">not</strong> capture
-                    file names, file contents, or any personally identifiable information. The room
-                    link is stripped from every error report and breadcrumb before it is sent.{' '}
-                    <a
-                        href="https://sentry.io/privacy/"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-zinc-300 underline decoration-white/20 underline-offset-4 transition hover:text-ice"
-                    >
-                        Sentry Privacy Policy
-                    </a>
-                    .
+                    Sentry does <strong>not</strong> capture file names, file contents, or any
+                    personally identifiable information. The room link is stripped from every error
+                    report, breadcrumb, and performance trace before it is sent.{' '}
+                    <LegalLink href="https://sentry.io/privacy/">Sentry Privacy Policy</LegalLink>.
                 </p>
             </LegalSection>
 
-            <LegalSection id="analytics" index="06" title="Usage analytics">
+            <LegalSection id="analytics" index={sectionIndex(toc, 'analytics')} title="Usage analytics">
                 <p>
-                    The <strong className="font-semibold text-zinc-200">web app</strong> uses Umami, a
-                    privacy-focused analytics tool, to understand how the service is used. This
-                    applies to floe.one in the browser only; the desktop app and the CLI contain no
-                    analytics. Umami collects:
+                    The <strong>web app</strong> uses Umami Cloud, the hosted analytics service run by
+                    Umami&apos;s makers, to understand how the service is used. This applies to the
+                    floe.one website only; the desktop app and the CLI contain no analytics. Umami
+                    collects:
                 </p>
                 <LegalList
                     items={[
-                        'Aggregate transfer metrics: number of files and total bytes transferred per session',
-                        'Connection type (direct or relay) and whether a transfer succeeded or failed',
-                        'Standard page view data: pages visited, browser type, country (not city)',
+                        'Transfer outcomes: for a completed transfer, the number of files, the total size in bytes, whether you were sending or receiving, and whether the connection was direct or relayed; for a failure, your role, one of five fixed labels (for example "ice-failed"), and, when you were sending, the file count and total size',
+                        "Which download button you clicked on the download page, the homepage, or the navigation bar, and, when Floe opens inside another app's built-in browser (such as Facebook or Instagram), the name of that app and whether it was Android or iOS",
+                        'Standard page view data: the page path, referring site, browser, operating system, device type, screen size, language, and approximate location (country, region, and city), derived from your IP address by Umami, which does not store the address',
                     ]}
                 />
                 <p>
-                    Umami does <strong className="font-semibold text-zinc-200">not</strong> use
-                    cookies, does not collect personally identifiable information, and does not track
-                    individuals across sessions or websites. File names and file contents are never
-                    recorded.{' '}
-                    <a
-                        href="https://umami.is/privacy"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-zinc-300 underline decoration-white/20 underline-offset-4 transition hover:text-ice"
-                    >
-                        Umami Privacy Policy
-                    </a>
-                    .
+                    Umami does not use cookies and stores nothing on your device. It does not collect
+                    personally identifiable information: your IP address and browser signature are
+                    hashed with a salt that rotates on a schedule, so Umami can count a returning
+                    visitor for a while without keeping the address, and the hash is tied to
+                    floe.one, so it cannot follow you to other websites. File names and file contents
+                    are never recorded. It is configured to drop the URL fragment and the query string
+                    before reporting a page view, so the room link never reaches it. If your browser
+                    sends the Do Not Track signal, Umami records nothing at all for your visit.{' '}
+                    <LegalLink href="https://umami.is/privacy">Umami Privacy Policy</LegalLink>.
                 </p>
             </LegalSection>
 
-            <LegalSection id="desktop" index="07" title="The desktop app">
+            <LegalSection id="browser" index={sectionIndex(toc, 'browser')} title="The web app on your device">
                 <p>
-                    Floe Desktop is the same peer-to-peer engine as the web app and the CLI, running
-                    as a Windows application. Its network behavior is identical: it contacts our
-                    signaling server to pair you with your peer, fetches relay credentials, and then
-                    streams file data directly between devices. It contains{' '}
-                    <strong className="font-semibold text-zinc-200">
-                        no analytics, no error monitoring, and no telemetry
-                    </strong>
-                    . It makes two optional requests, each with its own off switch: the same
-                    anonymous byte total described above, which you can turn off with &quot;Contribute
-                    to global stats&quot; in Settings, and a once-a-day update check. The update check
-                    (GitHub builds 0.2.3 and later) asks GitHub whether a newer release exists; it
-                    carries nothing about you beyond what any web request reveals (your IP address
-                    and a user agent), nothing about your files or transfers is in it, and nothing
-                    downloads or installs by itself. Turn off &quot;Check for updates&quot; in
-                    Settings and no request is made at all. Microsoft Store builds never check; the
-                    Store updates them itself.
+                    The web app keeps a few small things in your browser, and none of them leave it.
+                    So that floe.one loads quickly and can open without a network, your browser caches
+                    the app&apos;s pages and build files, the same files every visitor downloads; that
+                    cache never holds file data or anything from our API. Your &quot;Contribute to
+                    global stats&quot; choice is remembered in this browser&apos;s local storage, and a
+                    timestamp is kept for the life of the tab to avoid reload loops after a new version
+                    is deployed.
+                </p>
+                <p>
+                    Files you receive are held in the tab&apos;s memory until you download them;
+                    closing the tab discards anything you did not save, and nothing about a
+                    transfer&apos;s files is written to browser storage. While a transfer is running
+                    the app asks your browser to keep the screen awake and releases that when the
+                    transfer ends. The app writes to your clipboard only when you press Copy and never
+                    reads it, and it never asks for notification permission.
+                </p>
+            </LegalSection>
+
+            <LegalSection id="desktop" index={sectionIndex(toc, 'desktop')} title="The desktop app">
+                <p>
+                    Floe Desktop runs the same peer-to-peer engine as the CLI and speaks the same
+                    protocol as the web app, as a Windows application. It talks to the same servers
+                    the web app does: it contacts our signaling server to pair you with your peer (and
+                    to register the three-word code it shows), fetches relay credentials, and then
+                    streams file data directly between devices, or through the relay described above
+                    when no direct path exists or when &quot;Hide my IP address&quot; is on. Two more
+                    requests happen only when you ask for them: the Test button in Settings contacts
+                    only the server address you typed, and if the Microsoft WebView2 runtime that
+                    draws the interface is missing, the app offers to download it from Microsoft
+                    before it starts. It contains{' '}
+                    <strong>no analytics, no error monitoring, and no telemetry</strong>.
+                </p>
+                <p>
+                    It makes two optional requests, each with its own off switch: the same anonymous
+                    byte total described above, which you can turn off with &quot;Contribute to global
+                    stats&quot; in Settings, and a once-a-day update check. The update check (GitHub
+                    builds 0.2.3 and later) asks GitHub whether a newer release exists; it carries
+                    nothing about you beyond what any web request reveals (your IP address and a user
+                    agent), nothing about your files or transfers is in it, and nothing downloads or
+                    installs by itself. Turn off &quot;Check for updates&quot; in Settings (or set{' '}
+                    <InlineCode>FLOE_NO_UPDATE_CHECK=1</InlineCode>, the same variable the CLI honors)
+                    and no request is made at all. Microsoft Store builds never check; the Store
+                    updates them itself.
+                </p>
+                <p>
+                    It also adds one privacy switch the web app does not have. On a direct connection
+                    the other device learns your IP address, as in any peer-to-peer connection. Turn
+                    on &quot;Hide my IP address&quot; in Settings and the app uses only the relay, so
+                    the other person sees the relay&apos;s address instead; relayed transfers are
+                    slower and capped at 2 GB.
                 </p>
                 <p>Everything else it does stays on your device:</p>
-                <LegalList
-                    marker={null}
-                    items={[
-                        <>
-                            <strong className="font-semibold text-zinc-200">Clipboard.</strong> The
-                            app reads your clipboard only when you paste (Ctrl+V) to stage copied
-                            files or a screenshot for sending. It never reads the clipboard in the
-                            background.
-                        </>,
-                        <>
-                            <strong className="font-semibold text-zinc-200">Files.</strong> Received
-                            files are written to the folder you choose (your Downloads folder by
-                            default). Nothing is uploaded anywhere.
-                        </>,
-                        <>
-                            <strong className="font-semibold text-zinc-200">Settings.</strong> Your
-                            preferences are stored locally in your user profile and are not removed
-                            automatically when the app is uninstalled.
-                        </>,
-                        <>
-                            <strong className="font-semibold text-zinc-200">
-                                Optional right-click menu.
-                            </strong>{' '}
-                            The GitHub build can add a &quot;Send with Floe&quot; entry to the File
-                            Explorer right-click menu. Turning it on writes one per-user registry
-                            entry; turning it off (or uninstalling) removes it. The Microsoft Store
-                            build does not offer this entry.
-                        </>,
-                        <>
-                            <strong className="font-semibold text-zinc-200">Notifications.</strong>{' '}
-                            The app shows standard Windows notifications when a transfer completes or
-                            fails.
-                        </>,
+                <LegalLedger
+                    rows={[
+                        {
+                            term: 'Clipboard',
+                            body: (
+                                <p>
+                                    The app reads your clipboard only when you paste (Ctrl+V) to stage
+                                    copied files or a screenshot for sending. It never reads the
+                                    clipboard in the background.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'Files',
+                            body: (
+                                <p>
+                                    Received files are written to the folder you choose (your Downloads
+                                    folder by default). Nothing is uploaded anywhere.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'History',
+                            body: (
+                                <p>
+                                    The app keeps a list of your last 50 transfers on your device: for
+                                    each one, the direction, the file names (for a received transfer,
+                                    the names as saved and the folder they went to), the file count,
+                                    the total size, and the time. It never leaves your device. Remove
+                                    one entry with Remove inside its row, or all of them with Clear in
+                                    the History view. Reset in Settings and uninstalling the app both
+                                    leave it in place.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'Settings',
+                            body: (
+                                <p>
+                                    Your preferences are stored locally in your user profile and are
+                                    not removed automatically when the app is uninstalled.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'Right-click menu',
+                            body: (
+                                <p>
+                                    The GitHub build adds a &quot;Send with Floe&quot; entry to the
+                                    File Explorer right-click menu. It is on by default: the first time
+                                    the app runs it writes one per-user registry key (with a command
+                                    subkey) that holds the app&apos;s location, and if you move the app
+                                    it rewrites that key at the next start. Turn off &quot;Show in
+                                    right-click menu&quot; in Settings and the key is removed; the
+                                    installer&apos;s uninstall removes it too. The portable zip has no
+                                    uninstaller, so turn the switch off before deleting that build. The
+                                    Microsoft Store build does not offer this entry.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'Notifications',
+                            body: (
+                                <p>
+                                    The app shows standard Windows notifications when a transfer
+                                    completes or fails.
+                                </p>
+                            ),
+                        },
                     ]}
                 />
                 <p>
                     When installed from the Microsoft Store, installation and automatic updates are
-                    handled by Microsoft; see Microsoft&apos;s privacy statement for what the Store
-                    itself collects.
+                    handled by Microsoft; see{' '}
+                    <LegalLink href="https://www.microsoft.com/privacy/privacystatement">
+                        Microsoft&apos;s privacy statement
+                    </LegalLink>{' '}
+                    for what the Store itself collects.
                 </p>
             </LegalSection>
 
-            <LegalSection id="contact" index="08" title="Contact & abuse reports">
+            <LegalSection id="cli" index={sectionIndex(toc, 'cli')} title="The CLI">
                 <p>
-                    Questions about this policy, bug reports, and abuse reports all go to our public
+                    The <InlineCode>floe</InlineCode> command line tool runs the same peer-to-peer
+                    engine as Floe Desktop. <InlineCode>floe send</InlineCode> and{' '}
+                    <InlineCode>floe receive</InlineCode> contact our signaling server (api.floe.one,
+                    or the server you name with <InlineCode>--server</InlineCode> or{' '}
+                    <InlineCode>FLOE_SERVER</InlineCode>) to register or look up a short code, fetch
+                    relay credentials, and pair you with your peer, and then stream file data directly
+                    between devices, or through the relay described above when no direct path exists.
+                    The CLI contains no analytics, no error monitoring, and no telemetry, and it keeps
+                    no history or log of your transfers. It makes two optional requests, each with its
+                    own off switch:
+                </p>
+                <LegalLedger
+                    rows={[
+                        {
+                            term: 'Byte total',
+                            body: (
+                                <p>
+                                    After a transfer completes, <InlineCode>floe receive</InlineCode>{' '}
+                                    sends the number of bytes it received to the signaling server it
+                                    used, so on a self-hosted server the count goes to that server and
+                                    not to us. Pass <InlineCode>--no-report</InlineCode>, or set{' '}
+                                    <InlineCode>FLOE_NO_STATS=1</InlineCode>, and no request is made.{' '}
+                                    <InlineCode>floe send</InlineCode> never reports.
+                                </p>
+                            ),
+                        },
+                        {
+                            term: 'Update check',
+                            body: (
+                                <p>
+                                    <InlineCode>floe version</InlineCode> asks GitHub whether a newer
+                                    release exists when you run it, at most once a day (the answer is
+                                    kept for 24 hours in a small file in your user configuration
+                                    folder). The request carries nothing about you beyond what any web
+                                    request reveals (your IP address and a generic user agent); nothing
+                                    about your files or transfers is in it, and nothing downloads or
+                                    installs by itself. Set <InlineCode>FLOE_NO_UPDATE_CHECK=1</InlineCode>{' '}
+                                    and no request is made. <InlineCode>floe send</InlineCode> and{' '}
+                                    <InlineCode>floe receive</InlineCode> never check, and a build
+                                    compiled from source never checks.
+                                </p>
+                            ),
+                        },
+                    ]}
+                />
+                <p>
+                    <InlineCode>floe update</InlineCode> is you asking for an update: it fetches the
+                    latest release, its checksum file, and the archive for your platform from GitHub,
+                    verifies the SHA-256 checksum, and replaces the binary. On an install managed by
+                    Homebrew, Scoop, or Winget it stops before any request and points you at your
+                    package manager instead. Received files go to the folder you pass with{' '}
+                    <InlineCode>-o</InlineCode> (the folder you ran the command in, by default), and{' '}
+                    <InlineCode>--relay-only</InlineCode> (or{' '}
+                    <InlineCode>FLOE_RELAY_ONLY=1</InlineCode>) routes your side through the relay so
+                    the other device sees the relay&apos;s address instead of yours.
+                </p>
+            </LegalSection>
+
+            <LegalSection id="contact" index={sectionIndex(toc, 'contact')} title="Contact & reports">
+                <p>
+                    Questions about this policy, bug reports, and abuse reports go to our public
                     issue tracker:{' '}
-                    <a
-                        href="https://github.com/jannskiee/floe/issues"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-zinc-300 underline decoration-white/20 underline-offset-4 transition hover:text-ice"
-                    >
+                    <LegalLink href="https://github.com/jannskiee/floe/issues">
                         github.com/jannskiee/floe/issues
-                    </a>
-                    .
+                    </LegalLink>
+                    . Two things should not go there. If you have found a security vulnerability,
+                    report it privately through GitHub&apos;s{' '}
+                    <LegalLink href="https://github.com/jannskiee/floe/security/advisories/new">
+                        Report a vulnerability
+                    </LegalLink>{' '}
+                    form or the email address in our{' '}
+                    <LegalLink href="https://github.com/jannskiee/floe/security/policy">
+                        security policy
+                    </LegalLink>
+                    , so the problem is not public before there is a fix. If an abuse report includes
+                    personal details about anyone, or copies of the content itself, send it through
+                    those same private channels instead of opening a public issue.
                 </p>
                 <p>
-                    Because Floe is peer-to-peer, transferred content never reaches our servers: we
-                    cannot see, store, or remove files that users send to each other. What we can do
-                    in response to a report is restrict abusive use of the signaling and relay
-                    infrastructure. If you believe Floe is being used to send you illegal or harmful
-                    content, stop accepting transfers from that sender and report the details on the
-                    issue tracker so we can act on the infrastructure side.
+                    Because Floe is peer-to-peer, transferred content never sits on our servers: a
+                    direct transfer never touches them, and a relayed one passes through the relay only
+                    as encrypted packets it cannot read. We cannot see, store, or remove files that
+                    users send to each other. What we can do in response to a report is limited, and
+                    we would rather say so plainly. Our signaling server keeps no record of who joined
+                    which room, and the relay credentials it hands out are shared by every client
+                    rather than issued per person, so we cannot identify a particular sender after the
+                    fact or cut off their relay access alone. Per-address rate limits apply to everyone
+                    automatically, and that is the extent of what the service does on its own.
+                </p>
+                <p>
+                    If you believe Floe is being used to send you illegal or harmful content, do not
+                    open further links or codes from that sender (a transfer only starts when you open
+                    one, and the command line asks before it accepts) and report the details as
+                    described above.
                 </p>
             </LegalSection>
         </LegalShell>

--- a/client/app/terms/page.tsx
+++ b/client/app/terms/page.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import type { Metadata } from 'next';
 import {
     LegalCallout,
+    LegalLink,
     LegalList,
     LegalSection,
     LegalShell,
+    sectionIndex,
 } from '@/components/legal/LegalShell';
 import { sharedOpenGraph, sharedTwitter } from '@/lib/socialMetadata';
 
@@ -27,15 +29,22 @@ const toc = [
     { id: 'responsibility', label: 'User responsibility' },
     { id: 'license', label: 'Copyright & license' },
     { id: 'relay', label: 'Relay usage' },
-    { id: 'contact', label: 'Contact & abuse reports' },
+    { id: 'contact', label: 'Contact & reports' },
 ];
 
 export default function TermsOfUse() {
     return (
         <LegalShell
-            eyebrow="Legal"
+            document="terms"
             title="Terms of use"
-            updated="Effective date: May 2026"
+            // Effective when these terms were first published; the contact
+            // section arrived in August 2026 and the acceptable-use wording
+            // changed in September 2026, so both dates are shown.
+            dates={[
+                { label: 'Effective', iso: '2026-05', text: 'May 2026' },
+                { label: 'Last updated', iso: '2026-09', text: 'September 2026' },
+            ]}
+            historyHref="https://github.com/jannskiee/floe/commits/main/client/app/terms/page.tsx"
             toc={toc}
             intro={
                 <LegalCallout label="Disclaimer" tone="caution">
@@ -47,19 +56,27 @@ export default function TermsOfUse() {
                 </LegalCallout>
             }
         >
-            <LegalSection id="acceptable-use" index="01" title="Acceptable use">
+            <LegalSection id="acceptable-use" index={sectionIndex(toc, 'acceptable-use')} title="Acceptable use">
                 <p>By using Floe, you agree not to:</p>
                 <LegalList
                     marker="&#10005;"
                     items={[
                         'Transfer illegal content (e.g., malware, pirated software, child exploitation material).',
                         'Use the service for phishing or social engineering attacks.',
-                        'Attempt to disrupt, abuse, or reverse-engineer the signaling or relay servers.',
+                        'Disrupt, overload, or abuse the signaling server or the relay service behind floe.one.',
                     ]}
                 />
+                <p>
+                    The code itself is open source: reading it, running your own copy, and reporting
+                    what you find are welcome. See Copyright &amp; license below and our{' '}
+                    <LegalLink href="https://github.com/jannskiee/floe/security/policy">
+                        security policy
+                    </LegalLink>
+                    .
+                </p>
             </LegalSection>
 
-            <LegalSection id="responsibility" index="02" title="User responsibility">
+            <LegalSection id="responsibility" index={sectionIndex(toc, 'responsibility')} title="User responsibility">
                 <p>
                     Since Floe is a peer-to-peer service, you are solely responsible for the content
                     you send. We do not (and cannot) moderate file contents. You agree to indemnify the
@@ -67,39 +84,43 @@ export default function TermsOfUse() {
                 </p>
             </LegalSection>
 
-            <LegalSection id="license" index="03" title="Copyright & license">
+            <LegalSection id="license" index={sectionIndex(toc, 'license')} title="Copyright & license">
                 <p>
-                    The source code for Floe is available under the{' '}
-                    <strong className="font-semibold text-zinc-200">MIT License</strong>. You are free
-                    to inspect, modify, and host your own version of this software, subject to the
-                    terms of the license.
+                    The source code for Floe is available under the <strong>MIT License</strong>. You
+                    are free to inspect, modify, and host your own version of this software, subject
+                    to the terms of the license.
                 </p>
             </LegalSection>
 
-            <LegalSection id="relay" index="04" title="Relay usage">
+            <LegalSection id="relay" index={sectionIndex(toc, 'relay')} title="Relay usage">
                 <p>
-                    When your connection uses the TURN relay server, transfers are limited to 2 GB per
-                    session. Excessive or automated abuse of relay bandwidth may result in rate
-                    limiting or temporary access restrictions. These limits exist to keep Floe free for
-                    all users.
+                    When your connection uses the TURN relay, transfers are limited to 2 GB per
+                    session. Excessive or automated use of the relay may result in rate limiting or
+                    restrictions on access to the signaling and relay infrastructure. These limits
+                    exist to keep Floe free for all users.
                 </p>
             </LegalSection>
 
-            <LegalSection id="contact" index="05" title="Contact & abuse reports">
+            <LegalSection id="contact" index={sectionIndex(toc, 'contact')} title="Contact & reports">
                 <p>
-                    Questions about these terms, bug reports, and abuse reports all go to our public
+                    Questions about these terms, bug reports, and abuse reports go to our public
                     issue tracker:{' '}
-                    <a
-                        href="https://github.com/jannskiee/floe/issues"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-zinc-300 underline decoration-white/20 underline-offset-4 transition hover:text-ice"
-                    >
+                    <LegalLink href="https://github.com/jannskiee/floe/issues">
                         github.com/jannskiee/floe/issues
-                    </a>
-                    . Because transfers are peer-to-peer, we cannot inspect or remove content sent
-                    between users; reports of misuse are acted on by restricting access to the
-                    signaling and relay infrastructure.
+                    </LegalLink>
+                    . Security vulnerabilities, and abuse reports that include personal details or
+                    copies of the content, go privately instead: use the vulnerability report form or
+                    the email address in our{' '}
+                    <LegalLink href="https://github.com/jannskiee/floe/security/policy">
+                        security policy
+                    </LegalLink>{' '}
+                    rather than a public issue.
+                </p>
+                <p>
+                    Because transfers are peer-to-peer, we cannot inspect or remove content sent
+                    between users, and our signaling server keeps no record of who took part in a
+                    transfer. Automatic per-address rate limits are the only restriction the service
+                    applies on its own.
                 </p>
             </LegalSection>
         </LegalShell>

--- a/client/components/legal/LegalShell.tsx
+++ b/client/components/legal/LegalShell.tsx
@@ -1,72 +1,152 @@
 import React, { ReactNode } from 'react';
 import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, ArrowUpRight } from 'lucide-react';
 import { Footer } from '@/components/layout/Footer';
+import { LegalToc, type TocItem } from './LegalToc';
+import { EYEBROW, FOCUS_RING } from './styles';
 
 /**
  * Shared frame for the legal document pages (/privacy, /terms), following the
- * landing design system: mono ice eyebrow, hairline rules, asymmetric 4/8 grid
- * with a sticky on-page nav in the left rail. The shared site <Footer /> renders
- * at the bottom, replacing the private bottom bar this shell used to carry.
+ * landing design system: mono ice eyebrow, hairline rules, the asymmetric 4/8
+ * grid, with a sticky rail on the left that carries the document switcher,
+ * the dated meta and the scroll-spy table of contents. The shared site
+ * <Footer /> renders at the bottom.
+ *
+ * Everything here is server-rendered; the only client island is LegalToc.
  */
+
+const DOCUMENTS = [
+    { key: 'privacy', label: 'Privacy policy', href: '/privacy' },
+    { key: 'terms', label: 'Terms of use', href: '/terms' },
+] as const;
+
+export type LegalDocument = (typeof DOCUMENTS)[number]['key'];
+
+/**
+ * The number a section shows, taken from its position in the table of
+ * contents so the rail and the heading can never disagree. A section missing
+ * from the TOC throws, which fails the prerender at build time.
+ */
+export function sectionIndex(toc: readonly TocItem[], id: string): string {
+    const i = toc.findIndex((item) => item.id === id);
+    if (i < 0) throw new Error(`section "${id}" is not in the table of contents`);
+    return String(i + 1).padStart(2, '0');
+}
+
+export interface LegalDate {
+    label: string;
+    /** ISO month, e.g. "2026-09", for the <time> element. */
+    iso: string;
+    text: string;
+}
+
 export function LegalShell({
-    eyebrow,
+    document,
     title,
-    updated,
+    dates,
+    historyHref,
     toc,
     intro,
     children,
 }: {
-    eyebrow: string;
+    document: LegalDocument;
     title: string;
-    updated: string;
-    toc: { id: string; label: string }[];
+    dates: LegalDate[];
+    historyHref: string;
+    toc: TocItem[];
     intro?: ReactNode;
     children: ReactNode;
 }) {
     return (
-        <div className="min-h-dvh bg-zinc-950 font-sans text-zinc-100">
+        // print: browsers drop background colors by default, so the dark
+        // theme would print as light text on white paper. Every descendant
+        // takes the ink color and a visible hairline instead.
+        <div className="min-h-dvh bg-zinc-950 font-sans text-zinc-100 print:bg-white print:text-zinc-900 print:[&_*]:text-inherit! print:[&_*]:border-zinc-300!">
             <div className="mx-auto w-full max-w-5xl px-4 pb-10 pt-10 sm:px-6 sm:pt-14">
                 <Link
                     href="/"
-                    className="inline-flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-zinc-100"
+                    className={`inline-flex items-center gap-2 text-sm text-zinc-400 transition-colors hover:text-zinc-100 ${FOCUS_RING} print:hidden`}
                 >
-                    <ArrowLeft className="h-4 w-4" /> Back to Floe
+                    <ArrowLeft className="h-4 w-4" aria-hidden="true" /> Back to Floe
                 </Link>
+
                 <div className="mt-10 grid gap-10 lg:grid-cols-12 lg:gap-12">
-                    <header className="lg:sticky lg:top-12 lg:col-span-4 lg:self-start">
-                        <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-ice">{eyebrow}</p>
+                    <header className="lg:sticky lg:top-12 lg:col-span-4 lg:self-start print:static">
+                        {/* Document switcher: the same active-tab grammar as
+                            the install tabs on the homepage, ice marking the
+                            document you are on. */}
+                        <nav
+                            aria-label="Legal documents"
+                            className="flex gap-1 border-b border-white/[0.06] print:hidden"
+                        >
+                            {DOCUMENTS.map((doc) => {
+                                const active = doc.key === document;
+                                return (
+                                    <Link
+                                        key={doc.key}
+                                        href={doc.href}
+                                        aria-current={active ? 'page' : undefined}
+                                        className={`-mb-px border-b px-3 py-2 font-mono text-xs transition ${FOCUS_RING} ${
+                                            active
+                                                ? 'border-ice text-zinc-100'
+                                                : 'border-transparent text-zinc-400 hover:text-zinc-200'
+                                        }`}
+                                    >
+                                        {doc.label}
+                                    </Link>
+                                );
+                            })}
+                        </nav>
+
+                        <p className={`mt-8 ${EYEBROW} text-ice`}>
+                            Legal
+                        </p>
                         <h1 className="mt-4 text-3xl font-semibold tracking-tight text-zinc-100 sm:text-4xl">
                             {title}
                         </h1>
-                        <p className="mt-4 font-mono text-xs text-zinc-500">{updated}</p>
-                        <nav aria-label="On this page" className="mt-10 hidden lg:block">
-                            <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-zinc-600">
-                                On this page
-                            </p>
-                            <ul className="mt-4 space-y-3">
-                                {toc.map((item, i) => (
-                                    <li key={item.id}>
-                                        <a
-                                            href={`#${item.id}`}
-                                            className="group flex items-baseline gap-3 text-sm text-zinc-400 transition hover:text-ice"
-                                        >
-                                            <span className="font-mono text-xs text-zinc-600 transition group-hover:text-ice/70">
-                                                {String(i + 1).padStart(2, '0')}
-                                            </span>
-                                            {item.label}
-                                        </a>
-                                    </li>
-                                ))}
-                            </ul>
-                        </nav>
+
+                        <dl className="mt-6 grid grid-cols-[auto_1fr] items-baseline gap-x-5 gap-y-2 text-xs">
+                            {dates.map((date) => (
+                                <React.Fragment key={date.label}>
+                                    {/* zinc-400, not the eyebrow's zinc-600: on /terms these
+                                        labels are the only thing telling two dates apart. */}
+                                    <dt className={`${EYEBROW} text-zinc-400`}>
+                                        {date.label}
+                                    </dt>
+                                    <dd className="font-mono text-zinc-400">
+                                        <time dateTime={date.iso}>{date.text}</time>
+                                    </dd>
+                                </React.Fragment>
+                            ))}
+                        </dl>
+
+                        <a
+                            href={historyHref}
+                            target="_blank"
+                            rel="noreferrer"
+                            className={`group mt-5 inline-flex items-center gap-1.5 text-sm text-zinc-400 transition hover:text-ice ${FOCUS_RING} print:hidden`}
+                        >
+                            See every change on GitHub
+                            <ArrowUpRight
+                                className="h-3.5 w-3.5 text-zinc-600 transition group-hover:text-ice"
+                                aria-hidden="true"
+                            />
+                        </a>
+
+                        <div className="print:hidden">
+                            <LegalToc items={toc} />
+                        </div>
                     </header>
+
                     <main className="lg:col-span-8">
                         {intro}
-                        <div className={intro ? 'mt-10' : undefined}>{children}</div>
+                        <div className={intro ? 'mt-12' : undefined}>{children}</div>
                     </main>
                 </div>
-                <Footer />
+
+                <div className="print:hidden">
+                    <Footer />
+                </div>
             </div>
         </div>
     );
@@ -84,36 +164,66 @@ export function LegalSection({
     children: ReactNode;
 }) {
     return (
-        <section id={id} className="scroll-mt-8 border-t border-white/[0.06] py-8 sm:py-10">
-            <div className="flex gap-4 sm:gap-5">
-                <span className="w-6 shrink-0 pt-0.5 font-mono text-xs text-zinc-600" aria-hidden="true">
+        <section id={id} className="scroll-mt-10 border-t border-white/[0.06] py-9 sm:py-11">
+            <div className="flex items-baseline gap-4 sm:gap-6">
+                <span className="w-8 shrink-0 font-mono text-xs text-zinc-600" aria-hidden="true">
                     {index}
                 </span>
                 <div className="min-w-0 flex-1">
-                    <h2 className="text-lg font-medium tracking-tight text-zinc-100">{title}</h2>
-                    <div className="mt-3 space-y-4 text-sm leading-relaxed text-zinc-400">{children}</div>
+                    <h2 className="text-xl font-medium tracking-tight text-zinc-100">{title}</h2>
+                    <div className="mt-4 space-y-5 text-[15px] leading-7 text-zinc-400 [&_strong]:font-medium [&_strong]:text-zinc-200">
+                        {children}
+                    </div>
                 </div>
             </div>
         </section>
     );
 }
 
+/**
+ * The intro block: a plain-language summary on the privacy page, the warranty
+ * disclaimer on the terms page. `summary` carries the ice accent, the one the
+ * landing sections use for their eyebrows; `caution` stays amber, the color
+ * the homepage gives the relay path. Green is reserved for live status.
+ */
 export function LegalCallout({
     label,
     tone,
     children,
 }: {
     label: string;
-    tone: 'positive' | 'caution';
+    tone: 'summary' | 'caution';
     children: ReactNode;
 }) {
-    const border = tone === 'positive' ? 'border-green-400/40' : 'border-amber-400/40';
-    const text = tone === 'positive' ? 'text-green-400' : 'text-amber-400';
+    const border = tone === 'summary' ? 'border-ice/30' : 'border-amber-400/40';
+    const text = tone === 'summary' ? 'text-ice' : 'text-amber-400';
     return (
-        <aside className={`border-l-2 py-1 pl-5 ${border}`}>
-            <p className={`font-mono text-[11px] uppercase tracking-[0.2em] ${text}`}>{label}</p>
-            <div className="mt-3 space-y-3 text-sm leading-relaxed text-zinc-300">{children}</div>
+        <aside className={`border-l-2 py-1 pl-5 sm:pl-6 ${border}`}>
+            <p className={`${EYEBROW} ${text}`}>{label}</p>
+            <div className="mt-4 space-y-4 text-[15px] leading-7 text-zinc-300 [&_strong]:font-medium [&_strong]:text-zinc-100">
+                {children}
+            </div>
         </aside>
+    );
+}
+
+/**
+ * Term-and-description rows, the grammar the download page uses for its
+ * index: a label column and a body column on a hairline ledger.
+ */
+export function LegalLedger({ rows }: { rows: { term: string; body: ReactNode }[] }) {
+    return (
+        <dl className="divide-y divide-white/[0.06] border-y border-white/[0.06]">
+            {rows.map((row) => (
+                <div
+                    key={row.term}
+                    className="grid gap-y-1.5 py-4 sm:grid-cols-[9.5rem_1fr] sm:gap-x-6 sm:py-5"
+                >
+                    <dt className="text-sm font-medium text-zinc-200 sm:pt-0.5">{row.term}</dt>
+                    <dd className="min-w-0 space-y-3">{row.body}</dd>
+                </div>
+            ))}
+        </dl>
     );
 }
 
@@ -122,17 +232,15 @@ export function LegalList({
     marker = '→',
 }: {
     items: ReactNode[];
-    marker?: string | null;
+    marker?: string;
 }) {
     return (
         <ul className="divide-y divide-white/[0.06] border-y border-white/[0.06]">
             {items.map((item, i) => (
                 <li key={i} className="flex items-baseline gap-3 py-3">
-                    {marker !== null && (
-                        <span className="select-none font-mono text-xs text-zinc-600" aria-hidden="true">
-                            {marker}
-                        </span>
-                    )}
+                    <span className="select-none font-mono text-xs text-zinc-600" aria-hidden="true">
+                        {marker}
+                    </span>
                     <span className="min-w-0">{item}</span>
                 </li>
             ))}
@@ -140,9 +248,24 @@ export function LegalList({
     );
 }
 
+// Every link in the body of a legal page points off the page (a provider's
+// policy, GitHub, the docs), so they all open in a new tab.
+export function LegalLink({ href, children }: { href: string; children: ReactNode }) {
+    return (
+        <a
+            href={href}
+            target="_blank"
+            rel="noreferrer"
+            className={`text-zinc-200 underline decoration-white/20 underline-offset-4 transition hover:text-ice hover:decoration-ice/40 ${FOCUS_RING}`}
+        >
+            {children}
+        </a>
+    );
+}
+
 export function InlineCode({ children }: { children: ReactNode }) {
     return (
-        <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-xs text-zinc-300">
+        <code className="rounded bg-white/[0.06] px-1.5 py-0.5 font-mono text-[13px] text-zinc-300">
             {children}
         </code>
     );

--- a/client/components/legal/LegalToc.tsx
+++ b/client/components/legal/LegalToc.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { pickActiveSection } from '@/lib/legalToc';
+import { EYEBROW, FOCUS_RING } from './styles';
+
+export interface TocItem {
+    id: string;
+    label: string;
+}
+
+interface ActiveRow {
+    id: string;
+    /** The active row's box inside the rail list, for the indicator. */
+    top: number;
+    height: number;
+}
+
+/**
+ * "On this page" for the legal documents: a numbered list that follows the
+ * reader. From lg up it sits in the sticky rail with a hairline track and a
+ * one-pixel ice segment that slides to the current section; below lg it is a
+ * native <details>, collapsed, so a phone reader gets the list without a
+ * sticky strip eating the viewport.
+ *
+ * Hydration contract (e2e/hydration.spec.ts covers both routes): the first
+ * client render must match the server HTML, so nothing here reads window
+ * during render. The active row is set from an effect after mount, the same
+ * way Navbar's scroll-spy works, and the server renders the list with no item
+ * marked.
+ */
+export function LegalToc({ items }: { items: TocItem[] }) {
+    const [active, setActive] = useState<ActiveRow | null>(null);
+    const listRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const sections = items
+            .map((item) => document.getElementById(item.id))
+            .filter((el): el is HTMLElement => el !== null);
+        if (sections.length === 0) return;
+        const ids = new Set(sections.map((el) => el.id));
+
+        // A section the reader asked for by name (a TOC click, or a deep link
+        // like /terms#relay) stays current until they scroll by hand. Without
+        // this, a short page that cannot scroll the clicked section up to the
+        // reading line lands at the bottom, where the bottom rule marks the
+        // last entry instead of the one they clicked.
+        let pinned: string | null = ids.has(location.hash.slice(1)) ? location.hash.slice(1) : null;
+        const onHashChange = () => {
+            const id = location.hash.slice(1);
+            pinned = ids.has(id) ? id : null;
+            schedule();
+        };
+        const unpin = () => {
+            if (!pinned) return;
+            pinned = null;
+            schedule();
+        };
+
+        // One measurement per frame however many scroll events arrive: a
+        // trackpad can fire dozens per frame and each getBoundingClientRect
+        // forces layout. The row's box is read in the same frame as the
+        // section pick, so a resize that keeps the same section current (the
+        // lg breakpoint, where the rail list appears) still refreshes it.
+        let frame = 0;
+        const measure = () => {
+            frame = 0;
+            const atBottom =
+                window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+            const id =
+                pinned ??
+                pickActiveSection(
+                    sections.map((el) => ({ id: el.id, top: el.getBoundingClientRect().top })),
+                    atBottom
+                );
+            const row = id ? listRef.current?.querySelector<HTMLElement>(`[data-toc-id="${id}"]`) : null;
+            const next = id ? { id, top: row?.offsetTop ?? 0, height: row?.offsetHeight ?? 0 } : null;
+            setActive((prev) =>
+                prev && next && prev.id === next.id && prev.top === next.top && prev.height === next.height
+                    ? prev
+                    : next
+            );
+        };
+        const schedule = () => {
+            if (!frame) frame = requestAnimationFrame(measure);
+        };
+        measure();
+        window.addEventListener('scroll', schedule, { passive: true });
+        window.addEventListener('resize', schedule);
+        window.addEventListener('hashchange', onHashChange);
+        // Hand control back to the spy on the reader's own input, not on the
+        // scroll events a smooth scroll to the clicked section produces.
+        window.addEventListener('wheel', unpin, { passive: true });
+        window.addEventListener('touchstart', unpin, { passive: true });
+        window.addEventListener('keydown', unpin);
+        return () => {
+            if (frame) cancelAnimationFrame(frame);
+            window.removeEventListener('scroll', schedule);
+            window.removeEventListener('resize', schedule);
+            window.removeEventListener('hashchange', onHashChange);
+            window.removeEventListener('wheel', unpin);
+            window.removeEventListener('touchstart', unpin);
+            window.removeEventListener('keydown', unpin);
+        };
+    }, [items]);
+
+    const rows = items.map((item, i) => {
+        const current = item.id === active?.id;
+        return (
+            <li key={item.id} data-toc-id={item.id}>
+                <a
+                    href={`#${item.id}`}
+                    aria-current={current ? 'location' : undefined}
+                    className={`group flex items-baseline gap-3 py-1.5 text-sm transition-colors ${FOCUS_RING} ${
+                        current ? 'text-zinc-100' : 'text-zinc-400 hover:text-zinc-100'
+                    }`}
+                >
+                    <span
+                        className={`w-5 shrink-0 font-mono text-xs tabular-nums transition-colors ${
+                            current ? 'text-ice' : 'text-zinc-600 group-hover:text-zinc-400'
+                        }`}
+                        aria-hidden="true"
+                    >
+                        {String(i + 1).padStart(2, '0')}
+                    </span>
+                    <span className="min-w-0">{item.label}</span>
+                </a>
+            </li>
+        );
+    });
+
+    return (
+        <>
+            {/* Rail version: the wrapper's left border is the track and the
+                ice segment is positioned over it from the active row's box
+                (the wrapper, not the list, so the <ol> keeps a valid content
+                model). The slide is a transform so it stays on the compositor;
+                reduced motion snaps instead. role="list" because Tailwind's
+                preflight removes list markers, and Safari drops list semantics
+                with them. */}
+            <nav aria-label="On this page" className="mt-10 hidden lg:block">
+                <p className={`${EYEBROW} text-zinc-600`}>On this page</p>
+                <div ref={listRef} className="relative mt-4 border-l border-white/[0.06] pl-4">
+                    <span
+                        aria-hidden="true"
+                        className={`absolute -left-px top-0 w-px bg-ice transition-[transform,height,opacity] duration-300 ease-out motion-reduce:transition-none ${
+                            active && active.height > 0 ? 'opacity-100' : 'opacity-0'
+                        }`}
+                        style={{
+                            transform: `translateY(${active?.top ?? 0}px)`,
+                            height: active?.height ?? 0,
+                        }}
+                    />
+                    <ol role="list">{rows}</ol>
+                </div>
+            </nav>
+
+            {/* Phone and tablet version: a native disclosure, closed by
+                default. The server renders it closed too, so the markup
+                matches on hydration. */}
+            <details className="group mt-8 border-y border-white/[0.06] lg:hidden">
+                <summary
+                    className={`flex cursor-pointer list-none items-center justify-between py-3 ${EYEBROW} text-zinc-500 transition-colors hover:text-zinc-300 ${FOCUS_RING} [&::-webkit-details-marker]:hidden`}
+                >
+                    On this page
+                    <ChevronDown
+                        className="h-4 w-4 text-zinc-600 transition-transform duration-200 group-open:rotate-180 motion-reduce:transition-none"
+                        aria-hidden="true"
+                    />
+                </summary>
+                <ol role="list" className="pb-3">
+                    {rows}
+                </ol>
+            </details>
+        </>
+    );
+}

--- a/client/components/legal/styles.ts
+++ b/client/components/legal/styles.ts
@@ -1,0 +1,5 @@
+// Class strings the legal components share. LegalShell imports LegalToc, so
+// these live in their own module rather than on LegalShell, which would make
+// LegalToc -> LegalShell -> LegalToc circular.
+export const EYEBROW = 'font-mono text-[11px] uppercase tracking-[0.2em]';
+export const FOCUS_RING = 'focus-visible:outline-2 focus-visible:outline-ice';

--- a/client/lib/legalToc.test.ts
+++ b/client/lib/legalToc.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { pickActiveSection, ACTIVE_LINE_PX } from './legalToc';
+
+const tops = (values: number[]) => values.map((top, i) => ({ id: `s${i + 1}`, top }));
+
+describe('pickActiveSection', () => {
+    it('returns null for an empty list', () => {
+        expect(pickActiveSection([], false)).toBeNull();
+    });
+
+    it('marks the topmost section before any of them reaches the line', () => {
+        // Top of the page: the intro fills the viewport and every section is
+        // still below the line.
+        expect(pickActiveSection(tops([600, 1100, 1700]), false)).toBe('s1');
+    });
+
+    it('marks the lowest section whose top has crossed the line', () => {
+        expect(pickActiveSection(tops([-500, 60, 320, 900]), false)).toBe('s2');
+    });
+
+    it('treats a top exactly on the line as crossed', () => {
+        expect(pickActiveSection(tops([-200, ACTIVE_LINE_PX, 800]), false)).toBe('s2');
+    });
+
+    it('lands on the section a TOC click scrolls to, even when the next one is short', () => {
+        // scroll-mt leaves the clicked section 40px from the top. On the terms
+        // page the section after it can start only ~110px further down.
+        expect(pickActiveSection(tops([-300, 40, 150, 260]), false)).toBe('s2');
+    });
+
+    it('marks the lowest section at the bottom of the page whatever the geometry', () => {
+        // A short closing section that never reaches the line.
+        expect(pickActiveSection(tops([-1200, -600, 500]), true)).toBe('s3');
+    });
+
+    it('does not depend on the order the sections are passed in', () => {
+        const shuffled = [
+            { id: 'c', top: 320 },
+            { id: 'a', top: -500 },
+            { id: 'd', top: 900 },
+            { id: 'b', top: 60 },
+        ];
+        expect(pickActiveSection(shuffled, false)).toBe('b');
+        expect(pickActiveSection(shuffled, true)).toBe('d');
+        expect(pickActiveSection(shuffled.map((s) => ({ ...s, top: s.top + 1000 })), false)).toBe('a');
+    });
+});

--- a/client/lib/legalToc.ts
+++ b/client/lib/legalToc.ts
@@ -1,0 +1,42 @@
+// Pure scroll-spy logic for the legal pages' "On this page" list.
+//
+// One line, 96px below the viewport's top edge, decides which section is
+// current: the section that has crossed it and sits lowest on the page. Before
+// any section reaches the line (the top of the page, where the intro sits) the
+// topmost section is current, so the list never shows nothing marked. At the
+// bottom of the page the lowest section is current even when it is too short
+// to ever reach the line: a short closing section above a tall footer would
+// otherwise be the one entry the reader can never light up.
+//
+// Every pick is by measured position, never by array order, so the caller may
+// pass the sections in any order.
+//
+// The line is a fixed offset rather than a share of the viewport on purpose.
+// A share (30% was tried) is taller than the shortest terms sections, so
+// scrolling one of those to the top lit up the section after it. 96px sits
+// above the 40px anchor offset the TOC links scroll to (scroll-mt on each
+// section), so a clicked section always counts as current, and below the
+// height of every section on either page.
+
+export interface SectionTop {
+    id: string;
+    /** Distance from the viewport's top edge to the section's top edge, in px. */
+    top: number;
+}
+
+export const ACTIVE_LINE_PX = 96;
+
+function lowest(sections: readonly SectionTop[]): SectionTop {
+    return sections.reduce((a, b) => (b.top > a.top ? b : a));
+}
+
+function highest(sections: readonly SectionTop[]): SectionTop {
+    return sections.reduce((a, b) => (b.top < a.top ? b : a));
+}
+
+export function pickActiveSection(sections: readonly SectionTop[], atBottom: boolean): string | null {
+    if (sections.length === 0) return null;
+    if (atBottom) return lowest(sections).id;
+    const crossed = sections.filter((section) => section.top <= ACTIVE_LINE_PX);
+    return (crossed.length > 0 ? lowest(crossed) : highest(sections)).id;
+}


### PR DESCRIPTION
## Summary

Redesigns `/privacy` and `/terms` in the landing design system and corrects their content against the code. Follows #420, whose behavior (scrubbed performance traces, Do Not Track) the privacy page now states as live.

**Design.** The rail becomes the document header: a Privacy/Terms switcher (install-tabs grammar, ice marks the current document), dated meta as `<time>` elements, a link to the page's GitHub history, and an "On this page" list that follows the reader: `LegalToc` marks the current section with `aria-current="location"` and slides a one-pixel ice segment along the hairline track, one measurement per frame, snapping under reduced motion. Below `lg` the list is a closed native `<details>`. The intro callout uses ice for the summary (green is reserved for live status) and keeps amber for the terms disclaimer. Term-and-description lists become ledger rows; body type moves to 15px/28px; switcher, TOC, back link and footer are `print:hidden`.

**Content.** Every sentence was verified against `server/`, `client/`, `cli/` and `desktop/` and against `docs/security-privacy.mdx`. Material corrections: the other peer learns your IP address on a direct transfer (with Hide my IP and `--relay-only` as the remedies); Cloudflare's STUN and a standby TURN allocation are contacted on every transfer, not only relayed ones; the relay is Cloudflare's, not "our TURN server"; Umami Cloud records country, region and city; the desktop app's local transfer history and the on-by-default right-click registry key are disclosed; the CLI gets its own section (`floe version` contacts GitHub, `FLOE_NO_UPDATE_CHECK=1`); security and abuse reports route to the private channels instead of the public tracker; the terms no longer forbid reverse-engineering MIT-licensed code and show both the effective and last-updated month.

## Test plan

- [x] `corepack pnpm test` (294 tests, 6 new for `pickActiveSection`), `npx tsc --noEmit`, `corepack pnpm lint` (0 errors)
- [x] `next build` + `node scripts/check-titles.mjs` (titles unchanged)
- [x] Playwright `hydration.spec.ts` + `responsive.spec.ts` for both routes (no hydration error; no horizontal overflow at 20 viewports)
- [x] Headless scroll-spy proof on both routes: every section activates when scrolled to, last entry at the bottom, TOC click lands, reduced motion has `transition-property: none`, phone and tablet render the closed disclosure
- [x] Owner reviewed both pages on localhost and approved
- [x] Short QA fleet: rendered DOM and accessibility at 7 widths, content re-verification per page, code review, adversarial refute
- [ ] CI `CI green`
