### PR TITLE
refactor(desktop): move webPlaceholder into settings.ts with its mirror table

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -40,7 +40,7 @@ import {
     X,
 } from 'lucide-react';
 import {BoltMark, Button, cn, Eyebrow, Input, rowDescClass, rowLabelClass, StatusDot} from './components/ui';
-import {advancedSummary, hostOf} from './settings';
+import {advancedSummary, hostOf, webPlaceholder} from './settings';
 import {UNDO_WINDOW_MS, clearLabel, clearedAnnouncement, clearedLabel, restorable, restoredAnnouncement, stagedSnapshot, supersededBy, undoLabel, type Cleared} from './clear';
 import {resetWarning} from './reset';
 import {friendlyError} from './errors';
@@ -62,16 +62,6 @@ type Mode = 'send' | 'receive' | 'history';
 // a reset lands on the exact same copy a fresh launch shows.
 const INITIAL_SEND_STATUS = 'Select or drag files, then click Send.';
 const INITIAL_RECV_STATUS = 'Enter a code or link, then click Receive.';
-
-/** webPlaceholder shows what the Web address field falls back to when left blank,
- *  so the derivation is visible instead of implied. Mirrors engine/serverurl.Web,
- *  which is what actually builds the link; keep the two in step. */
-function webPlaceholder(server: string): string {
-    const s = server.trim().replace(/\/+$/, '');
-    if (s === '' || s === 'https://api.floe.one') return 'https://floe.one';
-    if (s === 'http://localhost:3001') return 'http://localhost:3000';
-    return s;
-}
 
 // Windows paths compare case-insensitively; normalize for dedupe and removal but
 // keep the original strings for display and for the Go side.

--- a/desktop/frontend/src/settings.test.ts
+++ b/desktop/frontend/src/settings.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from 'vitest';
-import {advancedSummary, hostOf} from './settings';
+import {advancedSummary, hostOf, webPlaceholder} from './settings';
 
 describe('hostOf', () => {
     it('reduces a full address to its host', () => {
@@ -66,5 +66,33 @@ describe('advancedSummary', () => {
         ]) {
             expect(s).not.toContain('—');
         }
+    });
+});
+
+describe('webPlaceholder', () => {
+    // The cases mirror TestWeb in cli/engine/serverurl/serverurl_test.go, which
+    // pins engine/serverurl.Web, the function that actually builds the link.
+    // Nothing runs both tables: this one guards only the TypeScript side, so a
+    // case added to the Go table has to be carried over here by hand.
+    it.each([
+        ['production', 'https://api.floe.one', 'https://floe.one'],
+        ['production with trailing slash', 'https://api.floe.one/', 'https://floe.one'],
+        ['local dev', 'http://localhost:3001', 'http://localhost:3000'],
+        ['local dev with trailing slash', 'http://localhost:3001/', 'http://localhost:3000'],
+        // One-domain self-hosting: the web app and the API share an origin, so
+        // the server address is already the right link base.
+        ['self-hosted one domain', 'https://floe.example.com', 'https://floe.example.com'],
+        ['self-hosted with trailing slash', 'https://floe.example.com/', 'https://floe.example.com'],
+    ])('%s', (_name, server, want) => {
+        expect(webPlaceholder(server)).toBe(want);
+    });
+
+    // The one deliberate divergence from the Go table, where Web('') is ''.
+    // Go's callers pass an already-resolved server; this placeholder is shown
+    // while the Server address field is still blank, and blank means Floe's
+    // own server, so the field shows what that resolves to rather than nothing.
+    it('shows the production link while the server field is blank', () => {
+        expect(webPlaceholder('')).toBe('https://floe.one');
+        expect(webPlaceholder('   ')).toBe('https://floe.one');
     });
 });

--- a/desktop/frontend/src/settings.ts
+++ b/desktop/frontend/src/settings.ts
@@ -46,3 +46,13 @@ export function advancedSummary(server: string, web: string): string {
     }
     return "This app uses Floe's server. You can point it at your own instead.";
 }
+
+/** webPlaceholder shows what the Web address field falls back to when left blank,
+ *  so the derivation is visible instead of implied. Mirrors engine/serverurl.Web,
+ *  which is what actually builds the link; keep the two in step. */
+export function webPlaceholder(server: string): string {
+    const s = server.trim().replace(/\/+$/, '');
+    if (s === '' || s === 'https://api.floe.one') return 'https://floe.one';
+    if (s === 'http://localhost:3001') return 'http://localhost:3000';
+    return s;
+}


### PR DESCRIPTION
## Summary

`webPlaceholder` is a pure function of the server address that mirrors `engine/serverurl.Web`, and it lived at module scope in `App.tsx` where nothing could exercise it without mounting the whole app. Two commits:

1. Move it, with its doc comment, into `desktop/frontend/src/settings.ts` beside `hostOf` and `advancedSummary` (the file's charter is "pure helpers for the Settings screen, testable without a DOM") and import it back. The only change to the body is the `export` keyword.
2. A `webPlaceholder` table in `settings.test.ts` mirroring the six named cases of `TestWeb` in `cli/engine/serverurl/serverurl_test.go` (production, local dev and a one-domain self-host, each with and without a trailing slash), plus the one deliberate divergence pinned on its own: Go's `Web('')` is `''` because its callers pass a resolved server, while the placeholder is shown against a blank field and so shows what blank resolves to (`https://floe.one`). The comment names the Go file and says it guards only the TypeScript side.

No behavior change; no Go change.

## Test plan

- Move proof: the nine moved lines (`App.tsx:66-74` at 3e733ab) diff against `settings.ts:50-58` as exactly one changed line, `function` to `export function`; `diff -w` after allowing that keyword is clean.
- `git diff 3e733ab -- desktop/frontend/src/App.tsx | grep '^+'`: the widened `./settings` import is the only added line.
- `npx tsc --noEmit -p tsconfig.json` in `desktop/frontend`: exit 0 after each commit.
- `npx vitest run` in `desktop/frontend`: 11 files, 140 tests after the move; 11 files, 147 tests with the table. `--reporter=verbose` on `settings.test.ts` lists the seven new cases by name.
- `desktop/frontend/wailsjs/go/main/App.d.ts`: byte-identical to 3e733ab.
- `check-consumers.mjs --root .`: 110 rows, 0 unmapped, 0 stale, 0 anchor-missing, 15 warnings (unchanged).
- `docs-check.mjs all`: 0 hard.
- Not run locally (CI only): the Wails packaging steps, e2e, back-compat, Docker.
