### PR TITLE
chore(client): name the Go twin beside each mirrored constant, and drop two dead exports

### DIFF
--- a/client/hooks/useFileManagement.ts
+++ b/client/hooks/useFileManagement.ts
@@ -59,7 +59,6 @@ export function useFileManagement() {
 
     return {
         files,
-        setFiles,
         isDragging,
         totalBytes,
         handleFileSelection,

--- a/client/hooks/useSignaling.ts
+++ b/client/hooks/useSignaling.ts
@@ -52,8 +52,7 @@ export interface UseSignalingCallbacks {
  * Owns the Socket.IO transport only: online status, round-trip ping, joining a
  * room, and relaying WebRTC signals. It is peer- and transfer-agnostic — every
  * event whose handling depends on peer/transfer state is delegated to a callback
- * supplied by the component. (Peer/WebRTC creation lives in the component until
- * the usePeerConnection extraction.)
+ * supplied by the component. Peer/WebRTC creation stays in the component.
  */
 export function useSignaling(callbacks: UseSignalingCallbacks) {
     const [isConnected, setIsConnected] = useState(false);

--- a/client/lib/relay.ts
+++ b/client/lib/relay.ts
@@ -2,6 +2,10 @@
 // useRelayConfiguration hook. Kept side-effect free so the relay gate (which the
 // e2e suite does not exercise) can be unit-tested directly.
 
+// Mirrors RelaySizeLimit in cli/engine/transfer/relay.go; keep the two in
+// sync. What has to agree is the comparison, not the arithmetic: both sides
+// block only a payload strictly OVER the limit (evaluateRelayGate here,
+// checkRelayGate there), so a payload of exactly 2 GB is allowed.
 export const RELAY_SIZE_LIMIT = 2 * 1024 * 1024 * 1024; // 2 GB
 
 /**

--- a/client/lib/staleBundle.ts
+++ b/client/lib/staleBundle.ts
@@ -60,7 +60,7 @@ function messageOf(value: unknown): string | undefined {
  * reload loops via a sessionStorage debounce. Returns true if a reload was
  * triggered.
  */
-export function reloadIfStaleBundle(message: string | undefined): boolean {
+function reloadIfStaleBundle(message: string | undefined): boolean {
     if (typeof window === 'undefined') return false;
     if (!isStaleBundleError(message)) return false;
 

--- a/client/lib/transfer/protocol.ts
+++ b/client/lib/transfer/protocol.ts
@@ -2,7 +2,7 @@
 // Mirrors cli/engine/transfer/protocol.go + sender.go + receiver.go - keep in sync.
 import { sanitizeDisplayText } from '../download';
 
-export const CONTROL_MSG_MAX = 1000; // bytes; matches browser byteLength guard
+export const CONTROL_MSG_MAX = 1000; // bytes; mirrors controlMsgMax in cli/engine/transfer/control.go
 export const HIGH_WATER = 8 * 1024 * 1024; // 8 MB — pause sending at/above
 export const LOW_WATER = 4 * 1024 * 1024;  // 4 MB — resume sending below
 export const READ_SLAB = 4 * 1024 * 1024;  // 4 MB — disk read slab size

--- a/client/lib/transferUtils.ts
+++ b/client/lib/transferUtils.ts
@@ -1,6 +1,10 @@
 /**
- * Pure utility functions for transfer speed and ETA formatting.
- * Extracted from P2PTransfer.tsx to avoid duplication between sender and receiver.
+ * Pure utility functions for transfer speed and ETA formatting, shared by the
+ * sender and receiver progress displays.
+ *
+ * Two twins mirror these: formatSpeed and formatDuration in
+ * cli/engine/transfer/format.go, and fmtSpeed and fmtEta in
+ * desktop/frontend/src/progress.ts. Keep the three in sync.
  */
 
 export function formatSpeed(bytesPerSec: number): string {
@@ -14,7 +18,9 @@ export function formatETA(etaSeconds: number): string {
     if (!Number.isFinite(etaSeconds) || etaSeconds < 0) return '';
     // Round to whole seconds FIRST. Applying Math.ceil to the remainder
     // instead let it reach 60, so 119.5s printed "1m 60s" and 59.9s printed
-    // "60s". The Go twin truncates and never had either.
+    // "60s". formatDuration in format.go truncates and never had either;
+    // fmtEta in progress.ts rounds up exactly like this. Keep Math.ceil: the
+    // 60-second carry test in transferUtils.test.ts pins it.
     const s = Math.ceil(etaSeconds);
     if (s < 60) return `${s}s`;
     if (s < 3600) return `${Math.floor(s / 60)}m ${s % 60}s`;


### PR DESCRIPTION
## Summary

Two commits, both housekeeping the September splits left behind in `client/`.

**Comments (commit 1).** Four mirrored constants now name the symbol on the other side instead of describing themselves or pointing at a file that no longer holds the twin:

- `client/lib/relay.ts`: `RELAY_SIZE_LIMIT` names `RelaySizeLimit` in `cli/engine/transfer/relay.go` and records that what has to agree is the strictly-greater comparison (`evaluateRelayGate` here, `checkRelayGate` there), not the arithmetic.
- `client/lib/transferUtils.ts`: the header names `formatSpeed` / `formatDuration` in `format.go` and `fmtSpeed` / `fmtEta` in `desktop/frontend/src/progress.ts`; the carry comment says which twin truncates and which rounds up, and that `Math.ceil` stays because the 60-second carry test pins it.
- `client/lib/transfer/protocol.ts`: `CONTROL_MSG_MAX` names `controlMsgMax` in `control.go` instead of "matches browser byteLength guard" (it is the browser).
- `client/hooks/useSignaling.ts`: the doc comment drops the promised `usePeerConnection` extraction, which was never planned.

**Deletes (commit 2).** `useFileManagement` stops returning `setFiles` (P2PTransfer, the only caller, never destructures it; every write goes through `addFiles` / `handleDeleteFile`), and `reloadIfStaleBundle` in `client/lib/staleBundle.ts` loses its `export` (its two callers are the listeners `registerStaleBundleReload` installs in the same file; `staleBundle.test.ts` imports only `isStaleBundleError`).

No CLAUDE.md edit here; that belongs to the docs PR in this program.

## Test plan

Run in a fresh clone at `811d398` with the branch applied:

- `corepack pnpm exec tsc --noEmit`: exit 0
- `corepack pnpm lint`: 0 errors, 2 warnings (the two known `no-location-assign-relative-destination` warnings, unchanged)
- `corepack pnpm test`: 29 files, 401 tests, all passing (unchanged)
- `node .claude/skills/untrusted-peer-data/scripts/check-consumers.mjs --root .`: 110 rows, 0 unmapped, 0 stale, 0 anchor-missing, 15 warnings (unchanged)
- `node .claude/skills/docs-verify/scripts/docs-check.mjs all`: 0 hard
- `grep -rn "setFiles\|reloadIfStaleBundle" client --include=*.ts --include=*.tsx` (node_modules excluded): no reader outside the defining file
- Commit 1's diff touches no executable line; commit 2's diff is one deleted return key and one dropped `export` keyword.

Left to CI: the e2e matrix, back-compat, desktop, docker (none touch code these edits reach).
