### PR TITLE
chore(desktop): drop what the September splits left behind

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -15,10 +15,6 @@ import (
 
 const desktopUpdateHint = "Update Floe from the Microsoft Store or floe.one/download."
 
-// The share-link origin is no longer a constant here. It is derived from the
-// signaling origin by engine/serverurl, which the CLI uses too, so both surfaces
-// emit identical links. See App.endpoints.
-
 // contextMenuBase is the per-user Explorer context-menu key for all file types.
 const contextMenuBase = `Software\Classes\*\shell\Floe`
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import {useEffect, useRef, useState} from 'react';
-import type {MutableRefObject} from 'react';
 import {
     CancelTransfer,
     ConfirmClose,
@@ -32,9 +31,7 @@ import {
     ArrowUpRight,
     Check,
     ChevronDown,
-    Copy,
     Download,
-    Files,
     Folder,
     FolderOpen,
     History,
@@ -44,14 +41,13 @@ import {
 } from 'lucide-react';
 import {BoltMark, Button, cn, Eyebrow, Input, rowDescClass, rowLabelClass, StatusDot} from './components/ui';
 import {advancedSummary, hostOf} from './settings';
-import {histKey} from './history';
 import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, restoredAnnouncement, stagedSnapshot, supersededBy, undoLabel, type Cleared} from './clear';
 import {resetWarning} from './reset';
 import {friendlyError} from './errors';
 import {fmtBytes, formatIncoming, type IncomingPreview} from './incoming';
 import {track, type Marker, type Prog} from './progress';
 import {baseName, mergePaths, normPath} from './paths';
-import {HISTORY_CAP, fmtWhen, loadHistory, type HistEntry} from './history';
+import {HISTORY_CAP, fmtWhen, histKey, loadHistory, type HistEntry} from './history';
 import {DOWNLOAD_URL, bareVersion, isNewerDesktopVersion} from './update';
 import TitleBar from './components/TitleBar';
 import {Tooltip} from './components/Tooltip';
@@ -196,7 +192,7 @@ function App() {
     const [offerUp, setOfferUp] = useState(false);
     const clearedTimer = useRef<number | null>(null);
     // Readable from the once-registered file-drop and paste closures, which see
-    // only the first render's state. Same idiom as busyRef above.
+    // only the first render's state. Same idiom as busyRef below.
     const clearedRef = useRef<Cleared | null>(null);
     clearedRef.current = cleared;
     // What the live region says. A piece of state rather than a render of
@@ -1529,7 +1525,7 @@ function App() {
                                     <Eyebrow as="h3">Transfers</Eyebrow>
                                     <div className={cardClass}>
                                         {/* The placeholder must stay in step with defaultReceiveDir
-                                            (app.go:406) and with the receive screen's own field: a
+                                            in reveal.go and with the receive screen's own field: a
                                             blank value saves to ~/Downloads, it does NOT prompt.
                                             An earlier "Ask every time" here was simply false. */}
                                         <SettingField

--- a/desktop/frontend/src/components/ui.tsx
+++ b/desktop/frontend/src/components/ui.tsx
@@ -132,20 +132,6 @@ export function Input({className, ...props}: InputHTMLAttributes<HTMLInputElemen
     );
 }
 
-export function Card({className, children}: {className?: string; children: ReactNode}) {
-    return (
-        <div
-            className={cn(
-                'w-full rounded-xl border border-white/10 bg-zinc-900/60 shadow-2xl ring-1 ring-white/5 backdrop-blur-xl',
-                className,
-            )}
-        >
-            {children}
-        </div>
-    );
-}
-
-
 // One geometry, three call sites: SettingRow, SettingField, and the Advanced
 // disclosure button. Kept as consts so the three cannot drift apart.
 //

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -64,5 +64,3 @@ require (
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 )
-
-// replace github.com/wailsapp/wails/v2 v2.12.0 => C:\Users\Admin\go\pkg\mod


### PR DESCRIPTION
## Summary

Housekeeping after the September splits (#401 to #419). Nothing behavioral: deletions, one merged import, two comment words.

- `desktop/frontend/src/App.tsx`: drop the unused `MutableRefObject` type import (unused since #409) and the unused `Copy` and `Files` lucide icons (unused since #417); fold the two `./history` imports into one; two comment fixes (`busyRef` is declared below the note, not above it; `defaultReceiveDir` lives in `reveal.go`, not at an `app.go` line number).
- `desktop/frontend/src/components/ui.tsx`: delete the `Card` export, which nothing imports.
- `desktop/app.go`: delete the tombstone comment about the share-link constant (both the constant and the function it pointed at left the file; `endpoints.go` records the decision beside the code). `contextMenuBase`'s doc comment stays.
- `desktop/go.mod`: delete the commented-out machine-local Wails `replace`. No `go mod tidy`.

Two commits: the frontend deletes and comment words, then the two Go deletes.

## Test plan

- `npx tsc --noEmit -p tsconfig.json` in `desktop/frontend`: exit 0
- `npx vitest run` in `desktop/frontend`: 11 files, 140 tests (unchanged)
- `go vet ./... && go test -count=1 ./...` in `desktop/`: ok, 86 test funcs, 85 PASS, 1 SKIP (unchanged)
- `go doc -all -u .` in `desktop/`: identical to a worktree at 811d398 (a floating comment is not doc output)
- `go list -m all` in `desktop/`: identical to 811d398
- `desktop/frontend/wailsjs/go/main/App.d.ts`: byte-identical to 811d398 (no Go method change)
- ci.yml's Wails pin grep (`github.com/wailsapp/wails/v2 v2.12.0$`) still matches `desktop/go.mod:7`
- `git diff` on App.tsx and ui.tsx: only `-` lines plus the merged `./history` import and the two comment edits
- `check-consumers.mjs --root .`: 110 rows, 0 unmapped, 0 stale, 0 anchor-missing, 15 warnings (unchanged)
- `docs-check.mjs all`: 0 hard
- Not run locally (CI only): the Wails packaging steps, e2e, back-compat, Docker.
