### PR TITLE
chore(client): point the download links at desktop-v0.2.10

### DIFF
--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.9';
-export const DESKTOP_RELEASE_DATE = 'Sep 4, 2026';
+export const DESKTOP_VERSION = '0.2.10';
+export const DESKTOP_RELEASE_DATE = 'Sep 7, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
## Summary

The `desktop-v0.2.10` assets exist, so the pin can move. `DESKTOP_VERSION` and `DESKTOP_RELEASE_DATE` bump together, as the file says.

The date is the tag's UTC date, `Sep 7, 2026`. The tag was pushed at 16:04 UTC, which is already past midnight in Manila and still the 7th in UTC, which is what `desktopRelease.test.ts` measures against.

Deliberately after the tag, never before: CI's "Check desktop release assets" step fails a bump whose release does not exist, and /download derives every asset URL from this one constant.

## Test plan

- `vitest run lib/desktopRelease.test.ts`: 7 passed, including the check that rejects a future release date against the runner's UTC clock.
- `check-version-pins.mjs --phase follow-up`: 1 finding, `client/lib/transfer/protocol.ts:269`, which is release history (the version `rejectDescription` shipped in) rather than a pin.
- All four asset URLs answer 200 after redirects:
  - `floe-desktop-setup-0.2.10.exe`
  - `floe-desktop-0.2.10-windows-amd64.zip`
  - `SHA256SUMS.txt`
  - the release page
- `desktop-v0.2.10` is a pre-release and not a draft, so `/releases/latest` still resolves to `v1.10.8`. Confirmed: `gh release view` with no tag returns `v1.10.8`, which is what the install scripts, `floe update` and the back-compat CI job depend on.
- `v1.10.8` published six archives plus `checksums.txt`.
