### PR TITLE
fix(skills): build the safety row from baseResult, and stop duplicating the tag parser

### DIFF
--- a/.claude/skills/transfer-audit/scripts/audit.mjs
+++ b/.claude/skills/transfer-audit/scripts/audit.mjs
@@ -68,7 +68,7 @@ import {
     tryAdapter as realTryAdapter,
 } from './lib/adapters.mjs';
 import { USAGE, UsageError, parseArgs } from './lib/args.mjs';
-import { RETRY_CAP, runCell } from './lib/cell.mjs';
+import { RETRY_CAP, baseResult, runCell } from './lib/cell.mjs';
 import { createFence, isUnder, normalizePath } from './lib/fence.mjs';
 import { formatBytes } from './lib/fixtures.mjs';
 import { get, getJson, head } from './lib/http.mjs';
@@ -1930,37 +1930,14 @@ export async function runCmd(opts, io = {}) {
                 if (e instanceof SafetyError || e.fence) {
                     safetyTripped = true;
                     log(`SAFETY ${cell.id}: ${e.message}`);
+                    // Spread first: baseResult carries both builds (the
+                    // report's Rcv build column) with verdict null, so the
+                    // overrides must follow it or exit 4 is lost.
                     result = {
-                        id: cell.id,
-                        profile: cell.profile === 'H' ? 'head' : 'shipped',
-                        path: cell.path,
-                        variant: cell.variant,
-                        sender: { surface: cell.sender.letter },
-                        receiver: {
-                            surface: cell.receiver.letter,
-                            input: cell.receiver.input,
-                        },
-                        fixture: {
-                            kind: cell.fixture.kind,
-                            files: [],
-                            totalBytes: cell.fixture.totalBytes,
-                        },
+                        ...baseResult(cell, ctx),
                         verdict: 'ERROR',
                         reason: 'safety',
-                        triage: null,
                         note: e.message,
-                        attempts: [],
-                        route: {
-                            expected: cell.path === 'REL' ? 'relay' : 'direct',
-                            observed: 'unobserved',
-                            label: '-',
-                            sources: [],
-                        },
-                        integrity: { ok: null, files: [] },
-                        completion: {},
-                        stats: {},
-                        metrics: {},
-                        durationS: 0,
                         countsForExit: true,
                     };
                     run.cells.push(result);

--- a/.claude/skills/transfer-audit/scripts/audit.test.mjs
+++ b/.claude/skills/transfer-audit/scripts/audit.test.mjs
@@ -788,6 +788,40 @@ test('a safety breach aborts the run with exit 4, above a FAIL', async () => {
         !i.lines.some((l) => l.startsWith('PROGRESS S-DIR-W2C')),
         'the run stops at the breach'
     );
+    // The safety row is built from baseResult like every other row, so the
+    // run's most serious row carries the receiver build (run.json's
+    // receiver.build and the report's Rcv build column) instead of the
+    // build-less stub and the '-' it printed while the row was assembled
+    // by hand. rcvBuild itself never reaches run.json (buildRunJsonRaw
+    // whitelists the row's fields), so the table is where it is checked.
+    const outDir = out('safety');
+    const runs = readdirSync(outDir).filter((d) => /-shipped-quick$/.test(d));
+    assert.equal(runs.length, 1);
+    const runDir = path.join(outDir, runs[0]);
+    const json = JSON.parse(
+        readFileSync(path.join(runDir, 'run.json'), 'utf8')
+    );
+    const row = json.cells.find((c) => c.id === 'S-DIR-C2W');
+    const sibling = json.cells.find((c) => c.id === 'S-DIR-W2W');
+    assert.equal(row.verdict, 'ERROR');
+    assert.equal(row.reason, 'safety');
+    assert.equal(row.countsForExit, true);
+    assert.equal(typeof row.receiver.build, 'string');
+    assert.equal(row.receiver.build, sibling.receiver.build, 'same web receiver');
+    assert.equal(row.receiver.version, sibling.receiver.version);
+    const md = readFileSync(path.join(runDir, 'audit.md'), 'utf8');
+    // Table columns: Cell, Verdict, Route, Size, t(s), Rcv build, Note.
+    const rcvBuildColumn = (id) => {
+        const line = md.split('\n').find((l) => l.startsWith(`| ${id} `));
+        assert.ok(line, `${id} is in the report table`);
+        return line.split('|')[6].trim();
+    };
+    assert.equal(
+        rcvBuildColumn('S-DIR-C2W'),
+        rcvBuildColumn('S-DIR-W2W'),
+        'Rcv build column on the safety row'
+    );
+    assert.notEqual(rcvBuildColumn('S-DIR-C2W'), '-');
 });
 
 test('two consecutive infra symptoms skip the rest and exit 3', async () => {

--- a/.claude/skills/transfer-audit/scripts/lib/cell.mjs
+++ b/.claude/skills/transfer-audit/scripts/lib/cell.mjs
@@ -1458,7 +1458,14 @@ export async function runAttempt(
     return rec;
 }
 
-function baseResult(cell, ctx) {
+/**
+ * The skeleton every cell row starts from: identity, both builds from
+ * ctx.buildFor (the report's Rcv build column), a null verdict and
+ * countsForExit. audit.mjs builds the safety ERROR row from it too: spread
+ * it FIRST and override verdict, reason, note and countsForExit after, or
+ * the verdict resets to null and exit 4 is lost.
+ */
+export function baseResult(cell, ctx) {
     const build = (surface, role) =>
         ctx.buildFor ? ctx.buildFor(surface, role) : null;
     const sb = build(cell.sender.surface, 'sender');

--- a/.claude/skills/transfer-audit/scripts/lib/desktop.mjs
+++ b/.claude/skills/transfer-audit/scripts/lib/desktop.mjs
@@ -89,7 +89,6 @@ export const LAUNCH_MODES = Object.freeze([
     'head',
     'wailsdev',
 ]);
-export const DESKTOP_TAG = /^desktop-v(\d+)\.(\d+)\.(\d+)$/;
 
 /**
  * Exact UI strings the driver keys on (App.tsx unless noted). Source case;
@@ -200,18 +199,12 @@ export class PreconditionError extends Error {
 
 // ------------------------------------------------------- pure functions
 
-export function parseTag(tag) {
-    const m = DESKTOP_TAG.exec(tag || '');
-    if (!m) return null;
-    const [major, minor, patch] = m.slice(1).map(Number);
-    return { tag, version: `${major}.${minor}.${patch}`, major, minor, patch };
-}
-
-/** desktop-v0.2.8 -> 1.2.8.0 (pack.ps1: the Store refuses a 0 first octet). */
-export function identityVersion(tag) {
-    const t = parseTag(tag);
-    return t ? `${t.major + 1}.${t.minor}.${t.patch}.0` : null;
-}
+// The tag parser and the pack.ps1 identity rule (desktop-v0.2.8 -> 1.2.8.0:
+// the Store refuses a 0 first octet) are versions.mjs's; this module used to
+// carry byte-identical copies. Re-exported so the module's surface is
+// unchanged (desktop.test.mjs imports them from here). The inverse mapping
+// below stays local: storePackage depends on its strict shape rule.
+export { parseTag, identityVersion } from './versions.mjs';
 
 /** 1.2.8.0 -> desktop-v0.2.8; null for a shape pack.ps1 never produces. */
 export function tagForIdentity(identity) {


### PR DESCRIPTION
## Summary

- Bug fix: the safety `ERROR` row in `transfer-audit/scripts/audit.mjs` was assembled by hand with build-less sender and receiver stubs, so the report's `Rcv build` column printed `-` on the run's most serious row and run.json's `receiver` object carried no `build` or `version`. `baseResult` is now exported from `lib/cell.mjs` and the row is built as `{ ...baseResult(cell, ctx), verdict: 'ERROR', reason: 'safety', note: e.message, countsForExit: true }`. The spread comes first on purpose: the other order resets the verdict to null and the run stops exiting 4.
- The safety-breach test in `audit.test.mjs` now reads `run.json` and `audit.md` for the row: `receiver.build` must be a string equal to the sibling web receiver's, and the table's `Rcv build` column must match that sibling's and not be `-`. (`rcvBuild` itself never reaches run.json because `buildRunJsonRaw` whitelists the row's fields, so the table is where it is checked.) The assertion fails on the previous `audit.mjs` and passes on this one.
- `lib/desktop.mjs` carried byte-identical copies of `parseTag` and `identityVersion` from `lib/versions.mjs` (only the regex constant's name differed) plus a `DESKTOP_TAG` whose only reader was the local `parseTag`. It now re-exports both from `versions.mjs`; its surface is unchanged (`desktop.test.mjs` still imports them from here) and `DESKTOP_TAG` is gone. `tagForIdentity` and `versionForIdentity` stay local because `storePackage` depends on their strict shape rule.

Two commits: the de-duplication first, then the fix with its test.

## Test plan

- `diff` of the deleted `desktop.mjs` bodies against `versions.mjs`: only the regex constant's name and one comment line differ. `node --check` on every edited module.
- `node --test` on `desktop.test.mjs`, `versions.test.mjs` and `audit.test.mjs` after each commit: 65 tests, 65 pass. The desktop suite is the one that matters here: `adapters.mjs` turns a load error in `desktop.mjs` into every desktop cell SKIPping silently.
- The new assertion run against the pre-fix `audit.mjs` and `cell.mjs` (checked out from HEAD): fails at the `receiver.build` check (`undefined`); passes after the fix is re-applied.
- `node --test ".claude/skills/**/*.test.mjs"`: 405 tests, 401 pass, 4 skipped (baseline).
- `check-consumers`: 110 rows, 0 unmapped, 0 stale, 0 anchor-missing. `docs-check.mjs all`: 0 hard.
- CI lane: skills-only (`Repo guardrails` in the gate, `Skill test suites` outside it).
