### PR TITLE
refactor(cli): retire two dead exports and correct the comments that describe the engine

### DIFF
--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -53,6 +53,13 @@ desktop/               Wails app: imports cli/engine/...
   frontend/            web UI (shared design with client/)
   app.go               Go methods bound to the UI
   main.go              Wails bootstrap
+  transfer.go          drives a send or a receive end to end and emits the UI events
+  transferstate.go     one-transfer-at-a-time state machine, CancelTransfer, close guard
+  endpoints.go         which server and web app this build talks to
+  reveal.go            Show in folder: the platform commands and the path checks before them
+  serverprobe.go       the Settings Test button: probes a server URL in stages
+  updatecheck.go       once-a-day check for a newer desktop release, notice only
+  config.go            desktop.json: persisted settings kept outside the WebView
 go.work                ties cli + desktop for local dev
 ```
 
@@ -76,7 +83,7 @@ go.work                ties cli + desktop for local dev
 ### Phase 2 - Real app  [IN PROGRESS]
 - [x] Send from desktop: native file picker (`SelectFiles`) + code/link via the engine sender, reported through Wails events (`send:code/status/done/error`)
 - [x] Basic Send / Receive two-mode UI
-- [x] Live progress bar (percent + bytes) via an engine progress callback (`SendFilesWithProgress`/`ReceiveFilesWithProgress`) plus throttled `send:progress`/`recv:progress` Wails events
+- [x] Live progress bar (percent + bytes) via an engine progress callback (`SendOptions.OnProgress`/`ReceiveOptions.OnProgress`) plus throttled `send:progress`/`recv:progress` Wails events
 - [x] Speed and ETA readout on the progress bar
 - [x] Drag and drop files onto the window to send
 - [x] Polished UI matching the web app's design: Tailwind v4 (`@tailwindcss/vite`, Vite 3->6 bump)
@@ -196,7 +203,7 @@ verify the connection independently of the server.
 
 **Robustness gap (found 2026-07-04)  [RESOLVED 2026-07]:** desktop `runSend` /
 `ReceiveByCode` used to block indefinitely on peer-connect and WebRTC setup with no
-timeout and no cancel. Fixed since: `CancelTransfer` (app.go) closes the signaling and
+timeout and no cancel. Fixed since: `CancelTransfer` (transferstate.go) closes the signaling and
 peer connections to unblock both flows, and role selection carries a 20s timeout on the
 send and receive paths. The only remaining unbounded wait is the sender waiting for a
 receiver, which is deliberate (share a link and wait) and cancellable.

--- a/cli/engine/ice/credentials.go
+++ b/cli/engine/ice/credentials.go
@@ -140,14 +140,14 @@ type iceServerJSON struct {
 	Credential string          `json:"credential,omitempty"`
 }
 
-// Fetch fetches ICE server credentials from serverURL/api/turn-credentials.
-// Falls back to Google STUN if the endpoint is unreachable or misconfigured.
 // client bounds the fetch. http.DefaultClient has no timeout at all, so a
 // server that accepts the TCP connection and then never answers used to hang
 // `floe send` at step 2 forever. Generous on purpose: falling back to STUN
 // costs a relay, so a slow-but-working server should still win.
 var client = &http.Client{Timeout: 30 * time.Second}
 
+// Fetch fetches ICE server credentials from serverURL/api/turn-credentials.
+// Falls back to Google STUN if the endpoint is unreachable or misconfigured.
 func Fetch(serverURL string) ([]webrtc.ICEServer, error) {
 	servers, _, err := FetchDetail(serverURL)
 	return servers, err

--- a/cli/engine/peer/connection.go
+++ b/cli/engine/peer/connection.go
@@ -390,11 +390,6 @@ func (conn *Connection) SetupAsReceiver() (*webrtc.DataChannel, error) {
 	}
 }
 
-// WaitConnected blocks until the peer connection reaches "connected" state or fails.
-func (conn *Connection) WaitConnected() error {
-	return <-conn.connected
-}
-
 // Close tears down the peer connection and releases the two goroutines New
 // started. Idempotent: the CLI defers this once, but the desktop builds a
 // fresh Connection per transfer, so a leak here is unbounded over a session.

--- a/cli/engine/peer/connection.go
+++ b/cli/engine/peer/connection.go
@@ -358,11 +358,12 @@ func (conn *Connection) SetupAsReceiver() (*webrtc.DataChannel, error) {
 		return nil, fmt.Errorf("failed to set local description: %w", err)
 	}
 
-	// pion v3.3.6 OMITS a=max-message-size from SDP entirely.
-	// RFC 8841 says absent = default 65536 (64 KB). Chrome enforces this,
-	// causing "Failure to send data" for chunks > 64 KB (browser uses 160 KB).
-	// Inject a large value into the SDP we SEND to the browser (not what pion
-	// uses internally — SetLocalDescription already consumed the original).
+	// The answer goes out with a=max-message-size pinned to 1 GB. Chrome caps
+	// RTCDataChannel.send() at whatever this SDP advertises, and at 64 KB when
+	// the attribute is absent, which is where pion v3 left it; pion v4 emits it
+	// with its own ceiling just under 1 GB, so today the rewrite is a pin, not a
+	// rescue. It changes only what is sent: SetLocalDescription already consumed
+	// the original. See patchMaxMessageSize.
 	patchedSDP := patchMaxMessageSize(answer.SDP)
 
 	// Send the answer to the sender
@@ -422,6 +423,9 @@ func (conn *Connection) Fingerprints() (local, remote string, err error) {
 // selected candidate pair is a TURN relay, "direct" otherwise. Only meaningful
 // once the connection is established (call after SetupAsSender/SetupAsReceiver
 // returns); before that it returns an error.
+//
+// pathTypeOf in engine/transfer is the same walk started from the data channel
+// rather than the PeerConnection; a change here is a change there too.
 func (conn *Connection) ConnectionType() (string, error) {
 	sctp := conn.pc.SCTP()
 	if sctp == nil {

--- a/cli/engine/peer/sdp.go
+++ b/cli/engine/peer/sdp.go
@@ -17,22 +17,25 @@ func extractFingerprint(sdp string) string {
 	return ""
 }
 
-// patchMaxMessageSize injects a=max-message-size into the SDP.
+// patchMaxMessageSize pins a=max-message-size to 1 GB in the SDP.
 //
-// pion/webrtc v3.3.6 does NOT include a=max-message-size in the SDP it
-// generates. Per RFC 8841 §5, when the attribute is absent the remote peer
-// MUST assume a default of 65536 bytes. Chrome enforces this default: any
-// call to RTCDataChannel.send() with a payload larger than 65536 bytes throws
-// "Failure to send data" (TypeError per the WebRTC spec §6.2 step 4).
+// Per RFC 8841 section 5 the attribute tells the remote peer how large a
+// message this side accepts, and when it is absent the remote peer must assume
+// 65536 bytes. Chrome enforces whichever applies: RTCDataChannel.send() past it
+// throws "Failure to send data" (a TypeError per the WebRTC spec), and the
+// browser sender's chunks run up to MAX_CHUNK, 256 KB, in
+// client/lib/transfer/protocol.ts.
 //
-// The browser's chunk size starts at 160 KB (chunkSizeRef = 160*1024), so
-// every single chunk send fails. The fix is to explicitly advertise a large
-// max-message-size (1 GB) after the a=sctp-port line that pion DOES emit.
-// pion/sctp transparently handles SCTP-level fragmentation for large messages.
+// pion/webrtc v3 omitted the attribute, and injecting one after the
+// a=sctp-port line was the fix. pion v4 (v4.2.19 in go.mod) emits it in every
+// description it generates (addDataMediaSection in its sdp.go) with the
+// SettingEngine ceiling, 1073741823 by default, so the replace branch below is
+// the live path and the inject branch only covers an SDP that lacks the
+// attribute. pion/sctp fragments large messages itself.
 func patchMaxMessageSize(sdp string) string {
 	const maxMsgAttr = "a=max-message-size:1073741824\r\n" // 1 GB
 
-	// If the attribute already exists (future pion versions), replace it.
+	// pion v4 always emits the attribute, so this is the path taken today.
 	if strings.Contains(sdp, "a=max-message-size:") {
 		lines := strings.Split(sdp, "\r\n")
 		for i, line := range lines {

--- a/cli/engine/transfer/control.go
+++ b/cli/engine/transfer/control.go
@@ -124,10 +124,12 @@ const controlMsgMax = 1000
 // else was already safe. What was not safe, and is what the framing gate on
 // the receive path fixes, is a JSON file whose "type" IS one of these.
 //
-// The receiver only acts on "metadata" and "end". The other recognized types
-// ("ack", "received", "incompatible") flow in the opposite direction and are
-// recognized here for the sender-side loops, which read this direction and
-// carry no file data.
+// The receive loop is the only caller, and it acts on "metadata", "end" and
+// "incompatible" (a sender's abort). "ack" and "received" flow the other way
+// and never come through here: the sender decodes the receiver's frames on its
+// own (the ack wait in sendFile, abortFromPeer and isReceived) under the same
+// controlMsgMax bound. A stray "ack" or "received" that does reach the receive
+// loop matches no arm of its switch and is dropped.
 func classifyControl(data []byte) (msgType string, isControl bool) {
 	if len(data) > controlMsgMax {
 		return "", false

--- a/cli/engine/transfer/format.go
+++ b/cli/engine/transfer/format.go
@@ -39,6 +39,10 @@ func formatBytes(n int64) string {
 	return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%.2f", val), "0"), ".") + " " + units[i]
 }
 
+// formatSpeed renders a byte rate for the progress line: one decimal, MB/s at
+// a megabyte and above, KB/s below, "" when the rate is not a positive finite
+// number. formatSpeed in client/lib/transferUtils.ts and fmtSpeed in
+// desktop/frontend/src/progress.ts print the same shape; keep the three in step.
 func formatSpeed(bytesPerSec float64) string {
 	if !isFinitePositive(bytesPerSec) {
 		return ""
@@ -49,6 +53,11 @@ func formatSpeed(bytesPerSec float64) string {
 	return fmt.Sprintf("%.1f KB/s", bytesPerSec/1024)
 }
 
+// formatDuration renders an ETA for the progress line: "Ns" under a minute,
+// "Nm Ns" under an hour, "Nh Nm" beyond. formatETA in
+// client/lib/transferUtils.ts and fmtEta in desktop/frontend/src/progress.ts
+// print the same shape, but they round up to whole seconds where this
+// truncates; keep the three in step.
 func formatDuration(d time.Duration) string {
 	secs := int(d.Seconds())
 	if secs < 0 {

--- a/cli/engine/transfer/progress.go
+++ b/cli/engine/transfer/progress.go
@@ -1,9 +1,9 @@
 package transfer
 
 // Progress describes the state of an in-flight transfer for one file. It is
-// reported by SendFilesWithProgress and ReceiveFilesWithProgress so a GUI can
-// render a live progress bar. The CLI does not use it; it renders a terminal
-// progress bar instead.
+// reported through SendOptions.OnProgress and ReceiveOptions.OnProgress so a
+// GUI can render a live progress bar. The CLI does not use it; it renders a
+// terminal progress bar instead.
 type Progress struct {
 	FileName   string `json:"fileName"`   // sender-supplied name of the current file, display-safe (see displayText); on the receive side never the on-disk name, see SavedName
 	FileIndex  int    `json:"fileIndex"`  // 1-based index of the current file

--- a/cli/engine/transfer/receiver.go
+++ b/cli/engine/transfer/receiver.go
@@ -1,6 +1,7 @@
-// Package transfer implements the Floe data channel protocol for receiving files.
-// See sender.go for the full protocol description.
 package transfer
+
+// The receive side of the data channel protocol. See sender.go for the full
+// protocol description, which is also the package doc.
 
 import (
 	"bytes"

--- a/cli/engine/transfer/relay.go
+++ b/cli/engine/transfer/relay.go
@@ -32,6 +32,10 @@ var ErrRelayOverLimit = errors.New("relay connections are capped at 2 GB")
 // "relay" when either side of the selected candidate pair is a TURN relay,
 // "direct" otherwise. Only meaningful once the connection is established;
 // before that it returns an error.
+//
+// ConnectionType in engine/peer is the same walk started from the
+// PeerConnection rather than the data channel; a change here is a change there
+// too.
 func pathTypeOf(dc *webrtc.DataChannel) (string, error) {
 	if dc == nil {
 		return "", fmt.Errorf("no data channel")

--- a/cli/engine/transfer/sender.go
+++ b/cli/engine/transfer/sender.go
@@ -170,13 +170,6 @@ func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
 	return SendFilesWithOptions(dc, paths, localVer, SendOptions{})
 }
 
-// SendFilesWithProgress is SendFiles with a progress callback for GUI clients.
-// When onProgress is non-nil, per-chunk progress is reported through it and the
-// terminal progress bar is suppressed.
-func SendFilesWithProgress(dc *webrtc.DataChannel, paths []string, localVer string, onProgress ProgressFunc) error {
-	return SendFilesWithOptions(dc, paths, localVer, SendOptions{OnProgress: onProgress})
-}
-
 // SendFilesWithOptions is the full-featured send entry point; the other two
 // delegate here.
 func SendFilesWithOptions(dc *webrtc.DataChannel, paths []string, localVer string, opts SendOptions) error {

--- a/cli/engine/transfer/sender.go
+++ b/cli/engine/transfer/sender.go
@@ -572,10 +572,11 @@ ackLoop:
 	// The file changed under the send. Say so here, where the cause is still
 	// visible, instead of sending an end marker and leaving the receiver to report
 	// a byte count that reads like a network fault.
+	changed := fmt.Sprintf("the sender's copy of %q changed while it was being sent, so nothing further was sent", entry.displayName)
 	if sentFile != fileSize {
 		// The receiver is mid-file with an unfinished .part and no idea why the
 		// bytes stopped. Name it, or its own diagnosis is a stalled connection.
-		abortReason(dc, localVer, fmt.Sprintf("the sender's copy of %q changed while it was being sent, so nothing further was sent", entry.displayName), true)
+		abortReason(dc, localVer, changed, true)
 		return fmt.Errorf("the file shrank while it was being sent (announced %d bytes, read %d); send it again once it stops changing",
 			fileSize, sentFile)
 	}
@@ -590,7 +591,7 @@ ackLoop:
 	if info.Mode().IsRegular() {
 		var probe [1]byte
 		if n, _ := f.Read(probe[:]); n > 0 {
-			abortReason(dc, localVer, fmt.Sprintf("the sender's copy of %q changed while it was being sent, so nothing further was sent", entry.displayName), true)
+			abortReason(dc, localVer, changed, true)
 			return fmt.Errorf("the file grew while it was being sent (announced %d bytes); send it again once it stops changing",
 				fileSize)
 		}

--- a/cli/engine/transfer/sender.go
+++ b/cli/engine/transfer/sender.go
@@ -59,12 +59,12 @@ func chunkSizeFor(sctpMax uint32) int {
 	return maxChunkSize
 }
 
-// Backpressure watermarks mirror the browser sender (P2PTransfer.tsx): pause
-// sending once pion's SCTP send buffer reaches the high-water mark, resume once
-// it drains back below the low-water mark. Without this the sender enqueues the
-// whole file as fast as the disk reads it — the progress bar races to 100% while
-// the receiver is still mid-transfer, and large files overflow pion's buffer and
-// stall the connection.
+// Backpressure watermarks mirror HIGH_WATER and LOW_WATER in the browser sender
+// (client/lib/transfer/protocol.ts): pause sending once pion's SCTP send buffer
+// reaches the high-water mark, resume once it drains back below the low-water
+// mark. Without this the sender enqueues the whole file as fast as the disk
+// reads it: the progress bar races to 100% while the receiver is still
+// mid-transfer, and large files overflow pion's buffer and stall the connection.
 const (
 	bufferedAmountHighWater = 8 * 1024 * 1024 // pause sending at/above 8 MB buffered
 	bufferedAmountLowWater  = 4 * 1024 * 1024 // resume sending below 4 MB buffered
@@ -170,8 +170,8 @@ func SendFiles(dc *webrtc.DataChannel, paths []string, localVer string) error {
 	return SendFilesWithOptions(dc, paths, localVer, SendOptions{})
 }
 
-// SendFilesWithOptions is the full-featured send entry point; the other two
-// delegate here.
+// SendFilesWithOptions is the full-featured send entry point; SendFiles
+// delegates here.
 func SendFilesWithOptions(dc *webrtc.DataChannel, paths []string, localVer string, opts SendOptions) error {
 	onProgress := opts.OnProgress
 	// Expand paths: collect all files (walk directories)


### PR DESCRIPTION
## Summary

Three commits, one story: the engine's dead exports go, and the comments that describe the engine say what the code does today.

- Deletes two exports with no caller. `peer.Connection.WaitConnected` (no caller since #228; both Setup paths drain `conn.connected` themselves, so a later caller would block forever; the channel and its writer stay) and `transfer.SendFilesWithProgress` (no caller since #282; a one-line wrapper over `SendFilesWithOptions`). `SendFiles` and `ReceiveFilesWithProgress` keep their callers and stay.
- Corrects the comments, code untouched. `receiver.go`'s second package paragraph becomes a per-file note below the package clause (`go doc ./engine/transfer` printed two concatenated paragraphs). The `Fetch` doc moves from above `var client` onto `func Fetch` (`go doc ./engine/ice Fetch` printed none). The `a=max-message-size` story in `peer/sdp.go` and `connection.go` is rewritten as fact: pion v4.2.19 emits the attribute in every description with its SettingEngine default of 1073741823, so the replace branch is the live path; the inject branch stays, since dropping it would change the answer SDP a browser receives. `classifyControl`'s paragraph about sender-side loops is corrected (the receive loop is its only caller, the sender decodes `ack`, `received` and `incompatible` itself, and the receiver does act on a sender's `incompatible` abort). The watermark comment names `HIGH_WATER`/`LOW_WATER` in `client/lib/transfer/protocol.ts` instead of P2PTransfer.tsx; `Progress` names `SendOptions.OnProgress`/`ReceiveOptions.OnProgress`; `pathTypeOf` and `ConnectionType` name each other; `formatSpeed` and `formatDuration` name their browser and desktop twins; `SendFilesWithOptions`'s doc no longer counts the deleted wrapper.
- `DESKTOP.md`: the repo layout lists the desktop files the September splits created (`transfer.go`, `transferstate.go`, `endpoints.go`, `reveal.go`, `serverprobe.go`, `updatecheck.go`, `config.go`), the progress-bar row names the options fields rather than the deleted wrapper, and `CancelTransfer` is located in `transferstate.go`.
- `sendFile` builds the changed-file abort text once for its two abort sites.

No wire message, user-facing string, CLI flag or Wails binding changes. No release.

## Test plan

- go doc proof per commit, against a worktree at 811d398, on Windows and with `GOOS=linux`: the delete commit removes exactly `func (conn *Connection) WaitConnected() error` and `func SendFilesWithProgress(...)` and nothing else; the comment commit shows doc text only for `engine/transfer`, `engine/ice` and `engine/peer`; the local commit is identical. Aggregate base to HEAD over all nine cli packages: 2 signature lines removed, every other delta is doc text, `cmd/floe` identical.
- Measured before and after: `go doc ./engine/transfer` printed two package paragraphs, now one; `go doc ./engine/ice Fetch` printed no doc, now prints it.
- `cd cli && go vet ./... && go test -count=1 ./...`: 9 packages ok (`engine/transfer` 87 s). `GOOS=linux go vet ./...` clean. `go build ./...` clean. gofmt clean on every changed file.
- `cd desktop && go vet ./...` clean with `frontend/dist` built (`npm ci && npm run build`), so the desktop still compiles against the trimmed engine.
- `node .claude/skills/untrusted-peer-data/scripts/check-consumers.mjs --root .`: 110 rows, 0 unmapped, 0 stale, 0 anchor-missing, 15 warnings (unchanged; `sender.go` and `control.go` anchors still resolve).
- `node .claude/skills/docs-verify/scripts/docs-check.mjs all`: 0 hard, 41 notes (unchanged; DESKTOP.md is a scan root). No em or en dash in any added line. Every DESKTOP.md file name and symbol named here was checked against the tree.
- Only CI can arbitrate: the other two CLI OSes, E2E x3, Back-compat, the Desktop packaging steps.
