### PR TITLE
fix(client): keep a broken stats odometer from taking down the homepage

### DIFF
--- a/client/components/AnimatedByteCount.tsx
+++ b/client/components/AnimatedByteCount.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import React from 'react';
+import NumberFlow, { continuous } from '@number-flow/react';
+import * as Sentry from '@sentry/nextjs';
+import { BYTE_COUNT_FORMAT, formatSplitBytes } from '@/lib/utils';
+
+/**
+ * The global byte counter, and a guarantee that it cannot take the page with it.
+ *
+ * @number-flow/react renders a <number-flow-react> custom element and, on every
+ * value change, calls `this.el?.willUpdate()` from getSnapshotBeforeUpdate. That
+ * optional chain is a NULL check only. If the element was created but never
+ * UPGRADED, the node is a plain HTMLElement, the method does not exist, and the
+ * call throws in React's commit phase.
+ *
+ * Registration is a silent module side effect in number-flow/dist/lite.mjs:
+ *
+ *   BROWSER && typeof HTMLElement < "u" && typeof customElements < "u"
+ *     && !customElements.get(n) && customElements.define(n, t)
+ *
+ * Four guards, every one of them a no-op that reports nothing. And because the
+ * library's own componentDidMount only writes plain properties, which land as
+ * inert expandos on an un-upgraded element, nothing fails until the first value
+ * CHANGES. GlobalStats renders 0 until /api/stats resolves, so in an affected
+ * environment that change is guaranteed on every single page load.
+ *
+ * '/' has no error.tsx, so before this component the throw reached
+ * app/global-error.tsx and the whole homepage became the default Next.js error
+ * page, with a "Try again" button that remounts straight back into the same
+ * crash. FLOE-G is one of those, reported through global-error's own
+ * captureException.
+ *
+ * Two independent mechanisms, because neither covers the other:
+ *
+ *   - componentDidMount checks whether the element is going to upgrade at all.
+ *     That is the common case and it avoids the throw entirely.
+ *   - getDerivedStateFromError catches what the check cannot see, such as the
+ *     tag being registered to some other class, or a host node that never
+ *     upgrades despite a valid registration.
+ *
+ * Deliberately NOT Sentry.ErrorBoundary: it implements only componentDidCatch,
+ * so React renders null for one commit (a visible blank) before the fallback
+ * appears, and it lands in legacyErrorBoundariesThatAlreadyFailed, after which a
+ * second error at the same boundary escalates to global-error anyway.
+ *
+ * Deliberately no reset()/retry either. Re-arming the boundary re-arms the crash.
+ */
+
+// The tag @number-flow/react registers. Hardcoded because the package exports no
+// name constant; e2e/animated-byte-count.spec.ts pins it so a rename in a future
+// release fails CI instead of silently degrading every visitor to a static number.
+const NUMBER_FLOW_TAG = 'number-flow-react';
+
+// One report per page load. The fallback is a recovery, not a crash, so it must
+// not be able to flood the project if it ever turns out to be common.
+let reported = false;
+
+type Props = { value: number; unit: string; className?: string };
+type State = { staticOnly: boolean };
+
+export class AnimatedByteCount extends React.Component<Props, State> {
+    state: State = { staticOnly: false };
+
+    static getDerivedStateFromError(): State {
+        return { staticOnly: true };
+    }
+
+    componentDidCatch(error: Error, info: React.ErrorInfo) {
+        if (reported) return;
+        reported = true;
+        // Warning, not error: the page is fine and the number is still correct,
+        // only the animation is gone. Same treatment the stale-bundle reloads
+        // get in sentry.client.config.ts. A fixed fingerprint keeps every
+        // occurrence in one issue instead of one per wording.
+        //
+        // Reported explicitly because nothing else would: @sentry/nextjs wires
+        // no onCaughtError, and Next's own production handler for a boundary
+        // that is not GlobalError is a bare console.error, which Sentry records
+        // as a breadcrumb and never as an event.
+        Sentry.captureException(error, {
+            level: 'warning',
+            fingerprint: ['number-flow-unavailable'],
+            tags: { auto_recovered: true },
+            contexts: { react: { componentStack: info.componentStack } },
+        });
+    }
+
+    componentDidMount() {
+        // The exact negation of the library's own registration guard, so it
+        // covers all four of its silent bail-outs at once: esm-env's BROWSER
+        // resolving false, a missing HTMLElement, a missing or stubbed
+        // customElements, and the tag already belonging to something else.
+        //
+        // In componentDidMount rather than in render(): the first client render
+        // has to emit what the server emitted or hydration mismatches. This runs
+        // after that, and being a layout effect it also runs before GlobalStats'
+        // passive effect issues the fetch, so it can never race the value change
+        // it exists to get ahead of.
+        if (!globalThis.customElements?.get(NUMBER_FLOW_TAG)) {
+            this.setState({ staticOnly: true });
+        }
+    }
+
+    render() {
+        const { value, unit, className } = this.props;
+
+        if (this.state.staticOnly) {
+            const text = formatSplitBytes({ value, unit });
+            // role and aria-label mirror what NumberFlowElement publishes about
+            // itself through ElementInternals, so both branches read the same to
+            // assistive technology.
+            return (
+                <span role="img" aria-label={text} className={className}>
+                    {text}
+                </span>
+            );
+        }
+
+        return (
+            <NumberFlow
+                value={value}
+                format={BYTE_COUNT_FORMAT}
+                suffix={' ' + unit}
+                plugins={[continuous]}
+                spinTiming={{ duration: 900, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
+                transformTiming={{ duration: 750, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
+                opacityTiming={{ duration: 350, easing: 'ease-out' }}
+                className={className}
+            />
+        );
+    }
+}

--- a/client/components/GlobalStats.tsx
+++ b/client/components/GlobalStats.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import NumberFlow, { continuous } from '@number-flow/react';
+import { AnimatedByteCount } from '@/components/AnimatedByteCount';
 import { splitBytes } from '@/lib/utils';
 import { resolveSocketUrl } from '@/lib/socketUrl';
 
@@ -46,14 +46,9 @@ export function GlobalStats() {
 
     return (
         <div className="mt-6 mb-2 flex items-center justify-center gap-2 text-sm select-none">
-            <NumberFlow
+            <AnimatedByteCount
                 value={value}
-                format={{ minimumFractionDigits: 2, maximumFractionDigits: 2 }}
-                suffix={' ' + unit}
-                plugins={[continuous]}
-                spinTiming={{ duration: 900, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
-                transformTiming={{ duration: 750, easing: 'cubic-bezier(0.16, 1, 0.3, 1)' }}
-                opacityTiming={{ duration: 350, easing: 'ease-out' }}
+                unit={unit}
                 className="font-mono font-medium text-zinc-300 tabular-nums"
             />
             <span className="text-zinc-600">transferred globally</span>

--- a/client/e2e/animated-byte-count.spec.ts
+++ b/client/e2e/animated-byte-count.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * The global stats odometer must never be able to take down the homepage.
+ *
+ * @number-flow/react renders a <number-flow-react> custom element and, one
+ * value change later, calls this.el.willUpdate() from getSnapshotBeforeUpdate.
+ * The optional chain there is a null check only: when the element was created
+ * but never UPGRADED, the method does not exist and the commit phase throws
+ *
+ *   TypeError: this.el?.willUpdate is not a function
+ *
+ * There is no error.tsx on '/', so before components/AnimatedByteCount.tsx that
+ * reached app/global-error.tsx and the whole page became the default Next.js
+ * error page. FLOE-G is exactly that, reported with handled:yes and
+ * mechanism:generic, i.e. through global-error's own captureException, from a
+ * runtime whose custom elements never upgrade.
+ *
+ * number-flow's define() fails SILENTLY in several different ways
+ * (number-flow/dist/lite.mjs), so each is driven here rather than letting one
+ * stand in for the others, and the last case bypasses the pre-check entirely so
+ * the error boundary itself is exercised.
+ *
+ * These specs start no transfer and need nothing from the signaling server, so
+ * they cannot reach the public byte counter. The report guard below is belt and
+ * braces, in the shape e2e/docs-screenshots.mjs already uses.
+ */
+import { test, expect, type Page } from '@playwright/test';
+
+// Pinned so the expected string is exact: NumberFlow formats with
+// Intl.NumberFormat(undefined, ...), i.e. the context's locale, and the static
+// fallback has to match it character for character.
+test.use({ locale: 'en-US' });
+
+// 1181116006 bytes is 1.10 GB. Chosen because the trailing zero is produced
+// only by minimumFractionDigits: 2 - splitBytes() returns 1.1, so a fallback
+// built with a bare template literal would render "1.1 GB" and fail here.
+const STUB_TOTAL_BYTES = 1181116006;
+const EXPECTED = '1.10 GB';
+const ELEMENT = 'number-flow-react';
+const A_WHILE = 15_000;
+
+// GlobalStats fetches `${resolveSocketUrl()}/api/stats`, which under Playwright
+// is http://localhost:3001, CROSS-ORIGIN from the http://localhost:3000
+// baseURL. The allow-origin header is mandatory, not tidiness: without it the
+// browser blocks the fulfilled response, GlobalStats swallows it in its own
+// `catch {}`, the counter stays at "0.00 Bytes" and every assertion below would
+// pass or fail for the wrong reason.
+async function stubStats(page: Page) {
+    await page.route('**/api/stats', (route) =>
+        route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            headers: { 'access-control-allow-origin': '*' },
+            body: JSON.stringify({ totalBytes: STUB_TOTAL_BYTES }),
+        })
+    );
+}
+
+function collectPageErrors(page: Page): string[] {
+    const seen: string[] = [];
+    page.on('pageerror', (error) => seen.push(error.message));
+    return seen;
+}
+
+async function guardStatsReport(page: Page, attempts: { n: number }) {
+    await page.route('**/api/stats/report', (route) => {
+        attempts.n += 1;
+        return route.abort();
+    });
+}
+
+// What every degraded case has to show: the hero is still there, the counter
+// reads the stubbed value rather than 0.00 Bytes (so the value change that used
+// to crash really did happen), the animated element gave way to the fallback,
+// and nothing escaped to global-error.
+// The counter is asserted FIRST on purpose. The crash does not happen on load,
+// it happens a moment later when the stats fetch resolves and the value changes,
+// so a hero assertion that ran before that would pass even on a page that is
+// about to be replaced. Waiting for the stubbed value first means the hero check
+// below is a statement about surviving the transition.
+async function expectDegradedButAlive(page: Page, errors: string[], reports: { n: number }) {
+    await expect(page.getByRole('img', { name: EXPECTED })).toBeVisible({ timeout: A_WHILE });
+    await expect(page.getByRole('heading', { level: 1, name: 'Floe' })).toBeVisible({
+        timeout: A_WHILE,
+    });
+    await expect(page.getByText('transferred globally')).toBeVisible({ timeout: A_WHILE });
+    await expect(page.locator(ELEMENT)).toHaveCount(0, { timeout: A_WHILE });
+    expect(errors.filter((message) => message.includes('willUpdate'))).toEqual([]);
+    expect(reports.n).toBe(0);
+}
+
+test('leaves the animated counter alone when number-flow is healthy', async ({ page }) => {
+    const reports = { n: 0 };
+    await guardStatsReport(page, reports);
+    await stubStats(page);
+    await page.goto('/');
+
+    await expect(page.locator(ELEMENT)).toHaveCount(1, { timeout: A_WHILE });
+    // Pins the tag name that AnimatedByteCount's pre-check hardcodes. If a
+    // future number-flow release renames it, the probe would otherwise report
+    // "not registered" forever and silently degrade every visitor to a static
+    // number. This assertion turns that into a CI failure instead.
+    expect(await page.evaluate(() => !!window.customElements.get('number-flow-react'))).toBe(true);
+    // And the fallback is not in play: NumberFlowElement publishes its role and
+    // label through ElementInternals, which Playwright's role engine does not
+    // read, so an img role here could only be the fallback span.
+    await expect(page.getByRole('img', { name: EXPECTED })).toHaveCount(0);
+    expect(reports.n).toBe(0);
+});
+
+test('survives number-flow-react never being defined', async ({ page }) => {
+    // The exact production shape: React creates the element, nothing upgrades
+    // it, and the first value change calls a method that is not there.
+    const errors = collectPageErrors(page);
+    const reports = { n: 0 };
+    await guardStatsReport(page, reports);
+    await stubStats(page);
+    await page.addInitScript(() => {
+        const define = window.customElements.define.bind(window.customElements);
+        window.customElements.define = (
+            name: string,
+            ctor: CustomElementConstructor,
+            options?: ElementDefinitionOptions
+        ) => {
+            if (name === 'number-flow-react') return;
+            return define(name, ctor, options);
+        };
+    });
+
+    await page.goto('/');
+    await expectDegradedButAlive(page, errors, reports);
+});
+
+test('survives an environment with no custom element registry', async ({ page }) => {
+    // A different guard inside number-flow's define(), which bails at
+    // `typeof customElements < "u"` before it ever reaches define. A stub
+    // rather than a delete, so nothing unrelated trips over a missing global.
+    const errors = collectPageErrors(page);
+    const reports = { n: 0 };
+    await guardStatsReport(page, reports);
+    await stubStats(page);
+    await page.addInitScript(() => {
+        Object.defineProperty(window, 'customElements', {
+            value: { get: () => undefined, define: () => {} },
+            configurable: true,
+        });
+    });
+
+    await page.goto('/');
+    await expectDegradedButAlive(page, errors, reports);
+});
+
+test('survives number-flow-react upgrading to a foreign element', async ({ page }) => {
+    // The one case the pre-check cannot see: the tag IS registered, so
+    // customElements.get() answers truthfully, but it upgrades to a class with
+    // no willUpdate. Only getDerivedStateFromError can save the page here.
+    const errors = collectPageErrors(page);
+    const reports = { n: 0 };
+    await guardStatsReport(page, reports);
+    await stubStats(page);
+    await page.addInitScript(() => {
+        const define = window.customElements.define.bind(window.customElements);
+        window.customElements.define = (
+            name: string,
+            ctor: CustomElementConstructor,
+            options?: ElementDefinitionOptions
+        ) => {
+            if (name === 'number-flow-react') {
+                return define(name, class extends HTMLElement {}, options);
+            }
+            return define(name, ctor, options);
+        };
+    });
+
+    await page.goto('/');
+    await expectDegradedButAlive(page, errors, reports);
+});

--- a/client/lib/utils.test.ts
+++ b/client/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatBytes, splitBytes } from './utils';
+import { BYTE_COUNT_FORMAT, formatBytes, formatSplitBytes, splitBytes } from './utils';
 import { RELAY_SIZE_LIMIT } from './relay';
 
 describe('formatBytes', () => {
@@ -38,5 +38,33 @@ describe('byte formatter guards', () => {
 
     it('renders the relay cap the way every other copy of the string spells it', () => {
         expect(formatBytes(RELAY_SIZE_LIMIT)).toBe('2 GB');
+    });
+});
+
+// The static fallback in components/AnimatedByteCount.tsx has to be
+// indistinguishable from the animated counter it replaces, and components are
+// not reachable from this suite, so the string itself is pinned here.
+describe('formatSplitBytes', () => {
+    // Built locally rather than hardcoded, because the runtime locale decides
+    // the group and decimal separators and a contributor's default is not
+    // necessarily en-US.
+    const asNumberFlowWouldPaint = (value: number, unit: string) =>
+        `${new Intl.NumberFormat(undefined, BYTE_COUNT_FORMAT).format(value)} ${unit}`;
+
+    it('pads to two fraction digits the way NumberFlow does', () => {
+        // 1181116006 bytes is 1.10 GB. splitBytes returns 1.1, so a bare
+        // template literal would render "1.1 GB" and drift from the animation.
+        expect(formatSplitBytes(splitBytes(1181116006))).toBe(asNumberFlowWouldPaint(1.1, 'GB'));
+        expect(formatSplitBytes(splitBytes(1181116006))).toMatch(/^1\D10 GB$/);
+    });
+
+    it('renders the pre-load zero the same way', () => {
+        expect(formatSplitBytes(splitBytes(0))).toBe(asNumberFlowWouldPaint(0, 'Bytes'));
+    });
+
+    it('groups large values, as Intl.NumberFormat does', () => {
+        expect(formatSplitBytes({ value: 1234.5, unit: 'TB' })).toBe(
+            asNumberFlowWouldPaint(1234.5, 'TB')
+        );
     });
 });

--- a/client/lib/utils.ts
+++ b/client/lib/utils.ts
@@ -33,3 +33,26 @@ export const splitBytes = (bytes: number): { value: number; unit: string } => {
         unit: BYTE_UNITS[i],
     };
 };
+
+// The NumberFlow options GlobalStats animates the global counter with. Shared
+// so components/AnimatedByteCount.tsx can format its static fallback with the
+// same settings instead of a second copy that could drift.
+//
+// Left to inference rather than annotated Intl.NumberFormatOptions, because
+// @number-flow/react's own `Format` type is a NARROWER subset of it (its
+// `notation` admits only 'standard' and 'compact'), and the wider annotation is
+// not assignable to the prop. The literal type satisfies both.
+export const BYTE_COUNT_FORMAT = {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+} as const;
+
+// The exact string NumberFlow paints for a splitBytes() pair.
+//
+// `undefined` locales rather than 'en-US': GlobalStats passes NumberFlow no
+// `locales` prop, so it builds Intl.NumberFormat(undefined, format) and
+// resolves the runtime default. The fallback has to resolve the same one.
+// toFixed() would not do: splitBytes(1181116006).value is 1.1, and only
+// minimumFractionDigits pads that back to the "1.10" NumberFlow shows.
+export const formatSplitBytes = ({ value, unit }: { value: number; unit: string }): string =>
+    `${value.toLocaleString(undefined, BYTE_COUNT_FORMAT)} ${unit}`;


### PR DESCRIPTION
## Summary

The global byte counter could replace the entire homepage with the default Next.js error page. **FLOE-G is a real visitor it happened to**: `handled: yes` + `mechanism: generic` is the signature of `app/global-error.tsx`'s own `captureException`, so that event is proof someone got `Application error: a client-side exception has occurred` instead of Floe.

`@number-flow/react` renders a `<number-flow-react>` custom element and, on every value change, calls `this.el?.willUpdate()` from `getSnapshotBeforeUpdate`. That optional chain is a **null check only**: if the element was created but never *upgraded*, the node is a plain `HTMLElement`, the method does not exist, and the call throws in React's commit phase. Registration is a silent module side effect in `number-flow/dist/lite.mjs` guarded four ways, and every one of those guards is a no-op that reports nothing.

Nothing fails at mount, because the library's own `componentDidMount` writes plain properties and those land as inert expandos on an un-upgraded element. It fails on the first value **change**, and `GlobalStats` deliberately renders `0` until `/api/stats` resolves, so in an affected environment the crash is guaranteed on every page load rather than intermittent. `/` has no `error.tsx` and `client/` had no error boundary anywhere, so it reached `global-error.tsx`, whose "Try again" button remounts straight back into the same crash. In that same environment the counter was already frozen at `0.00 Bytes` before the crash, for the same reason the property writes are inert, so the fallback is a real fix and not only crash avoidance.

`0.6.2` is the latest published version, so there is no upstream fix to take.

`AnimatedByteCount` owns the NumberFlow props now and guards them two ways, because neither mechanism covers the other:

- `componentDidMount` asks whether the element is going to upgrade at all, which is the exact negation of the library's own four-condition guard. That is the common case and it avoids the throw entirely. It runs after mount rather than in `render`, so the hydrated markup still matches the server's, and being a layout effect it runs before `GlobalStats`' passive effect issues the fetch, so it cannot race the value change it exists to get ahead of.
- `getDerivedStateFromError` catches what the check cannot see: the tag registered to some other class, or a host node that never upgrades despite a valid registration.

Both statics rather than `componentDidCatch` alone, and deliberately **not** `Sentry.ErrorBoundary`, which has only `componentDidCatch`: React then renders `null` for one commit (a visible blank) and the instance lands in `legacyErrorBoundariesThatAlreadyFailed`, after which a second error escalates to `global-error` anyway. No `reset()` either, because re-arming the boundary re-arms the crash.

Sentry still hears about it, at `warning` level with a fixed fingerprint, once per page load. Nothing else would report it: `@sentry/nextjs` wires no `onCaughtError`, and Next's own production handler for a boundary that is not `GlobalError` is a bare `console.error`, which Sentry keeps as a breadcrumb and never as an event.

## Test plan

- [x] **Reproduced before fixing.** `e2e/animated-byte-count.spec.ts` was written first and run against a production build of `main`: the healthy control passed and all three failure cases failed, with the page snapshot at failure being `heading "Application error: a client-side exception has occurred..." [level=2]` and `button "Try again"`. Note the hero assertion passed *before* the counter one, which is the real sequence: the page loads fine and dies a moment later when the value arrives. The helper asserts the counter first for that reason.
- [x] Same spec against the fix, production build: 4/4 pass, covering `define` swallowed for that one tag, no custom element registry at all, the tag upgrading to a foreign class (the only case that exercises `getDerivedStateFromError`), and a healthy control.
- [x] `e2e/hydration.spec.ts` + `e2e/responsive.spec.ts`: 12/12 pass, so the post-mount swap introduces no hydration mismatch on `/` and no layout change.
- [x] `corepack pnpm test` 379 pass, `npx tsc --noEmit`, `corepack pnpm lint` 0 errors (the 2 `no-location-assign-relative-destination` warnings predate this)
- [x] `corepack pnpm build`
- [x] Visual check of both paths against the production build at `1181116006` bytes: healthy renders `1.10 GB transferred globally` with `<number-flow-react>` present and no fallback span; degraded renders the identical `1.10 GB transferred globally` from the fallback span, with the hero intact. The two screenshots are indistinguishable apart from the missing roll-up.
- [ ] CI `CI green`
