### PR TITLE
fix(client): stop ingesting in-app-browser and injected-script noise

### DIFF
--- a/client/lib/browserExtensions.pipeline.test.ts
+++ b/client/lib/browserExtensions.pipeline.test.ts
@@ -5,10 +5,11 @@ import { BROWSER_EXTENSION_URL_PATTERNS } from './browserExtensions';
 
 // Proves the FLOE-E fix against the REAL @sentry/core filter rather than a
 // reimplementation of it. sentry.client.config.ts cannot be imported here: it
-// calls Sentry.replayIntegration() at module scope, and in a node test
-// '@sentry/nextjs' resolves to build/cjs/index.server.js where that export does
-// not exist. So we drive the same integration the SDK installs, with the same
-// denyUrls value the config passes it.
+// calls Sentry.init() at module scope, so importing it would configure the SDK
+// as a side effect of running the suite. So we drive the same integration the
+// SDK installs, with the same denyUrls value the config passes it.
+// (This comment used to blame Sentry.replayIntegration(). Replay was removed in
+// #242 and is now banned outright, see sentry.client.config.ts.)
 
 // --- Types -----------------------------------------------------------------
 // '@sentry/nextjs' re-exports Event/EventHint/ErrorEvent/Exception/StackFrame

--- a/client/lib/ignoredErrors.pipeline.test.ts
+++ b/client/lib/ignoredErrors.pipeline.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { eventFiltersIntegration } from '@sentry/nextjs';
+import type { ErrorEvent, Event, EventHint, Exception } from '@sentry/nextjs';
+import { IGNORED_ERROR_PATTERNS } from './ignoredErrors';
+import { BROWSER_EXTENSION_URL_PATTERNS } from './browserExtensions';
+
+// Proves the FLOE-H fix against the REAL @sentry/core filter rather than a
+// reimplementation of it. sentry.client.config.ts cannot be imported here: it
+// calls Sentry.init() at module scope. So we drive the same integration the SDK
+// installs, with the same ignoreErrors value the config passes it.
+//
+// The harness below is deliberately duplicated from
+// browserExtensions.pipeline.test.ts rather than extracted into a shared kit.
+// The two files test opposite halves of EventFilters, one message extraction
+// and one frame ordering, and coupling them would make each harder to change.
+
+// --- Types -----------------------------------------------------------------
+type ProcessEventFn = NonNullable<ReturnType<typeof eventFiltersIntegration>['processEvent']>;
+type ProcessEventResult = ReturnType<ProcessEventFn>;
+type SentryClientArg = Parameters<ProcessEventFn>[2];
+
+// EventFilters only ever calls client.getOptions() (_mergeOptions in
+// @sentry/core/integrations/eventFilters.js), so a one-method stub is faithful.
+type ClientStub = { getOptions: () => Record<string, unknown> };
+const CLIENT_STUB: ClientStub = { getOptions: () => ({}) };
+const CLIENT = CLIENT_STUB as unknown as SentryClientArg;
+
+// EventFilters names this parameter `_hint` and never reads it.
+const EMPTY_HINT: EventHint = {};
+
+function assertSync(result: ProcessEventResult | undefined): Event | null {
+    if (result === undefined) throw new Error('integration exposed no processEvent hook');
+    if (result !== null && 'then' in result) throw new Error('expected a synchronous integration');
+    return result;
+}
+
+// A FRESH integration instance per call, on purpose: EventFilters memoizes its
+// merged options on first use, so one shared instance would make the "no
+// ignoreErrors" case reuse the "with ignoreErrors" options and pass for free.
+function runEventFilters(
+    event: Event,
+    options: { ignoreErrors?: (string | RegExp)[]; denyUrls?: RegExp[] } = {}
+): Event | null {
+    const integration = eventFiltersIntegration(options);
+    return assertSync(integration.processEvent?.(event, EMPTY_HINT, CLIENT));
+}
+
+// --- Fixtures --------------------------------------------------------------
+
+// FLOE-H as Sentry received it. Every filename is ALREADY app://, the injected
+// logger's included: @sentry/nextjs rewrote them before the event was stored.
+// That is not incidental, it is the reason this fix cannot be a denyUrls entry.
+// Frames are oldest-first, the reverse of the issue page's display order.
+const FB_LOGGER = 'app://navigation_performance_logger_android';
+const FLOE_CHUNK = 'app:///_next/static/immutable/chunks/01etqiofowxq2.js';
+const FLOE_H_VALUE = 'Error invoking postMessage: Java object is gone';
+
+function makeFloeHEvent(value: string = FLOE_H_VALUE): ErrorEvent {
+    const values: Exception[] = [
+        {
+            type: 'Error',
+            value,
+            mechanism: { type: 'auto.browser.browserapierrors.addEventListener', handled: false },
+            stacktrace: {
+                frames: [
+                    { filename: FLOE_CHUNK, function: 'n', lineno: 32, colno: 1785, in_app: true },
+                    { filename: FB_LOGGER, lineno: 1, colno: 18239, in_app: true },
+                    { filename: FB_LOGGER, function: 'sendINPMessage', lineno: 1, colno: 13829, in_app: true },
+                    {
+                        filename: FB_LOGGER,
+                        function: 'sendDataToNative',
+                        lineno: 1,
+                        colno: 10198,
+                        in_app: true,
+                    },
+                ],
+            },
+        },
+    ];
+    return { type: undefined, level: 'error', platform: 'javascript', exception: { values } };
+}
+
+// FLOE-G, the NumberFlow commit-phase crash. The regression guard.
+function makeFloeGEvent(): ErrorEvent {
+    const values: Exception[] = [
+        {
+            type: 'TypeError',
+            value: 'this.el?.willUpdate is not a function',
+            mechanism: { type: 'generic', handled: true },
+            stacktrace: {
+                frames: [
+                    {
+                        filename: FLOE_CHUNK,
+                        function: 'z.getSnapshotBeforeUpdate',
+                        lineno: 1,
+                        colno: 16024,
+                    },
+                ],
+            },
+        },
+    ];
+    return { type: undefined, level: 'error', platform: 'javascript', exception: { values } };
+}
+
+function makeChunkLoadEvent(): ErrorEvent {
+    const values: Exception[] = [
+        {
+            type: 'ChunkLoadError',
+            value: 'Loading chunk 493 failed.',
+            mechanism: { type: 'onunhandledrejection', handled: false },
+            stacktrace: {
+                frames: [{ filename: FLOE_CHUNK, function: 'loadChunk', lineno: 1, colno: 20 }],
+            },
+        },
+    ];
+    return { type: undefined, level: 'error', platform: 'javascript', exception: { values } };
+}
+
+describe('ignoreErrors in the Sentry event pipeline', () => {
+    it('drops the Facebook WebView bridge error (FLOE-H)', () => {
+        expect(runEventFilters(makeFloeHEvent(), { ignoreErrors: IGNORED_ERROR_PATTERNS })).toBeNull();
+    });
+
+    it('keeps the same event when ignoreErrors is absent (guards a false pass)', () => {
+        // Without this, the test above could pass for a reason unrelated to the
+        // fix. DEFAULT_IGNORE_ERRORS is merged in unconditionally and carries
+        // /^Java exception was raised during method invocation$/, close enough
+        // in wording to be worth ruling out and anchored so it cannot match.
+        // _isUselessError cannot drop it either: it has both a stacktrace and a
+        // value. It must be OUR entry that drops FLOE-H.
+        expect(runEventFilters(makeFloeHEvent())).not.toBeNull();
+    });
+
+    it('is not something denyUrls could have done', () => {
+        // The executable reason this fix is not FLOE-E's fix. Every frame Sentry
+        // stored is already app://, the injected logger's included, so
+        // _getLastValidUrl hands BROWSER_EXTENSION_URL_PATTERNS a string none of
+        // them match, by design: browserExtensions.test.ts asserts that no
+        // pattern may match an app:// prefix.
+        expect(
+            runEventFilters(makeFloeHEvent(), { denyUrls: BROWSER_EXTENSION_URL_PATTERNS })
+        ).not.toBeNull();
+    });
+
+    it('drops on the top-level message alone, with no exception', () => {
+        // getPossibleEventMessages' first candidate, for the SDK paths that
+        // produce a message-only event.
+        const event: Event = { type: undefined, level: 'error', message: FLOE_H_VALUE };
+        expect(runEventFilters(event, { ignoreErrors: IGNORED_ERROR_PATTERNS })).toBeNull();
+    });
+
+    it('only ever tests the LAST exception value', () => {
+        // The sharp edge lib/ignoredErrors.ts warns about, made executable: a
+        // LinkedErrors cause appended after the matching value takes its place
+        // as the tested one, and the entry stops firing.
+        const event = makeFloeHEvent();
+        event.exception?.values?.push({
+            type: 'Error',
+            value: 'some chained cause',
+            mechanism: { type: 'chained', handled: false, parent_id: 0 },
+        });
+        expect(runEventFilters(event, { ignoreErrors: IGNORED_ERROR_PATTERNS })).not.toBeNull();
+    });
+
+    it('keeps a genuine Floe application error (FLOE-G)', () => {
+        expect(runEventFilters(makeFloeGEvent(), { ignoreErrors: IGNORED_ERROR_PATTERNS })).not.toBeNull();
+    });
+
+    it('keeps a stale-bundle error so beforeSend can still fingerprint it', () => {
+        expect(
+            runEventFilters(makeChunkLoadEvent(), { ignoreErrors: IGNORED_ERROR_PATTERNS })
+        ).not.toBeNull();
+    });
+});

--- a/client/lib/ignoredErrors.test.ts
+++ b/client/lib/ignoredErrors.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { IGNORED_ERROR_PATTERNS } from './ignoredErrors';
+
+// Replicates stringMatchesSomePattern/isMatchingPattern from @sentry/core for a
+// plain-string pattern: a case-sensitive substring test. The pipeline sibling
+// proves this replica against the real integration; this file is the cheap
+// per-entry sweep.
+const isIgnored = (message: string): boolean =>
+    IGNORED_ERROR_PATTERNS.some((pattern) =>
+        typeof pattern === 'string' ? message.includes(pattern) : pattern.test(message)
+    );
+
+// FLOE-H exactly as Sentry stored the exception value.
+const FLOE_H = 'Error invoking postMessage: Java object is gone';
+
+describe('IGNORED_ERROR_PATTERNS', () => {
+    it('matches the Facebook Android WebView bridge error (FLOE-H)', () => {
+        expect(isIgnored(FLOE_H)).toBe(true);
+    });
+
+    it('matches the "<type>: <value>" form Sentry also tests', () => {
+        // getPossibleEventMessages pushes `${type}: ${value}` as a third
+        // candidate alongside event.message and the bare value.
+        expect(isIgnored(`Error: ${FLOE_H}`)).toBe(true);
+    });
+
+    it('covers the bridge methods other than postMessage', () => {
+        // The entry deliberately matches the bridge's own words rather than
+        // "Error invoking postMessage", because the method name varies by host
+        // app while "Java object is gone" comes from Chromium itself.
+        expect(isIgnored('Error invoking onNavigation: Java object is gone')).toBe(true);
+    });
+
+    it('is a substring test, not an exact one', () => {
+        expect(isIgnored(`Uncaught (in promise) Error: ${FLOE_H} at x`)).toBe(true);
+    });
+
+    it('is case-sensitive, so an entry must keep its original casing', () => {
+        // isMatchingPattern uses String#includes for string patterns. Lowercase
+        // the entry later and the filter silently stops firing.
+        expect(isIgnored('error invoking postmessage: java object is gone')).toBe(false);
+    });
+
+    it('still matches every wording the config filtered before the extraction', () => {
+        expect(
+            isIgnored(
+                "Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node."
+            )
+        ).toBe(true);
+        expect(
+            isIgnored("Failed to execute 'insertBefore' on 'Node': parameter 1 is not of type 'Node'.")
+        ).toBe(true);
+        expect(isIgnored('Object Not Found Matching Id:3, MethodName:update, ParamCount:4')).toBe(true);
+        expect(isIgnored('Write permission denied.')).toBe(true);
+        expect(isIgnored('ResizeObserver loop completed with undelivered notifications.')).toBe(true);
+    });
+
+    it('never swallows a genuine Floe application error', () => {
+        expect(isIgnored("Cannot read properties of undefined (reading 'send')")).toBe(false);
+        expect(isIgnored('Failed to connect to MetaMask')).toBe(false);
+        // FLOE-G, the NumberFlow commit-phase crash that components/
+        // AnimatedByteCount.tsx contains. It must keep reaching Sentry: a
+        // filter that hides it from us is worse than the crash itself.
+        expect(isIgnored('this.el?.willUpdate is not a function')).toBe(false);
+    });
+
+    it('never swallows a stale-bundle error before beforeSend can fingerprint it', () => {
+        // EventFilters runs ahead of beforeSend, so anything matched here never
+        // reaches the stale-bundle branch in sentry.client.config.ts. Keep the
+        // wordings in lib/staleBundle.ts out of every entry.
+        for (const message of [
+            'Loading chunk 493 failed.',
+            'ChunkLoadError: Loading chunk app/page failed.',
+            'Failed to fetch dynamically imported module: https://www.floe.one/_next/static/chunks/x.js',
+            'Module 74891 was instantiated because it was required from module 88178, but the module factory is not available.',
+        ]) {
+            expect(isIgnored(message)).toBe(false);
+        }
+    });
+
+    it('carries only plain-string patterns today', () => {
+        // A future RegExp entry has to carry the no-g/no-y guard that
+        // browserExtensions.test.ts pins, because Sentry calls .test() on these
+        // same instances for every event and a sticky flag would advance
+        // lastIndex. This assertion is the reminder.
+        for (const pattern of IGNORED_ERROR_PATTERNS) {
+            expect(typeof pattern).toBe('string');
+        }
+    });
+});

--- a/client/lib/ignoredErrors.ts
+++ b/client/lib/ignoredErrors.ts
@@ -41,4 +41,22 @@ export const IGNORED_ERROR_PATTERNS: (string | RegExp)[] = [
     'Write permission denied',
     // Safari/iOS ResizeObserver noise
     'ResizeObserver loop',
+    // The Facebook in-app browser on Android runs the page inside a WebView
+    // whose JS-to-Java bridge is torn down before the page is. Its own injected
+    // navigation_performance_logger_android script then posts an INP report
+    // from a beforeunload listener, and the bridge answers "Error invoking
+    // postMessage: Java object is gone" (FLOE-H). Not our listener and not our
+    // code: nothing in this repo calls postMessage at all.
+    //
+    // denyUrls cannot reach it. @sentry/nextjs had already rewritten every
+    // frame, the injected script's included, to app://, and
+    // browserExtensions.test.ts deliberately asserts that no denyUrls pattern
+    // may match an app:// prefix. A message entry is the only lever left.
+    //
+    // Sentry ships the sibling wording /^Java exception was raised during
+    // method invocation$/ in DEFAULT_IGNORE_ERRORS, credited to the same
+    // Facebook mobile browser (sentry-javascript#15065); this one is simply not
+    // on that list yet. Matched on the bridge's own words rather than on
+    // "Error invoking postMessage", so it also covers the other bridge methods.
+    'Java object is gone',
 ];

--- a/client/lib/ignoredErrors.ts
+++ b/client/lib/ignoredErrors.ts
@@ -1,0 +1,44 @@
+/**
+ * Non-actionable error messages, fed to Sentry's `ignoreErrors`.
+ *
+ * Extracted from sentry.client.config.ts so it can be tested at all: that file
+ * calls Sentry.init() at module scope, so vitest cannot import it. Same reason
+ * browserExtensions.ts holds the denyUrls patterns rather than the config.
+ *
+ * EventFilters tests every entry against three strings per event, produced by
+ * getPossibleEventMessages in @sentry/core: the top-level `event.message`, the
+ * LAST exception value, and `"<type>: <value>"` for that same last value. A
+ * plain string entry is a case-sensitive SUBSTRING test (`value.includes(pattern)`
+ * in isMatchingPattern), so these are fragments rather than whole messages, and
+ * they have to keep the wording's original casing.
+ *
+ * Two properties are worth knowing before adding an entry:
+ *
+ *   - `ignoreErrors` is the FIRST check in _shouldDropEvent, ahead of
+ *     _isUselessError, ahead of _isDeniedUrl, and ahead of `beforeSend`
+ *     entirely. Anything matched here never reaches the stale-bundle
+ *     re-levelling in sentry.client.config.ts, so the chunk-load wordings in
+ *     lib/staleBundle.ts must never become a substring of an entry below.
+ *   - Unlike `denyUrls`, this is message-only: _isIgnoredError never reads a
+ *     stacktrace. So it is immune to the "app://" frame rewrite that forces
+ *     BROWSER_EXTENSION_URL_PATTERNS to run before
+ *     NextjsClientStackFrameNormalization (see lib/browserExtensions.ts).
+ *
+ * Only the LAST exception value is ever tested, so a LinkedErrors cause
+ * appended after the matching one would silently disable an entry.
+ */
+export const IGNORED_ERROR_PATTERNS: (string | RegExp)[] = [
+    // Browser extensions (Google Translate, Grammarly, ad blockers) modify the DOM
+    // directly, causing React's virtual DOM to desync. Not actionable.
+    "Failed to execute 'removeChild' on 'Node'",
+    "Failed to execute 'insertBefore' on 'Node'",
+    "The node to be removed is not a child of this node",
+    // Privacy/anti-fingerprint extensions bridge to native desktop software and
+    // reject a promise with a plain object when that bridge is not ready. Surfaces
+    // as "Object Not Found Matching Id:N, MethodName:..., ParamCount:N". Not our code.
+    'Object Not Found Matching Id',
+    // Clipboard blocked in restricted browsers (already handled with fallback)
+    'Write permission denied',
+    // Safari/iOS ResizeObserver noise
+    'ResizeObserver loop',
+];

--- a/client/lib/injectedScripts.test.ts
+++ b/client/lib/injectedScripts.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { isInjectedScriptError, type CheckableEvent } from './injectedScripts';
+
+const FLOE_CHUNK = 'app:///_next/static/chunks/354mhlwzyb0pq.js';
+
+// FLOE-F exactly as Sentry stored it. Frames are oldest-first, so Sentry's own
+// wrapped-setTimeout frame inside our bundle comes first and the injected
+// script that actually threw comes last.
+const floeF = (): CheckableEvent => ({
+    exception: {
+        values: [
+            {
+                mechanism: { },
+                stacktrace: {
+                    frames: [
+                        { filename: FLOE_CHUNK, lineno: 5 },
+                        { filename: '<anonymous>', lineno: 13 },
+                    ],
+                },
+            },
+        ],
+    },
+});
+
+describe('isInjectedScriptError', () => {
+    it('drops an error whose throwing frame is evaluated code (FLOE-F)', () => {
+        expect(isInjectedScriptError(floeF())).toBe(true);
+    });
+
+    it('keeps a positionless <anonymous> pseudo-frame', () => {
+        // V8 writes `at new Promise (<anonymous>)` with no source position, and
+        // that really can be the deepest frame of a genuine error: the fixture
+        // in browserExtensions.pipeline.test.ts is a real observed stack of
+        // exactly this shape. Without the lineno half of the test, this would
+        // silently discard our own promise bugs.
+        const event: CheckableEvent = {
+            exception: {
+                values: [
+                    {
+                        stacktrace: {
+                            frames: [
+                                { filename: FLOE_CHUNK, lineno: 1 },
+                                { filename: '<anonymous>' },
+                            ],
+                        },
+                    },
+                ],
+            },
+        };
+        expect(isInjectedScriptError(event)).toBe(false);
+    });
+
+    it('keeps a genuine Floe application error', () => {
+        const event: CheckableEvent = {
+            exception: {
+                values: [
+                    {
+                        stacktrace: {
+                            frames: [
+                                { filename: FLOE_CHUNK, lineno: 1 },
+                                { filename: FLOE_CHUNK, lineno: 4 },
+                            ],
+                        },
+                    },
+                ],
+            },
+        };
+        expect(isInjectedScriptError(event)).toBe(false);
+    });
+
+    it('reads the root exception, not a linked cause', () => {
+        // LinkedErrors appends causes with mechanism.parent_id set. The root is
+        // the last value WITHOUT one, matching _getEventFilterUrl. A cause
+        // whose own deepest frame is ours must not rescue an injected error.
+        const event = floeF();
+        event.exception!.values!.push({
+            mechanism: { parent_id: 0 },
+            stacktrace: { frames: [{ filename: FLOE_CHUNK, lineno: 9 }] },
+        });
+        expect(isInjectedScriptError(event)).toBe(true);
+    });
+
+    it('keeps events it cannot classify', () => {
+        expect(isInjectedScriptError({})).toBe(false);
+        expect(isInjectedScriptError({ exception: { values: [] } })).toBe(false);
+        expect(isInjectedScriptError({ exception: { values: [{}] } })).toBe(false);
+        expect(isInjectedScriptError({ exception: { values: [{ stacktrace: { frames: [] } }] } })).toBe(
+            false
+        );
+    });
+
+    it('ignores an <anonymous> frame that is not the one that threw', () => {
+        // Only the deepest frame decides. An injected script somewhere up the
+        // stack, with our code below it, is our bug.
+        const event: CheckableEvent = {
+            exception: {
+                values: [
+                    {
+                        stacktrace: {
+                            frames: [
+                                { filename: '<anonymous>', lineno: 13 },
+                                { filename: FLOE_CHUNK, lineno: 4 },
+                            ],
+                        },
+                    },
+                ],
+            },
+        };
+        expect(isInjectedScriptError(event)).toBe(false);
+    });
+});

--- a/client/lib/injectedScripts.ts
+++ b/client/lib/injectedScripts.ts
@@ -1,0 +1,65 @@
+/**
+ * Errors thrown by code that was evaluated from a string.
+ *
+ * A browser extension's content script can schedule work on our page, and when
+ * that work throws, Sentry's browserApiErrors integration reports it as ours:
+ * the wrapper it installs around setTimeout and addEventListener lives inside
+ * our own bundle, so the event carries an app:///_next/... frame and looks
+ * first-party. FLOE-F is exactly that, eight events of
+ *
+ *   TypeError: Cannot read properties of null (reading 'querySelector')
+ *     app:///_next/static/chunks/354mhlwzyb0pq.js:5:1818 (n)   <- Sentry's wrapper
+ *     <anonymous>:13:28                                        <- the actual throw
+ *
+ * Neither existing filter can see it. The message is far too generic for
+ * ignoreErrors: our own code could legitimately produce that wording one day,
+ * and hiding it would be worse than the noise. And denyUrls is structurally
+ * blind here, because _getLastValidUrl in @sentry/core skips <anonymous> and
+ * [native code] frames on purpose and falls back to the previous one, which is
+ * our chunk. That is the gap the FLOE-E fix (lib/browserExtensions.ts) left.
+ *
+ * So this matches on the shape instead: the frame that actually threw is
+ * <anonymous>, meaning eval, new Function, or a script injected with no
+ * sourceURL. Nothing we ship evaluates code from a string in a production
+ * build, so such a frame is never ours. (Turbopack uses eval in dev only, and
+ * fflate's zip worker is a blob: URL, not <anonymous>.)
+ *
+ * The lineno half of the test is load-bearing, not belt and braces. V8 also
+ * emits POSITIONLESS pseudo-frames such as `at new Promise (<anonymous>)`, and
+ * one of those really can be the deepest frame of a genuine error: see the
+ * fixture at browserExtensions.pipeline.test.ts, which is a real observed
+ * stack. Requiring a source position keeps those out.
+ *
+ * This runs in beforeSend rather than as a filter option, which is safe for the
+ * reason lib/browserExtensions.ts:16-25 explains it would NOT be safe there:
+ * NextjsClientStackFrameNormalization rewrites frame origins to app:// before
+ * beforeSend sees them, but it does that by parsing the filename as a URL, and
+ * new URL('<anonymous>') throws, so the frame is left exactly as it was.
+ */
+
+// Declared structurally, following lib/scrubUrl.ts, so this module and its
+// vitest never load the SDK.
+type CheckableFrame = { filename?: string; lineno?: number };
+type CheckableException = {
+    mechanism?: { parent_id?: number };
+    stacktrace?: { frames?: CheckableFrame[] };
+};
+export type CheckableEvent = { exception?: { values?: CheckableException[] } };
+
+export function isInjectedScriptError(event: CheckableEvent): boolean {
+    const values = event.exception?.values;
+    if (!values?.length) return false;
+
+    // The same root-exception rule _getEventFilterUrl applies for denyUrls: the
+    // last value that is not a linked cause and actually carries frames.
+    const root = [...values]
+        .reverse()
+        .find((value) => value.mechanism?.parent_id === undefined && value.stacktrace?.frames?.length);
+
+    const frames = root?.stacktrace?.frames;
+    if (!frames?.length) return false;
+
+    // Sentry stores frames oldest-first, so the throwing frame is the last one.
+    const threw = frames[frames.length - 1];
+    return threw?.filename === '<anonymous>' && typeof threw.lineno === 'number';
+}

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/nextjs';
 import { BROWSER_EXTENSION_URL_PATTERNS } from './lib/browserExtensions';
+import { IGNORED_ERROR_PATTERNS } from './lib/ignoredErrors';
 import { isStaleBundleError } from './lib/staleBundle';
 import { scrubSpanJson, scrubTransactionEvent, scrubUrl } from './lib/scrubUrl';
 
@@ -12,22 +13,11 @@ Sentry.init({
     // in the URL, which we additionally scrub below.
     sendDefaultPii: false,
 
-    // Filter out non-actionable errors caused by browser extensions and restricted environments
-    ignoreErrors: [
-        // Browser extensions (Google Translate, Grammarly, ad blockers) modify the DOM
-        // directly, causing React's virtual DOM to desync. Not actionable.
-        "Failed to execute 'removeChild' on 'Node'",
-        "Failed to execute 'insertBefore' on 'Node'",
-        "The node to be removed is not a child of this node",
-        // Privacy/anti-fingerprint extensions bridge to native desktop software and
-        // reject a promise with a plain object when that bridge is not ready. Surfaces
-        // as "Object Not Found Matching Id:N, MethodName:..., ParamCount:N". Not our code.
-        'Object Not Found Matching Id',
-        // Clipboard blocked in restricted browsers (already handled with fallback)
-        'Write permission denied',
-        // Safari/iOS ResizeObserver noise
-        'ResizeObserver loop',
-    ],
+    // Filter out non-actionable errors caused by browser extensions and
+    // restricted environments. The list lives in lib/ignoredErrors.ts, which
+    // also records how EventFilters matches it: this file cannot be imported by
+    // vitest, so an inline array is untestable.
+    ignoreErrors: IGNORED_ERROR_PATTERNS,
 
     // Drop errors thrown by browser extensions' injected content scripts: not
     // Floe code, never actionable. Matched on the frame's URL scheme rather

--- a/client/sentry.client.config.ts
+++ b/client/sentry.client.config.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 import { BROWSER_EXTENSION_URL_PATTERNS } from './lib/browserExtensions';
 import { IGNORED_ERROR_PATTERNS } from './lib/ignoredErrors';
+import { isInjectedScriptError } from './lib/injectedScripts';
 import { isStaleBundleError } from './lib/staleBundle';
 import { scrubSpanJson, scrubTransactionEvent, scrubUrl } from './lib/scrubUrl';
 
@@ -39,6 +40,13 @@ Sentry.init({
     // current bundle (see lib/staleBundle.ts). Collapse every wording variant into
     // one warning-level issue instead of a flood of distinct, non-actionable errors.
     beforeSend(event, hint) {
+        // An extension's injected script throwing on our page is reported as
+        // ours, because Sentry's own setTimeout/addEventListener wrapper sits in
+        // our bundle and supplies the only app:/// frame. Neither ignoreErrors
+        // (the messages are generic) nor denyUrls (it skips <anonymous> frames
+        // by design) can see it. Fixes FLOE-F. See lib/injectedScripts.ts.
+        if (isInjectedScriptError(event)) return null;
+
         const message =
             (hint?.originalException as Error | undefined)?.message ??
             event.exception?.values?.[0]?.value;


### PR DESCRIPTION
## Summary

Two unresolved Sentry issues, neither of them a bug in Floe, and neither reachable by the filters already in place.

**FLOE-H** `Error invoking postMessage: Java object is gone`. The Facebook in-app browser on Android injects a `navigation_performance_logger_android` script that posts an INP report from a `beforeunload` listener, and Chromium's Java bridge answers that its native peer is already gone. Nothing in this repo calls `postMessage` at all: the only `postMessage` that runs in the shipped app is fflate's zip worker and React's scheduler `MessageChannel`, neither of which crosses a native bridge. It reaches us only because Sentry's `browserApiErrors` integration wraps `addEventListener`, so its wrapper inside our bundle supplies the one `app:///` frame on the stack.

`denyUrls` cannot take it: every frame Sentry stored is already `app://`, and `browserExtensions.test.ts` deliberately asserts that no `denyUrls` pattern may match an `app://` prefix. So it goes in `ignoreErrors`, beside the `Object Not Found Matching Id` entry added for the structurally identical case. Sentry already ships the sibling wording `Java exception was raised during method invocation` in its own `DEFAULT_IGNORE_ERRORS`, credited to the same browser (getsentry/sentry-javascript#15065); ours is simply not on that list yet.

**FLOE-F** `Cannot read properties of null (reading 'querySelector')`, 8 events in two minutes: a browser extension's injected script throwing out of a `setTimeout` it scheduled on our page. Our whole shipped bundle contains one `querySelector`, in `components/legal/LegalToc.tsx`, it is optional-chained, and it does not run on the page this fired on.

It cannot be filtered by message, because the wording is generic enough that our own code could produce it one day. It cannot be filtered by URL either, because `_getLastValidUrl` skips `<anonymous>` frames on purpose and falls back to the previous one, which is our chunk. So `lib/injectedScripts.ts` matches on the shape instead: the frame that actually threw is `<anonymous>`, meaning eval, `new Function`, or a script injected with no sourceURL, and nothing we ship evaluates code from a string in a production build.

The `lineno` half of that test is load-bearing rather than defensive. V8 also emits positionless pseudo-frames such as `at new Promise (<anonymous>)`, and one of those really can be the deepest frame of a genuine error: the fixture in `browserExtensions.pipeline.test.ts` is a real observed stack of exactly that shape. Without the position check this would discard our own promise bugs.

The first commit is a pure move. `ignoreErrors` had no test coverage of any kind and could not have any, because vitest cannot import `sentry.client.config.ts` (`Sentry.init()` at module scope). Extracting it mirrors what `denyUrls` already does in `lib/browserExtensions.ts`, and the config now reads symmetrically.

## Test plan

- [x] `corepack pnpm test`: 29 files, 398 tests pass, 22 of them new
- [x] `npx tsc --noEmit`; `corepack pnpm lint` reports 0 errors (the 2 `no-location-assign-relative-destination` warnings in `P2PTransfer.tsx` and `Navbar.tsx` predate this)
- [x] `corepack pnpm build`, then `node scripts/check-titles.mjs`
- [x] Pure-move proof: the moved array and its comments `diff` clean against base, modulo the indentation change from no longer being nested in `Sentry.init`
- [x] Real-bundle A/B against a local sink DSN (`http://<32hex>@localhost:3001/9999`, inlined at build time, intercepted before the network, so nothing leaves the machine). Three errors thrown from a `setTimeout` on the built homepage: a control error is **sent**, the FLOE-H wording is **dropped**, the FLOE-F frame shape is **dropped**. The control is what makes each drop attributable rather than vacuous, and the first run of this harness failed usefully: it caught that the synthetic stack string had been written in Sentry's stored order rather than V8's, which is the reverse.
- [ ] CI `CI green`
