### PR TITLE
fix(engine): stop at the size the sender announced

### DIFF
--- a/cli/engine/transfer/changed_test.go
+++ b/cli/engine/transfer/changed_test.go
@@ -1,0 +1,199 @@
+// A file can change on disk between the Stat that fills in its announced size
+// and the read that puts its bytes on the wire: an active log, a download still
+// running, a video still being written. These tests drive the real sender over
+// a real pion pair and mutate the source file in the window the protocol opens
+// for them, between the metadata and the ack, which is deterministic rather
+// than timing-dependent.
+//
+// The contract they pin: the sender never puts more bytes on the wire than it
+// announced, it never follows a wrong byte count with an end marker, and the
+// error it returns names the file's own change rather than leaving the receiver
+// to report a count that reads like a network fault.
+package transfer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v4"
+)
+
+// sendWithMidFlightChange writes initial bytes to a source file, starts a real
+// SendFiles against a real receiver channel, waits for the metadata to land,
+// runs mutate on the file, and only then sends the ack that releases the read
+// loop. It returns the sender's error and every frame the receiver saw after
+// the metadata.
+func sendWithMidFlightChange(t *testing.T, initial []byte, mutate func(path string)) (error, [][]byte) {
+	t.Helper()
+
+	sender, recvCh, msgs, _, closeFn := newPumpedPair(t)
+	defer closeFn()
+
+	src := filepath.Join(t.TempDir(), "changing.bin")
+	if err := os.WriteFile(src, initial, 0o600); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	var rdc *webrtc.DataChannel
+	select {
+	case rdc = <-recvCh:
+	case <-time.After(20 * time.Second):
+		t.Fatal("receiver data channel never opened")
+	}
+
+	sendErr := make(chan error, 1)
+	go func() { sendErr <- SendFiles(sender, []string{src}, "") }()
+
+	var meta struct {
+		ID       string `json:"id"`
+		FileSize int64  `json:"fileSize"`
+	}
+	select {
+	case m := <-msgs:
+		if err := json.Unmarshal(m.Data, &meta); err != nil || meta.ID == "" {
+			t.Fatalf("first message is not the metadata: %q", m.Data)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("sender's metadata never reached the receiver")
+	}
+	if meta.FileSize != int64(len(initial)) {
+		t.Fatalf("announced %d bytes, source was %d", meta.FileSize, len(initial))
+	}
+
+	// The sender is parked on its ack deadline here, having already stated the
+	// size it will send. Change the file underneath it, then let it go.
+	mutate(src)
+
+	ack := `{"type":"ack","id":"` + meta.ID + `","offset":0,"pv":1,"pvMin":1}`
+	if err := rdc.Send([]byte(ack)); err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+
+	var err error
+	select {
+	case err = <-sendErr:
+	case <-time.After(30 * time.Second):
+		t.Fatal("SendFiles did not return")
+	}
+
+	// Anything still in flight has had the send's whole lifetime to arrive; a
+	// short settle keeps the "no end marker" assertion honest rather than lucky.
+	time.Sleep(300 * time.Millisecond)
+	var frames [][]byte
+	for {
+		select {
+		case m := <-msgs:
+			frames = append(frames, append([]byte(nil), m.Data...))
+			continue
+		default:
+		}
+		break
+	}
+	return err, frames
+}
+
+// assertNoEndMarker fails when the sender closed a file off after refusing it.
+// Sending "end" behind a wrong byte count is what made the receiver report the
+// mismatch instead of the sender reporting the cause.
+func assertNoEndMarker(t *testing.T, frames [][]byte) {
+	t.Helper()
+	for _, f := range frames {
+		if strings.Contains(string(f), `"type":"end"`) {
+			t.Fatalf("sender sent an end marker after refusing the file: %q", f)
+		}
+	}
+}
+
+// countBytesSent sums every frame that is not a control message, which for this
+// harness means every frame after the metadata that is not the end marker.
+func countBytesSent(frames [][]byte) int {
+	n := 0
+	for _, f := range frames {
+		if _, isControl := classifyControl(f); isControl {
+			continue
+		}
+		n += len(f)
+	}
+	return n
+}
+
+// TestSenderStopsAtAnnouncedSizeWhenFileGrows: a file that gains bytes after
+// its size was announced must not overrun the announcement. Before the cap the
+// read ran to EOF, so the receiver killed the whole batch with "sender exceeded
+// the announced size", naming nothing either person could act on.
+func TestSenderStopsAtAnnouncedSizeWhenFileGrows(t *testing.T) {
+	err, frames := sendWithMidFlightChange(t, make([]byte, 64), func(path string) {
+		f, oerr := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+		if oerr != nil {
+			t.Fatalf("reopen for append: %v", oerr)
+		}
+		if _, werr := f.Write(make([]byte, 64)); werr != nil {
+			t.Fatalf("append: %v", werr)
+		}
+		if cerr := f.Close(); cerr != nil {
+			t.Fatalf("close append handle: %v", cerr)
+		}
+	})
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "grew while it was being sent") {
+		t.Fatalf("error does not name the growth: %v", err)
+	}
+	if sent := countBytesSent(frames); sent > 64 {
+		t.Fatalf("sent %d bytes for a 64-byte announcement", sent)
+	}
+	assertNoEndMarker(t, frames)
+}
+
+// TestSenderReportsAFileThatShrinks: the other half of the same window. The
+// announcement can no longer be honored, so the sender says so instead of
+// sending an end marker and leaving the receiver to call it an incomplete file.
+func TestSenderReportsAFileThatShrinks(t *testing.T) {
+	err, frames := sendWithMidFlightChange(t, make([]byte, 64), func(path string) {
+		if terr := os.Truncate(path, 32); terr != nil {
+			t.Fatalf("truncate: %v", terr)
+		}
+	})
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "shrank while it was being sent") {
+		t.Fatalf("error does not name the shrink: %v", err)
+	}
+	if !strings.Contains(err.Error(), "64") || !strings.Contains(err.Error(), "32") {
+		t.Fatalf("error names neither the announced size nor what was read: %v", err)
+	}
+	assertNoEndMarker(t, frames)
+}
+
+// TestSenderRefusesAZeroStatFileThatHasBytes is the case a second Stat cannot
+// catch and the cap alone would hide. A descriptor that reports 0 and still
+// yields bytes (a log created moments earlier, or a /proc, /sys or
+// character-device path, all of which collectFiles accepts) would otherwise be
+// capped to nothing, closed off with an end marker, and reported as a success
+// by both ends because the receiver's guard sees 0 == 0.
+func TestSenderRefusesAZeroStatFileThatHasBytes(t *testing.T) {
+	err, frames := sendWithMidFlightChange(t, nil, func(path string) {
+		if werr := os.WriteFile(path, []byte("this arrived after the size was announced"), 0o600); werr != nil {
+			t.Fatalf("fill: %v", werr)
+		}
+	})
+
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "grew while it was being sent") {
+		t.Fatalf("error does not name the growth: %v", err)
+	}
+	if sent := countBytesSent(frames); sent != 0 {
+		t.Fatalf("sent %d bytes for a 0-byte announcement", sent)
+	}
+	assertNoEndMarker(t, frames)
+}

--- a/cli/engine/transfer/sender.go
+++ b/cli/engine/transfer/sender.go
@@ -483,9 +483,18 @@ ackLoop:
 		report(0) // emit the starting point (handles resume offset and 0-byte files)
 	}
 
+	// Hold the read to the size the metadata announced. Between the Stat above
+	// and this loop the file can change on disk: an active log, a download still
+	// running, a video still being written. Reading to EOF put MORE bytes on the
+	// wire than were promised, and the receiver then killed the whole batch with
+	// "sender exceeded the announced size", which names nothing either person can
+	// act on. The browser sender cannot make this mistake: a File's size is a
+	// snapshot, and both its loop bound and its slice end clamp to it.
+	announced := io.LimitReader(f, fileSize-offset)
+
 	buf := make([]byte, chunk)
 	for {
-		n, err := f.Read(buf)
+		n, err := announced.Read(buf)
 		if n > 0 {
 			// Backpressure: block until pion's buffer drains below the low-water
 			// mark before queuing more. The loop re-checks after each wakeup so a
@@ -519,6 +528,25 @@ ackLoop:
 			return fmt.Errorf("error reading file: %w", err)
 		}
 	}
+
+	// The file changed under the send. Say so here, where the cause is still
+	// visible, instead of sending an end marker and leaving the receiver to report
+	// a byte count that reads like a network fault.
+	if sentFile != fileSize {
+		return fmt.Errorf("the file shrank while it was being sent (announced %d bytes, read %d); send it again once it stops changing",
+			fileSize, sentFile)
+	}
+	// Growth is probed off the descriptor, never a second Stat. A descriptor that
+	// stats as 0 and still yields bytes (a log created moments earlier, or a
+	// /proc, /sys or character-device path, all of which collectFiles accepts) is
+	// exactly what a re-stat cannot see, and capping it silently would send an
+	// empty file that both ends reported as a success.
+	var probe [1]byte
+	if n, _ := f.Read(probe[:]); n > 0 {
+		return fmt.Errorf("the file grew while it was being sent (announced %d bytes); send it again once it stops changing",
+			fileSize)
+	}
+
 	if bar != nil {
 		fmt.Println()
 	}

--- a/desktop/frontend/src/errors.test.ts
+++ b/desktop/frontend/src/errors.test.ts
@@ -73,6 +73,19 @@ describe('friendlyError', () => {
         );
     });
 
+    it('names a source file that changed under the send, not a lost connection', () => {
+        // Two backend wrappers sit in front of the engine sentence, which is
+        // why this is a substring rule rather than an equality one.
+        const grew = 'transfer failed: error sending app.log: the file grew while it was being sent (announced 64 bytes); send it again once it stops changing';
+        expect(friendlyError(grew)).toBe(
+            'Error: A file changed while it was being sent, so it was not delivered. Send it again once the file has stopped changing.',
+        );
+        const shrank = 'transfer failed: error sending app.log: the file shrank while it was being sent (announced 64 bytes, read 32); send it again once it stops changing';
+        expect(friendlyError(shrank)).toBe(
+            'Error: A file changed while it was being sent, so it was not delivered. Send it again once the file has stopped changing.',
+        );
+    });
+
     it('passes hand-written actionable messages through verbatim', () => {
         const relay = 'transfer blocked: relay connections are capped at 2 GB (selected relay). Turn off Hide my IP to send larger files';
         expect(friendlyError(relay)).toBe('Error: ' + relay);

--- a/desktop/frontend/src/errors.ts
+++ b/desktop/frontend/src/errors.ts
@@ -33,6 +33,11 @@ const RULES: Array<[pattern: string, friendly: string]> = [
     ['no data arrived from the sender', 'Connected, but the sender never started sending. Ask them to try again.'],
     ['transfer stalled', 'The transfer stalled and gave up. Start it again.'],
     ['incomplete file', 'A file arrived incomplete, so it was not kept. Start the transfer again.'],
+    // The sender caught its own source file changing between the size it
+    // announced and the bytes it read, so nothing was delivered. The engine
+    // sentence is already actionable but arrives behind two wrappers
+    // ('transfer failed: error sending x: ...'); say it once, cleanly.
+    ['while it was being sent', 'A file changed while it was being sent, so it was not delivered. Send it again once the file has stopped changing.'],
     ['timed out waiting for the peer', 'The other side never connected. Both people need Floe open at the same time.'],
     ['timed out waiting for ack', 'The other side never connected. Both people need Floe open at the same time.'],
     ['timed out establishing a connection', 'A connection could not be established. Check that both devices are online and try again.'],

--- a/docs/reference/transfer-protocol.mdx
+++ b/docs/reference/transfer-protocol.mdx
@@ -236,6 +236,12 @@ A file is committed only when the bytes written match `fileSize` exactly. A mism
 direction discards the file, because a short count means truncation and an over-count means a
 frame boundary was wrong, which corrupts the result just as thoroughly.
 
+The sender holds itself to the same number. It reads at most `fileSize` bytes, so a
+file that grows after its size is announced cannot overrun the announcement, and if
+the file changed on disk in that window the sender fails locally and sends no end
+marker. The person who owns the file is told the file changed, instead of the person
+receiving it being told the transfer was incomplete.
+
 **Floe computes no hash of file contents at any point.** The check is a byte count. The transport
 already authenticates every packet, so corruption in flight is not the gap being covered here;
 truncation is.


### PR DESCRIPTION
## Summary

`sendFile` stats the file, announces `info.Size()`, and then reads to `io.EOF` with no cap (`cli/engine/transfer/sender.go`). A file that grows in that window (an active log, a download still running, a video still being written) put more bytes on the wire than the metadata promised, and the receiver killed the whole batch with `sender exceeded the announced size of "x"`, which names nothing either person can act on.

The read is now bounded by `io.LimitReader(f, fileSize-offset)`, created after the resume Seek, so an overrun is structurally impossible. That is the guarantee the browser sender already has for free, because a `File`'s size is a snapshot and both its loop bound and its slice end clamp to it.

### The part worth reviewing: capping alone is not enough

A descriptor that stats as **0** and still yields bytes would be capped to nothing, closed off with an end marker, and reported as a **success by both ends**, because the receiver's integrity guard sees `0 == 0`. Today that case fails loudly, so a bare `io.LimitReader` would have been a regression that turned a loud failure into silent data loss.

That is not hypothetical. `collectFiles` accepts any path `os.Stat` succeeds on, which includes a log file created moments before the send, and on Linux any `/proc` or `/sys` path or a character device.

So growth is probed **off the descriptor** after the loop (one 1-byte read), never from a second `Stat`, because a second `Stat` is exactly what cannot see that case.

Both directions now fail on the sender, before the end marker:

| The file | Before | After |
|---|---|---|
| grew | receiver aborts the batch: `sender exceeded the announced size` | `the file grew while it was being sent (announced N bytes); send it again once it stops changing` |
| shrank | receiver: `incomplete file "x": received N of M bytes` | `the file shrank while it was being sent (announced M bytes, read N); ...` |
| stats 0, has bytes | receiver aborts the batch | same growth error, and nothing is sent |

Sender-local. **No wire change and no `ProtocolVersion` bump.** A transfer is protected as soon as the sending end runs the new build; the CLI and the desktop app share `sendFile`, so both need a release to ship it.

`desktop/frontend/src/errors.ts` gets one rule, keyed on `while it was being sent`, because the engine sentence arrives behind two backend wrappers (`transfer failed: error sending x: ...`). It sits above the connection family, which the file's own comment requires.

## Test plan

- `go vet ./...` and `go test -count=1 ./...` in `cli/` pass (76 s, unchanged set plus the three below).
- `npm test` in `desktop/frontend` passes, 138 tests across 11 files.
- New `cli/engine/transfer/changed_test.go` drives the **real** `SendFiles` over a real pion pair and mutates the source file in the window the protocol already opens, between the metadata and the ack, so it is deterministic rather than timing-dependent:
  - `TestSenderStopsAtAnnouncedSizeWhenFileGrows` (64 bytes announced, 64 appended) asserts the error names the growth, that no more than 64 bytes reached the wire, and that no end marker followed.
  - `TestSenderReportsAFileThatShrinks` (truncated to 32) asserts both numbers are named and no end marker followed.
  - `TestSenderRefusesAZeroStatFileThatHasBytes` is the zero-stat hole: **0** bytes announced, content written after, asserts zero bytes sent and no end marker.
- **Verified the tests fail without the fix.** With `sender.go` reverted, all three fail with `expected an error, got nil`: the old sender reported success in every case, including sending 128 bytes for a 64-byte announcement and delivering an empty file for one that had content.
- `node .claude/skills/untrusted-peer-data/scripts/check-consumers.mjs`: 105 rows, 0 unmapped, 0 stale, 0 anchor-missing. The new error text is built from the sender's own file metadata, not from anything the peer sent, so it adds no sink.
- `node .claude/skills/docs-verify/scripts/docs-check.mjs`: 0 hard, notes unchanged from `main`.

## Notes for the release author

Needs a paired `v*` and `desktop-v*` release to reach users. No browser change, so nothing ships on merge.

Closes #315
