### PR TITLE
fix(server): close six unauthenticated remote kills of the signaling server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ cd server
 npm install
 npm run dev      # nodemon auto-restart on :3001
 npm start        # production
-npm test         # node --test server.test.js
+npm test         # node --test (discovers every server/*.test.js)
 ```
 
 ### CLI (Go)
@@ -181,7 +181,10 @@ disk, and what must be undone, is visible in a single pass. `App.tsx`'s mount
 effect is eleven listeners with a matching teardown and a first-render closure
 contract. Its keyboard effects reference action refs declared below them, so
 hoisting them into a hook is a temporal-dead-zone crash. The ws upgrade
-handler's ordering is load-bearing for transport quality. Leave these alone.
+handler's ordering is load-bearing twice over: the no-op socket error listener
+has to precede anything that can throw, and the Socket.IO pass-through has to
+precede anything that can refuse, or every browser silently drops to
+long-polling. Leave these alone.
 
 Separate a move from a behavior change. Never put both in one commit: git
 cannot merge "this hunk moved to a new file" with "this hunk changed in

--- a/docs/self-hosting/operations.mdx
+++ b/docs/self-hosting/operations.mdx
@@ -48,9 +48,12 @@ Worth knowing before you go looking. The signaling server has no access log, no 
 no startup banner, not even a line saying which port it bound. `docker compose logs server` on a
 perfectly healthy instance is empty, and that is expected rather than a symptom.
 
-The only thing it ever writes is a stack trace when an unhandled error reaches its error handler.
-To confirm the server is alive, or that a restart actually landed, use the health endpoint below
-rather than the logs.
+It writes a stack trace in exactly two cases: when an unhandled error reaches its error handler,
+and when an unexpected exception reaches the process-level backstop. The second kind is prefixed
+`Unhandled error` and means the server caught something it did not anticipate and kept serving
+rather than exiting, so the transfers in progress survived. It is worth reporting. To confirm the
+server is alive, or that a restart actually landed, use the health endpoint below rather than the
+logs.
 
 `docker compose ps` is a similar case: **the client image ships no healthcheck**, so it never
 reports a health state. Only the server does.

--- a/server/crashguard.test.js
+++ b/server/crashguard.test.js
@@ -1,0 +1,377 @@
+'use strict';
+
+// Regression tests for six unauthenticated remote kills of the signaling
+// server, and for the Socket.IO upgrade pass-through they must not break.
+//
+// These spawn server.js as a CHILD PROCESS rather than requiring it. That is the
+// whole design of the file, not a convenience. An in-process test cannot observe
+// the failure it exists to catch: `node --test` installs its own uncaughtException
+// handling, so a throw escaping into the socket layer never ends the test runner,
+// and a TCP connect from inside the server's own process answers whether the
+// event loop is momentarily free, not whether the process is alive. An earlier
+// version of this file asserted liveness that way, and its test for the
+// unclaimed-path reset passed with the fix fully reverted.
+//
+// With a child, death is a fact (`child.exitCode`) and so is the backstop
+// (its stderr). Each attack ends in assertSurvived(); see the note there for
+// why the stderr half is the one that actually discriminates.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const net = require('node:net');
+const { spawn } = require('node:child_process');
+const { randomUUID } = require('node:crypto');
+const WebSocket = require('ws');
+
+const SERVER = require.resolve('./server.js');
+
+// Every socket and child this file opens, so a failed assertion is a red test
+// rather than a hung runner. `node --test` waits on live handles, and the
+// previous version leaked a websocket on any failure, which turned a 3-second
+// failure into a 10-minute CI job timeout.
+const openSockets = new Set();
+const children = new Set();
+
+function track(sock) {
+    openSockets.add(sock);
+    sock.on('close', () => openSockets.delete(sock));
+    return sock;
+}
+
+test.after(() => {
+    for (const s of openSockets) { try { s.destroy ? s.destroy() : s.terminate(); } catch { /* already gone */ } }
+    for (const c of children) { try { c.kill('SIGKILL'); } catch { /* already gone */ } }
+});
+
+// --- harness ---------------------------------------------------------------
+
+// A port nobody is listening on yet. server.js reads PORT and logs nothing on a
+// healthy start (docs/self-hosting/operations.mdx promises exactly that), so
+// there is no ready line to parse and no reason to add one just for tests.
+function freePort() {
+    return new Promise((resolve, reject) => {
+        const probe = net.createServer();
+        probe.once('error', reject);
+        probe.listen(0, '127.0.0.1', () => {
+            const { port } = probe.address();
+            probe.close(() => resolve(port));
+        });
+    });
+}
+
+async function startServer(extraEnv = {}) {
+    const port = await freePort();
+    const child = spawn(process.execPath, [SERVER], {
+        cwd: __dirname,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: {
+            ...process.env,
+            PORT: String(port),
+            // Hermetic: without this the child inherits server/.env and initStats()
+            // makes a live Upstash call on every spawn.
+            UPSTASH_REDIS_REST_URL: '',
+            UPSTASH_REDIS_REST_TOKEN: '',
+            ...extraEnv,
+        },
+    });
+    children.add(child);
+    let stderr = '';
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.stdout.resume();
+
+    const srv = {
+        child,
+        port,
+        get stderr() { return stderr; },
+        stop() { children.delete(child); child.kill('SIGKILL'); },
+    };
+
+    const deadline = Date.now() + 10000;
+    for (;;) {
+        if (child.exitCode !== null) throw new Error(`server exited ${child.exitCode} during startup: ${stderr}`);
+        try {
+            const resp = await fetch(`http://127.0.0.1:${port}/health`);
+            if (resp.ok) { await resp.json(); break; }
+        } catch { /* not listening yet */ }
+        if (Date.now() > deadline) throw new Error(`server did not start: ${stderr}`);
+        await new Promise((r) => setTimeout(r, 50));
+    }
+    return srv;
+}
+
+// The server is alive AND nothing reached the process-level backstop.
+//
+// Both halves are load-bearing, and the second is the one that discriminates.
+// server.js installs an uncaughtException handler that logs and keeps serving,
+// so for four of the six kills the process survives whether or not the guard is
+// present: "did it exit" cannot tell them apart. What can is whether the throw
+// happened at all. Confirmed by mutation: reverting any one of the six guards
+// puts exactly one "Unhandled error" line in the child's stderr, and reverting
+// none leaves it empty.
+async function assertSurvived(srv, what) {
+    // A synchronous exit is observable at once; give an in-flight one a tick to
+    // be reported, and the backstop's console.error time to flush.
+    await new Promise((r) => setTimeout(r, 250));
+    assert.equal(
+        srv.child.exitCode, null,
+        `server process exited (${srv.child.exitCode}) after ${what}\n--- stderr ---\n${srv.stderr}`
+    );
+    assert.doesNotMatch(
+        srv.stderr, /Unhandled error/,
+        `${what} reached the uncaughtException backstop instead of being handled at its source\n--- stderr ---\n${srv.stderr}`
+    );
+    const resp = await fetch(`http://127.0.0.1:${srv.port}/health`);
+    assert.equal(resp.status, 200, `server stopped serving after ${what}`);
+    assert.equal((await resp.json()).status, 'healthy');
+}
+
+const UPGRADE_HEADERS =
+    'Upgrade: websocket\r\n' +
+    'Connection: Upgrade\r\n' +
+    'Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==\r\n' +
+    'Sec-WebSocket-Version: 13\r\n';
+
+// One raw upgrade request. Resolves with the reply headers, the socket (so a
+// caller can write frames on an accepted connection), and afterHandshake(), which
+// waits for a pattern in whatever the server sends once the headers are done.
+function rawUpgrade(srv, target) {
+    return new Promise((resolve, reject) => {
+        const socket = track(net.connect(srv.port, '127.0.0.1', () => {
+            socket.write(`GET ${target} HTTP/1.1\r\nHost: 127.0.0.1:${srv.port}\r\n${UPGRADE_HEADERS}\r\n`);
+        }));
+        let buf = '';
+        let headEnd = -1;
+        const timer = setTimeout(() => reject(new Error(`no reply to ${target}`)), 5000);
+        const waiters = [];
+        const check = () => {
+            for (let i = waiters.length - 1; i >= 0; i--) {
+                if (waiters[i].pattern.test(buf.slice(headEnd + 4))) waiters.splice(i, 1)[0].resolve(true);
+            }
+        };
+        socket.on('data', (d) => {
+            buf += d.toString('latin1');
+            if (headEnd === -1 && buf.includes('\r\n\r\n')) {
+                headEnd = buf.indexOf('\r\n\r\n');
+                clearTimeout(timer);
+                resolve({
+                    head: buf.slice(0, headEnd),
+                    body: buf.slice(headEnd + 4),
+                    socket,
+                    afterHandshake: (pattern, ms) => new Promise((res) => {
+                        if (pattern.test(buf.slice(headEnd + 4))) return res(true);
+                        const w = { pattern, resolve: res };
+                        waiters.push(w);
+                        setTimeout(() => { const i = waiters.indexOf(w); if (i !== -1) { waiters.splice(i, 1); res(false); } }, ms);
+                    }),
+                });
+            }
+            if (headEnd !== -1) check();
+        });
+        socket.on('error', (err) => { clearTimeout(timer); reject(err); });
+        socket.on('close', () => {
+            clearTimeout(timer);
+            for (const w of waiters.splice(0)) w.resolve(false);
+            if (!buf) reject(new Error(`socket closed with no reply to ${target}`));
+        });
+    });
+}
+
+function open(srv) {
+    const ws = new WebSocket(`ws://127.0.0.1:${srv.port}/ws`);
+    track(ws);
+    return new Promise((resolve, reject) => {
+        ws.once('open', () => resolve(ws));
+        ws.once('error', reject);
+    });
+}
+
+function waitFor(ws, type, ms = 5000) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => { ws.off('message', onMessage); reject(new Error(`timed out waiting for ${type}`)); }, ms);
+        function onMessage(raw) {
+            let msg;
+            try { msg = JSON.parse(raw); } catch { return; }
+            if (!msg || msg.type !== type) return;
+            clearTimeout(timer);
+            ws.off('message', onMessage);
+            resolve(msg);
+        }
+        ws.on('message', onMessage);
+    });
+}
+
+async function pair(srv) {
+    const roomId = randomUUID();
+    const a = await open(srv);
+    const b = await open(srv);
+    const aJoined = waitFor(a, 'room-joined');
+    a.send(JSON.stringify({ type: 'join-room', roomId }));
+    await aJoined;
+    const bJoined = waitFor(b, 'room-joined');
+    const aSawPeer = waitFor(a, 'user-connected');
+    b.send(JSON.stringify({ type: 'join-room', roomId }));
+    await Promise.all([bJoined, aSawPeer]);
+    return { a, b, roomId };
+}
+
+// --- (a) request targets Node accepts and WHATWG URL rejects ---------------
+
+test('an unparseable upgrade target is refused, not fatal', async (t) => {
+    const srv = await startServer();
+    t.after(() => srv.stop());
+
+    for (const target of ['//', '///', '//?', '//[', '//@', '//%']) {
+        const { head, body } = await rawUpgrade(srv, target);
+        assert.match(head, /^HTTP\/1\.1 400 Bad Request\r\n/, `target ${JSON.stringify(target)}`);
+        assert.equal(body, 'Bad Request');
+    }
+    await assertSurvived(srv, 'six unparseable upgrade targets');
+});
+
+// --- (e) a target both routers claim ---------------------------------------
+
+test('a dot-segment target is left to Socket.IO, not claimed twice', async (t) => {
+    const srv = await startServer();
+    t.after(() => srv.stop());
+
+    // engine.io claims an upgrade by a literal prefix compare on the UNPARSED
+    // target; this server compares a WHATWG-normalized pathname. Each of these
+    // satisfies both, so engine.io completed the handshake and then
+    // wss.handleUpgrade threw "called more than once with the same socket".
+    //
+    // The 101 alone proves nothing here: engine.io sends it before this server
+    // ever runs, so it arrives either way. What separates a working connection
+    // from a broken one is what comes after it, which is why the engine.io OPEN
+    // packet is the assertion. Without the guard the throw is caught one frame
+    // later and the socket is destroyed, so the packet never arrives.
+    for (const target of [
+        '/socket.io/../ws?EIO=4&transport=websocket',
+        '/socket.io/%2e%2e/ws?EIO=4&transport=websocket',
+        '/socket.io/a/b/../../../ws?EIO=4&transport=websocket',
+    ]) {
+        const { head, afterHandshake } = await rawUpgrade(srv, target);
+        assert.match(head, /^HTTP\/1\.1 101 /, `target ${target} should be handled by Socket.IO`);
+        const opened = await afterHandshake(/"sid"/, 3000);
+        assert.ok(opened, `${target} produced a 101 but no usable Socket.IO session`);
+    }
+    await assertSurvived(srv, 'three dot-segment upgrade targets');
+});
+
+test('a plain /socket.io/ upgrade still reaches Socket.IO', async (t) => {
+    const srv = await startServer();
+    t.after(() => srv.stop());
+
+    // The guard that matters most in this file. Break the pass-through and every
+    // browser silently falls back to long-polling: transfers still work, nothing
+    // errors, and no other test notices.
+    const { head } = await rawUpgrade(srv, '/socket.io/?EIO=4&transport=websocket');
+    assert.match(head, /^HTTP\/1\.1 101 /);
+    await assertSurvived(srv, 'a Socket.IO upgrade');
+});
+
+// --- (b) a JSON scalar as a message ----------------------------------------
+
+test('a literal null frame is ignored and the socket keeps working', async (t) => {
+    const srv = await startServer();
+    t.after(() => srv.stop());
+
+    // JSON.parse('null') returns null without throwing, so the parse guard misses
+    // it and reading .type raised a TypeError inside a ws 'message' listener.
+    const ws = await open(srv);
+    ws.send('null');
+    const pong = waitFor(ws, 'pong');
+    ws.send(JSON.stringify({ type: 'ping' }));
+    assert.equal((await pong).type, 'pong');
+    await assertSurvived(srv, 'a null frame');
+});
+
+// --- (d) a deeply nested signal --------------------------------------------
+
+// Smallest depth at which JSON.stringify overflows the stack on THIS runtime,
+// found by doubling. Not a constant: V8's JSON.parse is iterative while
+// JSON.stringify is recursive, and the recursion budget varies with the stack
+// size, so the figure differs between Node majors and machines. Measured 2235 on
+// Node 22.18 here, a 4.4 KB frame. The test asserts the premise instead of
+// assuming it, so a future runtime that changes either half fails loudly rather
+// than passing for the wrong reason.
+function stringifyOverflowDepth() {
+    for (let depth = 512; depth <= 262144; depth *= 2) {
+        const value = JSON.parse('['.repeat(depth) + ']'.repeat(depth));
+        try { JSON.stringify(value); } catch (err) {
+            if (err instanceof RangeError) return depth;
+            throw err;
+        }
+    }
+    return null;
+}
+
+test('a deeply nested signal is dropped and both peers stay usable', async (t) => {
+    const srv = await startServer();
+    t.after(() => srv.stop());
+
+    const depth = stringifyOverflowDepth();
+    assert.ok(depth, 'JSON.stringify no longer overflows at any depth this test can build, so it is not exercising the kill');
+    const nested = '['.repeat(depth) + ']'.repeat(depth);
+    const frame = `{"type":"signal","signal":${nested}}`;
+    assert.ok(frame.length < 1e6, `frame is ${frame.length} bytes, over the server's 1 MB maxPayload`);
+    assert.doesNotThrow(() => JSON.parse(nested), 'the server must be able to parse this or it never reaches handleSignal');
+
+    const { a, b } = await pair(srv);
+    a.send(frame);
+
+    // Three claims. The last two are what separate the fix at its source from
+    // the uncaughtException backstop: with the backstop alone the process lives,
+    // but the sending peer's ws Receiver is left mid-write and that socket
+    // answers nothing at all, so it never leaves `rooms` either.
+    await assertSurvived(srv, `a ${depth}-deep signal`);
+
+    const pong = waitFor(a, 'pong');
+    a.send(JSON.stringify({ type: 'ping' }));
+    assert.equal((await pong).type, 'pong', 'the sending peer should still be answering');
+
+    const relayed = waitFor(b, 'signal');
+    a.send(JSON.stringify({ type: 'signal', signal: { sdp: 'ok' } }));
+    assert.deepEqual((await relayed).signal, { sdp: 'ok' }, 'a normal signal should still relay');
+});
+
+// --- (c) a reset inside the upgrade window ---------------------------------
+
+test('a client reset on an unclaimed upgrade path is not fatal', async (t) => {
+    const srv = await startServer();
+    t.after(() => srv.stop());
+
+    // Node removes its own socket 'error' listener before emitting 'upgrade',
+    // and for a path neither /ws nor engine.io's nothing attaches another.
+    for (let i = 0; i < 5; i++) {
+        await new Promise((resolve) => {
+            const socket = track(net.connect(srv.port, '127.0.0.1', () => {
+                socket.write(`GET /nope HTTP/1.1\r\nHost: 127.0.0.1:${srv.port}\r\n${UPGRADE_HEADERS}\r\n`);
+                setTimeout(() => { socket.resetAndDestroy(); resolve(); }, 40);
+            }));
+            socket.on('error', resolve);
+        });
+    }
+    await assertSurvived(srv, 'five resets on an unclaimed upgrade path');
+});
+
+// --- (f) a malformed frame on a rate-limited connection --------------------
+
+test('a malformed frame on a rate-limited connection is not fatal', async (t) => {
+    // MAX_CONNECTIONS_PER_IP is what the production default (30) would need 31
+    // connections to reach; 2 reaches the same branch in three.
+    const srv = await startServer({ MAX_CONNECTIONS_PER_IP: '2' });
+    t.after(() => srv.stop());
+
+    await open(srv);
+    await open(srv);
+
+    // The third is accepted at the HTTP layer and rejected by the handler, which
+    // used to return before attaching any 'error' listener. close() only starts
+    // the handshake, so the Receiver keeps reading for 30 seconds.
+    const { head, socket } = await rawUpgrade(srv, '/ws');
+    assert.match(head, /^HTTP\/1\.1 101 /);
+    // An unmasked text frame from a client. Four bytes, no crafting.
+    socket.write(Buffer.from([0x81, 0x02, 0x41, 0x42]));
+
+    await assertSurvived(srv, 'an unmasked frame on a rate-limited connection');
+});

--- a/server/server.js
+++ b/server/server.js
@@ -413,7 +413,17 @@ function handleSignal(senderPeer, signal, targetId) {
     if (!targetPeer) return;
     if (targetId && targetPeer.id !== targetId) return;
 
-    targetPeer.send('signal', { signal, sender: senderPeer.id });
+    // signal is the only peer-supplied value this server serializes: roomId is
+    // UUID-checked and target is only compared. JSON.stringify recurses, so a
+    // nested-array signal overflows the stack (measured: 2235 levels, a 4.4 KB
+    // frame) inside createWSPeer.send for a CLI target or socket.io's encoder
+    // for a browser one, and throws where nothing catches it. Silent on purpose:
+    // logging per attempt is a flood lever at a rate the caller picks.
+    try {
+        targetPeer.send('signal', { signal, sender: senderPeer.id });
+    } catch {
+        // Undeliverable. The peers time out on their own.
+    }
 }
 
 function handleDisconnect(peer) {
@@ -491,21 +501,84 @@ io.on('connection', (socket) => {
 // Signaling carries only SDP/ICE (< 10 KB); larger frames are rejected (close 1009).
 const wss = new WebSocketServer({ noServer: true, maxPayload: 1e6 });
 
+// Answer an upgrade we will not complete, then close. Same shape as ws's own
+// abortHandshake. A bare destroy would also work; a reason on the wire is what
+// makes a misconfigured proxy diagnosable.
+function refuseUpgrade(socket, code) {
+    if (!socket.writable) {
+        socket.destroy();
+        return;
+    }
+    const body = http.STATUS_CODES[code] || 'Bad Request';
+    socket.once('finish', () => socket.destroy());
+    socket.end(
+        `HTTP/1.1 ${code} ${body}\r\n` +
+        'Connection: close\r\n' +
+        'Content-Type: text/plain\r\n' +
+        `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+        '\r\n' +
+        body
+    );
+}
+
 // Manually route WebSocket upgrades so the ws library does NOT interfere
 // with Socket.IO's own WebSocket upgrade on /socket.io/.
 // Without this, ws calls socket.destroy() for paths that don't match '/ws',
 // which kills Socket.IO's transport upgrade and forces unreliable long-polling.
-server.on('upgrade', (req, socket, head) => {
-    const pathname = new URL(req.url, 'http://x').pathname;
-    if (pathname === '/ws') {
+function handleUpgradeRequest(req, socket, head) {
+    // First, before anything below can throw. Node removes its own socket
+    // 'error' listener before emitting 'upgrade', and for a target neither we
+    // nor engine.io claims nothing attaches another, so a client reset in that
+    // window is an unhandled 'error' event. ws attaches its own in setSocket, so
+    // a completed /ws connection is unaffected.
+    socket.on('error', () => {});
+
+    // req.url is a raw request target, not a URL. Node's parser accepts several
+    // that WHATWG URL rejects ("//", "///", "//?", "//[", "//@", "//%"), and a
+    // throw here runs synchronously inside the listener. new URL rather than a
+    // split on '?' because it also matches the absolute-form target
+    // (GET http://api.floe.one/ws HTTP/1.1) some proxies send.
+    let pathname;
+    try {
+        pathname = new URL(req.url, 'http://x').pathname;
+    } catch {
+        refuseUpgrade(socket, 400);
+        return;
+    }
+
+    if (pathname !== '/ws') return;
+
+    // engine.io claims a socket by a literal prefix compare on the UNPARSED
+    // target (`path === req.url.slice(0, path.length)`) while the line above
+    // compares a normalized pathname, so "/socket.io/../ws?EIO=4" satisfies
+    // both. engine.io runs first and has already upgraded the socket, and
+    // completing it twice throws. Reusing engine.io's own predicate, rather than
+    // matching dot segments, covers the %2e%2e and backslash spellings too.
+    if (req.url.startsWith(io.path() + '/')) return;
+
+    // Any future drift between the two routers lands on that same throw.
+    // Destroy rather than refuse: reaching here means someone else may own this
+    // socket, and writing a 400 into one engine.io has upgraded puts
+    // "HTTP/1.1 400 Bad Request" mid-stream in a live WebSocket (measured).
+    try {
         wss.handleUpgrade(req, socket, head, (ws) => {
             wss.emit('connection', ws, req);
         });
+    } catch {
+        socket.destroy();
     }
-    // All other paths (e.g. /socket.io/) are left untouched for Socket.IO
-});
+}
+
+server.on('upgrade', handleUpgradeRequest);
 
 wss.on('connection', (ws, req) => {
+    // Before the rate-limit return below, which never reaches the real handler
+    // at the foot of this function. ws emits 'error' on the WebSocket for any
+    // framing fault (an unmasked frame is 4 bytes), close() only starts the
+    // handshake and leaves the Receiver reading for 30s, and an 'error' with no
+    // listener throws. Both listeners run; handleDisconnect is idempotent.
+    ws.on('error', () => {});
+
     const ip = getClientIp(req.headers['x-forwarded-for'], req.socket.remoteAddress);
     if (!checkRateLimit(ip)) {
         ws.close(1008, 'Rate limit exceeded');
@@ -522,6 +595,12 @@ wss.on('connection', (ws, req) => {
     ws.on('message', (raw) => {
         let msg;
         try { msg = JSON.parse(raw); } catch { return; }
+
+        // JSON.parse('null') returns null without throwing, so the catch above
+        // does not cover it and reading .type raises a TypeError inside a ws
+        // 'message' listener, where nothing catches it: a 4-byte frame ends the
+        // process. Same guard the Socket.IO signal handler already applies.
+        if (!msg || typeof msg !== 'object') return;
 
         switch (msg.type) {
             case 'join-room':
@@ -576,7 +655,40 @@ function shutdown() {
 // ---------------------------------------------------------------------------
 
 if (require.main === module) {
-    server.listen(PORT);
+    // Mandatory once uncaughtException is handled below, or a bind failure
+    // (EADDRINUSE, EACCES) is absorbed by it and the process stays alive
+    // listening to nothing. Removed once bound: left attached it also fires for
+    // post-listen accept errors (EMFILE, ENFILE), which would make exhausting
+    // the descriptor table another way to end the process.
+    const failFastOnBindError = (err) => {
+        console.error('HTTP server error:', err);
+        process.exit(1);
+    };
+    server.on('error', failFastOnBindError);
+
+    // Log and keep serving. Rooms, codes and the stats total are in memory, so
+    // exiting drops every transfer in progress, and a caller who can reach a
+    // throw on demand would burn PM2's max_restarts and take the server down for
+    // good: the exit IS the attack. No crash budget, for the same reason.
+    //
+    // A backstop, not a repair. Measured: a throw out of a ws 'message' listener
+    // leaves that Receiver stuck mid-write, so ws never emits 'close',
+    // handleDisconnect never runs, and the peer leaks from `rooms` and
+    // `wss.clients` for the life of the process, poisoning that room id. The
+    // heartbeat reaps the descriptor, not the seat. Hence every throw we know of
+    // is fixed at its source above rather than left to this, and
+    // crashguard.test.js fails on an "Unhandled error" line reaching here.
+    //
+    // Also catches unhandled rejections, which arrive with origin
+    // 'unhandledRejection' (verified on Node 20, 22 and 24, the CI, dev and
+    // image versions), so a separate handler for them would be dead code.
+    //
+    // Inside require.main so `node --test` keeps Node's default behavior.
+    process.on('uncaughtException', (err, origin) => {
+        console.error(`Unhandled error (${origin}), server still serving:`, err);
+    });
+
+    server.listen(PORT, () => server.off('error', failFastOnBindError));
     initStats().catch(() => {}); // seed cachedTotal from Redis on startup
     process.on('SIGTERM', shutdown);
     process.on('SIGINT', shutdown);


### PR DESCRIPTION
## Summary

Six ways to end the signaling server process with an unauthenticated request. Each was reproduced against a real listener. None needs a room, a code, or any credential, and rooms are in memory, so every crash also drops every transfer in progress. PM2 restarts, and the attacker sends the next packet.

| | Trigger | Cost |
|---|---------|------|
| a | Upgrade target Node's parser accepts and WHATWG `URL` rejects: `//`, `///`, `//?`, `//[`, `//@`, `//%` | one ~130 byte request |
| b | A frame containing `null`. `JSON.parse('null')` returns null without throwing, so the parse guard missed it and reading `.type` threw | 4 bytes |
| c | Upgrade to an unclaimed path, then a TCP reset. Node removes its own socket `'error'` listener before emitting `'upgrade'` | one request |
| d | A `signal` of nested arrays. `JSON.stringify` recurses and overflows at 2235 levels. Reachable from a browser peer too, since socket.io's encoder stringifies synchronously | 4.4 KB |
| e | `/socket.io/../ws?EIO=4&transport=websocket`. engine.io claims an upgrade by a literal prefix compare on the **unparsed** target while this server compared a **normalized** pathname, so one target satisfied both and `ws` threw `handleUpgrade() was called more than once` | one request |
| f | 31 connections from one IP, then a 4-byte unmasked frame. The rate-limit early return fired before any `'error'` listener was attached, and `close()` leaves the Receiver reading for 30s | 31 connections + 4 bytes |

(e) is the one worth reviewing closely: it is not caught by guarding `new URL`, because the URL parses fine. The fix reuses engine.io's own predicate (`req.url.startsWith(io.path() + '/')`) rather than matching dot segments, so the `%2e%2e` and backslash spellings are covered by construction.

## Notes on the approach

**The backstop logs and keeps serving rather than exiting.** Exiting drops every live room and burns PM2's `max_restarts`, so for a caller who can reach a throw on demand the exit *is* the attack. It is a net, not a repair: a throw out of a ws `'message'` listener leaves that Receiver stuck mid-write, so `ws` never emits `'close'`, `handleDisconnect` never runs, and the peer leaks from `rooms` for the life of the process. So every throw above is fixed at its source, and the tests fail if one reaches the backstop.

`server.on('error')` is removed once the port is bound. Left attached it also fires for post-listen `EMFILE`/`ENFILE`, which would make descriptor exhaustion a new way to end the process.

No `unhandledRejection` handler: rejections already arrive at `uncaughtException` with `origin === 'unhandledRejection'` (verified on Node 20, 22 and 24, the CI, dev and image versions).

**The tests drive `server.js` as a child process.** In-process the failure is not observable: `node --test` installs its own uncaughtException handling, and a TCP connect from inside the server's own process cannot outlive it. An earlier draft of this file asserted liveness that way and its test for (c) passed with (c) fully reverted.

The nested-JSON test measures the overflow depth at runtime rather than hardcoding it, because `JSON.parse` being iterative while `JSON.stringify` is recursive is a V8 detail that varies with stack size and Node major. It fails loudly if either half ever changes.

## Test plan

- `cd server && node --test` - 58 pass, and the runner exits (the previous draft hung on any failure, which in CI is a 10 minute job timeout rather than a red).
- **Mutation tested.** Reverting any one of the six guards turns its test red. All six verified, none hangs.
- Six kill probes re-run against a freshly spawned child for each: all six targets in (a), the `null` frame, five resets on an unclaimed path, the nested signal, the three killing variants of (e), and trip-the-limiter-then-malformed-frame for (f).
- Playwright, signaling paths: browser to browser 50 MB with SHA-256, CLI to browser and browser to CLI, CLI to CLI, folder transfer, reconnect, invalid room. 11 passed.
- `/socket.io/` pass-through has its own regression guard. Break it and every browser silently drops to long-polling with nothing else failing.

Three `/download` specs (hydration, image-density, responsive) fail locally under `next dev`. Reproduced with this branch's changes stashed, so they are pre-existing and unrelated; CI runs the production build.

## Not in this PR

`createWSPeer.send` has no backpressure check, and the heartbeat that bounds it is defeated by unsolicited pong frames. Measured at +149 MB RSS from one attacker pair. Memory exhaustion rather than a crash, so it gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JGhNigcXefyMWS5rHb8Xhf
