### PR TITLE
feat(client): let a light cross the /how-it-works figure, once on paint and on hover

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -127,8 +127,9 @@
    motion-reduce:animate-none in the Tailwind v4 cascade (the desktop app hit
    this), while an unlayered media block can never lose. Reduced motion, the
    e2e sweep, the screenshot matrix and a JS-off reader all get the completed
-   figure at first paint. Only stroke-dashoffset, stroke and opacity animate,
-   and the box is reserved by aspect-ratio, so nothing shifts layout.
+   figure at first paint. Only stroke-dashoffset, stroke, opacity,
+   stroke-opacity and pointer-events animate, and the box is reserved by
+   aspect-ratio, so nothing shifts layout.
    The spurs draw on a plain ease-out rather than the expo-out the ice line
    keeps. Under expo-out 80% of a line is laid down in the first 23% of its
    duration, so lengthening the spurs only lengthened a tail nobody watches and
@@ -142,10 +143,15 @@
    a tail with nothing in it: the 1000ms window is about 450ms of visible
    drawing. The beats after it are therefore timed off that visible finish, not
    off the window, or the figure stalls with the arch just sitting there.
-   Sequence (about 2.45 s, once, no loop): the spurs draw from the devices to
-   the server tick in ice, the direct line draws across, the spurs thaw to
-   zinc-700 (the server has left), the ring lands on THEM, then the relay
-   detour fades in. */
+   Sequence (about 4.7 s, once, no loop): the spurs draw from the devices to
+   the server tick in a lit zinc (#a1a1aa, never ice: see hiw-thaw), the direct
+   line draws across, the spurs thaw to zinc-700 (the server steps aside), the
+   ring lands on THEM, the relay detour fades in, and then, with the map
+   complete, a light crosses the direct line from YOU to THEM (2500 to 4300ms)
+   and the ring blooms as it lands (fading out by 4650ms). The draw-in tells
+   the order; the light tells the direction and which line carries the file.
+   Once that finale has played, hovering the drawing replays the crossing in a
+   slow loop (see .hiw-box:hover below). */
 .hiw-fig svg {
     display: block;
     width: 100%;
@@ -184,14 +190,105 @@
 .hiw-direct {
     stroke: oklch(0.87 0.05 220);
 }
+/* zinc-500 and a 1 4 dot, up from zinc-600 and 1 5. This is the path that
+   carries the 2 GB rule, and at DPR 1 the old dotting left about a sixth of a
+   hairline's ink at 2.57:1, so on a desktop it all but vanished (the phone, at
+   DPR 3, was fine). #71717a is the ticks' own gray at 4.12:1; solid against
+   dotted still tells the relay tick from the path it sits on, and the dots stay
+   well under the ice line. */
 .hiw-detour {
-    stroke: #52525b;
-    stroke-dasharray: 1 5;
+    stroke: #71717a;
+    stroke-dasharray: 1 4;
     stroke-linecap: round;
 }
 .hiw-fig circle.hiw-ring {
     stroke: oklch(0.87 0.05 220);
     fill: #09090b;
+}
+/* The light that crosses the direct line: three dashed copies of that line,
+   swept by one stroke-dashoffset. Every dash ends at pattern position 160, so
+   the three heads travel as one: the core is the last 40 of those units, the
+   tail the last 120, the halo all 160, and a leading 0-length dash lets the
+   shorter two start their pattern with a gap. That zero-length dash is why
+   the caps stay butt: under a round cap a zero-length dash renders as a dot of
+   the stroke's width, and the core's dot rode along at the tail's start,
+   brighter than the head at the narrow variant's scale. The 1200 gap keeps
+   the next copy of the pattern off the path for the whole sweep (it needs at
+   least 1004). At rest the pattern sits 164 units before YOU (160 plus 4 of
+   slack), which is the finished drawing: no light on the line. The sweep runs
+   the offset from 164 to -1004, 1168 units, so the head enters at YOU, reaches
+   THEM 86% of the way through, and the tail drains into the ring's fill.
+   vector-effect: none, not the figure's non-scaling-stroke. Every engine lays
+   a non-scaling stroke's dashes out in screen space (Blink's DashScaleFactor is
+   pathLength-only, Gecko skips the transform for stroking, and the SVG WG's
+   2018 minutes on w3c/svgwg#323, still open, read the spec as host space), so
+   a MOVING dash would cover a fixed number of screen pixels whatever the
+   scale: at the narrow variant's 1.333 cap the head would stop at 87% of the
+   line with the next copy of the pattern already parked on THEM, the same
+   class of bug the 1600 headroom above exists for. In user units the dash
+   scales with the path and the head always arrives; the price is a stroke
+   that scales 0.7x to 1.33x with the figure, which a glow can afford and a
+   hairline cannot.
+   shape-rendering: auto, unlike the crispEdges line beneath, which is the
+   soft edge a light should have. At the wide variant's scale of exactly 1
+   that line snaps into the device row below its coordinate while the 1.75
+   core, centered on the coordinate, lights that row and most of the row
+   above it, with the halo two rows either side: the light sits half a pixel
+   high. A half-unit lift would center it there and miscenter it at the
+   phone's 1.333, so it stays; at DPR 2 the object is symmetric.
+   Written as .hiw-fig .hiw-comet because .hiw-fig path (0,1,1) outranks a bare
+   .hiw-comet (0,1,0). Nothing here is a fill: ice is never a fill on this site,
+   and a filter would re-rasterize a blur every frame and promote a layer that
+   drops the 11px labels to grayscale antialiasing (see the `both` note
+   below); the halo is a wider stroke at low opacity instead. */
+.hiw-fig .hiw-comet {
+    vector-effect: none;
+    shape-rendering: auto;
+    stroke-linecap: butt;
+    stroke: oklch(0.87 0.05 220);
+    stroke-dashoffset: 164;
+}
+/* 0.15, measured against the spur beside it: at 0.22 the halo rows read L54
+   over the background's 9, a flat gray sleeve brighter than the spur arch
+   (L63) it passes under; at 0.15 they read about L40, under the spur, and the
+   falloff from head to line to halo to background steps evenly. */
+.hiw-fig .hiw-comet-halo {
+    stroke-width: 4;
+    stroke-opacity: 0.15;
+    stroke-dasharray: 160 1200;
+}
+/* The tail is the head's color at 0.35, not ice: ice at any opacity over the
+   full-opacity ice line is a no-op, so an ice tail faded only in the fringe
+   rows and left the line itself unchanged behind the head. In the head's color
+   the line steps 245 (head) to about 224 (tail) to 213 (line), a real fade on
+   the line, and 0.35 keeps the tail under the 228 the spec uses to find the
+   head. */
+.hiw-fig .hiw-comet-tail {
+    stroke-width: 1.5;
+    stroke-opacity: 0.35;
+    stroke: oklch(0.97 0.03 220);
+    stroke-dasharray: 0 40 120 1200;
+}
+/* The head is whiter than the line it rides, not more saturated: the base line
+   is already full-opacity ice, so a brighter L is the only way up. */
+.hiw-fig .hiw-comet-core {
+    stroke-width: 1.75;
+    stroke: oklch(0.97 0.03 220);
+    stroke-dasharray: 0 120 40 1200;
+}
+/* The arrival: a 5-unit ring around the 3-unit one, invisible until the head
+   lands, then a bloom to 0.4 that fades over 600ms. stroke-opacity, not
+   opacity: Chromium composites an opacity animation even on an SVG child, and
+   that layer pulled the ring and the five 11px labels into an overlap layer
+   that dropped them to grayscale antialiasing for every hover and for the
+   last 2.2 s of every page load (measured with the LayerTree; the labels'
+   subpixel fringes vanished and came back). stroke-opacity is a paint
+   property and never leaves the main thread; the circle has no fill, so the
+   pixels are identical. Never stroke itself, which would override the user's
+   colors under forced-colors for as long as the bloom runs. */
+.hiw-fig circle.hiw-ring-halo {
+    stroke: oklch(0.87 0.05 220);
+    stroke-opacity: 0;
 }
 /* 1600, not the 1000 that pathLength normalizes to. vector-effect:
    non-scaling-stroke makes Chromium lay the dash out in unscaled user units
@@ -232,6 +329,59 @@
     .hiw-lbl-relay {
         animation: hiw-fade 500ms ease 1950ms backwards;
     }
+    /* The crossing, once, as the finale: 2500ms is after the relay has faded
+       in (1850 + 600), so the map is complete before the transfer is shown and
+       the detour reads as the other route rather than the next step. The
+       halo's window is longer than the sweep so the bloom that starts at the
+       head's arrival (86% of 1800ms) has 600ms to fade. */
+    .hiw-comet {
+        animation: hiw-comet-once 1800ms linear 2500ms backwards;
+    }
+    .hiw-fig circle.hiw-ring-halo {
+        animation: hiw-ring-halo-once 2200ms linear 2500ms backwards;
+    }
+}
+/* Hover replays the crossing in a slow loop: 1800ms of travel, then the line is
+   quiet for 1600ms, for as long as the pointer stays on the drawing, and it
+   stops the moment the pointer leaves. Linear, because constant motion reads as
+   a steady flow and an ease would whip out of YOU and crawl into THEM, which
+   misreports a transfer. The 80ms delay swallows a pointer merely crossing the
+   figure; a slower pass still starts a light and cuts it off on the way out,
+   which is the one abrupt beat here and has no CSS-only cure (a paused loop
+   would freeze the light mid-line, which is worse), so it stays. Three gates
+   in one query: reduced motion gets no loop, and neither does a touch screen,
+   where :hover would stick after a tap and start a light that never stops
+   (Tailwind wraps its own hover: variants in (hover: hover); this block is
+   hand-written, so the gate is too). The hover rule APPENDS the loop to the
+   once-only list rather than replacing it: css-animations matches animations
+   by name when the list changes, so the finished once-only entry is kept as
+   it is on hover-in and hover-out, and never replays with its 2.5s delay when
+   the pointer leaves.
+   The box ignores the pointer until the finale has played (hiw-arm: 4300ms,
+   the crossing's 2500 + 1800). Two animations of one property on one element
+   resolve to the later name in the list, so a loop started during the draw-in
+   would own the light's offset from then on: measured, a pointer arriving at
+   1s put the loop's head at 82% of the line the moment the group appeared and
+   the finale never showed, and leaving mid-finale popped the once light in at
+   wherever its clock had reached. With the pointer ignored until 4300ms the
+   loop cannot exist before the finale ends, and the first hover after that
+   starts it fresh from YOU on the next pointer move. pointer-events animates
+   as a discrete step, promotes no layer, and the box holds nothing
+   interactive (the label overlay is pointer-events: none already). */
+@media (prefers-reduced-motion: no-preference) and (hover: hover) and (pointer: fine) {
+    .hiw-box {
+        animation: hiw-arm 1ms linear 4300ms backwards;
+    }
+    .hiw-box:hover .hiw-comet {
+        animation:
+            hiw-comet-once 1800ms linear 2500ms backwards,
+            hiw-comet-loop 3400ms linear 80ms infinite;
+    }
+    .hiw-box:hover circle.hiw-ring-halo {
+        animation:
+            hiw-ring-halo-once 2200ms linear 2500ms backwards,
+            hiw-ring-halo-loop 3400ms linear 80ms infinite;
+    }
 }
 @keyframes hiw-draw {
     from {
@@ -264,6 +414,67 @@
         opacity: 1;
     }
 }
+/* pointer-events interpolates as a step: none for the whole backwards-filled
+   delay, auto from the first frame of the 1ms window, base (auto) after. */
+@keyframes hiw-arm {
+    from {
+        pointer-events: none;
+    }
+    to {
+        pointer-events: auto;
+    }
+}
+/* 164 to -1004: from the pattern parked 164 units before YOU to fully past
+   THEM, see the .hiw-comet note. The loop spends 1800 of its 3400ms travelling
+   (52.94%) and holds off the path for the rest. */
+@keyframes hiw-comet-once {
+    from {
+        stroke-dashoffset: 164;
+    }
+    to {
+        stroke-dashoffset: -1004;
+    }
+}
+@keyframes hiw-comet-loop {
+    0% {
+        stroke-dashoffset: 164;
+    }
+    52.94%,
+    100% {
+        stroke-dashoffset: -1004;
+    }
+}
+/* The head lands at 86% of the 1800ms sweep (1548ms). Once: on a 2200ms window
+   that is 70.4%, with the 600ms fade ending at 97.6%. Loop: on 3400ms it is
+   45.5%, fading out by 63.2%. Each ramps up over the 66ms before the landing
+   (3% of the once window, 2% of the loop's) so the bloom is a beat, not a
+   pop. */
+@keyframes hiw-ring-halo-once {
+    0%,
+    67.4% {
+        stroke-opacity: 0;
+    }
+    70.4% {
+        stroke-opacity: 0.4;
+    }
+    97.6%,
+    100% {
+        stroke-opacity: 0;
+    }
+}
+@keyframes hiw-ring-halo-loop {
+    0%,
+    43.5% {
+        stroke-opacity: 0;
+    }
+    45.5% {
+        stroke-opacity: 0.4;
+    }
+    63.2%,
+    100% {
+        stroke-opacity: 0;
+    }
+}
 @media (forced-colors: active) {
     .hiw-direct,
     .hiw-fig circle.hiw-ring {
@@ -278,6 +489,20 @@
     .hiw-spur,
     .hiw-detour {
         stroke: GrayText;
+    }
+    /* The light takes the user's highlight color and the bloom the text color;
+       both animate only stroke-dashoffset and stroke-opacity, so nothing
+       overrides these for the animation's duration. The ring's knockout fill
+       maps to Canvas, or on a light high-contrast theme THEM was a black disc
+       and the head landed in it rather than in a ring. */
+    .hiw-fig .hiw-comet {
+        stroke: Highlight;
+    }
+    .hiw-fig circle.hiw-ring-halo {
+        stroke: CanvasText;
+    }
+    .hiw-fig circle.hiw-ring {
+        fill: Canvas;
     }
 }
 /* Draw, but do not thaw. A keyframe that animates stroke names a literal color,

--- a/client/components/how-it-works/RouteFigure.tsx
+++ b/client/components/how-it-works/RouteFigure.tsx
@@ -17,15 +17,21 @@ import { RELAY_CAP } from '@/lib/howItWorksStrings';
  * routeGeometry() so the two cannot drift; the CSS gate is the only switch.
  * That gate is a pixel rather than md, and so are the width caps: see the
  * comment beside the variants for why a rem there truncated the draw-in.
- * Motion is CSS only and plays once on paint: the .hiw-* rules in globals.css,
- * inside
- * prefers-reduced-motion: no-preference. The base rules are the finished
- * figure, so reduced motion, the e2e sweep and the screenshot matrix all get
- * the completed drawing at first paint, and a reader with JavaScript off gets
- * the sequence anyway, since CSS animations do not need it. No client
- * island: the route stays a Server Component. A plain load puts the figure
- * inside the first viewport at every width; a reader arriving at #direct,
- * #relay or #size-limit lands below it and sees that same finished drawing.
+ * Motion is CSS only: the .hiw-* rules in globals.css, inside
+ * prefers-reduced-motion: no-preference. On paint the drawing draws itself in
+ * once, then a light crosses the direct line from YOU to THEM, once, the only
+ * thing on the figure that ever moves along a stroke. On a device with a fine
+ * pointer, hovering the drawing once that finale has played replays the
+ * crossing in a slow loop (the box ignores the pointer until then); touch
+ * gets the once-on-paint crossing and nothing on tap. The base rules are the
+ * finished figure with the light off the path, so reduced motion, the e2e
+ * sweep and the screenshot matrix all get the completed drawing at first
+ * paint, and a reader with JavaScript off gets the sequence anyway, since CSS
+ * animations do not need it. No client island: the route stays a Server
+ * Component, and nothing in here carries an id, so the two variants that share
+ * the DOM cannot cross-reference. A plain load puts the figure inside the
+ * first viewport at every width; a reader arriving at #direct, #relay or
+ * #size-limit lands below it and sees that same finished drawing.
  */
 
 // leading-none, as the page header does for its eyebrow: an 11px label
@@ -37,8 +43,11 @@ const LABEL = 'font-mono text-[11px] leading-none uppercase tracking-[0.2em]';
 function Variant({ g, className }: { g: RouteGeometry; className: string }) {
     const [left, right] = g.deviceTicks;
     const L = g.labels;
+    // hiw-box is the hover target for the light: the drawing's own box, not
+    // the <figure>, which spans the whole column and would fire beside the
+    // phone drawing between 480 and 767px.
     return (
-        <div className={`relative ${className}`} style={{ aspectRatio: `${g.width} / ${g.height}` }}>
+        <div className={`hiw-box relative ${className}`} style={{ aspectRatio: `${g.width} / ${g.height}` }}>
             <svg viewBox={`0 0 ${g.width} ${g.height}`} aria-hidden="true" focusable="false">
                 <line className="hiw-tick" x1={left.x1} y1={left.y1} x2={left.x2} y2={left.y2} />
                 <line className="hiw-tick" x1={right.x1} y1={right.y1} x2={right.x2} y2={right.y2} />
@@ -62,6 +71,22 @@ function Variant({ g, className }: { g: RouteGeometry; className: string }) {
                     y2={g.relayTick.y2}
                 />
                 <path className="hiw-direct" pathLength={1000} d={g.direct} />
+                {/* The light: three dashed copies of the direct line whose dashes all
+                    end at the same pattern position, so one stroke-dashoffset sweep
+                    moves a bright head with a fading tail and a soft halo as one
+                    object (the .hiw-comet rules in globals.css). Halo under tail
+                    under core; all three sit under the ring, whose zinc-950 fill
+                    swallows the head at THEM. The halo circle is the arrival: it
+                    blooms and fades as the head lands. Only the direct line ever
+                    carries a moving light. Not the spurs, which would draw the file
+                    through the signaling server, and not the detour, because a
+                    transfer takes one route. */}
+                <g className="hiw-light">
+                    <path className="hiw-comet hiw-comet-halo" pathLength={1000} d={g.direct} />
+                    <path className="hiw-comet hiw-comet-tail" pathLength={1000} d={g.direct} />
+                    <path className="hiw-comet hiw-comet-core" pathLength={1000} d={g.direct} />
+                    <circle className="hiw-ring-halo" cx={g.them.x} cy={g.them.y} r={5} />
+                </g>
                 {/* A 1px ice ring marks the arrival; ice is never a fill on this site. */}
                 <circle className="hiw-ring" cx={g.them.x} cy={g.them.y} r={3} />
             </svg>
@@ -148,9 +173,9 @@ export function RouteFigure() {
             <Variant g={routeGeometry(ROUTE_NARROW)} className="max-w-[480px] min-[768px]:hidden" />
             {/* The only description assistive tech gets; it claims exactly what is drawn. */}
             <figcaption className="sr-only">
-                A line runs from You to Them. Two thin spurs rise from each device and meet at the
-                signaling server above them: it introduces the two devices and then takes no further
-                part, carrying no file data itself. The direct line runs straight across, labeled
+                A line runs from You to Them. Two thin spurs, one from each device, rise and meet at
+                the signaling server above both: it introduces the two devices and then steps aside,
+                carrying no file data itself. The direct line runs straight across, labeled
                 Direct, and carries no size limit. A
                 dotted second path dips through a relay and rejoins at Them, labeled Relay, and is
                 capped at {RELAY_CAP} per session.

--- a/client/e2e/route-figure-light.spec.ts
+++ b/client/e2e/route-figure-light.spec.ts
@@ -1,0 +1,453 @@
+/**
+ * The light on the /how-it-works route figure.
+ *
+ * The specs that look at this figure force reduced motion, which is the right
+ * setting for an overflow sweep and the reason the figure's motion was never
+ * checked by CI (hydration.spec.ts opens the route with motion on but never
+ * looks at the drawing): the scaled-dash truncation that shipped in #423 lived
+ * exactly there. This spec is the one place the draw-in and the hover loop
+ * are watched. Nothing here reads a wall clock: a test either waits for every
+ * animation to end or pauses them all on first paint, then seeks a paused
+ * animation to a chosen time, screenshots the drawing's box with animations
+ * allowed, and decodes the baseline rows in-page, so a slow runner changes
+ * nothing.
+ *
+ * Geometry comes from the DOM (the direct path's own `d`), not from a copy of
+ * routeFigure.ts, so a retuned drawing cannot desynchronize the test.
+ */
+import { test, expect, type Page, type Locator } from '@playwright/test';
+
+// The ice line is about rgb(177, 221, 235), luminance 213 on the 0.2126 /
+// 0.7152 / 0.0722 scale. The light's head is whiter than the line, so a pixel
+// on the baseline above this threshold can only be the light.
+const HEAD_LUMINANCE = 228;
+
+interface Figure {
+    box: Locator;
+    rect: { x: number; y: number; width: number; height: number };
+    /** CSS pixels per viewBox unit. */
+    scale: number;
+    /** Screenshot pixels per CSS pixel: 1 under the chromium project, read from
+     *  the page so a DPR-2 profile (a local WebKit run) also works. */
+    dpr: number;
+    youX: number;
+    themX: number;
+    baseY: number;
+    apexY: number;
+}
+
+async function figure(page: Page): Promise<Figure> {
+    const box = page.locator('.hiw-box:visible');
+    await expect(box).toHaveCount(1);
+    const rect = (await box.boundingBox())!;
+    const g = await box.evaluate((el) => {
+        const svg = el.querySelector('svg')!;
+        const vb = svg.viewBox.baseVal;
+        const d = svg
+            .querySelector('.hiw-direct')!
+            .getAttribute('d')!
+            .match(/M ([\d.]+) ([\d.]+) H ([\d.]+)/)!;
+        // The server tick is the topmost tick, whatever order the JSX draws
+        // them in.
+        const apex = Math.min(
+            ...[...svg.querySelectorAll('.hiw-tick:not(.hiw-relay-tick)')].map(
+                (t) => Number(t.getAttribute('y1'))
+            )
+        );
+        return {
+            vbW: vb.width,
+            dpr: window.devicePixelRatio,
+            youX: Number(d[1]),
+            baseY: Number(d[2]),
+            themX: Number(d[3]),
+            apexY: apex,
+        };
+    });
+    expect(g.apexY, 'the apex sits above the baseline').toBeLessThan(g.baseY);
+    return {
+        box,
+        rect,
+        scale: rect.width / g.vbW,
+        dpr: g.dpr,
+        youX: g.youX,
+        themX: g.themX,
+        baseY: g.baseY,
+        apexY: g.apexY,
+    };
+}
+
+/** Pause every animation on the page, seek it to `t` milliseconds, and let a frame paint. */
+async function seekAll(page: Page, t: number): Promise<void> {
+    await page.evaluate(async (t) => {
+        for (const a of document.getAnimations()) {
+            a.pause();
+            a.currentTime = t;
+        }
+        // Two frames, not none: WebKit screenshots the last painted frame, and a
+        // seek alone has not painted yet.
+        await new Promise<void>((resolve) =>
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+        );
+    }, t);
+}
+
+async function animationNames(page: Page): Promise<string[]> {
+    return page.evaluate(() =>
+        document
+            .getAnimations()
+            .map((a) => (a as CSSAnimation).animationName)
+            .sort()
+    );
+}
+
+interface RowScan {
+    maxL: number;
+    maxX: number;
+    iceCount: number;
+}
+
+/** Decode a PNG of the box in-page and scan one pixel row for ice-hued ink and the brightest pixel. */
+async function scanRows(
+    page: Page,
+    png: Buffer,
+    ys: number[]
+): Promise<Record<number, RowScan>> {
+    return page.evaluate(
+        async ({ b64, ys }) => {
+            const bmp = await createImageBitmap(
+                await (await fetch('data:image/png;base64,' + b64)).blob()
+            );
+            // A DOM canvas, not OffscreenCanvas, which Playwright's WebKit lacks;
+            // it is never attached, so nothing on the page changes.
+            const canvas = document.createElement('canvas');
+            canvas.width = bmp.width;
+            canvas.height = bmp.height;
+            const ctx = canvas.getContext('2d', { willReadFrequently: true })!;
+            ctx.drawImage(bmp, 0, 0);
+            const out: Record<
+                number,
+                { maxL: number; maxX: number; iceCount: number }
+            > = {};
+            for (const y of ys) {
+                if (y < 0 || y >= bmp.height) continue;
+                const d = ctx.getImageData(0, y, bmp.width, 1).data;
+                let maxL = 0;
+                let maxX = -1;
+                let iceCount = 0;
+                for (let x = 0; x < bmp.width; x++) {
+                    const r = d[x * 4];
+                    const g = d[x * 4 + 1];
+                    const b = d[x * 4 + 2];
+                    const L = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+                    if (b > r + 6 && g > r + 4 && L > 40) iceCount++;
+                    if (L > maxL) {
+                        maxL = L;
+                        maxX = x;
+                    }
+                }
+                out[y] = { maxL, maxX, iceCount };
+            }
+            return out;
+        },
+        { b64: png.toString('base64'), ys }
+    );
+}
+
+/** The brightest pixel across the baseline's device rows: where the head is (in CSS px), and how bright. */
+async function head(page: Page, f: Figure): Promise<RowScan> {
+    const png = await f.box.screenshot({ animations: 'allow' });
+    const y = Math.round(f.baseY * f.scale * f.dpr);
+    const rows = await scanRows(page, png, [y - 1, y, y + 1]);
+    const best = Object.values(rows).reduce((a, r) =>
+        r.maxL > a.maxL ? r : a
+    );
+    return { ...best, maxX: best.maxX / f.dpr };
+}
+
+/** Ice-hued pixels on the apex row, where the signaling server's tick sits. */
+async function apexIce(page: Page, f: Figure): Promise<number> {
+    const png = await f.box.screenshot({ animations: 'allow' });
+    const y = Math.round(f.apexY * f.scale * f.dpr);
+    const rows = await scanRows(page, png, [y - 1, y, y + 1]);
+    return Object.values(rows).reduce((n, r) => n + r.iceCount, 0);
+}
+
+/** Every once-only animation, the light's crossing included, has run out. */
+async function waitForStill(page: Page): Promise<void> {
+    await page.waitForFunction(
+        () => document.getAnimations().length === 0,
+        null,
+        { timeout: 15_000 }
+    );
+}
+
+/**
+ * Open the route and pause every animation on first paint, before any of them
+ * can finish and drop out of getAnimations(). A paused animation can then be
+ * seeked to any figure time, however slow the runner was to get here.
+ */
+async function freezeOnPaint(page: Page): Promise<void> {
+    await page.goto('/how-it-works', { waitUntil: 'commit' });
+    await page.waitForFunction(
+        () =>
+            document
+                .getAnimations()
+                .some(
+                    (a) =>
+                        (a as CSSAnimation).animationName === 'hiw-comet-once'
+                ),
+        null,
+        { timeout: 30_000 }
+    );
+    await page.evaluate(() => {
+        for (const a of document.getAnimations()) a.pause();
+    });
+}
+
+// The loop's timeline, read from the CSS at globals.css: 80ms delay, then 1800ms
+// of travel inside a 3400ms period. Seeks below are offsets into that travel.
+const LOOP_DELAY = 80;
+const TRAVEL = 1800;
+
+test.describe('desktop, fine pointer', () => {
+    test.use({ viewport: { width: 1280, height: 720 } });
+
+    test('hovering the drawing runs one light left to right along the direct line only', async ({
+        page,
+    }) => {
+        await page.goto('/how-it-works');
+        await waitForStill(page);
+        const f = await figure(page);
+        expect(
+            f.scale,
+            'the wide variant at its 1024px cap renders at scale 1'
+        ).toBeCloseTo(1, 2);
+
+        const still = await head(page, f);
+        expect(still.maxL, 'no light on the line before hover').toBeLessThan(
+            HEAD_LUMINANCE
+        );
+
+        await f.box.hover();
+        await expect
+            .poll(
+                async () =>
+                    (await animationNames(page)).filter(
+                        (n) => n === 'hiw-comet-loop'
+                    ).length,
+                {
+                    message: 'three comet layers loop while hovered',
+                }
+            )
+            .toBe(3);
+        expect(await animationNames(page)).toContain('hiw-ring-halo-loop');
+        // Every running animation targets an SVG child of the drawing: nothing
+        // animates the labels overlay or the box itself, which would promote a
+        // layer and gray the 11px labels.
+        expect(
+            await page.evaluate(() =>
+                document.getAnimations().every((a) => {
+                    const el =
+                        a.effect && 'target' in a.effect
+                            ? (a.effect as KeyframeEffect).target
+                            : null;
+                    return (
+                        !!el && !!el.closest('svg') && !!el.closest('.hiw-box')
+                    );
+                })
+            )
+        ).toBe(true);
+
+        const xs: number[] = [];
+        for (const fraction of [0.1, 0.5, 0.8]) {
+            await seekAll(page, LOOP_DELAY + TRAVEL * fraction);
+            const h = await head(page, f);
+            expect(
+                h.maxL,
+                `head visible at ${fraction} of the travel`
+            ).toBeGreaterThan(HEAD_LUMINANCE);
+            expect(h.maxX).toBeGreaterThanOrEqual(f.youX * f.scale - 2);
+            expect(h.maxX).toBeLessThanOrEqual(f.themX * f.scale + 2);
+            xs.push(h.maxX);
+            expect(
+                await apexIce(page, f),
+                'nothing ice-colored ever rides the arch'
+            ).toBe(0);
+        }
+        expect(xs[0]).toBeLessThan(xs[1]);
+        expect(xs[1]).toBeLessThan(xs[2]);
+
+        // Past the travel the loop rests: the line is quiet again.
+        await seekAll(page, LOOP_DELAY + TRAVEL + 200);
+        expect((await head(page, f)).maxL).toBeLessThan(HEAD_LUMINANCE);
+
+        // Leaving the drawing stops the loop and leaves the finished drawing.
+        await page.mouse.move(2, 2);
+        await expect.poll(() => animationNames(page)).toEqual([]);
+        expect((await head(page, f)).maxL).toBeLessThan(HEAD_LUMINANCE);
+    });
+
+    test('the ring blooms as the head lands', async ({ page }) => {
+        await page.goto('/how-it-works');
+        await waitForStill(page);
+        const f = await figure(page);
+        await f.box.hover();
+        await expect
+            .poll(() => animationNames(page))
+            .toContain('hiw-ring-halo-loop');
+        const halo = f.box.locator('.hiw-ring-halo');
+        // stroke-opacity, never opacity: an opacity animation composites and
+        // grays the labels (see the .hiw-ring-halo note in globals.css).
+        const bloom = () =>
+            halo.evaluate((el) => Number(getComputedStyle(el).strokeOpacity));
+        await seekAll(page, LOOP_DELAY + TRAVEL * 0.5);
+        expect(await bloom()).toBe(0);
+        // The head reaches THEM at 86% of the sweep; the bloom peaks there.
+        await seekAll(page, LOOP_DELAY + TRAVEL * 0.86);
+        expect(await bloom()).toBeGreaterThan(0.3);
+        await seekAll(page, LOOP_DELAY + TRAVEL * 0.86 + 700);
+        expect(await bloom()).toBe(0);
+    });
+
+    test('the light waits for the map: the pointer is ignored until the finale has played', async ({
+        page,
+    }) => {
+        await freezeOnPaint(page);
+        const f = await figure(page);
+        const pointerEvents = () =>
+            f.box.evaluate((el) => getComputedStyle(el).pointerEvents);
+        // Mid draw-in: the box does not take the pointer, so a pointer parked
+        // on it hovers nothing and the line carries no light. mouse.move, not
+        // locator.hover, which waits for the box to become hit-testable.
+        const box = (await f.box.boundingBox())!;
+        await seekAll(page, 1200);
+        expect(await pointerEvents()).toBe('none');
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.waitForTimeout(200);
+        expect(await f.box.evaluate((el) => el.matches(':hover'))).toBe(false);
+        expect(await animationNames(page)).not.toContain('hiw-comet-loop');
+        expect((await head(page, f)).maxL).toBeLessThan(HEAD_LUMINANCE);
+        // Mid finale: still ignored, and the once-only light is the one on the
+        // line, a third of the way across.
+        await seekAll(page, 3100);
+        expect(await pointerEvents()).toBe('none');
+        expect(await animationNames(page)).not.toContain('hiw-comet-loop');
+        const h = await head(page, f);
+        expect(h.maxL).toBeGreaterThan(HEAD_LUMINANCE);
+        expect(h.maxX).toBeGreaterThan(
+            (f.youX + 0.2 * (f.themX - f.youX)) * f.scale
+        );
+        expect(h.maxX).toBeLessThan(
+            (f.youX + 0.5 * (f.themX - f.youX)) * f.scale
+        );
+        // After the finale the box arms itself; the next pointer move starts the
+        // loop fresh from YOU.
+        await seekAll(page, 4400);
+        expect(await pointerEvents()).toBe('auto');
+        await page.mouse.move(
+            box.x + box.width / 2 + 1,
+            box.y + box.height / 2
+        );
+        await expect
+            .poll(() => animationNames(page))
+            .toContain('hiw-comet-loop');
+    });
+
+    test('reduced motion: no crossing, no loop, the finished drawing', async ({
+        page,
+    }) => {
+        await page.emulateMedia({ reducedMotion: 'reduce' });
+        await page.goto('/how-it-works');
+        const f = await figure(page);
+        expect(await animationNames(page)).toEqual([]);
+        await f.box.hover();
+        await page.waitForTimeout(200);
+        expect(await animationNames(page)).toEqual([]);
+        expect((await head(page, f)).maxL).toBeLessThan(HEAD_LUMINANCE);
+    });
+
+    test('forced colors: the light takes the system highlight color', async ({
+        page,
+    }) => {
+        await page.emulateMedia({ forcedColors: 'active' });
+        await page.goto('/how-it-works');
+        const f = await figure(page);
+        const [stroke, highlight, canvasText, haloStroke] =
+            await f.box.evaluate((el) => {
+                const probe = document.createElement('span');
+                probe.style.color = 'Highlight';
+                document.body.append(probe);
+                const highlight = getComputedStyle(probe).color;
+                probe.style.color = 'CanvasText';
+                const canvasText = getComputedStyle(probe).color;
+                probe.remove();
+                return [
+                    getComputedStyle(el.querySelector('.hiw-comet-core')!)
+                        .stroke,
+                    highlight,
+                    canvasText,
+                    getComputedStyle(el.querySelector('.hiw-ring-halo')!)
+                        .stroke,
+                ];
+            });
+        expect(stroke).toBe(highlight);
+        expect(haloStroke).toBe(canvasText);
+    });
+});
+
+test.describe('narrow variant at its largest scale', () => {
+    // 640 wide: the phone drawing at its 480px cap, scale 1.333, the exact
+    // scale at which a non-scaling dash once stopped 98.8px short of THEM.
+    test.use({ viewport: { width: 640, height: 900 } });
+
+    test('the head reaches THEM', async ({ page }) => {
+        await page.goto('/how-it-works');
+        await waitForStill(page);
+        const f = await figure(page);
+        expect(f.scale).toBeGreaterThan(1.3);
+        await f.box.hover();
+        await expect
+            .poll(() => animationNames(page))
+            .toContain('hiw-comet-loop');
+        // Just before the head lands: it must be in the last tenth of the line.
+        await seekAll(page, LOOP_DELAY + TRAVEL * 0.8);
+        const h = await head(page, f);
+        expect(h.maxL).toBeGreaterThan(HEAD_LUMINANCE);
+        expect(h.maxX).toBeGreaterThan(
+            (f.youX + 0.85 * (f.themX - f.youX)) * f.scale
+        );
+        expect(h.maxX).toBeLessThanOrEqual(f.themX * f.scale + 2);
+    });
+});
+
+test.describe('touch', () => {
+    test.use({
+        viewport: { width: 390, height: 844 },
+        hasTouch: true,
+        isMobile: true,
+    });
+
+    test('the crossing plays once on paint and a tap starts nothing', async ({
+        page,
+    }) => {
+        await page.goto('/how-it-works');
+        // The precondition, or the test passes vacuously on a desktop context.
+        expect(
+            await page.evaluate(() => matchMedia('(hover: none)').matches)
+        ).toBe(true);
+        await waitForStill(page);
+        const f = await figure(page);
+        // The once-only crossing is scheduled for touch readers too: read from
+        // the computed style, which outlives the animation, not from the live
+        // list, which a slow load would have emptied already.
+        expect(
+            await f.box
+                .locator('.hiw-comet-core')
+                .evaluate((el) => getComputedStyle(el).animationName)
+        ).toBe('hiw-comet-once');
+        await f.box.tap();
+        await page.waitForTimeout(300);
+        expect(await animationNames(page)).toEqual([]);
+        expect((await head(page, f)).maxL).toBeLessThan(HEAD_LUMINANCE);
+    });
+});

--- a/client/lib/routeFigure.test.ts
+++ b/client/lib/routeFigure.test.ts
@@ -254,3 +254,235 @@ describe('the draw-in dash survives the figure being scaled up', () => {
         expect(from).toBe(dash);
     });
 });
+
+// The light that crosses the direct line once on paint, and the hover loop that
+// replays it. The specs that look at this figure force reduced motion
+// (hydration.spec.ts opens the route without looking at it), and
+// e2e/route-figure-light.spec.ts is the one that watches the motion, so the CSS
+// is also pinned here as text, the way the dash headroom above is. Each block
+// guards a decision the .hiw-comet comment in globals.css records; the numbers
+// are read from the file, not repeated here.
+describe('the light on the direct line', () => {
+    const css = readFileSync(new URL('../app/globals.css', import.meta.url), 'utf8');
+    const component = readFileSync(new URL('../components/how-it-works/RouteFigure.tsx', import.meta.url), 'utf8');
+    const page = readFileSync(new URL('../app/how-it-works/page.tsx', import.meta.url), 'utf8');
+    const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // The body of the FIRST rule block with exactly this selector.
+    const block = (selector: string) => {
+        const m = css.match(new RegExp('(?:^|\\n)\\s*' + escape(selector) + '\\s*\\{([^}]*)\\}'));
+        expect(m, selector).not.toBeNull();
+        return m![1];
+    };
+    // The body of a media block: from its query to the closing brace at column 0.
+    const media = (query: string) => {
+        const m = css.match(new RegExp('\\n@media ' + escape(query) + '\\s*\\{([\\s\\S]*?)\\n\\}'));
+        expect(m, query).not.toBeNull();
+        return m![1];
+    };
+    const HOVER_QUERY = '(prefers-reduced-motion: no-preference) and (hover: hover) and (pointer: fine)';
+
+    it('draws the light as three dashed copies of the direct line, under the ring, with no ids', () => {
+        const light = component.indexOf('className="hiw-light"');
+        const ring = component.indexOf('className="hiw-ring"');
+        expect(light).toBeGreaterThan(-1);
+        // Under the ring, or its zinc-950 fill could not swallow the head at THEM.
+        expect(light).toBeLessThan(ring);
+        for (const layer of ['halo', 'tail', 'core']) {
+            expect(component).toContain(`className="hiw-comet hiw-comet-${layer}" pathLength={1000} d={g.direct}`);
+        }
+        expect(component).toContain('className="hiw-ring-halo"');
+        // Both variants share the DOM and url(#id) resolves to the first, so
+        // nothing in the figure may carry an id.
+        expect(component).not.toMatch(/\bid=/);
+    });
+
+    it('stays a Server Component: no client directive, no handlers, no hooks', () => {
+        for (const src of [component, page]) {
+            expect(src).not.toMatch(/['"]use client['"]/);
+            expect(src).not.toMatch(/\bon[A-Z]\w+=\{/);
+            expect(src).not.toMatch(/\buse(?:State|Effect|Ref|Id|LayoutEffect)\(/);
+        }
+    });
+
+    it('lets the comet dashes scale with the path, so the head arrives at every scale', () => {
+        // Under non-scaling-stroke every engine lays dashes out in screen space
+        // and a moving dash stops short of THEM above scale 1.
+        expect(block('.hiw-fig .hiw-comet')).toMatch(/vector-effect:\s*none/);
+    });
+
+    it('keeps the caps butt, so the zero-length lead dash never renders as a dot', () => {
+        expect(block('.hiw-fig .hiw-comet')).toMatch(/stroke-linecap:\s*butt/);
+        // The figure's shared base rule must not hand the comet a cap either.
+        const shared = css.match(/\.hiw-fig path,\s*\.hiw-fig line,\s*\.hiw-fig circle\s*\{([^}]*)\}/);
+        expect(shared, 'the shared base rule').not.toBeNull();
+        expect(shared![1]).not.toMatch(/stroke-linecap/);
+    });
+
+    it('ends every layer dash at one pattern position and sweeps that pattern clear of both ends', () => {
+        const rest = Number(block('.hiw-fig .hiw-comet').match(/stroke-dashoffset:\s*(-?\d+)/)![1]);
+        const ends = new Set<number>();
+        for (const layer of ['halo', 'tail', 'core']) {
+            const arr = block(`.hiw-fig .hiw-comet-${layer}`)
+                .match(/stroke-dasharray:\s*([\d. ]+)/)![1]
+                .trim()
+                .split(/\s+/)
+                .map(Number);
+            expect(arr.length % 2, `${layer} pattern is dash/gap pairs`).toBe(0);
+            const gap = arr.at(-1)!;
+            const end = arr.slice(0, -1).reduce((a, b) => a + b, 0);
+            ends.add(end);
+            // The next copy of the pattern must stay off the path for the whole
+            // sweep, whose offset never drops below -(1000 + 4).
+            expect(gap, `${layer} gap`).toBeGreaterThanOrEqual(1004);
+        }
+        expect(ends.size, 'all three heads travel together').toBe(1);
+        const P = [...ends][0];
+        // Parked one pattern length before YOU, plus 4 of slack so the head's
+        // butt end clears the device tick (see the .hiw-comet note).
+        expect(rest).toBe(P + 4);
+        const once = css.match(
+            /@keyframes hiw-comet-once\s*\{\s*from\s*\{\s*stroke-dashoffset:\s*(-?\d+)[^}]*\}\s*to\s*\{\s*stroke-dashoffset:\s*(-?\d+)/
+        )!;
+        expect(Number(once[1])).toBe(rest);
+        expect(Number(once[2])).toBe(-1004);
+        const loop = css.match(
+            /@keyframes hiw-comet-loop\s*\{\s*0%\s*\{\s*stroke-dashoffset:\s*(-?\d+)[^}]*\}\s*([\d.]+)%,\s*100%\s*\{\s*stroke-dashoffset:\s*(-?\d+)/
+        )!;
+        expect(Number(loop[1])).toBe(rest);
+        expect(Number(loop[3])).toBe(-1004);
+
+        // The bloom is timed off the head's landing, which the sweep fixes at
+        // (rest + 1000 - P) / (rest + 1004) of the travel; the durations are read
+        // from the shorthands so a retuned sweep drags the bloom with it or fails.
+        const arrival = (rest + 1000 - P) / (rest + 1004);
+        const base = media('(prefers-reduced-motion: no-preference)');
+        const onceMs = Number(base.match(/hiw-comet-once (\d+)ms/)![1]);
+        const haloOnceMs = Number(base.match(/hiw-ring-halo-once (\d+)ms/)![1]);
+        const loopMs = Number(media(HOVER_QUERY).match(/hiw-comet-loop (\d+)ms/)![1]);
+        expect(Math.abs((Number(loop[2]) / 100) * loopMs - onceMs), 'the loop travels for the once duration').toBeLessThan(1);
+        const peak = (name: string) => {
+            const body = css.match(new RegExp('@keyframes ' + name + '\\s*\\{([\\s\\S]*?)\\n\\}'))![1];
+            const stops = [...body.matchAll(/([\d.]+)%\s*\{\s*stroke-opacity:\s*([\d.]+)/g)].map((m) => ({ at: Number(m[1]), v: Number(m[2]) }));
+            return stops.reduce((a, s) => (s.v > a.v ? s : a)).at;
+        };
+        expect(Math.abs(peak('hiw-ring-halo-once') - (arrival * onceMs * 100) / haloOnceMs)).toBeLessThan(0.5);
+        expect(Math.abs(peak('hiw-ring-halo-loop') - (arrival * onceMs * 100) / loopMs)).toBeLessThan(0.5);
+    });
+
+    it('keeps the base rules as the finished drawing: no animation outside the motion blocks', () => {
+        for (const sel of ['.hiw-fig .hiw-comet', '.hiw-fig .hiw-comet-core', '.hiw-fig .hiw-comet-tail', '.hiw-fig .hiw-comet-halo', '.hiw-fig circle.hiw-ring-halo']) {
+            expect(block(sel), sel).not.toMatch(/animation/);
+        }
+        expect(block('.hiw-fig circle.hiw-ring-halo')).toMatch(/stroke-opacity:\s*0\b/);
+        // Every animation that names the light lives inside one of the two
+        // motion queries, wherever in the file it was written: a stray base rule
+        // appended later would animate under reduced motion and block() alone,
+        // which sees only the first rule per selector, would never notice.
+        const spans = ['(prefers-reduced-motion: no-preference)', HOVER_QUERY].map((q) => {
+            const m = css.match(new RegExp('\\n@media ' + escape(q) + '\\s*\\{[\\s\\S]*?\\n\\}'))!;
+            return [m.index!, m.index! + m[0].length];
+        });
+        for (const m of css.matchAll(/animation:\s*[^;]*hiw-(?:comet|ring-halo|arm)[^;]*;/g)) {
+            expect(spans.some(([a, b]) => m.index! > a && m.index! < b), m[0]).toBe(true);
+        }
+        // Unlayered, like the rest of the figure's CSS, so the Tailwind cascade
+        // can never outrank the reduced-motion gate.
+        expect(css.lastIndexOf('@layer')).toBeLessThan(css.indexOf('.hiw-fig svg'));
+    });
+
+    it('plays the crossing once after the map is complete, from the reduced-motion gate', () => {
+        const body = media('(prefers-reduced-motion: no-preference)');
+        const once = body.match(/\.hiw-comet\s*\{\s*animation:\s*([^;]+);/)![1].replace(/\s+/g, ' ');
+        expect(once).toMatch(/^hiw-comet-once \d+ms linear (\d+)ms backwards$/);
+        const start = Number(once.match(/linear (\d+)ms/)![1]);
+        // After the last beat of the draw-in (the detour's fade, 1850 + 600).
+        const detour = body.match(/\.hiw-detour,\s*\.hiw-relay-tick\s*\{\s*animation:\s*hiw-fade (\d+)ms ease (\d+)ms/)!;
+        expect(start).toBeGreaterThanOrEqual(Number(detour[1]) + Number(detour[2]));
+        expect(body).toMatch(/\.hiw-fig circle\.hiw-ring-halo\s*\{\s*animation:\s*hiw-ring-halo-once/);
+    });
+
+    it('gates the hover loop on motion, hover and a fine pointer, in one query', () => {
+        const body = media(HOVER_QUERY);
+        expect(body).toMatch(/\.hiw-box:hover \.hiw-comet\s*\{/);
+        expect(body).toMatch(/\.hiw-box:hover circle\.hiw-ring-halo\s*\{/);
+        // No hover rule anywhere else in the file (a selector starts its line;
+        // the comments that mention the hover do not count).
+        const rules = (s: string) => (s.match(/^\s*\.hiw-box:hover/gm) ?? []).length;
+        expect(rules(css)).toBe(rules(body));
+        // And the hover block touches only the light and the box's own arming:
+        // never the draw-in's classes, whose animation shorthand it would
+        // otherwise replace.
+        const selectors = [...body.matchAll(/^\s*([^{}\n]+?)\s*\{/gm)].map((m) => m[1].trim());
+        expect(selectors.length).toBeGreaterThanOrEqual(3);
+        for (const s of selectors) expect(s).toMatch(/^(?:\.hiw-box|\.hiw-box:hover (?:\.hiw-comet|circle\.hiw-ring-halo))$/);
+    });
+
+    it('ignores the pointer until the finale has played', () => {
+        // Two animations of one property on one element resolve to the later
+        // name, so a loop started during the draw-in would own the light and
+        // mask the finale; the box therefore ignores the pointer until the
+        // crossing has ended.
+        const hover = media(HOVER_QUERY);
+        const arm = hover.match(/\.hiw-box\s*\{\s*animation:\s*hiw-arm 1ms linear (\d+)ms backwards;/)!;
+        expect(arm, 'the box arms itself with hiw-arm').not.toBeNull();
+        const base = media('(prefers-reduced-motion: no-preference)');
+        const once = base.match(/hiw-comet-once (\d+)ms linear (\d+)ms/)!;
+        expect(Number(arm[1])).toBeGreaterThanOrEqual(Number(once[1]) + Number(once[2]));
+        const frames = css.match(/@keyframes hiw-arm\s*\{([\s\S]*?)\n\}/)![1];
+        expect(frames).toMatch(/from\s*\{\s*pointer-events:\s*none/);
+        expect(frames).toMatch(/to\s*\{\s*pointer-events:\s*auto/);
+    });
+
+    it('appends the loop to the once-only list instead of replacing it', () => {
+        // css-animations matches animations by name across a list change, so the
+        // finished once-only entry survives hover-in and hover-out untouched and
+        // can never replay with its delay when the pointer leaves.
+        const base = media('(prefers-reduced-motion: no-preference)');
+        const hover = media(HOVER_QUERY);
+        const norm = (s: string) => s.replace(/\s+/g, ' ').trim();
+        const baseComet = norm(base.match(/\.hiw-comet\s*\{\s*animation:\s*([^;]+);/)![1]);
+        const hoverComet = norm(hover.match(/\.hiw-box:hover \.hiw-comet\s*\{\s*animation:\s*([^;]+);/)![1]);
+        expect(hoverComet.startsWith(baseComet + ', hiw-comet-loop ')).toBe(true);
+        expect(hoverComet).toMatch(/hiw-comet-loop \d+ms linear \d+ms infinite$/);
+        const baseHalo = norm(base.match(/circle\.hiw-ring-halo\s*\{\s*animation:\s*([^;]+);/)![1]);
+        const hoverHalo = norm(hover.match(/\.hiw-box:hover circle\.hiw-ring-halo\s*\{\s*animation:\s*([^;]+);/)![1]);
+        expect(hoverHalo.startsWith(baseHalo + ', hiw-ring-halo-loop ')).toBe(true);
+    });
+
+    it('animates only stroke-dashoffset, stroke-opacity and pointer-events, and never fills forwards', () => {
+        // Not opacity: an opacity animation is composited even on an SVG child,
+        // and its layer dragged the ring and the 11px labels into an overlap
+        // layer that grayed the labels. Not stroke: a literal color in a
+        // keyframe overrides the user's colors under forced-colors.
+        for (const name of ['hiw-arm', 'hiw-comet-once', 'hiw-comet-loop', 'hiw-ring-halo-once', 'hiw-ring-halo-loop']) {
+            const body = css.match(new RegExp('@keyframes ' + name + '\\s*\\{([\\s\\S]*?)\\n\\}'))!;
+            expect(body, name).not.toBeNull();
+            const props = [...body[1].matchAll(/([a-z-]+)\s*:/g)].map((m) => m[1]);
+            expect(props.length, name).toBeGreaterThan(0);
+            for (const p of props) expect(['stroke-dashoffset', 'stroke-opacity', 'pointer-events'], `${name} animates ${p}`).toContain(p);
+        }
+        // `both` pins a composited layer and grays the labels; `forwards` would
+        // hold the light past its window.
+        for (const m of css.matchAll(/animation:\s*([^;]*hiw-(?:comet|ring-halo|arm)[^;]*);/g)) {
+            expect(m[1]).not.toMatch(/\b(?:both|forwards)\b/);
+        }
+    });
+
+    it('maps the light to the system palette under forced colors', () => {
+        const body = media('(forced-colors: active)');
+        expect(body).toMatch(/\.hiw-fig \.hiw-comet\s*\{\s*stroke:\s*Highlight/);
+        expect(body).toMatch(/\.hiw-fig circle\.hiw-ring-halo\s*\{\s*stroke:\s*CanvasText/);
+        expect(body).toMatch(/\.hiw-fig circle\.hiw-ring\s*\{\s*fill:\s*Canvas/);
+        // The core's own color is beaten only by source order at equal
+        // specificity, so the forced rule must come later and the core must not
+        // gain a type selector.
+        expect(css.indexOf('.hiw-fig .hiw-comet-core {')).toBeLessThan(css.indexOf('stroke: Highlight'));
+        expect(css).not.toMatch(/path\.hiw-comet/);
+    });
+
+    it('keeps the caption true of what is drawn', () => {
+        expect(component).toMatch(/then steps aside,\s*carrying no file data itself/);
+        expect(component).toMatch(/carries no size limit/);
+        expect(component).toMatch(/capped at \{RELAY_CAP\} per session/);
+    });
+});

--- a/client/lib/routeFigure.ts
+++ b/client/lib/routeFigure.ts
@@ -153,7 +153,9 @@ export function routeGeometry(width: number): RouteGeometry {
     // read as a stroke that had failed to render. The arch is continuous now,
     // and the distinction is carried by weight, color and order instead. The
     // ice line is the only bright stroke on the page, the spurs are the
-    // dimmest, and they thaw from ice to zinc as the ice line draws across.
+    // dimmest, and they thaw from a lit zinc to zinc-700 as the ice line draws
+    // across (never from ice: an ice arch would put the file through the
+    // server, see the hiw-thaw note in globals.css).
     //
     // The second control point holds the tangent horizontal at the end, so a
     // spur arrives flat and flush against the tick it joins.


### PR DESCRIPTION
## Summary

The route figure on `/how-it-works` was audited before anything was touched: every claim it makes holds against the code (the server forwards only offer/answer/ICE and never sees file bytes, the direct path is never metered, the cap is a sender-side once-only strictly-greater-than check, a relayed path is a complete second route, bytes flow sender to receiver only). Against the canonical WebRTC figures (RFC 8825, web.dev, MDN, Tailscale) it is the same "signaling up, media across" topology reduced to hairlines, and the only product figure in the field that draws the route at all. So the drawing stays.

Its one weakness was direction: statically only the ring on THEM says where the file ends up, and the ice line's visible draw-in is about 128ms, a cut rather than a travel. This PR adds the one thing that was missing.

**A light crosses the direct line from YOU to THEM.** It plays once as the finale of the draw-in, after the relay has faded in, so the map is complete before the transfer is shown. On a device with a fine pointer, hovering the drawing after that replays it in a slow loop (1800ms of travel, 1600ms of rest) that stops the moment the pointer leaves. A 5-unit halo around the ring blooms as the head lands. Nothing ever moves on the arch (that would put the file through the signaling server) or on the detour (a transfer takes one route). Touch gets the once-on-paint crossing and nothing on tap; reduced motion gets the finished drawing with no light.

**Mechanism.** Three dashed copies of the direct line whose dashes all end at the same pattern position (a leading zero-length dash lets the shorter two start with a gap), swept by one `stroke-dashoffset` animation, so a bright head, a fading tail and a soft halo travel as one object. No filter, no fill, no ids, no client island, no compositing layer.

Five facts worth recording, each measured:

- **`vector-effect: none` on the comet layers, not the figure's `non-scaling-stroke`.** Every engine lays a non-scaling stroke's dashes out in screen space (Blink's `DashScaleFactor` is pathLength-only, Gecko skips the transform for stroking, and the SVG WG's 2018 minutes on w3c/svgwg#323, still open, read the spec as host space), so a moving dash would cover a fixed number of screen pixels and stop at 87% of the narrow line at its 1.333 cap. In user units the head always arrives; the price is a stroke that scales 0.7x to 1.33x with the figure, which a glow can afford.
- **Butt caps, declared.** A zero-length dash under a round cap renders as a dot of the stroke's width, and at the narrow variant's scale that dot rode along at the tail's start, brighter than the head.
- **The arrival bloom animates `stroke-opacity`, never `opacity`.** Chromium composites an opacity animation even on an SVG child, and that layer pulled the ring and the five 11px labels into an overlap layer that dropped them to grayscale antialiasing for every hover and for the last 2.2s of every page load (CDP LayerTree, headed Chromium with ClearType). `stroke-opacity` is a paint property; the LayerTree now shows no figure-owned layer at rest, during the loop, or after leaving.
- **The box ignores the pointer until the finale has played** (`hiw-arm`, a discrete `pointer-events` keyframe with a 4300ms delay, inside the hover query). Two animations of one property on one element resolve to the later name, so a loop started during the draw-in owned the light's offset: measured, a pointer arriving at 1s put the loop's head at 82% of the line the moment the light group appeared and the finale never showed. With the pointer ignored until 4300ms the loop cannot exist before the finale ends, and the first hover after that starts it fresh from YOU on the next pointer move. The hover rule also appends the loop to the once-only animation list rather than replacing it, so the finished finale never replays on hover-out.
- **Tail and halo are tuned against the line, not against black.** Ice at any opacity over the full-opacity ice line is a no-op, so the tail takes the head's color at 0.35 (line steps 245, about 224, 213: a real fade on the line), and the halo sits at 0.15 so its rows read under the spur arch it passes beneath rather than over it.

**Also in here.** The relay detour lifts from zinc-600 with a `1 5` dot to zinc-500 with `1 4`: at DPR 1 the path that carries the 2 GB rule left about a sixth of a hairline's ink and all but vanished on a desktop. The ring's knockout fill maps to `Canvas` under forced colors (it was a black disc on a light high-contrast theme, pre-existing). The sr-only figcaption says the server "steps aside" (it keeps the socket open and relays a peer-disconnected notice, so "takes no further part" was too strong; the privacy page already uses "steps aside") and no longer reads as two spurs per device. Two stale comments that said the spurs draw "in ice" are corrected; they draw in zinc-400 since #426, on purpose.

Timing of the finale, once, no loop: draw-in as before to 2450ms, light 2500 to 4300ms, bloom peaks at 4048ms and fades by 4650ms.

## Test plan

- [x] `corepack pnpm test` 369 passing (13 new in `routeFigure.test.ts`: dash math, one-pattern-position heads, gap headroom, butt caps, media gating with all three features, the arm's delay against the finale's end, hover selectors touch only the light and the box, append semantics, every light animation inside a motion query wherever it sits in the file, keyframes animate only dashoffset / stroke-opacity / pointer-events, the bloom's peak tied to the head's arrival through the durations, no `both`/`forwards`, forced-colors rows and their cascade order, Server Component guard, no ids, figcaption wording)
- [x] `corepack pnpm lint` 0 errors, `tsc --noEmit` clean, `corepack pnpm build`, `node scripts/check-titles.mjs`; the built CSS chunk carries the hover block unlayered and inside its query, and the route's client-reference manifest lists only the pre-existing Navbar and service-worker modules
- [x] `playwright test e2e/responsive.spec.ts e2e/hydration.spec.ts` 12/12
- [x] New `e2e/route-figure-light.spec.ts` 7/7: hover runs exactly the comet animations on SVG children, the head moves left to right on the baseline rows and never on the apex row, the ring blooms at the head's arrival, hover-out stops it, the box ignores the pointer during the draw-in and the finale and takes it after, reduced motion has zero animations, forced colors map the light to Highlight, the narrow variant at scale 1.333 reaches THEM, touch plays the finale and a tap starts nothing. A test either waits for every animation to end or pauses them all on first paint, then seeks; nothing reads a wall clock. Also green under WebKit and Firefox locally (local-only config, not committed).
- [x] Screenshot matrix (reduced motion, 90 captures, 0 flagged): the base drawing is unchanged apart from the detour lift
- [x] QA fleet of six lenses (CDP cost and LayerTree, accessibility and modes in three engines, code review, design critique, built CSS, hover edge cases), each defect measured and fixed or recorded; pixel sweep of the light at 1100/767/390/320px wide at 1x and 2x
- [x] No docs change (the figure's copy is unchanged apart from the sr-only caption; docs-check baseline unchanged), no changelog entry (written per tag), no CLI or desktop tag implied
