### PR TITLE
chore(client): point the download links at desktop-v0.2.11

### DIFF
--- a/client/lib/desktopRelease.ts
+++ b/client/lib/desktopRelease.ts
@@ -14,8 +14,8 @@
  */
 
 // Bump these two together on every desktop release.
-export const DESKTOP_VERSION = '0.2.10';
-export const DESKTOP_RELEASE_DATE = 'Sep 7, 2026';
+export const DESKTOP_VERSION = '0.2.11';
+export const DESKTOP_RELEASE_DATE = 'Sep 9, 2026';
 
 /**
  * The Microsoft Store listing: the primary Windows install path. The Store


### PR DESCRIPTION
## Summary

The follow-up half of the release order. The prep PR (#435) deliberately left `client/lib/desktopRelease.ts` alone, because CI's release-asset check fails a bump whose release does not exist yet and `/download` would derive URLs that 404. `desktop-v0.2.11` has published, so the pin moves now.

`DESKTOP_RELEASE_DATE` is the tag's UTC date. The tag was pushed at 00:40 +08:00 on the 10th, which is 16:40 UTC on the 9th, so it reads `Sep 9, 2026` and matches both changelog entries.

## Test plan

- `corepack pnpm exec vitest run lib/desktopRelease.test.ts`: **7 passed**. That suite rejects a `DESKTOP_RELEASE_DATE` in the future against the runner's UTC clock, which is the check that catches getting the date backwards.
- All four derived URLs answer **200** after redirects:
  - `floe-desktop-setup-0.2.11.exe`
  - `floe-desktop-0.2.11-windows-amd64.zip`
  - `SHA256SUMS.txt`
  - the `desktop-v0.2.11` tag page
- `gh api repos/jannskiee/floe/releases/latest` still resolves to `v1.10.9`, not the desktop prerelease, so the CLI install scripts are unaffected.
- `check-version-pins.mjs --desktop desktop-v0.2.11 --phase follow-up`: 1 finding, in `.refactor-audit/`, which is an untracked record of a past audit rather than part of the pin surface.

## Notes

Last step after this is the Microsoft Store submission for 9NBQ8ZQ1065L. Partner Center already shows the previous submission as **In Microsoft Store** with **Start update** available and no draft in flight.
