### PR TITLE
fix(protocol): classify a frame by its framing, not by its bytes

### DIFF
--- a/cli/engine/transfer/control.go
+++ b/cli/engine/transfer/control.go
@@ -37,27 +37,26 @@ func rejectDescription(dc *webrtc.DataChannel, localVer, detail string) {
 // peer sending prose where a control message belongs.
 const controlMsgMax = 1000
 
-// classifyControl reports whether a data channel message is a Floe control
-// message and, if so, its type.
+// classifyControl reports whether a frame's BYTES are a Floe control message
+// and, if so, its type. It answers a question about content only; whether a
+// frame is eligible to be control at all is the caller's to answer, and on the
+// receive path the answer is framing: see the ReceiveFiles message loop, which
+// calls this for string frames only.
 //
-// Control messages are JSON objects. The browser (SimplePeer) sends them as
-// strings, but depending on SCTP framing they can also arrive as small binary
-// messages, so binary payloads are probed too. The size probe applies to
-// string and binary alike (matching the browser's `data.byteLength <= 1000`
-// guard, which never asks about framing): the Floe sender uses SendText for
-// its metadata, so the old binary-only gate left strings bounded by nothing
-// but pion's 1 GB default and let a hostile peer hand parseMetadata a file
-// name of any length. The message loop rejects an over-cap STRING with an
-// error before this runs; an over-cap BINARY lands here and is file data.
-// Crucially, a message is treated as control ONLY when it parses as a JSON
-// object whose "type" is a known control type. Anything else, including a
-// small file whose bytes happen to be a JSON object, is file data and must be
-// written, not dropped.
+// Control messages are JSON objects and are capped at controlMsgMax. The cap
+// applies here regardless of framing, because without it a peer could hand
+// parseMetadata a file name bounded by nothing but pion's 1 GB default. The
+// receive loop rejects an over-cap string with an error before this runs.
+//
+// A message is treated as control ONLY when it parses as a JSON object whose
+// "type" is a known control type, so a JSON file whose "type" is something
+// else was already safe. What was not safe, and is what the framing gate on
+// the receive path fixes, is a JSON file whose "type" IS one of these.
 //
 // The receiver only acts on "metadata" and "end". The other recognized types
-// ("ack", "received", "incompatible") flow in the opposite direction; they are
-// classified as control so they are never mistakenly written as file data if
-// they somehow arrive on this side.
+// ("ack", "received", "incompatible") flow in the opposite direction and are
+// recognized here for the sender-side loops, which read this direction and
+// carry no file data.
 func classifyControl(data []byte) (msgType string, isControl bool) {
 	if len(data) > controlMsgMax {
 		return "", false

--- a/cli/engine/transfer/loopback_test.go
+++ b/cli/engine/transfer/loopback_test.go
@@ -235,6 +235,62 @@ func TestLoopbackSmallJSONFile(t *testing.T) {
 	}
 }
 
+// TestLoopbackControlShapedFiles is the #316 repro, end to end over a real pion
+// pair. TestLoopbackSmallJSONFile above only ever covered a JSON object whose
+// "type" was NOT a control type, so it passed for the wrong reason: content
+// probing declined it because of the type value, not because of the framing.
+//
+// A file whose whole content IS a control frame is what content probing could
+// not survive. Each of these arrived as a 0-byte file before #311 and as a hard
+// error afterwards; both are the same lost bytes. The receiver now decides from
+// the SCTP framing, so a binary chunk is file data whatever it spells.
+func TestLoopbackControlShapedFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping ICE loopback transfer in -short mode")
+	}
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		// The issue's own repro: 14 bytes, and a one-click send from desktop's
+		// Send text box.
+		{"end.json", `{"type":"end"}`},
+		{"received.json", `{"type":"received"}`},
+		{"ack.json", `{"type":"ack","id":"x","offset":0}`},
+		{"incompatible.json", `{"type":"incompatible","reason":"nope"}`},
+		// A whole metadata frame saved to a file, which is what anyone
+		// debugging the protocol ends up with on disk.
+		{"metadata.json", `{"type":"metadata","id":"a","fileName":"x","fileSize":1,"index":1,"total":1}`},
+		// Leading whitespace still reaches looksLikeJSONObject.
+		{"padded.json", "   " + `{"type":"end"}`},
+	}
+
+	srcDir := t.TempDir()
+	var paths []string
+	for _, tc := range cases {
+		srcPath := filepath.Join(srcDir, tc.name)
+		if err := os.WriteFile(srcPath, []byte(tc.content), 0644); err != nil {
+			t.Fatalf("write %s: %v", tc.name, err)
+		}
+		paths = append(paths, srcPath)
+	}
+
+	// One batch, not one transfer each: a frame eaten mid-batch also derails
+	// every file queued behind it, and that is the failure people actually hit.
+	outDir := runTransfer(t, paths)
+
+	for _, tc := range cases {
+		got, err := os.ReadFile(filepath.Join(outDir, tc.name))
+		if err != nil {
+			t.Fatalf("read %s: %v", tc.name, err)
+		}
+		if string(got) != tc.content {
+			t.Fatalf("%s corrupted in transit:\n got: %q\nwant: %q", tc.name, got, tc.content)
+		}
+	}
+}
+
 // TestLoopbackDuplicateNames is the end-to-end guard for the receiver's
 // never-overwrite rule: two files with the same base name (two pasted
 // screenshots, or a repeat send) must both survive, the second de-collided to

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -252,10 +252,25 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 		}
 
 		// Decide whether this is a Floe control message (metadata/end) or file
-		// data. Only recognized control types are consumed as control — a small
-		// binary chunk that merely happens to be a JSON object is file data and
-		// must be written, never dropped.
-		msgType, isControl := classifyControl(msg.Data)
+		// data, and decide it from the SCTP framing rather than from the bytes.
+		//
+		// Every Floe sender since v1.0.0 sends metadata and end with SendText
+		// (a JS string through simple-peer on the browser side) and file chunks
+		// with Send, so on this side a BINARY frame is file data, full stop.
+		// Probing its bytes was the bug: a whole small file whose content is a
+		// control-shaped JSON object, such as the 14 bytes {"type":"end"}, was
+		// consumed as control and never written. Desktop's StartSendText makes
+		// that a one-click send.
+		//
+		// This is a PROHIBITION as much as a decision: a future
+		// sender-to-receiver control frame MUST go out as text, or it lands in
+		// somebody's file. Receiver-to-sender frames are unaffected and stay
+		// binary, because no file data travels that way.
+		var msgType string
+		var isControl bool
+		if msg.IsString {
+			msgType, isControl = classifyControl(msg.Data)
+		}
 		if isControl {
 			switch msgType {
 
@@ -538,7 +553,7 @@ func ReceiveFilesWithOptions(dc *webrtc.DataChannel, outputDir string, autoAccep
 			continue
 		}
 
-		// A string that wasn't a recognized control message is never file data.
+		// A string that was not a recognized control message is never file data.
 		if msg.IsString {
 			continue
 		}

--- a/client/components/P2PTransfer.tsx
+++ b/client/components/P2PTransfer.tsx
@@ -11,6 +11,17 @@ if (typeof window !== 'undefined') {
 
 import {useEffect, useRef, useState} from 'react';
 import SimplePeer, { Instance as PeerInstance } from 'simple-peer';
+
+// simple-peer extends a readable-stream Duplex and forwards its whole
+// options object to super(opts), but @types/simple-peer stops at the peer
+// options and never declares the stream ones. Declare the single one Floe
+// sets rather than casting at each construction site, which would also
+// silence a genuine typo in the peer options next to it.
+declare module 'simple-peer' {
+    interface Options {
+        readableObjectMode?: boolean;
+    }
+}
 import {v4 as uuidv4} from 'uuid';
 import * as Sentry from '@sentry/nextjs';
 import {formatSpeed, formatETA} from '@/lib/transferUtils';
@@ -347,6 +358,15 @@ export function P2PTransfer() {
         const peer = new SimplePeer({
             initiator: false,
             trickle: true,
+            // readableObjectMode keeps the SCTP text/binary bit intact.
+            // simple-peer pushes frames into a readable-stream Duplex, and
+            // without it every text frame is Buffer.from()ed before Floe sees
+            // it, so the receiver could only guess a frame from its bytes and
+            // would eat a small file whose whole content was control-shaped
+            // JSON (#316). Binary frames still arrive as a Buffer; text frames
+            // now arrive as a string. simple-peer passes its options straight
+            // to super(opts) and never sets objectMode itself.
+            readableObjectMode: true,
             config: {
                 iceServers: iceServersRef.current,
             },
@@ -614,6 +634,15 @@ export function P2PTransfer() {
             const peer = new SimplePeer({
                 initiator: true,
                 trickle: true,
+                // readableObjectMode keeps the SCTP text/binary bit intact.
+                // simple-peer pushes frames into a readable-stream Duplex, and
+                // without it every text frame is Buffer.from()ed before Floe sees
+                // it, so the receiver could only guess a frame from its bytes and
+                // would eat a small file whose whole content was control-shaped
+                // JSON (#316). Binary frames still arrive as a Buffer; text frames
+                // now arrive as a string. simple-peer passes its options straight
+                // to super(opts) and never sets objectMode itself.
+                readableObjectMode: true,
                 config: {
                     iceServers: iceConfig,
                 },

--- a/client/lib/transfer/progressSync.test.ts
+++ b/client/lib/transfer/progressSync.test.ts
@@ -151,10 +151,10 @@ describe('receiver: progress cadence', () => {
         });
 
         const SIZE = 5 * 1024 * 1024;
-        rx.handleMessage(enc.encode(metadataMessage('big', 'big.bin', SIZE, 1, 1, SIZE)));
+        rx.handleMessage(metadataMessage('big', 'big.bin', SIZE, 1, 1, SIZE));
         const chunk = new Uint8Array(256 * 1024); // > 1000 bytes, treated as file data
         for (let i = 0; i < 20; i++) rx.handleMessage(chunk);
-        rx.handleMessage(enc.encode(endMessage()));
+        rx.handleMessage(endMessage());
 
         // 1 MB steps plus completion, then the (0,0,0) reset on 'end'. The old
         // exact-modulo condition emitted nothing at all for this sequence.

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -1,5 +1,5 @@
 // Floe wire-protocol constants and message helpers.
-// Mirrors cli/internal/transfer/sender.go + receiver.go — keep in sync.
+// Mirrors cli/engine/transfer/sender.go + receiver.go - keep in sync.
 import { sanitizeDisplayText } from '../download';
 
 export const CONTROL_MSG_MAX = 1000; // bytes; matches browser byteLength guard
@@ -174,26 +174,35 @@ export function compatErrorMessage(
 // --- Control message classifier ---
 
 const decoder = new TextDecoder();
+const encoder = new TextEncoder();
 
 /**
- * Classifies a data channel message as a Floe control message or file data.
- * Returns the parsed control message if recognized, null if it should be
- * treated as file data (written to disk / appended to the receive buffer).
+ * Classifies a frame's BYTES as a Floe control message or as file data, and
+ * returns the parsed control message or null.
  *
- * Preserves exact browser semantics:
+ * This answers a question about content only. Whether a frame is ELIGIBLE to be
+ * control is the caller's to answer, and on the receive path the answer is the
+ * SCTP framing, not the bytes: see `isControlFrame` and `createReceiver`.
+ *
  *   - Only probe if byteLength <= CONTROL_MSG_MAX (1000)
  *   - Decoded text must start with '{'
  *   - JSON.parse must succeed and 'type' must be a known control type
  */
-export function classifyControl(data: ArrayBuffer | Uint8Array): ControlMessage | null {
-    const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
-    if (buf.byteLength > CONTROL_MSG_MAX) return null;
-
+export function classifyControl(data: string | ArrayBuffer | Uint8Array): ControlMessage | null {
     let text: string;
-    try {
-        text = decoder.decode(buf);
-    } catch {
-        return null;
+    if (typeof data === 'string') {
+        // A JS string measures in UTF-16 code units, and the cap is a byte
+        // budget the Go receiver enforces on the same frame, so measure bytes.
+        if (encoder.encode(data).byteLength > CONTROL_MSG_MAX) return null;
+        text = data;
+    } else {
+        const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
+        if (buf.byteLength > CONTROL_MSG_MAX) return null;
+        try {
+            text = decoder.decode(buf);
+        } catch {
+            return null;
+        }
     }
 
     if (!text.startsWith('{')) return null;
@@ -212,6 +221,33 @@ export function classifyControl(data: ArrayBuffer | Uint8Array): ControlMessage 
     if (t === 'received') return msg as unknown as Received;
     if (t === 'incompatible') return msg as unknown as Incompatible;
     return null;
+}
+
+/**
+ * Whether a frame arriving at a RECEIVER may be a control message at all.
+ *
+ * The wire already answers this and Floe used to ignore it. Every Floe sender
+ * since v1.0.0 sends `metadata` and `end` as a TEXT frame (a JS string handed
+ * to `peer.send`, or `dc.SendText` in the Go engine) and file chunks as BINARY.
+ * So on the receive path a binary frame is file data, whatever its bytes spell.
+ *
+ * Probing the bytes was the bug (#316): a whole small file whose content is a
+ * control-shaped JSON object, such as the 14 bytes `{"type":"end"}`, was
+ * consumed as control and never written. Floe Desktop's Send-text box makes
+ * that a one-click send.
+ *
+ * This is a PROHIBITION as much as a decision: a future sender-to-receiver
+ * control frame MUST go out as text, or it lands in somebody's file. The
+ * receiver-to-sender direction is unaffected and keeps its mixed framing
+ * (`ack` is a string, `incompatible` is binary), because no file data travels
+ * that way, so the sender's loops still classify by content.
+ *
+ * The browser could not see this bit until the peer was given
+ * `readableObjectMode`: simple-peer pushes text frames through a non-objectMode
+ * readable-stream Duplex, which Buffer.from()s them before Floe sees them.
+ */
+export function isControlFrame(data: string | ArrayBuffer | Uint8Array): data is string {
+    return typeof data === 'string';
 }
 
 /**

--- a/client/lib/transfer/receiver.ts
+++ b/client/lib/transfer/receiver.ts
@@ -2,6 +2,8 @@
 // Extracted from P2PTransfer.tsx peer.on('data') handler.
 import {
     classifyControl,
+    isControlFrame,
+    CONTROL_MSG_MAX,
     ackMessage,
     incompatibleMessage,
     checkCompat,
@@ -68,7 +70,7 @@ interface PartialDownload {
  *   });
  *   peer.on('data', rx.handleMessage);
  */
-export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: Uint8Array | ArrayBuffer) => void } {
+export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: string | Uint8Array | ArrayBuffer) => void } {
     const partialDownloads = new Map<string, PartialDownload>();
     let currentMetadata: Metadata | null = null;
     let hasCheckedCompat = false;
@@ -84,13 +86,35 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
     let receiveSpeedBytes = 0;
     let lastReceiveSpeedUpdate = 0;
 
-    function handleMessage(data: Uint8Array | ArrayBuffer): void {
+    function handleMessage(data: string | Uint8Array | ArrayBuffer): void {
         if (aborted) return;
 
-        const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
-        const msg = classifyControl(buf);
+        // Framing decides, not content. See isControlFrame: a binary frame on
+        // this side is file data even when its bytes spell a control message,
+        // which is what a small .json file's whole content can do.
+        if (isControlFrame(data)) {
+            const text = data;
+            // Mirrors the Go receiver: a string past the control cap is not
+            // something to write and not something to parse, it is a peer
+            // sending prose where a control message belongs. The browser used
+            // to fall through and append it to the file instead, which quietly
+            // corrupted any transfer whose metadata ran long (a deep enough
+            // folder path does it).
+            if (new TextEncoder().encode(text).byteLength > CONTROL_MSG_MAX) {
+                aborted = true;
+                cb.onError?.(
+                    'The sender sent a control message larger than ' +
+                        `${CONTROL_MSG_MAX} bytes, so the transfer was stopped.`
+                );
+                return;
+            }
+            const msg = classifyControl(text);
+            // An unrecognized control type is dropped, not written. The Go
+            // receiver has always done this; the browser used to append it to
+            // whatever file was open, which is what made adding any new frame
+            // type unsafe.
+            if (!msg) return;
 
-        if (msg) {
             if (msg.type === 'metadata') {
                 // Protocol compatibility check on first file, before sending ack
                 // or accepting any file bytes.
@@ -217,7 +241,8 @@ export function createReceiver(cb: ReceiverCallbacks): { handleMessage: (data: U
             return;
         }
 
-        // Binary chunk — file data
+        // Binary frame: file data, unconditionally.
+        const buf = data instanceof Uint8Array ? data : new Uint8Array(data);
         if (!currentMetadata) return;
         const fileData = partialDownloads.get(currentMetadata.id);
         if (!fileData) return;

--- a/client/lib/transfer/sender.ts
+++ b/client/lib/transfer/sender.ts
@@ -46,7 +46,7 @@ export interface SenderDeps {
     send: (data: string | Uint8Array) => void;
     // Registers a handler for incoming data (peer.on('data')).
     // Returns an unsubscribe function.
-    onData: (handler: (data: Uint8Array | ArrayBuffer) => void) => () => void;
+    onData: (handler: (data: string | Uint8Array | ArrayBuffer) => void) => () => void;
     channel: BufferChannel;
     sctpMaxMessageSize?: number | null;
 }
@@ -376,7 +376,7 @@ async function sendSingleFile(
 }
 
 function waitForAck(
-    onData: (handler: (data: Uint8Array | ArrayBuffer) => void) => () => void,
+    onData: (handler: (data: string | Uint8Array | ArrayBuffer) => void) => () => void,
     fileId: string
 ): Promise<AckResult> {
     // Both arms of the race clean up after the other wins. The listener used
@@ -395,8 +395,11 @@ function waitForAck(
     return Promise.race([
         new Promise<AckResult>((resolve) => {
             off = onData((raw) => {
-                const buf = raw instanceof Uint8Array ? raw : new Uint8Array(raw);
-                const msg = classifyControl(buf);
+                // The SENDER keeps classifying by content, and must: a Go
+                // receiver sends its ack, received and incompatible frames as
+                // BINARY. That is safe here in a way it is not on the receive
+                // path, because no file data ever travels receiver to sender.
+                const msg = classifyControl(raw);
                 if (!msg) return;
                 if (msg.type === 'ack' && (msg as Ack).id === fileId) {
                     const ack = msg as Ack;

--- a/client/lib/transfer/transfer.test.ts
+++ b/client/lib/transfer/transfer.test.ts
@@ -36,15 +36,19 @@ async function loopback(
     const received: { name: string; bytes: Uint8Array }[] = [];
 
     // Queue of data handlers the sender registers for acks
-    let senderDataHandler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+    let senderDataHandler: ((d: string | Uint8Array | ArrayBuffer) => void) | null = null;
 
     const rx = createReceiver({
         send: (d) => {
             // Defer so the sender's waitForAck handler is registered before the ack fires.
             // In production there is a real network round-trip; queueMicrotask reproduces
             // that "not yet registered" gap in the synchronous loopback.
-            const data = typeof d === 'string' ? enc.encode(d) : d;
-            queueMicrotask(() => senderDataHandler?.(data));
+            //
+            // The frame is passed through as-is: a string stays a string. This
+            // harness used to encode it, modelling simple-peer's old flattening
+            // of text frames, which is exactly what readableObjectMode removes.
+            // Encoding here would hide the framing the receiver now classifies on.
+            queueMicrotask(() => senderDataHandler?.(d));
         },
         onFileComplete: (file) => {
             file.blob.arrayBuffer().then((ab) => {
@@ -55,9 +59,8 @@ async function loopback(
 
     const deps: SenderDeps = {
         send: (d) => {
-            // Sender output → receiver input
-            const data = typeof d === 'string' ? enc.encode(d) : d;
-            rx.handleMessage(data);
+            // Sender output → receiver input, framing intact (see above).
+            rx.handleMessage(d);
         },
         onData: (handler) => {
             senderDataHandler = handler;
@@ -156,7 +159,7 @@ describe('receiver: stores tight copies of chunk bytes', () => {
         for (let i = 0; i < SIZE; i++) fileBytes[i] = i + 1; // never 0x7B at index 0
 
         // Metadata first so the receiver opens a partial download.
-        rx.handleMessage(enc.encode(metadataMessage('rid', 'r.bin', SIZE, 1, 1, SIZE)));
+        rx.handleMessage(metadataMessage('rid', 'r.bin', SIZE, 1, 1, SIZE));
 
         // Place the payload inside a larger backing Buffer at a non-zero offset and
         // hand the receiver subarray VIEWS (16 bytes each) — sharing one backing AB.
@@ -166,7 +169,7 @@ describe('receiver: stores tight copies of chunk bytes', () => {
         rx.handleMessage(backing.subarray(36, 52));
         rx.handleMessage(backing.subarray(52, 68));
 
-        rx.handleMessage(enc.encode(endMessage()));
+        rx.handleMessage(endMessage());
 
         expect(completedBlob).not.toBeNull();
         const got = new Uint8Array(await completedBlob!.arrayBuffer());
@@ -181,17 +184,17 @@ describe('receiver: onAllComplete fires once per transfer', () => {
     // bytes — never once per file — so multi-file transfers are counted correctly
     // and are not partially dropped by the server's per-IP report rate limit.
     function feedFile(
-        rx: { handleMessage: (d: Uint8Array | ArrayBuffer) => void },
+        rx: { handleMessage: (d: string | Uint8Array | ArrayBuffer) => void },
         id: string,
         size: number,
         index: number,
         total: number,
     ) {
-        rx.handleMessage(enc.encode(metadataMessage(id, `${id}.bin`, size, index, total, 0)));
+        rx.handleMessage(metadataMessage(id, `${id}.bin`, size, index, total, 0));
         const chunk = new Uint8Array(size);
         for (let i = 0; i < size; i++) chunk[i] = (i + 1) % 256; // never starts with '{'
         if (size > 0) rx.handleMessage(chunk);
-        rx.handleMessage(enc.encode(endMessage()));
+        rx.handleMessage(endMessage());
     }
 
     it('fires a single time with the total bytes and file count for a 3-file transfer', () => {
@@ -249,6 +252,131 @@ describe('loopback: small binary framing guard', () => {
 });
 
 /**
+ * Framing, not content, decides whether a frame reaching a RECEIVER is control.
+ *
+ * classifyControl infers a frame's type from its bytes, so a whole small file
+ * whose content is a control-shaped JSON object was consumed as control and
+ * never written (#316). Before #311 that produced a 0-byte file that looked
+ * complete; after it, a hard error and an aborted batch. Both are the same lost
+ * bytes.
+ *
+ * Every Floe sender since v1.0.0 sends metadata and end as a TEXT frame and
+ * file chunks as BINARY, so the wire already carried the answer. The browser
+ * could not see it until the peer was given readableObjectMode, because
+ * simple-peer Buffer.from()s text frames on the way through readable-stream.
+ * These tests model the wire, which is what the loopback harness above now
+ * does too.
+ */
+describe('receiver: framing decides, not content', () => {
+    function receiver() {
+        const files: Record<string, string> = {};
+        const errors: string[] = [];
+        const pending: Promise<void>[] = [];
+        const rx = createReceiver({
+            send: () => {},
+            onFileComplete: (f) => {
+                pending.push(
+                    f.blob.arrayBuffer().then((ab) => {
+                        files[f.fileName] = new TextDecoder().decode(new Uint8Array(ab));
+                    }),
+                );
+            },
+            onError: (m) => errors.push(m),
+        });
+        return { rx, files, errors, settle: () => Promise.all(pending) };
+    }
+
+    // Every control type Floe knows, as the entire content of a small file.
+    // A binary frame is file data whatever its bytes spell.
+    const controlShaped = [
+        // The issue's own repro: 14 bytes, and a one-click send from Floe
+        // Desktop's Send-text box.
+        ['end', '{"type":"end"}'],
+        ['received', '{"type":"received"}'],
+        ['ack', '{"type":"ack","id":"x","offset":0}'],
+        ['incompatible', '{"type":"incompatible","reason":"nope"}'],
+        ['metadata', '{"type":"metadata","id":"a","fileName":"x","fileSize":1,"index":1,"total":1}'],
+        ['padded end', '   {"type":"end"}'],
+    ] as const;
+
+    it.each(controlShaped)('writes a file whose whole content is a %s frame', async (_name, content) => {
+        const h = receiver();
+        const bytes = enc.encode(content);
+        h.rx.handleMessage(metadataMessage('j', 'payload.json', bytes.byteLength, 1, 1, bytes.byteLength));
+        h.rx.handleMessage(bytes);
+        h.rx.handleMessage(endMessage());
+        await h.settle();
+
+        expect(h.errors).toEqual([]);
+        expect(h.files['payload.json']).toBe(content);
+    });
+
+    it('does not derail the rest of the batch', async () => {
+        // The failure people actually hit: one eaten frame also takes down every
+        // file queued behind it.
+        const h = receiver();
+        const trap = enc.encode('{"type":"end"}');
+        h.rx.handleMessage(metadataMessage('a', 'end.json', trap.byteLength, 1, 2, trap.byteLength + 3));
+        h.rx.handleMessage(trap);
+        h.rx.handleMessage(endMessage());
+        h.rx.handleMessage(metadataMessage('b', 'after.txt', 3, 2, 2, trap.byteLength + 3));
+        h.rx.handleMessage(enc.encode('abc'));
+        h.rx.handleMessage(endMessage());
+        await h.settle();
+
+        expect(h.errors).toEqual([]);
+        expect(Object.keys(h.files).sort()).toEqual(['after.txt', 'end.json']);
+        expect(h.files['after.txt']).toBe('abc');
+    });
+
+    it('still honors a short end marker, which is what the truncation guard needs', async () => {
+        // The reason the fix is framing and not "a control frame is only real
+        // once the announced bytes have arrived": a legitimately short end
+        // marker arrives while the budget is unsatisfied, and it is the exact
+        // frame both truncation guards depend on. A position rule would turn
+        // this precise error into a silent hang.
+        const h = receiver();
+        h.rx.handleMessage(metadataMessage('a', 'a.bin', 100, 1, 1, 100));
+        h.rx.handleMessage(new Uint8Array(40));
+        h.rx.handleMessage(endMessage());
+        await h.settle();
+
+        expect(h.errors).toHaveLength(1);
+        expect(h.errors[0]).toContain('received 40 of 100 bytes');
+        expect(h.files).toEqual({});
+    });
+
+    it('drops an unrecognized control type instead of writing it into the file', async () => {
+        // The Go receiver has always done this. The browser used to append the
+        // frame to whatever file was open, which is what made adding any new
+        // frame type unsafe for a stale tab.
+        const h = receiver();
+        h.rx.handleMessage(metadataMessage('a', 'a.bin', 3, 1, 1, 3));
+        h.rx.handleMessage(JSON.stringify({ type: 'somethingNew', reason: 'from a future Floe' }));
+        h.rx.handleMessage(enc.encode('abc'));
+        h.rx.handleMessage(endMessage());
+        await h.settle();
+
+        expect(h.errors).toEqual([]);
+        expect(h.files['a.bin']).toBe('abc');
+    });
+
+    it('refuses an over-cap control message instead of appending it to the file', async () => {
+        // Mirrors cli/engine/transfer/receiver.go. A deep enough folder path
+        // produces a metadata frame past the cap, and the browser used to write
+        // it into the file; the Go receiver has always rejected it.
+        const h = receiver();
+        h.rx.handleMessage(metadataMessage('a', 'a.bin', 3, 1, 1, 3));
+        h.rx.handleMessage('{"type":"metadata","pad":"' + 'x'.repeat(CONTROL_MSG_MAX) + '"}');
+        await h.settle();
+
+        expect(h.errors).toHaveLength(1);
+        expect(h.errors[0]).toContain(String(CONTROL_MSG_MAX));
+        expect(h.files).toEqual({});
+    });
+});
+
+/**
  * The receiver must refuse a file whose byte count does not match the size the
  * sender announced, matching cli/engine/transfer/receiver.go. Before this it
  * labelled the file with however many bytes arrived, so announced and actual
@@ -257,20 +385,20 @@ describe('loopback: small binary framing guard', () => {
 describe('receiver: truncation guard', () => {
     // Feeds metadata announcing `announced` bytes but only delivers `actual`.
     function feedTruncated(
-        rx: { handleMessage: (d: Uint8Array | ArrayBuffer) => void },
+        rx: { handleMessage: (d: string | Uint8Array | ArrayBuffer) => void },
         id: string,
         announced: number,
         actual: number,
         index = 1,
         total = 1,
     ) {
-        rx.handleMessage(enc.encode(metadataMessage(id, `${id}.bin`, announced, index, total, 0)));
+        rx.handleMessage(metadataMessage(id, `${id}.bin`, announced, index, total, 0));
         if (actual > 0) {
             const chunk = new Uint8Array(actual);
             for (let i = 0; i < actual; i++) chunk[i] = (i + 1) % 256; // never starts with '{'
             rx.handleMessage(chunk);
         }
-        rx.handleMessage(enc.encode(endMessage()));
+        rx.handleMessage(endMessage());
     }
 
     function harness() {
@@ -345,15 +473,14 @@ describe('receiver: truncation guard', () => {
     it('accepts a peer that announces no size at all', () => {
         // metadataMessage always writes a fileSize, so build the frame by hand.
         const h = harness();
-        h.rx.handleMessage(
-            enc.encode(JSON.stringify({
+        h.rx.handleMessage(JSON.stringify({
                 type: 'metadata', id: 'a', fileName: 'a.bin', index: 1, total: 1, totalBytes: 0,
-            }))
+            })
         );
         const chunk = new Uint8Array(50);
         for (let i = 0; i < 50; i++) chunk[i] = (i + 1) % 256;
         h.rx.handleMessage(chunk);
-        h.rx.handleMessage(enc.encode(endMessage()));
+        h.rx.handleMessage(endMessage());
         expect(h.completed).toEqual(['a.bin']);
         expect(h.errors).toEqual([]);
     });
@@ -361,16 +488,15 @@ describe('receiver: truncation guard', () => {
     it('treats an unusable announced size as unknown rather than failing', () => {
         for (const bad of ['100', -1, 1.5, null, Number.MAX_SAFE_INTEGER + 2]) {
             const h = harness();
-            h.rx.handleMessage(
-                enc.encode(JSON.stringify({
+            h.rx.handleMessage(JSON.stringify({
                     type: 'metadata', id: 'a', fileName: 'a.bin',
                     fileSize: bad, index: 1, total: 1, totalBytes: 0,
-                }))
+                })
             );
             const chunk = new Uint8Array(10);
             for (let i = 0; i < 10; i++) chunk[i] = (i + 1) % 256;
             h.rx.handleMessage(chunk);
-            h.rx.handleMessage(enc.encode(endMessage()));
+            h.rx.handleMessage(endMessage());
             expect(h.completed).toEqual(['a.bin']);
             expect(h.errors).toEqual([]);
         }
@@ -392,11 +518,11 @@ describe('receiver: truncation guard', () => {
             for (let i = 0; i < n; i++) c[i] = (i + 1) % 256;
             return c;
         };
-        rx.handleMessage(enc.encode(metadataMessage('a', 'a.bin', 100, 1, 1, 0)));
+        rx.handleMessage(metadataMessage('a', 'a.bin', 100, 1, 1, 0));
         rx.handleMessage(part(40));
-        rx.handleMessage(enc.encode(metadataMessage('a', 'a.bin', 100, 1, 1, 0)));
+        rx.handleMessage(metadataMessage('a', 'a.bin', 100, 1, 1, 0));
         rx.handleMessage(part(60));
-        rx.handleMessage(enc.encode(endMessage()));
+        rx.handleMessage(endMessage());
 
         expect(JSON.parse(acks[1]).offset).toBe(40);
         expect(h.completed).toEqual(['a.bin']);
@@ -408,16 +534,15 @@ describe('receiver: truncation guard', () => {
         // the banner around it exactly as it does in a file manager, so the
         // error carries the display form of the name, not the wire string.
         const h = harness();
-        h.rx.handleMessage(
-            enc.encode(JSON.stringify({
+        h.rx.handleMessage(JSON.stringify({
                 type: 'metadata', id: 'a', fileName: 'photo\u202egnp.exe',
                 fileSize: 100, index: 1, total: 1, totalBytes: 100,
-            }))
+            })
         );
         const chunk = new Uint8Array(60);
         for (let i = 0; i < 60; i++) chunk[i] = (i + 1) % 256;
         h.rx.handleMessage(chunk);
-        h.rx.handleMessage(enc.encode(endMessage()));
+        h.rx.handleMessage(endMessage());
         expect(h.errors).toHaveLength(1);
         expect(h.errors[0]).toContain('Incomplete file "photognp.exe"');
         expect(h.errors[0]).not.toContain('\u202e');
@@ -435,7 +560,7 @@ describe('receiver: truncation guard', () => {
 // every string frame the sender emits, for "never announced the file as done"
 // assertions.
 function scriptedDeps(reply: (metadataId: string) => string, sent: string[] = []): SenderDeps {
-    let senderDataHandler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+    let senderDataHandler: ((d: string | Uint8Array | ArrayBuffer) => void) | null = null;
     return {
         send: (d) => {
             if (typeof d !== 'string') return;
@@ -551,7 +676,7 @@ describe('sender: unreadable file', () => {
 
         // The sender blocks on the ack before it reads anything, so the harness
         // has to answer it or the test just waits out the ack timeout.
-        let senderDataHandler: ((d: Uint8Array | ArrayBuffer) => void) | null = null;
+        let senderDataHandler: ((d: string | Uint8Array | ArrayBuffer) => void) | null = null;
 
         const deps: SenderDeps = {
             send: (d) => {

--- a/docs/reference/transfer-protocol.mdx
+++ b/docs/reference/transfer-protocol.mdx
@@ -38,33 +38,36 @@ Four things that order does not show.
 
 ## How a frame is classified
 
-There is no length prefix and no envelope. A receiver decides whether an arriving frame is a
-control message or file data by probing it, and the rule is deliberately conservative because
-getting it wrong means either dropping a chunk or writing JSON into a file.
+There is no length prefix and no envelope. What a frame is comes from **how it was sent**, not
+from what is inside it.
 
-A frame is treated as a control message only when all of these hold:
+In the direction file data travels, sender to receiver, a frame is a control message if and only
+if it is a **text** frame. A **binary** frame is file data, whatever its bytes spell. That is the
+whole rule, and it is what lets a small `.json` file whose entire content is `{"type":"end"}`
+arrive intact instead of being swallowed as an end marker.
 
-1. It is at most **1000 bytes**.
-2. Its first non-whitespace byte is `{`.
-3. It parses as JSON with a `type` field naming a message below.
+A text frame is then read as a control message when both of these hold:
 
-A **binary** frame that is not a control message is file data and gets written, **including a
-small chunk that happens to look like a JSON object.** That case is real and both implementations
-handle it.
+1. It is at most **1000 bytes**. A longer one is a protocol error and stops the transfer, rather
+   than being written to a file.
+2. It parses as JSON with a `type` field naming a message below.
 
-A **string** frame that is not a control message is where they part company: the Go receiver
-discards it, and the browser receiver writes it into the file. Nothing in Floe sends such a frame,
-so this only matters if you are building another client.
+A text frame that parses but names a type the receiver does not know is **ignored**. That is what
+makes a new message type safe to add: an older peer drops it instead of writing it into whatever
+file is open.
 
-Two divergences are worth knowing if you are writing another client:
+The other direction, receiver to sender, carries no file data, so nothing there can be confused
+with a chunk and a sender accepts a control message in either framing. It has to: a Go receiver
+sends `ack`, `received` and `incompatible` as binary, and a browser receiver sends `ack` as a
+string and `incompatible` as binary.
 
-- The Go receiver applies the 1000-byte cap to **binary** frames only, so an oversized string
-  frame is still parsed. The browser applies it to every frame. A metadata frame larger than
-  1000 bytes, which a deep folder path can produce, is therefore handled by a Go receiver and
-  misread as file data by a browser receiver.
-- **Framing differs by sender.** Go sends `metadata` and `end` as strings but `ack`, `received`,
-  and `incompatible` as binary. The browser sends `metadata`, `ack`, and `end` as strings and
-  `incompatible` as binary. Both work because every receiver decodes bytes and strings alike.
+If you are building another client, one rule falls out of all of this: **every frame you send to
+a receiver that is not file data has to be a text frame.** A binary one lands in somebody's file.
+
+One implementation detail worth knowing, because it is the one place the two disagree. The Go
+receiver skips leading whitespace before looking for the opening `{`; the browser requires the
+frame to start with it. So a control message padded with leading spaces is read by a Go receiver
+and treated as file data by a browser receiver. Nothing in Floe sends one.
 
 ## Message types
 


### PR DESCRIPTION
## Summary

`classifyControl` decided what an arriving frame was by **reading** it: any frame of 1000 bytes or fewer that parsed as JSON with a known `type` was consumed as a control message. A whole small file whose content is such an object was therefore eaten and never written. The issue's repro is 14 bytes:

```
metadata(id, 'end.json', 14); chunk('{"type":"end"}'); end()
```

Before #311 that produced a 0-byte file that looked complete; since #311, a hard error and an aborted batch. Both are the same lost bytes. Floe Desktop's Send-text box makes it a one-click send.

### The wire already carried the answer

Every Floe sender since **v1.0.0** sends `metadata` and `end` as a **TEXT** frame and file chunks as **BINARY**. I checked this per tag with `git show <tag>:<sender>` from v1.0.0 through v1.10.7, on both implementations. A receiver only ever needs those two types; `ack`, `received` and `incompatible` travel the other way.

So on the receive path a binary frame is file data, whatever its bytes spell. **No wire change and no `ProtocolVersion` bump.** The issue expected both; neither is needed, because nothing about what senders emit changes.

**Go** had the bit in hand and was not passing it. `msg.IsString` is in scope at the classify call and is now the gate. `classifyControl` keeps its signature and its meaning (a question about content); the receive loop decides eligibility. Every existing Go test already framed correctly, so the whole suite passes **unchanged**.

**The browser** could not see the bit at all: simple-peer pushes frames into a `readable-stream` Duplex and, without `readableObjectMode`, that `Buffer.from()`s every text frame before Floe sees it. Passing `readableObjectMode: true` recovers it. simple-peer forwards its options straight to `super(opts)` and never sets `objectMode` itself, and readable-stream honors `readableObjectMode` for a Duplex. Text frames now arrive as strings; binary still arrives as a Buffer.

### Two latent bugs go with it

Both were already written down in `docs/reference/transfer-protocol.mdx` as divergences, and both were live:

- An **over-cap string** is now a protocol error on the browser too, instead of being appended to the file. A deep enough folder path produces a metadata frame past 1000 bytes; the Go receiver has always rejected it.
- An **unrecognized control type** is now dropped rather than written into whatever file is open. That is what makes adding a message type safe for a stale tab, and #317 needs it.

### The design that was tried first and is wrong

A "protocol position" rule (a frame is control only once the announced bytes have all arrived) fixes the repro without touching simple-peer, and it is a trap. A legitimately **short** `end` marker arrives while the budget is unsatisfied, and that is the exact frame both truncation guards depend on. It would turn a precise error into a 60-second stall. #315 was a first-party source of exactly that frame. There is now a test pinning the short-`end` path so this cannot be re-proposed silently.

### What deliberately does not change

The **sender** side of both implementations still classifies by content, and must: a Go receiver sends `ack`, `received` and `incompatible` as binary. That is safe because no file data travels receiver to sender.

Stated as a prohibition in both implementations and in the docs: **a future sender-to-receiver control frame MUST go out as text**, or it lands in somebody's file.

## Test plan

- `go vet ./...` and `go test -count=1 ./...` in `cli/` pass. The whole pre-existing suite is untouched, which is the point: the tests already used `SendText` for metadata and end and `Send` for chunks.
- `pnpm lint`, `pnpm test` (**332 tests across 25 files**) and `pnpm build` pass in `client/`. Lint is clean apart from the two pre-existing `no-location-assign-relative-destination` warnings.
- `tsc --noEmit` clean. `isControlFrame` is a type predicate, so the binary branch narrows without a cast.
- New `TestLoopbackControlShapedFiles` sends **six** control-shaped files in one batch over a real pion pair (`{"type":"end"}`, `received`, `ack`, `incompatible`, a whole `metadata` frame, and a whitespace-padded one) and asserts each arrives byte-identical.
- New `describe('receiver: framing decides, not content')` in `transfer.test.ts`: the same six as a table, a two-file batch proving one eaten frame no longer derails the rest, the short-`end` guard, the unknown-type drop, and the over-cap refusal.
- **Verified the tests fail without the fix.** With content sniffing restored, `TestLoopbackControlShapedFiles` fails with `error sending received.json: timed out waiting for ack` after 120 s, and 6 of the 10 new browser tests fail. The 4 that pass either way are the whitespace-padded case (the browser requires a literal leading `{`, so content sniffing already declined it) and the three that were never about framing.
- The loopback harness in `transfer.test.ts` used to do `typeof d === 'string' ? enc.encode(d) : d`, which modelled exactly the simple-peer flattening this removes. It now passes the frame through, so the tests exercise the real wire. 14 direct `handleMessage(enc.encode(...))` calls were unwrapped for the same reason; the ones that deliver an **ack to the sender** keep their `enc.encode`, because that is a faithful model of a Go receiver's binary ack.
- `check-consumers.mjs`: 105 rows, 0 unmapped, 0 stale, 0 anchor-missing. `docs-check.mjs`: 0 hard, notes unchanged.

**The back-compat job is the real gate here** (released CLI against HEAD, all four pairings) and must be green rather than skipped.

## Notes for the release author

The browser half ships to floe.one on merge. The Go half needs a paired `v*` and `desktop-v*` release. A transfer is protected once the RECEIVING end runs the new build.

Also corrects a stale path in `client/lib/transfer/protocol.ts`'s header comment: `cli/internal/transfer` has been `cli/engine/transfer` since #228.

Closes #316
