### PR TITLE
feat(client): redesign /how-it-works around one figure

### DIFF
--- a/.claude/skills/docs-verify/references/claim-map.md
+++ b/.claude/skills/docs-verify/references/claim-map.md
@@ -7,7 +7,7 @@ The map names where a value is stated; grep the old literal repo-wide before fin
 ## Relay cap
 
 - `RelaySizeLimit` (cli/engine/transfer/relay.go) and `RELAY_SIZE_LIMIT` (client/lib/relay.ts); the comparison is strictly greater-than, sender-side only.
-- `RELAY_CAP` (client/lib/howItWorksStrings.ts) derives the figure /how-it-works prints from `RELAY_SIZE_LIMIT`; its test pins `CLI_BLOCKED` to the Go wording, so a limit change on one side fails the client suite.
+- `RELAY_CAP` (client/lib/howItWorksStrings.ts) is `formatBytes(RELAY_SIZE_LIMIT)` and is what /how-it-works prints; its test pins it to "2 GB", so a change to client/lib/relay.ts fails the client suite. The Go constant is not read by the client, so only this map couples the two.
 - Docs: docs/how-it-works/2gb-limit.mdx (whole page, including the "exactly N is allowed" sentence), docs/troubleshooting.mdx (the relay-limit headings and the desktop "capped" heading), docs/self-hosting/turn-relay.mdx (end of "How credentials work"), docs/cli/send.mdx "Notes", docs/desktop/settings.mdx "Hide my IP address", CLAUDE.md "Relay Size Limit".
 
 ## Protocol version
@@ -48,7 +48,7 @@ The map names where a value is stated; grep the old literal repo-wide before fin
 
 - cli/cmd/floe/main.go: `flagServer` (`--server`, with its compiled default), `flagNoRelay`, `flagRelayOnly` (`--relay-only`, mutually exclusive with `--no-relay` via `MarkFlagsMutuallyExclusive`), `flagWebURL` (`--web`), `flagIface` (`--iface`, repeatable), `flagOutput` (`-o`, with its default), `flagAutoAccept` (`-y`), `flagNoReport`, `flagUpdateCheck` (`--check`); `FLOE_SERVER`, `FLOE_WEB` and `FLOE_RELAY_ONLY` in `applyEnv` (called from the root `PersistentPreRunE`; a typed `--no-relay` beats `FLOE_RELAY_ONLY`), `FLOE_NO_STATS` in the receive command.
 - cli/cmd/floe/main.go `connectedLine`: the `Connected (direct)` / `Connected (relay)` / bare `Connected` status line, read once from `Connection.ConnectionType()` after setup.
-- client/lib/howItWorksStrings.ts mirrors the badge words (client/components/ConnectionStatusBadge.tsx, desktop/frontend/src/App.tsx) for /how-it-works; its test pins them.
+- client/lib/howItWorksStrings.ts mirrors the badge words `Direct` and `Relay` (client/components/ConnectionStatusBadge.tsx, desktop/frontend/src/App.tsx) for /how-it-works. Its test asserts the literals, so it catches an edit to the module but NOT a rename in the badge itself; that pairing is hand-read.
 - cli/internal/selfupdate/selfupdate.go: `FLOE_NO_UPDATE_CHECK`.
 - Docs: docs/cli/flags.mdx (every table), docs/cli/send.mdx and docs/cli/receive.mdx ("Output" quotes the `Connected` line), docs/cli/update.mdx, docs/cli/self-hosted-server.mdx, docs/snippets/stats-optout.mdx, README.md CLI section. `--relay-only` is also described as the twin of Hide my IP in docs/how-it-works/relay-connection.mdx (the badge row, "Turning it off, and the opposite", and the accordion), docs/desktop/settings.mdx "Hide my IP address", docs/choosing-floe.mdx (the "Force the relay" row), docs/how-it-works/known-limitations.mdx, docs/security-privacy.mdx, docs/how-it-works/2gb-limit.mdx "One case that catches people out", and docs/troubleshooting.mdx `timed out establishing a connection`.
 
@@ -64,7 +64,7 @@ Script (`env`). Canonical: docs/self-hosting/configuration.mdx. Mirrors: CONTRIB
 
 ## Docs URLs inside shipped binaries and workflows
 
-Script (`links`). cli/cmd/floe/main.go (two `https://www.floe.one/docs` strings), desktop/frontend/src/App.tsx (`BrowserOpenURL`), client/lib/desktopRelease.ts and .github/workflows/desktop-release.yml (changelog URL), client/components/layout/Footer.tsx (mirror of docs.json `footer.links`). Hand-read: client/app/how-it-works/page.tsx (the six `DocsLink` hrefs under `DOCS`, labels mirroring the docs sidebar titles).
+Script (`links`). cli/cmd/floe/main.go (two `https://www.floe.one/docs` strings), desktop/frontend/src/App.tsx (`BrowserOpenURL`), client/lib/desktopRelease.ts and .github/workflows/desktop-release.yml (changelog URL), client/components/layout/Footer.tsx (mirror of docs.json `footer.links`). client/app/how-it-works/page.tsx `DOCS_PAGES` keeps each label beside its own href so the script sees all six; the labels are the docs sidebarTitles.
 
 ## Frozen zones (never edit)
 

--- a/.claude/skills/docs-verify/references/claim-map.md
+++ b/.claude/skills/docs-verify/references/claim-map.md
@@ -7,6 +7,7 @@ The map names where a value is stated; grep the old literal repo-wide before fin
 ## Relay cap
 
 - `RelaySizeLimit` (cli/engine/transfer/relay.go) and `RELAY_SIZE_LIMIT` (client/lib/relay.ts); the comparison is strictly greater-than, sender-side only.
+- `RELAY_CAP` (client/lib/howItWorksStrings.ts) derives the figure /how-it-works prints from `RELAY_SIZE_LIMIT`; its test pins `CLI_BLOCKED` to the Go wording, so a limit change on one side fails the client suite.
 - Docs: docs/how-it-works/2gb-limit.mdx (whole page, including the "exactly N is allowed" sentence), docs/troubleshooting.mdx (the relay-limit headings and the desktop "capped" heading), docs/self-hosting/turn-relay.mdx (end of "How credentials work"), docs/cli/send.mdx "Notes", docs/desktop/settings.mdx "Hide my IP address", CLAUDE.md "Relay Size Limit".
 
 ## Protocol version
@@ -47,6 +48,7 @@ The map names where a value is stated; grep the old literal repo-wide before fin
 
 - cli/cmd/floe/main.go: `flagServer` (`--server`, with its compiled default), `flagNoRelay`, `flagRelayOnly` (`--relay-only`, mutually exclusive with `--no-relay` via `MarkFlagsMutuallyExclusive`), `flagWebURL` (`--web`), `flagIface` (`--iface`, repeatable), `flagOutput` (`-o`, with its default), `flagAutoAccept` (`-y`), `flagNoReport`, `flagUpdateCheck` (`--check`); `FLOE_SERVER`, `FLOE_WEB` and `FLOE_RELAY_ONLY` in `applyEnv` (called from the root `PersistentPreRunE`; a typed `--no-relay` beats `FLOE_RELAY_ONLY`), `FLOE_NO_STATS` in the receive command.
 - cli/cmd/floe/main.go `connectedLine`: the `Connected (direct)` / `Connected (relay)` / bare `Connected` status line, read once from `Connection.ConnectionType()` after setup.
+- client/lib/howItWorksStrings.ts mirrors the badge words (client/components/ConnectionStatusBadge.tsx, desktop/frontend/src/App.tsx) for /how-it-works; its test pins them.
 - cli/internal/selfupdate/selfupdate.go: `FLOE_NO_UPDATE_CHECK`.
 - Docs: docs/cli/flags.mdx (every table), docs/cli/send.mdx and docs/cli/receive.mdx ("Output" quotes the `Connected` line), docs/cli/update.mdx, docs/cli/self-hosted-server.mdx, docs/snippets/stats-optout.mdx, README.md CLI section. `--relay-only` is also described as the twin of Hide my IP in docs/how-it-works/relay-connection.mdx (the badge row, "Turning it off, and the opposite", and the accordion), docs/desktop/settings.mdx "Hide my IP address", docs/choosing-floe.mdx (the "Force the relay" row), docs/how-it-works/known-limitations.mdx, docs/security-privacy.mdx, docs/how-it-works/2gb-limit.mdx "One case that catches people out", and docs/troubleshooting.mdx `timed out establishing a connection`.
 
@@ -62,7 +64,7 @@ Script (`env`). Canonical: docs/self-hosting/configuration.mdx. Mirrors: CONTRIB
 
 ## Docs URLs inside shipped binaries and workflows
 
-Script (`links`). cli/cmd/floe/main.go (two `https://www.floe.one/docs` strings), desktop/frontend/src/App.tsx (`BrowserOpenURL`), client/lib/desktopRelease.ts and .github/workflows/desktop-release.yml (changelog URL), client/components/layout/Footer.tsx (mirror of docs.json `footer.links`).
+Script (`links`). cli/cmd/floe/main.go (two `https://www.floe.one/docs` strings), desktop/frontend/src/App.tsx (`BrowserOpenURL`), client/lib/desktopRelease.ts and .github/workflows/desktop-release.yml (changelog URL), client/components/layout/Footer.tsx (mirror of docs.json `footer.links`). Hand-read: client/app/how-it-works/page.tsx (the six `DocsLink` hrefs under `DOCS`, labels mirroring the docs sidebar titles).
 
 ## Frozen zones (never edit)
 
@@ -76,5 +78,4 @@ Script (`links`). cli/cmd/floe/main.go (two `https://www.floe.one/docs` strings)
 - server/.env.example NODE_ENV comment describes the Express stack-trace behavior that #239 made irrelevant, and the file has two em dashes (not a `dashes` surface, so the script cannot see them).
 - CONTRIBUTING.md "Corepack ships with Node 22": true only below Node 25.
 - client/components/layout/Footer.tsx and docs/docs.json footer say "Self-Hosting"; the docs settled on "Self-hosting" (#337). Change both together.
-- client/app/how-it-works/page.tsx chips name pages by titles they do not have (the `labels` NOTEs).
 - Two links target the unstable heading in docs/web-app/receiving.mdx (the `links` NOTEs at docs/faq.mdx:62 and docs/troubleshooting.mdx:24); the heading needs an explicit `{#id}`.

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -146,17 +146,13 @@
     stroke-width: 1;
     vector-effect: non-scaling-stroke;
 }
-/* The two dash-drawn paths opt out of non-scaling-stroke. Chromium lays a dash
-   out in unscaled user units while the path renders scaled, so above scale 1
-   the ink ran out before the end: at the narrow variant's 1.333 cap the ice
-   line stopped 98.8px short of THEM and the ring floated unattached, which
-   reads as a failed connection. Every earlier check missed it because they all
-   run with reduced motion, where no dash exists. The cost is that these two
-   strokes scale with the figure, 0.8px at the 320px viewport to 1.33px at the
-   cap; the ticks and the detour keep their exact hairline. */
-.hiw-fig path.hiw-direct,
-.hiw-fig path.hiw-spur {
-    vector-effect: none;
+/* Axis-aligned, so snapping them to the device grid costs no curve quality and
+   buys a real hairline: at the canonical desktop scale of exactly 1 the box top
+   is an integer, every 1px stroke straddled two device rows, and the line the
+   page is built around rendered at about half its intended brightness. */
+.hiw-tick,
+.hiw-direct {
+    shape-rendering: crispEdges;
 }
 .hiw-tick {
     stroke: #52525b;
@@ -176,37 +172,49 @@
     stroke: oklch(0.87 0.05 220);
     fill: #09090b;
 }
+/* 1600, not the 1000 that pathLength normalizes to. vector-effect:
+   non-scaling-stroke makes Chromium lay the dash out in unscaled user units
+   while the path renders scaled, so the ink covers dasharray/scale of the path:
+   at 1000 the ice line stopped 98.8px short of THEM at the narrow variant's
+   1.333 cap and the ring floated unattached, which reads as a failed
+   connection. 1600 covers any scale up to 1.6, well past that cap. The draw
+   therefore completes a little before its own window ends, which is invisible
+   inside a staggered sequence and is the price of one uniform hairline.
+   backwards, not both: `both` holds the animation in effect forever, which
+   pins a composited layer and drops the five 11px labels to grayscale
+   antialiasing. Every keyframe already ends on its base value, so releasing
+   them changes nothing but the text rendering. */
 @media (prefers-reduced-motion: no-preference) {
     .hiw-spur {
-        stroke-dasharray: 1000;
+        stroke-dasharray: 1600;
         animation:
-            hiw-draw 700ms cubic-bezier(0.16, 1, 0.3, 1) 150ms both,
-            hiw-thaw 700ms ease 1600ms both;
+            hiw-draw 700ms cubic-bezier(0.16, 1, 0.3, 1) 150ms backwards,
+            hiw-thaw 700ms ease 1600ms backwards;
     }
     .hiw-direct {
-        stroke-dasharray: 1000;
-        animation: hiw-draw 900ms cubic-bezier(0.16, 1, 0.3, 1) 900ms both;
+        stroke-dasharray: 1600;
+        animation: hiw-draw 900ms cubic-bezier(0.16, 1, 0.3, 1) 900ms backwards;
     }
     .hiw-ring {
-        animation: hiw-fade 400ms ease 1700ms both;
+        animation: hiw-fade 400ms ease 1700ms backwards;
     }
     .hiw-detour,
     .hiw-relay-tick {
-        animation: hiw-fade 600ms ease 2000ms both;
+        animation: hiw-fade 600ms ease 2000ms backwards;
     }
     .hiw-lbl-server {
-        animation: hiw-fade 500ms ease 300ms both;
+        animation: hiw-fade 500ms ease 300ms backwards;
     }
     .hiw-lbl-direct {
-        animation: hiw-fade 500ms ease 1600ms both;
+        animation: hiw-fade 500ms ease 1600ms backwards;
     }
     .hiw-lbl-relay {
-        animation: hiw-fade 500ms ease 2100ms both;
+        animation: hiw-fade 500ms ease 2100ms backwards;
     }
 }
 @keyframes hiw-draw {
     from {
-        stroke-dashoffset: 1000;
+        stroke-dashoffset: 1600;
     }
     to {
         stroke-dashoffset: 0;
@@ -226,5 +234,16 @@
     }
     to {
         opacity: 1;
+    }
+}
+@media (forced-colors: active) {
+    .hiw-direct,
+    .hiw-fig circle.hiw-ring {
+        stroke: CanvasText;
+    }
+    .hiw-spur,
+    .hiw-tick,
+    .hiw-detour {
+        stroke: GrayText;
     }
 }

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -120,3 +120,99 @@
         opacity: 0;
     }
 }
+/* The route figure on /how-it-works (components/how-it-works/RouteFigure.tsx).
+   The base rules ARE the finished drawing. The animation block lives inside
+   prefers-reduced-motion: no-preference on purpose, and as plain CSS rather
+   than motion-reduce: utilities: custom animations in @layer utilities beat
+   motion-reduce:animate-none in the Tailwind v4 cascade (the desktop app hit
+   this), while an unlayered media block can never lose. Reduced motion, the
+   e2e sweep, the screenshot matrix and a JS-off reader all get the completed
+   figure at first paint. Only stroke-dashoffset, stroke and opacity animate,
+   and the box is reserved by aspect-ratio, so nothing shifts layout.
+   Sequence (about 2.6 s, once, no loop): the spurs draw from the devices to
+   the server tick in ice, the direct line draws across, the spurs thaw to
+   zinc-700 (the server has left), the ring lands on THEM, then the relay
+   detour fades in. */
+.hiw-fig svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    overflow: visible;
+}
+.hiw-fig path,
+.hiw-fig line,
+.hiw-fig circle {
+    fill: none;
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+}
+.hiw-tick {
+    stroke: #52525b;
+}
+.hiw-spur {
+    stroke: #3f3f46;
+}
+.hiw-direct {
+    stroke: oklch(0.87 0.05 220);
+}
+.hiw-detour {
+    stroke: #52525b;
+    stroke-dasharray: 1 5;
+    stroke-linecap: round;
+}
+.hiw-ring {
+    stroke: oklch(0.87 0.05 220);
+    fill: #09090b;
+}
+@media (prefers-reduced-motion: no-preference) {
+    .hiw-spur {
+        stroke-dasharray: 1000;
+        animation:
+            hiw-draw 700ms cubic-bezier(0.16, 1, 0.3, 1) 150ms both,
+            hiw-thaw 700ms ease 1600ms both;
+    }
+    .hiw-direct {
+        stroke-dasharray: 1000;
+        animation: hiw-draw 900ms cubic-bezier(0.16, 1, 0.3, 1) 900ms both;
+    }
+    .hiw-ring {
+        animation: hiw-fade 400ms ease 1700ms both;
+    }
+    .hiw-detour,
+    .hiw-relay-tick {
+        animation: hiw-fade 600ms ease 2000ms both;
+    }
+    .hiw-lbl-server {
+        animation: hiw-fade 500ms ease 300ms both;
+    }
+    .hiw-lbl-direct {
+        animation: hiw-fade 500ms ease 1600ms both;
+    }
+    .hiw-lbl-relay {
+        animation: hiw-fade 500ms ease 2100ms both;
+    }
+}
+@keyframes hiw-draw {
+    from {
+        stroke-dashoffset: 1000;
+    }
+    to {
+        stroke-dashoffset: 0;
+    }
+}
+@keyframes hiw-thaw {
+    from {
+        stroke: oklch(0.87 0.05 220 / 0.55);
+    }
+    to {
+        stroke: #3f3f46;
+    }
+}
+@keyframes hiw-fade {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}

--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -146,6 +146,18 @@
     stroke-width: 1;
     vector-effect: non-scaling-stroke;
 }
+/* The two dash-drawn paths opt out of non-scaling-stroke. Chromium lays a dash
+   out in unscaled user units while the path renders scaled, so above scale 1
+   the ink ran out before the end: at the narrow variant's 1.333 cap the ice
+   line stopped 98.8px short of THEM and the ring floated unattached, which
+   reads as a failed connection. Every earlier check missed it because they all
+   run with reduced motion, where no dash exists. The cost is that these two
+   strokes scale with the figure, 0.8px at the 320px viewport to 1.33px at the
+   cap; the ticks and the detour keep their exact hairline. */
+.hiw-fig path.hiw-direct,
+.hiw-fig path.hiw-spur {
+    vector-effect: none;
+}
 .hiw-tick {
     stroke: #52525b;
 }
@@ -160,7 +172,7 @@
     stroke-dasharray: 1 5;
     stroke-linecap: round;
 }
-.hiw-ring {
+.hiw-fig circle.hiw-ring {
     stroke: oklch(0.87 0.05 220);
     fill: #09090b;
 }

--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -32,19 +32,26 @@ export const metadata: Metadata = {
     twitter: { ...sharedTwitter, title: 'How Floe works' },
 };
 
-const DOCS = 'https://www.floe.one/docs/how-it-works';
+const DOCS_SIGNALING = 'https://www.floe.one/docs/how-it-works/signaling';
 
-// The six docs pages, in the order the line reads them.
-const DOCS_PAGES: { label: string; slug: string }[] = [
-    { label: 'Signaling', slug: 'signaling' },
-    { label: 'Direct connection', slug: 'direct-connection' },
-    { label: 'Relay connection', slug: 'relay-connection' },
-    { label: `${RELAY_CAP} limit`, slug: '2gb-limit' },
-    { label: 'Encryption', slug: 'encryption' },
-    { label: 'Known limitations', slug: 'known-limitations' },
+// The six docs pages, in the order the line reads them. Each label is that
+// page's own sidebarTitle, not an editorial shortening: a link that names a
+// page by a title it does not have is the drift docs-check's `labels` check
+// exists to catch, and it can only see a label when the href sits in the same
+// object literal, so these are written out in full.
+const DOCS_PAGES: { label: string; href: string }[] = [
+    { label: 'How a transfer works', href: 'https://www.floe.one/docs/how-it-works/signaling' },
+    { label: 'Direct connections', href: 'https://www.floe.one/docs/how-it-works/direct-connection' },
+    { label: 'Relay fallback', href: 'https://www.floe.one/docs/how-it-works/relay-connection' },
+    { label: 'File size limits', href: 'https://www.floe.one/docs/how-it-works/2gb-limit' },
+    { label: 'Encryption', href: 'https://www.floe.one/docs/how-it-works/encryption' },
+    { label: 'Known limitations', href: 'https://www.floe.one/docs/how-it-works/known-limitations' },
 ];
 
-const LABEL = 'font-mono text-[11px] uppercase tracking-[0.2em] text-zinc-500';
+// zinc-400, not the zinc-500 the landing ledgers use for their labels: at 11px
+// zinc-500 measures 4.12:1 on zinc-950, under the 4.5:1 AA minimum, and these
+// four labels are informative copy. The legal pages made the same lift.
+const LABEL = 'font-mono text-[11px] uppercase tracking-[0.2em] text-zinc-400';
 
 // The badge dot the app draws (ConnectionStatusBadge.tsx core dot, no halo):
 // green means Direct, amber means Relay, and those are the only two colors on
@@ -70,7 +77,7 @@ export default function HowItWorks() {
                     below starts under these words, at YOU. pt-24/28 clears the
                     fixed pill; leading-none on the eyebrow drops its dead
                     half-leading; mt-3 offsets the headline's own leading. */}
-                <header className="pt-24 sm:pt-28">
+                <header className="pt-[calc(6rem_+_env(safe-area-inset-top))] sm:pt-[calc(7rem_+_env(safe-area-inset-top))]">
                     <p className="font-mono text-[11px] leading-none uppercase tracking-[0.2em] text-ice">
                         The short version
                     </p>
@@ -80,7 +87,8 @@ export default function HowItWorks() {
                     <p className="mt-6 max-w-lg text-base leading-relaxed text-balance text-zinc-400">
                         Two devices, one line between them. A server makes the introduction and
                         leaves. Most transfers go straight across. When a network blocks the way, the
-                        transfer can take a relay instead, capped at {RELAY_CAP} per session.
+                        transfer can take a relay instead, capped at{' '}
+                        <span className="whitespace-nowrap">{RELAY_CAP}</span> per session.
                     </p>
                 </header>
 
@@ -95,47 +103,50 @@ export default function HowItWorks() {
                     notice to #size-limit; scroll-mt-28 clears the pill for all
                     three. */}
                 <div className="mt-12 grid gap-8 md:grid-cols-3">
-                    <section className="max-w-lg scroll-mt-28">
+                    <section className="max-w-lg scroll-mt-[calc(7rem_+_env(safe-area-inset-top))]">
                         <p className={LABEL}>Signaling</p>
                         <h2 className="mt-3 text-base font-medium text-zinc-100">
-                            The server introduces, then leaves.
+                            <span className="sr-only">Signaling. </span>The server introduces, then
+                            leaves.
                         </h2>
                         <p className="mt-2 text-sm leading-relaxed text-zinc-400">
                             It puts your two devices in a room and passes the offer, the answer, and each
-                            side&apos;s network addresses between them. Once the connection opens, it plays
-                            no further part.
+                            side&apos;s network addresses between them. Once the connection opens, no file
+                            data goes back through it.
                         </p>
                     </section>
-                    <section id="direct" className="max-w-lg scroll-mt-28">
+                    <section id="direct" className="max-w-lg scroll-mt-[calc(7rem_+_env(safe-area-inset-top))]">
                         <p className={`flex items-center gap-2 ${LABEL}`}>
                             <Dot tone="direct" />
                             {BADGE_DIRECT}
                         </p>
                         <h2 className="mt-3 text-base font-medium text-zinc-100">
-                            Straight across, most of the time.
+                            <span className="sr-only">Direct. </span>Straight across, most of the time.
                         </h2>
                         <p className="mt-2 text-sm leading-relaxed text-zinc-400">
                             Device to device, with no server carrying the file. There is no size limit,
                             and speed is whatever the slower of your two connections allows. The badge
-                            shows {BADGE_DIRECT}, in green.
+                            shows {BADGE_DIRECT} with a green dot.
                         </p>
                     </section>
-                    <section id="relay" className="max-w-lg scroll-mt-28">
+                    <section id="relay" className="max-w-lg scroll-mt-[calc(7rem_+_env(safe-area-inset-top))]">
                         <p className={`flex items-center gap-2 ${LABEL}`}>
                             <Dot tone="relay" />
                             {BADGE_RELAY}
                         </p>
                         <h2 className="mt-3 text-base font-medium text-zinc-100">
-                            The detour, when a network blocks the way.
+                            <span className="sr-only">Relay. </span>The detour, when the way is blocked.
                         </h2>
                         <p className="mt-2 text-sm leading-relaxed text-zinc-400">
                             A TURN relay both devices can reach forwards encrypted packets it cannot read;
-                            on floe.one that relay is Cloudflare&apos;s. The badge shows {BADGE_RELAY}, in
-                            amber.
+                            on floe.one that relay is Cloudflare&apos;s. The badge shows {BADGE_RELAY} with
+                            an amber dot.
                         </p>
-                        <p id="size-limit" className="mt-3 scroll-mt-28 text-sm leading-relaxed text-zinc-400">
-                            Relay bandwidth costs money, so a relayed session is capped at {RELAY_CAP}. The
-                            sender checks once, before any file data moves; exactly {RELAY_CAP} passes.
+                        <p id="size-limit" className="mt-3 scroll-mt-[calc(7rem_+_env(safe-area-inset-top))] text-sm leading-relaxed text-zinc-400">
+                            Relay bandwidth costs money, so a relayed session is capped at{' '}
+                            <span className="whitespace-nowrap">{RELAY_CAP}</span>. The sender checks once,
+                            before any file data moves; exactly{' '}
+                            <span className="whitespace-nowrap">{RELAY_CAP}</span> passes.
                         </p>
                     </section>
                 </div>
@@ -143,11 +154,11 @@ export default function HowItWorks() {
                 {/* Encryption is not a beat on the line, it is true of every route,
                     so it sits alone, one shade lighter than the captions, with
                     whitespace rather than a hairline separating it. */}
-                <div className="mt-14 max-w-2xl">
+                <div className="mt-14 max-w-lg">
                     <p className={LABEL}>On every route</p>
                     <p className="mt-3 text-base leading-relaxed text-zinc-300">
                         Every transfer is encrypted end to end with WebRTC&apos;s DTLS. The keys exist only
-                        on the two devices, and nothing is stored on any server. The browser, Floe Desktop
+                        on the two devices, and no file is stored on any server. The browser, Floe Desktop
                         for Windows, and the CLI all speak the same protocol.
                     </p>
                 </div>
@@ -164,12 +175,12 @@ export default function HowItWorks() {
                     </p>
                     <div className="mt-8">
                         <a
-                            href={`${DOCS}/signaling`}
+                            href={DOCS_SIGNALING}
                             target="_blank"
                             rel="noreferrer"
                             className="inline-flex min-h-10 items-center gap-1.5 rounded-full bg-white px-4 py-2 text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
                         >
-                            Read the full technical breakdown
+                            Read the full breakdown
                             <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
                         </a>
                     </div>
@@ -177,9 +188,9 @@ export default function HowItWorks() {
                         drops list semantics with them. */}
                     <ul role="list" className="mt-8 grid gap-y-3 sm:grid-cols-3 sm:gap-x-8">
                         {DOCS_PAGES.map((page, i) => (
-                            <li key={page.slug}>
+                            <li key={page.href}>
                                 <a
-                                    href={`${DOCS}/${page.slug}`}
+                                    href={page.href}
                                     target="_blank"
                                     rel="noreferrer"
                                     className="group inline-flex min-h-10 items-center gap-3 text-sm font-medium text-zinc-300 transition hover:text-ice focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0"

--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -100,11 +100,17 @@ export default function HowItWorks() {
                     not set 14px type across 105 characters; from md the grid
                     columns are 218px and the cap never binds. The badge tooltips in
                     the app deep-link to #direct and #relay and the over-limit
-                    notice to #size-limit; scroll-mt-28 clears the pill for all
-                    three. */}
+                    notice to #size-limit; each scroll margin clears the pill,
+                    inset included. */}
                 <div className="mt-12 grid gap-8 md:grid-cols-3">
                     <section className="max-w-lg scroll-mt-[calc(7rem_+_env(safe-area-inset-top))]">
-                        <p className={LABEL}>Signaling</p>
+                        {/* The spacer stands in for the dot the other two labels
+                            carry, so all three label texts share a left edge
+                            across the row. */}
+                        <p className={`flex items-center gap-2 ${LABEL}`}>
+                            <span className="h-1.5 w-1.5" aria-hidden="true" />
+                            Signaling
+                        </p>
                         <h2 className="mt-3 text-base font-medium text-zinc-100">
                             <span className="sr-only">Signaling. </span>The server introduces, then
                             leaves.
@@ -156,7 +162,7 @@ export default function HowItWorks() {
                     whitespace rather than a hairline separating it. */}
                 <div className="mt-14 max-w-lg">
                     <p className={LABEL}>On every route</p>
-                    <p className="mt-3 text-base leading-relaxed text-zinc-300">
+                    <p className="mt-3 text-base leading-relaxed text-pretty text-zinc-300">
                         Every transfer is encrypted end to end with WebRTC&apos;s DTLS. The keys exist only
                         on the two devices, and no file is stored on any server. The browser, Floe Desktop
                         for Windows, and the CLI all speak the same protocol.
@@ -186,14 +192,14 @@ export default function HowItWorks() {
                     </div>
                     {/* role="list": Tailwind's preflight strips list markers and Safari
                         drops list semantics with them. */}
-                    <ul role="list" className="mt-8 grid gap-y-3 sm:grid-cols-3 sm:gap-x-8">
+                    <ul role="list" className="mt-8 grid gap-y-3 md:grid-cols-3 md:gap-x-8">
                         {DOCS_PAGES.map((page, i) => (
                             <li key={page.href}>
                                 <a
                                     href={page.href}
                                     target="_blank"
                                     rel="noreferrer"
-                                    className="group inline-flex min-h-10 items-center gap-3 text-sm font-medium text-zinc-300 transition hover:text-ice focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0"
+                                    className="group inline-flex min-h-10 items-center gap-3 text-sm font-medium text-zinc-300 transition hover:text-ice focus-visible:outline-2 focus-visible:outline-ice md:min-h-0"
                                 >
                                     <span className="font-mono text-xs text-zinc-600" aria-hidden="true">
                                         {String(i + 1).padStart(2, '0')}

--- a/client/app/how-it-works/page.tsx
+++ b/client/app/how-it-works/page.tsx
@@ -1,158 +1,203 @@
 import React from 'react';
 import type { Metadata } from 'next';
-import { ArrowLeft, Zap, Server, ShieldCheck, BookOpen } from 'lucide-react';
-import Link from 'next/link';
+import { ArrowUpRight } from 'lucide-react';
+import { Navbar } from '@/components/layout/Navbar';
 import { Footer } from '@/components/layout/Footer';
+import { RouteFigure } from '@/components/how-it-works/RouteFigure';
+import { BADGE_DIRECT, BADGE_RELAY, RELAY_CAP } from '@/lib/howItWorksStrings';
 import { sharedOpenGraph, sharedTwitter } from '@/lib/socialMetadata';
 
-// This page is static prose: no hooks, no state, no event handlers, no browser
-// APIs. It carried 'use client' until 2026-07, which forced the whole body into
-// a client-hydrated subtree and forced the metadata below out into a
-// pass-through layout.tsx. As a Server Component it can export metadata itself.
+// The short version: one drawing, three beats, a pointer to the docs. This
+// page summarizes; docs/how-it-works/* carries the depth. Under 300 words of
+// visible copy on purpose, and every sentence is literally true of the current
+// release (checked against docs/how-it-works/*.mdx, docs/security-privacy.mdx,
+// client/lib/relay.ts, server/server.js, server/turn.js and
+// cli/engine/transfer/relay.go on 2026-09-07).
+//
+// A Server Component with no client island: the figure's motion is CSS that
+// plays once on paint (see the .hiw-* rules in globals.css), so
+// e2e/hydration.spec.ts is satisfied by construction.
 export const metadata: Metadata = {
     // Bare title: the "%s - Floe" template in app/layout.tsx adds the suffix.
     title: 'How It Works',
     description:
-        'Learn how Floe transfers files directly between devices using WebRTC, end-to-end encryption, and TURN relay fallback.',
+        "Floe's server introduces two devices, then leaves. What Direct and Relay mean, why relayed transfers are capped at 2 GB, and how every transfer is encrypted.",
     alternates: {
         canonical: '/how-it-works',
     },
     // Spread before overriding: a bare object here would replace the root's
-    // whole openGraph block and drop the images with it.
-    openGraph: { ...sharedOpenGraph, title: 'How Floe Works' },
-    twitter: { ...sharedTwitter, title: 'How Floe Works' },
+    // whole openGraph block and drop the images with it. Sentence case, the
+    // same string as the h1 and the 404's link to this page.
+    openGraph: { ...sharedOpenGraph, title: 'How Floe works' },
+    twitter: { ...sharedTwitter, title: 'How Floe works' },
 };
+
+const DOCS = 'https://www.floe.one/docs/how-it-works';
+
+// The six docs pages, in the order the line reads them.
+const DOCS_PAGES: { label: string; slug: string }[] = [
+    { label: 'Signaling', slug: 'signaling' },
+    { label: 'Direct connection', slug: 'direct-connection' },
+    { label: 'Relay connection', slug: 'relay-connection' },
+    { label: `${RELAY_CAP} limit`, slug: '2gb-limit' },
+    { label: 'Encryption', slug: 'encryption' },
+    { label: 'Known limitations', slug: 'known-limitations' },
+];
+
+const LABEL = 'font-mono text-[11px] uppercase tracking-[0.2em] text-zinc-500';
+
+// The badge dot the app draws (ConnectionStatusBadge.tsx core dot, no halo):
+// green means Direct, amber means Relay, and those are the only two colors on
+// the page besides ice.
+function Dot({ tone }: { tone: 'direct' | 'relay' }) {
+    return (
+        <span
+            className={`h-1.5 w-1.5 rounded-full ${tone === 'direct' ? 'bg-green-500' : 'bg-amber-500'}`}
+            aria-hidden="true"
+        />
+    );
+}
 
 export default function HowItWorks() {
     return (
         // Same centering flex shell as / and /download, so the shared <Footer />
         // gets identical width math on every page that renders it.
         <div className="flex min-h-dvh flex-col items-center bg-zinc-950 font-sans text-zinc-100 px-[max(1rem,env(safe-area-inset-left),env(safe-area-inset-right))] pb-[max(1rem,env(safe-area-inset-bottom))] sm:px-[max(1.5rem,env(safe-area-inset-left),env(safe-area-inset-right))] sm:pb-[max(1.5rem,env(safe-area-inset-bottom))]">
-            <div className="w-full max-w-3xl space-y-8 pt-6 md:pt-12">
-                <div className="space-y-4">
-                    <Link
-                        href="/"
-                        className="inline-flex items-center text-sm text-zinc-400 hover:text-white transition-colors mb-4"
-                    >
-                        <ArrowLeft className="w-4 h-4 mr-2" /> Back to Home
-                    </Link>
-                    <h1 className="text-4xl font-bold tracking-tight text-white">
-                        How Floe Works
+            <Navbar />
+
+            <main className="w-full max-w-5xl">
+                {/* Left-aligned, unlike the centered /download hero: the line
+                    below starts under these words, at YOU. pt-24/28 clears the
+                    fixed pill; leading-none on the eyebrow drops its dead
+                    half-leading; mt-3 offsets the headline's own leading. */}
+                <header className="pt-24 sm:pt-28">
+                    <p className="font-mono text-[11px] leading-none uppercase tracking-[0.2em] text-ice">
+                        The short version
+                    </p>
+                    <h1 className="mt-3 text-4xl font-semibold tracking-tight text-zinc-100 sm:text-5xl lg:text-6xl">
+                        How Floe works
                     </h1>
-                    <p className="text-zinc-400">
-                        A plain-language overview of what happens behind the scenes when you share a file.
+                    <p className="mt-6 max-w-lg text-base leading-relaxed text-balance text-zinc-400">
+                        Two devices, one line between them. A server makes the introduction and
+                        leaves. Most transfers go straight across. When a network blocks the way, the
+                        transfer can take a relay instead, capped at {RELAY_CAP} per session.
                     </p>
-                </div>
+                </header>
 
-                {/* Hero summary card */}
-                <div className="p-6 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-4">
-                    <div className="flex items-center gap-3 text-green-400 mb-2">
-                        <ShieldCheck className="w-6 h-6" />
-                        <h2 className="text-lg font-semibold">The Short Version</h2>
-                    </div>
-                    <p className="text-zinc-300 leading-relaxed">
-                        Floe uses a technology called <strong>WebRTC</strong> to send your files directly from
-                        one device to another, whether each side is a browser tab, the desktop app, or
-                        the CLI. Think of it like handing a USB drive to someone. It
-                        happens over the internet, in real time. In most cases, no one else is in the middle.
-                        <br /><br />
-                        In some network situations, a secure relay server acts as a bridge. Either way,
-                        your files are <strong>end-to-end encrypted</strong> and never stored on any server.
-                    </p>
-                </div>
+                <RouteFigure />
 
-                {/* Direct + Relay side-by-side cards */}
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div className="p-5 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-3">
-                        <div className="flex items-center gap-2.5">
-                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-green-500/10 ring-1 ring-green-500/20">
-                                <Zap className="w-4 h-4 text-green-400" />
-                            </div>
-                            <div>
-                                <p className="text-sm font-semibold text-white leading-none">Direct Connection</p>
-                                <span className="text-[10px] text-green-400 font-medium uppercase tracking-wide">Fastest</span>
-                            </div>
-                        </div>
-                        <p className="text-sm text-zinc-400 leading-relaxed">
-                            Files travel straight from your device to the recipient. No server sits in between.
-                            Speed is limited only by your internet connection.
+                {/* Three beats in the line's order. md, not sm: at 640 three text
+                    columns would be a 22ch measure. Below md they stack, and each
+                    one keeps the hero lede's max-w-lg so a 719px column at 767 does
+                    not set 14px type across 105 characters; from md the grid
+                    columns are 218px and the cap never binds. The badge tooltips in
+                    the app deep-link to #direct and #relay and the over-limit
+                    notice to #size-limit; scroll-mt-28 clears the pill for all
+                    three. */}
+                <div className="mt-12 grid gap-8 md:grid-cols-3">
+                    <section className="max-w-lg scroll-mt-28">
+                        <p className={LABEL}>Signaling</p>
+                        <h2 className="mt-3 text-base font-medium text-zinc-100">
+                            The server introduces, then leaves.
+                        </h2>
+                        <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                            It puts your two devices in a room and passes the offer, the answer, and each
+                            side&apos;s network addresses between them. Once the connection opens, it plays
+                            no further part.
                         </p>
-                        <ul className="space-y-1 text-xs text-zinc-500">
-                            <li className="flex items-center gap-1.5"><span className="text-green-500">+</span> No file size limit</li>
-                            <li className="flex items-center gap-1.5"><span className="text-green-500">+</span> Zero bandwidth cost to Floe</li>
-                            <li className="flex items-center gap-1.5"><span className="text-green-500">+</span> Works on most home and mobile networks</li>
-                        </ul>
-                    </div>
-
-                    <div className="p-5 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-3">
-                        <div className="flex items-center gap-2.5">
-                            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-amber-500/10 ring-1 ring-amber-500/20">
-                                <Server className="w-4 h-4 text-amber-400" />
-                            </div>
-                            <div>
-                                <p className="text-sm font-semibold text-white leading-none">Relay Connection</p>
-                                <span className="text-[10px] text-amber-400 font-medium uppercase tracking-wide">Via TURN Server</span>
-                            </div>
-                        </div>
-                        <p className="text-sm text-zinc-400 leading-relaxed">
-                            Used on strict corporate firewalls or carrier-grade NAT networks where a direct
-                            path cannot be found. Floe falls back automatically.
+                    </section>
+                    <section id="direct" className="max-w-lg scroll-mt-28">
+                        <p className={`flex items-center gap-2 ${LABEL}`}>
+                            <Dot tone="direct" />
+                            {BADGE_DIRECT}
                         </p>
-                        <ul className="space-y-1 text-xs text-zinc-500">
-                            <li className="flex items-center gap-1.5"><span className="text-amber-500">~</span> Works on restricted networks</li>
-                            <li className="flex items-center gap-1.5"><span className="text-amber-500">~</span> Files remain encrypted in transit</li>
-                            <li className="flex items-center gap-1.5"><span className="text-amber-500">~</span> Capped at 2 GB per session</li>
-                        </ul>
-                    </div>
+                        <h2 className="mt-3 text-base font-medium text-zinc-100">
+                            Straight across, most of the time.
+                        </h2>
+                        <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                            Device to device, with no server carrying the file. There is no size limit,
+                            and speed is whatever the slower of your two connections allows. The badge
+                            shows {BADGE_DIRECT}, in green.
+                        </p>
+                    </section>
+                    <section id="relay" className="max-w-lg scroll-mt-28">
+                        <p className={`flex items-center gap-2 ${LABEL}`}>
+                            <Dot tone="relay" />
+                            {BADGE_RELAY}
+                        </p>
+                        <h2 className="mt-3 text-base font-medium text-zinc-100">
+                            The detour, when a network blocks the way.
+                        </h2>
+                        <p className="mt-2 text-sm leading-relaxed text-zinc-400">
+                            A TURN relay both devices can reach forwards encrypted packets it cannot read;
+                            on floe.one that relay is Cloudflare&apos;s. The badge shows {BADGE_RELAY}, in
+                            amber.
+                        </p>
+                        <p id="size-limit" className="mt-3 scroll-mt-28 text-sm leading-relaxed text-zinc-400">
+                            Relay bandwidth costs money, so a relayed session is capped at {RELAY_CAP}. The
+                            sender checks once, before any file data moves; exactly {RELAY_CAP} passes.
+                        </p>
+                    </section>
                 </div>
 
-                {/* Encryption note */}
-                <p className="text-sm text-zinc-500 text-center px-4">
-                    Every connection, direct or relayed, is encrypted with{' '}
-                    <strong className="text-zinc-400">DTLS</strong> built into WebRTC. Even the relay server cannot read your files.
-                </p>
-
-                {/* Docs CTA */}
-                <div className="p-6 rounded-2xl bg-zinc-900/50 border border-zinc-800 space-y-4">
-                    <div className="flex items-center gap-3">
-                        <BookOpen className="w-5 h-5 text-zinc-400" />
-                        <h2 className="text-base font-semibold text-white">Want the full technical detail?</h2>
-                    </div>
-                    <p className="text-sm text-zinc-400">
-                        The Floe documentation covers signaling, ICE and NAT traversal, DTLS encryption,
-                        and the binary transfer protocol in depth.
+                {/* Encryption is not a beat on the line, it is true of every route,
+                    so it sits alone, one shade lighter than the captions, with
+                    whitespace rather than a hairline separating it. */}
+                <div className="mt-14 max-w-2xl">
+                    <p className={LABEL}>On every route</p>
+                    <p className="mt-3 text-base leading-relaxed text-zinc-300">
+                        Every transfer is encrypted end to end with WebRTC&apos;s DTLS. The keys exist only
+                        on the two devices, and nothing is stored on any server. The browser, Floe Desktop
+                        for Windows, and the CLI all speak the same protocol.
                     </p>
-                    <a
-                        href="https://www.floe.one/docs/how-it-works/signaling"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-sm font-bold text-black transition hover:bg-zinc-200"
-                    >
-                        Read the full technical breakdown
-                        <ArrowLeft className="w-3.5 h-3.5 rotate-180" />
-                    </a>
-                    <div className="flex flex-wrap gap-x-4 gap-y-1 pt-1">
-                        {[
-                            { label: 'Signaling', href: 'https://www.floe.one/docs/how-it-works/signaling' },
-                            { label: 'Direct Connection', href: 'https://www.floe.one/docs/how-it-works/direct-connection' },
-                            { label: 'Relay Connection', href: 'https://www.floe.one/docs/how-it-works/relay-connection' },
-                            { label: '2 GB Limit', href: 'https://www.floe.one/docs/how-it-works/2gb-limit' },
-                            { label: 'Encryption', href: 'https://www.floe.one/docs/how-it-works/encryption' },
-                        ].map(({ label, href }) => (
-                            <a
-                                key={label}
-                                href={href}
-                                target="_blank"
-                                rel="noreferrer"
-                                className="text-[10px] text-zinc-500 uppercase tracking-wide hover:text-white transition-colors whitespace-nowrap"
-                            >
-                                {label}
-                            </a>
+                </div>
+
+                {/* The page's one hairline besides the footer's: the handoff to the
+                    docs, which carry the depth this page leaves out. */}
+                <section className="mt-28 border-t border-white/[0.06] pt-12 sm:mt-32 sm:pt-14">
+                    <h2 className="text-2xl font-semibold tracking-tight text-zinc-100 sm:text-3xl">
+                        Want the full technical detail?
+                    </h2>
+                    <p className="mt-4 max-w-lg text-base leading-relaxed text-zinc-400">
+                        Six pages take each stop on the line apart at depth, the known limitations
+                        included.
+                    </p>
+                    <div className="mt-8">
+                        <a
+                            href={`${DOCS}/signaling`}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex min-h-10 items-center gap-1.5 rounded-full bg-white px-4 py-2 text-sm font-bold text-black transition hover:bg-zinc-200 focus-visible:outline-2 focus-visible:outline-ice"
+                        >
+                            Read the full technical breakdown
+                            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+                        </a>
+                    </div>
+                    {/* role="list": Tailwind's preflight strips list markers and Safari
+                        drops list semantics with them. */}
+                    <ul role="list" className="mt-8 grid gap-y-3 sm:grid-cols-3 sm:gap-x-8">
+                        {DOCS_PAGES.map((page, i) => (
+                            <li key={page.slug}>
+                                <a
+                                    href={`${DOCS}/${page.slug}`}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="group inline-flex min-h-10 items-center gap-3 text-sm font-medium text-zinc-300 transition hover:text-ice focus-visible:outline-2 focus-visible:outline-ice sm:min-h-0"
+                                >
+                                    <span className="font-mono text-xs text-zinc-600" aria-hidden="true">
+                                        {String(i + 1).padStart(2, '0')}
+                                    </span>
+                                    {page.label}
+                                    <ArrowUpRight
+                                        className="h-3.5 w-3.5 text-zinc-500 transition group-hover:text-ice"
+                                        aria-hidden="true"
+                                    />
+                                </a>
+                            </li>
                         ))}
-                    </div>
-                </div>
-
-            </div>
+                    </ul>
+                </section>
+            </main>
 
             <Footer />
         </div>

--- a/client/components/ConnectionStatusBadge.tsx
+++ b/client/components/ConnectionStatusBadge.tsx
@@ -81,7 +81,7 @@ export function ConnectionStatusBadge({
                                         <p className="text-[10px] font-bold text-green-400 uppercase tracking-wider mb-1">Direct Connection</p>
                                         <p className="text-[10px] font-normal normal-case tracking-normal text-zinc-400 leading-relaxed font-sans">
                                             Your files go directly to the other device, even across different networks like mobile data. No servers involved. Unlimited speed and size.{' '}
-                                            <a href="/how-it-works" target="_blank" rel="noreferrer" className="text-zinc-500 hover:text-white underline underline-offset-2 transition-colors">
+                                            <a href="/how-it-works#direct" target="_blank" rel="noreferrer" className="text-zinc-500 hover:text-white underline underline-offset-2 transition-colors">
                                                 Learn more
                                             </a>
                                         </p>
@@ -91,7 +91,7 @@ export function ConnectionStatusBadge({
                                         <p className="text-[10px] font-bold text-amber-400 uppercase tracking-wider mb-1">Relay Connection</p>
                                         <p className="text-[10px] font-normal normal-case tracking-normal text-zinc-400 leading-relaxed font-sans">
                                             A server bridges the connection when a direct path is unavailable. Your files stay encrypted. 2 GB limit per session.{' '}
-                                            <a href="/how-it-works" target="_blank" rel="noreferrer" className="text-zinc-500 hover:text-white underline underline-offset-2 transition-colors">
+                                            <a href="/how-it-works#relay" target="_blank" rel="noreferrer" className="text-zinc-500 hover:text-white underline underline-offset-2 transition-colors">
                                                 Learn more
                                             </a>
                                         </p>

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -875,7 +875,7 @@ export function P2PTransfer() {
                                     <AlertTriangle className="h-4 w-4 text-amber-400 flex-shrink-0 mt-0.5" />
                                     <div className="flex-1 text-xs text-amber-300 leading-relaxed">
                                         Transfer limit exceeded. Relay connections are capped at 2 GB. Remove files to proceed, or switch to a network that supports a direct connection.{' '}
-                                        <a href="/how-it-works" target="_blank" rel="noreferrer" className="underline underline-offset-2 text-amber-400 hover:text-white transition-colors">
+                                        <a href="/how-it-works#size-limit" target="_blank" rel="noreferrer" className="underline underline-offset-2 text-amber-400 hover:text-white transition-colors">
                                             Learn more
                                         </a>
                                     </div>

--- a/client/components/RelayFallbackToggle.tsx
+++ b/client/components/RelayFallbackToggle.tsx
@@ -37,7 +37,7 @@ export function RelayFallbackToggle({ relayEnabled, onChange }: RelayFallbackTog
                     <p className="text-xs text-zinc-500 leading-relaxed">
                         Only used when a direct connection isn&apos;t possible; most transfers stay direct. 2 GB limit when relayed.{' '}
                         <a
-                            href="/how-it-works"
+                            href="/how-it-works#relay"
                             target="_blank"
                             rel="noreferrer"
                             onClick={(e) => e.stopPropagation()}

--- a/client/components/how-it-works/RouteFigure.tsx
+++ b/client/components/how-it-works/RouteFigure.tsx
@@ -16,8 +16,9 @@ import { RELAY_CAP } from '@/lib/howItWorksStrings';
  * Motion is CSS only and plays once on paint: the .hiw-* rules in globals.css,
  * inside
  * prefers-reduced-motion: no-preference. The base rules are the finished
- * figure, so reduced motion, the e2e sweep, the screenshot matrix and a
- * JS-off reader all get the completed drawing at first paint. No client
+ * figure, so reduced motion, the e2e sweep and the screenshot matrix all get
+ * the completed drawing at first paint, and a reader with JavaScript off gets
+ * the sequence anyway, since CSS animations do not need it. No client
  * island: the route stays a Server Component. A plain load puts the figure
  * inside the first viewport at every width; a reader arriving at #direct,
  * #relay or #size-limit lands below it and sees that same finished drawing.
@@ -112,9 +113,9 @@ export function RouteFigure() {
             <figcaption className="sr-only">
                 A line runs from You to Them. Two thin spurs rise from each device to the signaling
                 server and end there: it introduces the devices and takes no further part. The
-                direct line runs straight across, labeled Direct, no size limit. A dotted second
-                path dips through a relay and rejoins at Them, labeled Relay, {RELAY_CAP} per
-                session.
+                direct line runs straight across, labeled Direct, and carries no size limit. A
+                dotted second path dips through a relay and rejoins at Them, labeled Relay, and is
+                capped at {RELAY_CAP} per session.
             </figcaption>
         </figure>
     );

--- a/client/components/how-it-works/RouteFigure.tsx
+++ b/client/components/how-it-works/RouteFigure.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { ROUTE_NARROW, ROUTE_WIDE, routeGeometry, type RouteGeometry } from '@/lib/routeFigure';
+import { RELAY_CAP } from '@/lib/howItWorksStrings';
+
+/**
+ * The one drawing on /how-it-works: a transfer as a single line.
+ *
+ * A baseline runs from YOU to THEM. Two spurs rise from the devices to the
+ * signaling server's tick and end there (it introduces, then leaves). The
+ * direct line is the ice stroke. A dotted second path dips through the relay
+ * tick and back up to THEM. Labels are the product's own badge words with the
+ * badge's green and amber dots; no boxes, no arrowheads, no icons.
+ *
+ * Two variants, wide from md and narrow below it, both drawn from
+ * routeGeometry() so the two cannot drift; the CSS gate is the only switch.
+ * Motion is CSS only and plays once on paint (the figure sits in the first
+ * viewport at every width): the .hiw-* rules in globals.css, inside
+ * prefers-reduced-motion: no-preference. The base rules are the finished
+ * figure, so reduced motion, the e2e sweep, the screenshot matrix and a
+ * JS-off reader all get the completed drawing at first paint. No client
+ * island: the route stays a Server Component.
+ */
+
+const LABEL = 'font-mono text-[11px] uppercase tracking-[0.2em]';
+
+function Variant({ g, className }: { g: RouteGeometry; className: string }) {
+    const [left, right] = g.deviceTicks;
+    const L = g.labels;
+    return (
+        <div className={`relative ${className}`} style={{ aspectRatio: `${g.width} / ${g.height}` }}>
+            <svg viewBox={`0 0 ${g.width} ${g.height}`} aria-hidden="true" focusable="false">
+                <line className="hiw-tick" x1={left.x1} y1={left.y1} x2={left.x2} y2={left.y2} />
+                <line className="hiw-tick" x1={right.x1} y1={right.y1} x2={right.x2} y2={right.y2} />
+                <line
+                    className="hiw-tick"
+                    x1={g.serverTick.x1}
+                    y1={g.serverTick.y1}
+                    x2={g.serverTick.x2}
+                    y2={g.serverTick.y2}
+                />
+                {/* pathLength normalizes both spurs and the line to 1000 units so one
+                    stroke-dasharray value draws them regardless of their real length. */}
+                <path className="hiw-spur" pathLength={1000} d={g.spurLeft} />
+                <path className="hiw-spur" pathLength={1000} d={g.spurRight} />
+                <path className="hiw-detour" d={g.detour} />
+                <line
+                    className="hiw-tick hiw-relay-tick"
+                    x1={g.relayTick.x1}
+                    y1={g.relayTick.y1}
+                    x2={g.relayTick.x2}
+                    y2={g.relayTick.y2}
+                />
+                <path className="hiw-direct" pathLength={1000} d={g.direct} />
+                {/* A 1px ice ring marks the arrival; ice is never a fill on this site. */}
+                <circle className="hiw-ring" cx={g.them.x} cy={g.them.y} r={3} />
+            </svg>
+            {/* HTML labels over the SVG so they get Geist Mono, the page's color
+                tokens and normal text rendering. Centered labels carry pl-[0.2em]
+                to repay the letter-space that tracking adds after the last glyph. */}
+            <div className={`pointer-events-none absolute inset-0 ${LABEL}`} aria-hidden="true">
+                <span
+                    className="absolute -translate-x-1/2 pl-[0.2em] text-zinc-400"
+                    style={{ left: `${L.you.left}%`, top: `${L.you.top}%` }}
+                >
+                    You
+                </span>
+                <span
+                    className="absolute -translate-x-1/2 pl-[0.2em] text-zinc-400"
+                    style={{ left: `${L.them.left}%`, top: `${L.them.top}%` }}
+                >
+                    Them
+                </span>
+                <span
+                    className="hiw-lbl-server absolute -translate-x-1/2 -translate-y-1/2 whitespace-nowrap pl-[0.2em] text-zinc-500"
+                    style={{ left: `${L.server.left}%`, top: `${L.server.top}%` }}
+                >
+                    Signaling server
+                </span>
+                <span
+                    className="hiw-lbl-direct absolute flex -translate-x-1/2 -translate-y-full items-center gap-2 whitespace-nowrap pl-[0.2em] text-zinc-300"
+                    style={{ left: `${L.direct.left}%`, top: `${L.direct.top}%` }}
+                >
+                    <i className="h-1.5 w-1.5 rounded-full bg-green-500" />
+                    Direct
+                    <span className="text-zinc-600">·</span>
+                    <span className="text-zinc-500">No size limit</span>
+                </span>
+                <span
+                    className="hiw-lbl-relay absolute flex -translate-x-1/2 -translate-y-1/2 items-center gap-2 whitespace-nowrap pl-[0.2em] text-zinc-300"
+                    style={{ left: `${L.relay.left}%`, top: `${L.relay.top}%` }}
+                >
+                    <i className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+                    Relay
+                    <span className="text-zinc-600">·</span>
+                    <span className="text-zinc-500">{RELAY_CAP} per session</span>
+                </span>
+            </div>
+        </div>
+    );
+}
+
+export function RouteFigure() {
+    return (
+        <figure className="hiw-fig mt-14 sm:mt-16">
+            <Variant g={routeGeometry(ROUTE_WIDE)} className="hidden md:block" />
+            {/* max-w-[30rem]: between 640 and 767 the narrow drawing would otherwise
+                balloon to 480px tall in a 720px column. */}
+            <Variant g={routeGeometry(ROUTE_NARROW)} className="max-w-[30rem] md:hidden" />
+            {/* The only description assistive tech gets; it claims exactly what is drawn. */}
+            <figcaption className="sr-only">
+                A line runs from You to Them. Two thin spurs rise from each device to the signaling
+                server and end there: it introduces the devices and takes no further part. The
+                direct line runs straight across. A dotted second path dips through a relay and
+                rejoins at Them, labeled Relay, {RELAY_CAP} per session.
+            </figcaption>
+        </figure>
+    );
+}

--- a/client/components/how-it-works/RouteFigure.tsx
+++ b/client/components/how-it-works/RouteFigure.tsx
@@ -13,12 +13,14 @@ import { RELAY_CAP } from '@/lib/howItWorksStrings';
  *
  * Two variants, wide from md and narrow below it, both drawn from
  * routeGeometry() so the two cannot drift; the CSS gate is the only switch.
- * Motion is CSS only and plays once on paint (the figure sits in the first
- * viewport at every width): the .hiw-* rules in globals.css, inside
+ * Motion is CSS only and plays once on paint: the .hiw-* rules in globals.css,
+ * inside
  * prefers-reduced-motion: no-preference. The base rules are the finished
  * figure, so reduced motion, the e2e sweep, the screenshot matrix and a
  * JS-off reader all get the completed drawing at first paint. No client
- * island: the route stays a Server Component.
+ * island: the route stays a Server Component. A plain load puts the figure
+ * inside the first viewport at every width; a reader arriving at #direct,
+ * #relay or #size-limit lands below it and sees that same finished drawing.
  */
 
 const LABEL = 'font-mono text-[11px] uppercase tracking-[0.2em]';
@@ -71,7 +73,7 @@ function Variant({ g, className }: { g: RouteGeometry; className: string }) {
                     Them
                 </span>
                 <span
-                    className="hiw-lbl-server absolute -translate-x-1/2 -translate-y-1/2 whitespace-nowrap pl-[0.2em] text-zinc-500"
+                    className="hiw-lbl-server absolute -translate-x-1/2 -translate-y-1/2 whitespace-nowrap pl-[0.2em] text-zinc-400"
                     style={{ left: `${L.server.left}%`, top: `${L.server.top}%` }}
                 >
                     Signaling server
@@ -82,8 +84,8 @@ function Variant({ g, className }: { g: RouteGeometry; className: string }) {
                 >
                     <i className="h-1.5 w-1.5 rounded-full bg-green-500" />
                     Direct
-                    <span className="text-zinc-600">·</span>
-                    <span className="text-zinc-500">No size limit</span>
+                    <span className="max-sm:hidden text-zinc-500">·</span>
+                    <span className="max-sm:hidden text-zinc-400">No size limit</span>
                 </span>
                 <span
                     className="hiw-lbl-relay absolute flex -translate-x-1/2 -translate-y-1/2 items-center gap-2 whitespace-nowrap pl-[0.2em] text-zinc-300"
@@ -91,8 +93,8 @@ function Variant({ g, className }: { g: RouteGeometry; className: string }) {
                 >
                     <i className="h-1.5 w-1.5 rounded-full bg-amber-500" />
                     Relay
-                    <span className="text-zinc-600">·</span>
-                    <span className="text-zinc-500">{RELAY_CAP} per session</span>
+                    <span className="max-sm:hidden text-zinc-500">·</span>
+                    <span className="max-sm:hidden text-zinc-400">{RELAY_CAP} per session</span>
                 </span>
             </div>
         </div>
@@ -110,8 +112,9 @@ export function RouteFigure() {
             <figcaption className="sr-only">
                 A line runs from You to Them. Two thin spurs rise from each device to the signaling
                 server and end there: it introduces the devices and takes no further part. The
-                direct line runs straight across. A dotted second path dips through a relay and
-                rejoins at Them, labeled Relay, {RELAY_CAP} per session.
+                direct line runs straight across, labeled Direct, no size limit. A dotted second
+                path dips through a relay and rejoins at Them, labeled Relay, {RELAY_CAP} per
+                session.
             </figcaption>
         </figure>
     );

--- a/client/e2e/responsive.spec.ts
+++ b/client/e2e/responsive.spec.ts
@@ -193,8 +193,8 @@ test('download: no horizontal overflow at any viewport', async ({ page }) => {
 test('how-it-works: no horizontal overflow at any viewport', async ({ page }) => {
     await page.emulateMedia({ reducedMotion: 'reduce' });
     await page.goto('/how-it-works');
-    await expect(page.getByRole('heading', { name: 'How Floe Works' })).toBeVisible();
-    await sweepViewports(page, '/how-it-works');
+    await expect(page.getByRole('heading', { name: 'How Floe works' })).toBeVisible();
+    await sweepViewports(page, '/how-it-works', true);
 });
 
 test('privacy: no horizontal overflow at any viewport', async ({ page }) => {

--- a/client/e2e/screenshot-matrix.mjs
+++ b/client/e2e/screenshot-matrix.mjs
@@ -158,6 +158,11 @@ const run = async () => {
     await page.getByRole('heading', { name: 'Floe Desktop' }).waitFor();
     for (const vp of VIEWPORTS) await capture(page, 'download', vp);
 
+    // How it works: reduced motion (set on this context) renders the signal
+    // log in its finished state, which is the section at its tallest.
+    await page.goto(BASE + '/how-it-works', { waitUntil: 'networkidle' });
+    await page.getByRole('heading', { name: 'How Floe works' }).waitFor();
+    for (const vp of VIEWPORTS) await capture(page, 'how-it-works', vp);
     // Download, non-Windows arrangement (mac UA) at the subset
     const macCtx = await browser.newContext({
         reducedMotion: 'reduce',

--- a/client/e2e/screenshot-matrix.mjs
+++ b/client/e2e/screenshot-matrix.mjs
@@ -158,8 +158,8 @@ const run = async () => {
     await page.getByRole('heading', { name: 'Floe Desktop' }).waitFor();
     for (const vp of VIEWPORTS) await capture(page, 'download', vp);
 
-    // How it works: reduced motion (set on this context) renders the signal
-    // log in its finished state, which is the section at its tallest.
+    // How it works: reduced motion (set on this context) renders the route
+    // figure in its finished state, which is what a shipped screenshot shows.
     await page.goto(BASE + '/how-it-works', { waitUntil: 'networkidle' });
     await page.getByRole('heading', { name: 'How Floe works' }).waitFor();
     for (const vp of VIEWPORTS) await capture(page, 'how-it-works', vp);

--- a/client/lib/howItWorksStrings.test.ts
+++ b/client/lib/howItWorksStrings.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import * as strings from './howItWorksStrings';
+
+describe('howItWorksStrings', () => {
+    it('derives the relay cap figure from RELAY_SIZE_LIMIT', () => {
+        // The docs, the CLI error and the page all say "2 GB". If relay.ts ever
+        // moves the limit, this is the assertion that says the page moved too.
+        expect(strings.RELAY_CAP).toBe('2 GB');
+    });
+
+    it('matches the badge words the app renders', () => {
+        expect(strings.BADGE_DIRECT).toBe('Direct');
+        expect(strings.BADGE_RELAY).toBe('Relay');
+    });
+
+    it('never carries an em dash or an en dash', () => {
+        for (const [name, value] of Object.entries(strings)) {
+            expect(typeof value, name).toBe('string');
+            expect(value, name).not.toMatch(/[–—]/);
+        }
+    });
+});

--- a/client/lib/howItWorksStrings.ts
+++ b/client/lib/howItWorksStrings.ts
@@ -1,0 +1,17 @@
+// The product strings /how-it-works quotes, each beside the file that prints
+// it. The page describes what the app shows, so a rename in any of these
+// sources must reach the page in the same change; the test next door pins the
+// values, and the claim map (.claude/skills/docs-verify/references/claim-map.md)
+// lists this module as a mirror of each source.
+import { RELAY_SIZE_LIMIT } from './relay';
+import { formatBytes } from './utils';
+
+/** "2 GB", derived from the gate's own constant so the figure cannot drift
+ *  from client/lib/relay.ts (RelaySizeLimit in cli/engine/transfer/relay.go
+ *  is the same number; the docs and the CLI error both say "2 GB"). */
+export const RELAY_CAP = formatBytes(RELAY_SIZE_LIMIT);
+
+/** The connection badge's route words: client/components/ConnectionStatusBadge.tsx
+ *  and desktop/frontend/src/App.tsx render exactly these, green and amber. */
+export const BADGE_DIRECT = 'Direct';
+export const BADGE_RELAY = 'Relay';

--- a/client/lib/routeFigure.test.ts
+++ b/client/lib/routeFigure.test.ts
@@ -29,11 +29,14 @@ describe.each([ROUTE_WIDE, ROUTE_NARROW])('routeGeometry(%i)', (width) => {
         expect(g.them.y).toBe(g.baselineY);
     });
 
-    it('ends both spurs on the server tick and nowhere else', () => {
+    it('stops both spurs short of the server tick, level with it', () => {
+        // Flush against the tick the spurs and the tick render as one arch from
+        // YOU over to THEM, which reads as the file passing through the server.
+        expect(g.serverGap).toBeGreaterThan(0);
         expect(startOf(g.spurLeft)).toEqual(g.you);
-        expect(endOf(g.spurLeft)).toEqual({ x: g.serverTick.x1, y: g.serverTick.y1 });
+        expect(endOf(g.spurLeft)).toEqual({ x: g.serverTick.x1 - g.serverGap, y: g.serverTick.y1 });
         expect(startOf(g.spurRight)).toEqual(g.them);
-        expect(endOf(g.spurRight)).toEqual({ x: g.serverTick.x2, y: g.serverTick.y2 });
+        expect(endOf(g.spurRight)).toEqual({ x: g.serverTick.x2 + g.serverGap, y: g.serverTick.y2 });
     });
 
     it('runs the detour as a complete second path from you to them through the relay tick', () => {
@@ -70,5 +73,31 @@ describe.each([ROUTE_WIDE, ROUTE_NARROW])('routeGeometry(%i)', (width) => {
         expect(g.labels.server.left).toBe(50);
         expect(g.labels.direct.left).toBe(50);
         expect(g.labels.relay.left).toBe(50);
+    });
+
+    // Without these the anchors are free to drift anywhere inside 0..100 and
+    // still pass: a label could sit on the wrong side of the thing it names.
+    it('anchors the device labels on their own ticks', () => {
+        const pct = (v: number, of: number) => Math.round((v / of) * 1000) / 10;
+        expect(g.labels.you.left).toBe(pct(g.you.x, width));
+        expect(g.labels.them.left).toBe(pct(g.them.x, width));
+        expect(g.labels.you.top).toBe(g.labels.them.top);
+    });
+
+    it('puts each figure label on the correct side of what it names', () => {
+        const pct = (v: number) => (v / ROUTE_HEIGHT) * 100;
+        // Server label above its tick, relay label below its own.
+        expect(g.labels.server.top).toBeLessThan(pct(g.serverTick.y1));
+        expect(g.labels.relay.top).toBeGreaterThan(pct(g.relayTick.y1));
+        // Direct label above the baseline, device labels below it.
+        expect(g.labels.direct.top).toBeLessThan(pct(g.baselineY));
+        expect(g.labels.you.top).toBeGreaterThan(pct(g.baselineY));
+        // And clear of the device ticks it sits under.
+        expect(g.labels.you.top).toBeGreaterThan(pct(g.deviceTicks[0].y2));
+    });
+
+    it('reports the width and height the component feeds to viewBox and aspect-ratio', () => {
+        expect(g.width).toBe(width);
+        expect(g.height).toBe(ROUTE_HEIGHT);
     });
 });

--- a/client/lib/routeFigure.test.ts
+++ b/client/lib/routeFigure.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { ROUTE_HEIGHT, ROUTE_NARROW, ROUTE_WIDE, routeGeometry } from './routeFigure';
+
+// Every point a path visits, control points included. H carries one x at the
+// current y, so the numbers cannot simply be read in pairs.
+const pointsOf = (d: string) => {
+    const out: { x: number; y: number }[] = [];
+    let y = 0;
+    for (const cmd of d.match(/[MCH][^MCH]*/g)!) {
+        const nums = cmd.slice(1).trim().split(/\s+/).map(Number);
+        if (cmd[0] === 'H') {
+            out.push({ x: nums[0], y });
+            continue;
+        }
+        for (let i = 0; i < nums.length; i += 2) out.push({ x: nums[i], y: nums[i + 1] });
+        y = nums[nums.length - 1];
+    }
+    return out;
+};
+const startOf = (d: string) => pointsOf(d)[0];
+const endOf = (d: string) => pointsOf(d).at(-1)!;
+
+describe.each([ROUTE_WIDE, ROUTE_NARROW])('routeGeometry(%i)', (width) => {
+    const g = routeGeometry(width);
+
+    it('draws the direct line flat across the baseline, device to device', () => {
+        expect(g.direct).toBe(`M ${g.you.x} ${g.baselineY} H ${g.them.x}`);
+        expect(g.you.y).toBe(g.baselineY);
+        expect(g.them.y).toBe(g.baselineY);
+    });
+
+    it('ends both spurs on the server tick and nowhere else', () => {
+        expect(startOf(g.spurLeft)).toEqual(g.you);
+        expect(endOf(g.spurLeft)).toEqual({ x: g.serverTick.x1, y: g.serverTick.y1 });
+        expect(startOf(g.spurRight)).toEqual(g.them);
+        expect(endOf(g.spurRight)).toEqual({ x: g.serverTick.x2, y: g.serverTick.y2 });
+    });
+
+    it('runs the detour as a complete second path from you to them through the relay tick', () => {
+        expect(startOf(g.detour)).toEqual(g.you);
+        expect(endOf(g.detour)).toEqual(g.them);
+        expect(g.detour).toContain(`${g.relayTick.x1} ${g.relayTick.y1} H ${g.relayTick.x2}`);
+    });
+
+    it('mirrors the server and relay ticks across the baseline', () => {
+        expect(g.serverTick.x1).toBe(g.relayTick.x1);
+        expect(g.serverTick.x2).toBe(g.relayTick.x2);
+        expect(g.baselineY - g.serverTick.y1).toBe(g.relayTick.y1 - g.baselineY);
+        expect(g.serverTick.x1 + g.serverTick.x2).toBe(width);
+    });
+
+    it('keeps every coordinate inside the viewBox', () => {
+        for (const d of [g.spurLeft, g.spurRight, g.detour, g.direct]) {
+            for (const { x, y } of pointsOf(d)) {
+                expect(x).toBeGreaterThanOrEqual(0);
+                expect(x).toBeLessThanOrEqual(width);
+                expect(y).toBeGreaterThanOrEqual(0);
+                expect(y).toBeLessThanOrEqual(ROUTE_HEIGHT);
+            }
+        }
+        for (const a of Object.values(g.labels)) {
+            expect(a.left).toBeGreaterThanOrEqual(0);
+            expect(a.left).toBeLessThanOrEqual(100);
+            expect(a.top).toBeGreaterThanOrEqual(0);
+            expect(a.top).toBeLessThanOrEqual(100);
+        }
+    });
+
+    it('centers the server, direct and relay labels', () => {
+        expect(g.labels.server.left).toBe(50);
+        expect(g.labels.direct.left).toBe(50);
+        expect(g.labels.relay.left).toBe(50);
+    });
+});

--- a/client/lib/routeFigure.test.ts
+++ b/client/lib/routeFigure.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { describe, it, expect } from 'vitest';
 import { ROUTE_HEIGHT, ROUTE_NARROW, ROUTE_WIDE, routeGeometry } from './routeFigure';
 
@@ -99,5 +100,31 @@ describe.each([ROUTE_WIDE, ROUTE_NARROW])('routeGeometry(%i)', (width) => {
     it('reports the width and height the component feeds to viewBox and aspect-ratio', () => {
         expect(g.width).toBe(width);
         expect(g.height).toBe(ROUTE_HEIGHT);
+    });
+});
+
+// The figure's draw-in is a stroke dash, and Chromium lays a dash out in
+// unscaled user units while the path renders scaled, so the ink only covers
+// dasharray/scale of the path. At the pathLength-normalized 1000 the ice line
+// stopped 98.8px short of THEM wherever the narrow variant rendered above
+// scale 1, and the arrival ring floated unattached. Nothing caught it: every
+// Playwright context that opens this page forces reduced motion, where no dash
+// exists at all. This is the guard for that.
+describe('the draw-in dash survives the figure being scaled up', () => {
+    const css = readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
+    // The narrow variant's box is capped by max-w-[30rem] in RouteFigure.tsx.
+    const NARROW_MAX_PX = 480;
+    const maxScale = NARROW_MAX_PX / ROUTE_NARROW;
+
+    it('sets a dasharray with headroom for the largest scale the figure reaches', () => {
+        const values = [...css.matchAll(/\.hiw-(?:spur|direct)\s*\{[^}]*?stroke-dasharray:\s*(\d+)/g)].map((m) => Number(m[1]));
+        expect(values.length, 'both dash-drawn paths declare a dasharray').toBe(2);
+        for (const v of values) expect(v).toBeGreaterThanOrEqual(1000 * maxScale);
+    });
+
+    it('starts the keyframe at the same value it dashes with', () => {
+        const dash = Number(css.match(/\.hiw-direct\s*\{[^}]*?stroke-dasharray:\s*(\d+)/)![1]);
+        const from = Number(css.match(/@keyframes hiw-draw\s*\{\s*from\s*\{\s*stroke-dashoffset:\s*(\d+)/)![1]);
+        expect(from).toBe(dash);
     });
 });

--- a/client/lib/routeFigure.ts
+++ b/client/lib/routeFigure.ts
@@ -139,10 +139,12 @@ export function routeGeometry(width: number): RouteGeometry {
         labels: {
             you: { left: pct(you.x, width), top: pct(BASELINE_Y + 36, ROUTE_HEIGHT) },
             them: { left: pct(them.x, width), top: pct(BASELINE_Y + 36, ROUTE_HEIGHT) },
+            // 20 above and 20 below: the drawing mirrors about the baseline, so
+            // its two mirrored labels sit the same distance from their ticks.
             server: { left: 50, top: pct(SERVER_Y - 20, ROUTE_HEIGHT) },
             // Bottom-anchored 11px above the line.
             direct: { left: 50, top: pct(BASELINE_Y - 11, ROUTE_HEIGHT) },
-            relay: { left: 50, top: pct(RELAY_Y + 22, ROUTE_HEIGHT) },
+            relay: { left: 50, top: pct(RELAY_Y + 20, ROUTE_HEIGHT) },
         },
     };
 }

--- a/client/lib/routeFigure.ts
+++ b/client/lib/routeFigure.ts
@@ -11,12 +11,14 @@
 // function at two widths, so the two drawings cannot drift apart; the test
 // next door pins the endpoints.
 
-export interface Point {
+// These three type the fields of RouteGeometry and are never named by a
+// consumer, so they stay unexported.
+interface Point {
     x: number;
     y: number;
 }
 
-export interface Segment {
+interface Segment {
     x1: number;
     y1: number;
     x2: number;
@@ -25,7 +27,7 @@ export interface Segment {
 
 /** A label anchor as percentages of the figure box, for an absolutely
  *  positioned HTML span over the SVG. */
-export interface Anchor {
+interface Anchor {
     left: number;
     top: number;
 }
@@ -39,15 +41,14 @@ export interface RouteGeometry {
     deviceTicks: [Segment, Segment];
     serverTick: Segment;
     relayTick: Segment;
+    /** How far short of the server tick each spur stops, in viewBox units. */
+    serverGap: number;
     /** SVG path data. The spurs run device to server tick; the detour runs
      *  YOU to relay tick to THEM; the direct line is the baseline. */
     spurLeft: string;
     spurRight: string;
     detour: string;
     direct: string;
-    /** The detour's endpoints, exposed for the test. */
-    detourStart: Point;
-    detourEnd: Point;
     labels: {
         you: Anchor;
         them: Anchor;
@@ -66,6 +67,12 @@ const SERVER_Y = 44;
 const RELAY_Y = 236;
 const TICK = 32;
 const DEVICE_TICK = 24;
+// The spurs stop short of the server tick instead of joining it. Rendered
+// flush, the two spurs and the tick are one C1-continuous arch from YOU over
+// to THEM, which draws the opposite of what the page says: it looks like the
+// file travels through the server. The gap makes the eye read line, stop,
+// mark, stop, line, so the spurs visibly END at the server.
+const SERVER_GAP = 10;
 
 const n = (v: number) => String(Math.round(v * 100) / 100);
 const cubic = (from: Point, c1: Point, c2: Point, to: Point) =>
@@ -92,8 +99,20 @@ export function routeGeometry(width: number): RouteGeometry {
     const relayL: Point = { x: cx - TICK / 2, y: RELAY_Y };
     const relayR: Point = { x: cx + TICK / 2, y: RELAY_Y };
 
-    const spurLeft = cubic(you, { x: you.x + reach, y: BASELINE_Y }, { x: serverL.x - approach, y: SERVER_Y }, serverL);
-    const spurRight = cubic(them, { x: them.x - reach, y: BASELINE_Y }, { x: serverR.x + approach, y: SERVER_Y }, serverR);
+    // The second control point keeps the tangent horizontal at the end, so a
+    // spur still arrives flat and parallel to the tick it stops beside.
+    const spurLeft = cubic(
+        you,
+        { x: you.x + reach, y: BASELINE_Y },
+        { x: serverL.x - approach, y: SERVER_Y },
+        { x: serverL.x - SERVER_GAP, y: SERVER_Y }
+    );
+    const spurRight = cubic(
+        them,
+        { x: them.x - reach, y: BASELINE_Y },
+        { x: serverR.x + approach, y: SERVER_Y },
+        { x: serverR.x + SERVER_GAP, y: SERVER_Y }
+    );
     const detour =
         cubic(you, { x: you.x + reach, y: BASELINE_Y }, { x: relayL.x - approach, y: RELAY_Y }, relayL) +
         ` H ${n(relayR.x)}` +
@@ -116,8 +135,7 @@ export function routeGeometry(width: number): RouteGeometry {
         spurRight,
         detour,
         direct,
-        detourStart: you,
-        detourEnd: them,
+        serverGap: SERVER_GAP,
         labels: {
             you: { left: pct(you.x, width), top: pct(BASELINE_Y + 36, ROUTE_HEIGHT) },
             them: { left: pct(them.x, width), top: pct(BASELINE_Y + 36, ROUTE_HEIGHT) },

--- a/client/lib/routeFigure.ts
+++ b/client/lib/routeFigure.ts
@@ -1,0 +1,130 @@
+// Geometry for the route figure on /how-it-works: one drawing of a transfer.
+//
+// A baseline runs from YOU to THEM. Two spurs rise from the devices to a
+// short signaling-server tick and END there (the server introduces, then
+// leaves). A second, dotted path dips from YOU through a relay tick and back
+// up to THEM: a relayed route is a complete second path, not a bypass of the
+// middle. Both are built from the same curve so the figure reads as one
+// symmetric composition, mirrored across the line.
+//
+// Pure math, no DOM. The wide (1024) and narrow (360) variants are the same
+// function at two widths, so the two drawings cannot drift apart; the test
+// next door pins the endpoints.
+
+export interface Point {
+    x: number;
+    y: number;
+}
+
+export interface Segment {
+    x1: number;
+    y1: number;
+    x2: number;
+    y2: number;
+}
+
+/** A label anchor as percentages of the figure box, for an absolutely
+ *  positioned HTML span over the SVG. */
+export interface Anchor {
+    left: number;
+    top: number;
+}
+
+export interface RouteGeometry {
+    width: number;
+    height: number;
+    baselineY: number;
+    you: Point;
+    them: Point;
+    deviceTicks: [Segment, Segment];
+    serverTick: Segment;
+    relayTick: Segment;
+    /** SVG path data. The spurs run device to server tick; the detour runs
+     *  YOU to relay tick to THEM; the direct line is the baseline. */
+    spurLeft: string;
+    spurRight: string;
+    detour: string;
+    direct: string;
+    /** The detour's endpoints, exposed for the test. */
+    detourStart: Point;
+    detourEnd: Point;
+    labels: {
+        you: Anchor;
+        them: Anchor;
+        server: Anchor;
+        direct: Anchor;
+        relay: Anchor;
+    };
+}
+
+export const ROUTE_HEIGHT = 280;
+export const ROUTE_WIDE = 1024;
+export const ROUTE_NARROW = 360;
+
+const BASELINE_Y = 140;
+const SERVER_Y = 44;
+const RELAY_Y = 236;
+const TICK = 32;
+const DEVICE_TICK = 24;
+
+const n = (v: number) => String(Math.round(v * 100) / 100);
+const cubic = (from: Point, c1: Point, c2: Point, to: Point) =>
+    `M ${n(from.x)} ${n(from.y)} C ${n(c1.x)} ${n(c1.y)} ${n(c2.x)} ${n(c2.y)} ${n(to.x)} ${n(to.y)}`;
+const pct = (v: number, of: number) => Math.round((v / of) * 1000) / 10;
+
+export function routeGeometry(width: number): RouteGeometry {
+    // The device ticks are inset far enough that the YOU and THEM labels,
+    // which are 11px whatever the figure's scale, stay inside the box. The
+    // narrow variant needs the larger share: at the 320px viewport it renders
+    // at 0.8 scale, where half of "Them" is 18.7px, so a 20-unit inset (16px)
+    // put the label 2.5px past the edge and 32 units (25.6px) clears it.
+    // The curves' reach scales with the width, so the spurs leave the baseline
+    // tangent and arrive at the server tick flat at both sizes.
+    const pad = width > 600 ? 40 : 32;
+    const reach = width * 0.16;
+    const approach = width * 0.19;
+    const cx = width / 2;
+
+    const you: Point = { x: pad, y: BASELINE_Y };
+    const them: Point = { x: width - pad, y: BASELINE_Y };
+    const serverL: Point = { x: cx - TICK / 2, y: SERVER_Y };
+    const serverR: Point = { x: cx + TICK / 2, y: SERVER_Y };
+    const relayL: Point = { x: cx - TICK / 2, y: RELAY_Y };
+    const relayR: Point = { x: cx + TICK / 2, y: RELAY_Y };
+
+    const spurLeft = cubic(you, { x: you.x + reach, y: BASELINE_Y }, { x: serverL.x - approach, y: SERVER_Y }, serverL);
+    const spurRight = cubic(them, { x: them.x - reach, y: BASELINE_Y }, { x: serverR.x + approach, y: SERVER_Y }, serverR);
+    const detour =
+        cubic(you, { x: you.x + reach, y: BASELINE_Y }, { x: relayL.x - approach, y: RELAY_Y }, relayL) +
+        ` H ${n(relayR.x)}` +
+        ` C ${n(relayR.x + approach)} ${n(RELAY_Y)} ${n(them.x - reach)} ${n(BASELINE_Y)} ${n(them.x)} ${n(BASELINE_Y)}`;
+    const direct = `M ${n(you.x)} ${n(BASELINE_Y)} H ${n(them.x)}`;
+
+    return {
+        width,
+        height: ROUTE_HEIGHT,
+        baselineY: BASELINE_Y,
+        you,
+        them,
+        deviceTicks: [
+            { x1: you.x, y1: BASELINE_Y - DEVICE_TICK / 2, x2: you.x, y2: BASELINE_Y + DEVICE_TICK / 2 },
+            { x1: them.x, y1: BASELINE_Y - DEVICE_TICK / 2, x2: them.x, y2: BASELINE_Y + DEVICE_TICK / 2 },
+        ],
+        serverTick: { x1: serverL.x, y1: SERVER_Y, x2: serverR.x, y2: SERVER_Y },
+        relayTick: { x1: relayL.x, y1: RELAY_Y, x2: relayR.x, y2: RELAY_Y },
+        spurLeft,
+        spurRight,
+        detour,
+        direct,
+        detourStart: you,
+        detourEnd: them,
+        labels: {
+            you: { left: pct(you.x, width), top: pct(BASELINE_Y + 36, ROUTE_HEIGHT) },
+            them: { left: pct(them.x, width), top: pct(BASELINE_Y + 36, ROUTE_HEIGHT) },
+            server: { left: 50, top: pct(SERVER_Y - 20, ROUTE_HEIGHT) },
+            // Bottom-anchored 11px above the line.
+            direct: { left: 50, top: pct(BASELINE_Y - 11, ROUTE_HEIGHT) },
+            relay: { left: 50, top: pct(RELAY_Y + 22, ROUTE_HEIGHT) },
+        },
+    };
+}


### PR DESCRIPTION
## Summary

`/how-it-works` was the last marketing route that predated the design system. Its visual grammar was 27 days older than `SectionHeader.tsx` and every commit since had been plumbing: four `rounded-2xl` zinc-800 cards, green and amber promoted to headline color, 10px uppercase sans link chips, a 768px content column under the 1024px footer (the footer rule overhung it by 128px per side at 1440), no navbar, no ice, no focus rings, no landmarks, and 249 words of which nine facts were already on the homepage.

It is now the short version it was always meant to be, in the site's own grammar.

**One drawing carries the page.** A 1px line runs from You to Them. Two spurs rise from the device ticks toward a signaling-server tick and stop just short of it, then settle to zinc-700 once the direct line has drawn across in ice: the server introduces, then leaves. A dotted second path dips from You through a relay tick and back up to Them, because a relayed route is a complete second path rather than a bypass of the middle. The labels are the app's own badge words with the badge's green and amber dots, so a reader who arrived from the Direct or Relay tooltip sees their answer before reading a sentence.

**Then three short beats** in the line's order (Signaling, Direct, Relay including the 2 GB cap), one line about encryption, and the docs pointer, which keeps its white pill and adds an index of all six pages including Known limitations. About 250 words of visible copy. At 1440 the hero, the figure and the three beats sit above the fold.

**How it is built.** `client/lib/routeFigure.ts` is a pure geometry function; `RouteFigure.tsx` renders it at two widths (1024 from `md`, 360 below), so the wide and narrow drawings cannot drift, and a vitest pins the endpoints, the mirror symmetry, the label anchors and the viewBox bounds. The motion is CSS in `globals.css`, gated inside `prefers-reduced-motion: no-preference`, and the base rules are the finished drawing, so reduced motion, JS off, the e2e sweep and the screenshot matrix all get the completed figure at first paint. The route stays a Server Component with no client island and no new dependency; the only new bytes are inline SVG.

**Deep links.** The three in-app "Learn more" links now land on the answer instead of the top of the page: the badge tooltips on `#direct` and `#relay`, the over-limit notice on `#size-limit`.

## What the QA pass changed

A 12-agent audit (nine auditors, then an adversarial refuter, an independent re-measurement and a completeness critic) plus a 29-viewport instrumented sweep found three defects no existing check could see:

- **The ice line was permanently truncated above scale 1.** Chromium lays a dash out in unscaled user units while the path renders scaled, so at the narrow variant's 1.333 cap the line stopped 98.8px short of Them with the arrival ring floating unattached. Every earlier check missed it because they all run with reduced motion, where no dash exists. The two dash-drawn paths now opt out of `non-scaling-stroke`.
- **The spurs and the server tick rendered as one unbroken arch**, so the drawing said the file travels through the signaling server, the opposite of what the page asserts. The spurs now stop short of the tick.
- **The figure's labels collided with the spurs on every phone width.** The tails drop below `sm`, where the caption underneath already carries them.

Also fixed: the 11px labels move from zinc-500 (4.12:1, below AA) to zinc-400; the arrival ring gets the specificity its knockout fill needed to apply at all; the header clearance and anchor scroll margins add `env(safe-area-inset-top)`, without which the navbar covered the heading in the installed app on a notched phone; each beat's heading gains its route word for heading navigation; `2 GB` can no longer break across a line at iPad portrait width; and the stacked caption measure is capped so it does not run 105 characters per line at 767.

Four claims were wrong and are corrected: "nothing is stored on any server" becomes "no file is stored" (the server does keep a byte total and a room code); the badge word is gray in both apps, so the page says the badge shows Direct **with a green dot**; the signaling socket stays open, so what stops is file data; and four of the six docs links named their page by a title it does not have, so they now use each page's own sidebar title, with the href beside the label so `docs-check`'s label scanner sees all six again.

Adjacent drift found while verifying, left for its own PR: the Direct tooltip says "No servers involved. Unlimited speed and size." (the STUN server sees the address request, and speed is bounded by the slower connection), and the over-limit notice says "Remove files to proceed" although the file list is locked once the link exists.

## Test plan

- [x] `pnpm lint` (0 errors), `tsc --noEmit`, `pnpm test` (320 tests; new: `routeFigure.test.ts`, `howItWorksStrings.test.ts`)
- [x] `pnpm build` + `node scripts/check-titles.mjs` (titles unchanged: `How It Works - Floe`)
- [x] Playwright `responsive.spec.ts` and `hydration.spec.ts`, all 12 route tests: no horizontal overflow at 20 viewports, the navbar pill now measured on this route, no hydration error
- [x] Pixel and position sweep at 29 viewports from 320x568 to 3440x1440: label-to-geometry clearances, label collisions, left-edge agreement across every block, caption grid, vertical rhythm, reading measure, overflow. 0 problems
- [x] Ink scan that decodes the rendered pixels: the ice line is continuous at every width with motion allowed, which is the state the reduced-motion checks cannot see
- [x] Motion proof: finished figure at first paint under reduced motion with no animation declared, sequence ends under 3.3 s with the same end state, CLS 0, built CSS keeps the rules inside `prefers-reduced-motion: no-preference`
- [x] Deep links `#direct`, `#relay`, `#size-limit` land clear of the fixed navbar, including with a simulated 59px notch inset
- [x] Identical render with JavaScript disabled
- [x] Repo guardrails: `check-consumers.mjs` (0 unmapped, 0 stale), `docs-check.mjs` (0 hard), skill suites (401 pass)
- [ ] CI green
