### PR TITLE
refactor(cli): one ice.StunOnly for the two --no-relay loops

### DIFF
--- a/cli/cmd/floe/receive.go
+++ b/cli/cmd/floe/receive.go
@@ -76,16 +76,7 @@ func runReceive(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if flagNoRelay {
-		filtered := iceServers[:0]
-		for _, s := range iceServers {
-			for _, u := range s.URLs {
-				if len(u) >= 4 && u[:4] == "stun" {
-					filtered = append(filtered, s)
-					break
-				}
-			}
-		}
-		iceServers = filtered
+		iceServers = ice.StunOnly(iceServers)
 	}
 
 	// 4. Connect to signaling server

--- a/cli/cmd/floe/send.go
+++ b/cli/cmd/floe/send.go
@@ -55,17 +55,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if flagNoRelay {
-		// Keep only STUN servers, drop TURN
-		filtered := iceServers[:0]
-		for _, s := range iceServers {
-			for _, u := range s.URLs {
-				if len(u) >= 4 && u[:4] == "stun" {
-					filtered = append(filtered, s)
-					break
-				}
-			}
-		}
-		iceServers = filtered
+		iceServers = ice.StunOnly(iceServers)
 	}
 
 	// 3. Connect to the signaling server via WebSocket

--- a/cli/engine/ice/credentials.go
+++ b/cli/engine/ice/credentials.go
@@ -60,6 +60,32 @@ func HasRelay(servers []webrtc.ICEServer) bool {
 	return false
 }
 
+// StunOnly keeps the entries that offer a STUN URL and drops the rest, which
+// is what --no-relay means on both CLI commands: gather host and
+// server-reflexive candidates, never a relay. Both call it after requireRelay,
+// which has to see the server's full list.
+//
+// The body is the loop the two commands each carried, kept as it was. The
+// filter is in place: the result aliases the input's backing array, so the
+// caller reassigns and never reads the input again. An entry is kept or
+// dropped whole, so one carrying both a stun and a turn URL survives with
+// both. The prefix test is case-sensitive; iceURLClass is the
+// case-insensitive classifier HasRelay uses, and this deliberately does not
+// go through it, so a change in what --no-relay keeps is a decision rather
+// than a side effect.
+func StunOnly(servers []webrtc.ICEServer) []webrtc.ICEServer {
+	filtered := servers[:0]
+	for _, s := range servers {
+		for _, u := range s.URLs {
+			if len(u) >= 4 && u[:4] == "stun" {
+				filtered = append(filtered, s)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
 // pick returns the first URL in urls that contains pref, else the first URL.
 func pick(urls []string, pref string) string {
 	for _, u := range urls {

--- a/cli/engine/ice/credentials_test.go
+++ b/cli/engine/ice/credentials_test.go
@@ -211,6 +211,69 @@ func TestHasRelay(t *testing.T) {
 	}
 }
 
+// TestStunOnly pins the --no-relay filter as the two CLI loops had it before
+// they were folded here: whole entries survive on any stun URL, everything
+// else goes, the prefix test is case-sensitive, and the result is built in
+// place over the input.
+func TestStunOnly(t *testing.T) {
+	cases := []struct {
+		name    string
+		servers []webrtc.ICEServer
+		want    []webrtc.ICEServer
+	}{
+		{
+			"mixed list keeps the stun entries, in order, and drops the turn entries",
+			[]webrtc.ICEServer{
+				{URLs: []string{"stun:a:3478"}},
+				{URLs: []string{"turn:a:3478?transport=udp", "turns:a:443?transport=tcp"}, Username: "u", Credential: "c"},
+				{URLs: []string{"stun:b:3478"}},
+			},
+			[]webrtc.ICEServer{{URLs: []string{"stun:a:3478"}}, {URLs: []string{"stun:b:3478"}}},
+		},
+		{
+			"an entry carrying both survives whole, turn url and credentials included",
+			[]webrtc.ICEServer{{URLs: []string{"turn:a:3478", "stun:a:3478"}, Username: "u", Credential: "c"}},
+			[]webrtc.ICEServer{{URLs: []string{"turn:a:3478", "stun:a:3478"}, Username: "u", Credential: "c"}},
+		},
+		{
+			"turn only leaves nothing",
+			[]webrtc.ICEServer{{URLs: []string{"turn:a:3478"}}, {URLs: []string{"turns:a:443?transport=tcp"}}},
+			[]webrtc.ICEServer{},
+		},
+		{
+			"the prefix test is case-sensitive, as the loops were",
+			[]webrtc.ICEServer{{URLs: []string{"STUN:a:3478"}}},
+			[]webrtc.ICEServer{},
+		},
+		{"empty list", []webrtc.ICEServer{}, []webrtc.ICEServer{}},
+		{"nil list", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StunOnly(tc.servers); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("StunOnly() = %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("filters in place", func(t *testing.T) {
+		in := []webrtc.ICEServer{
+			{URLs: []string{"turn:a:3478"}},
+			{URLs: []string{"stun:a:3478"}},
+		}
+		got := StunOnly(in)
+		if len(got) != 1 || got[0].URLs[0] != "stun:a:3478" {
+			t.Fatalf("StunOnly() = %#v", got)
+		}
+		if &got[0] != &in[0] {
+			t.Fatal("the result does not alias the input's backing array")
+		}
+		if in[0].URLs[0] != "stun:a:3478" {
+			t.Fatalf("the input was left as it was, so the aliasing contract changed: in[0] = %#v", in[0])
+		}
+	})
+}
+
 // TestDefaultsHaveNoRelay pins the fact the whole missing-relay problem turns
 // on. Fetch degrades to these on any non-200, including the TURN endpoint's own
 // rate limiter, so a relay-only transfer against a perfectly good server can


### PR DESCRIPTION
## Summary

`floe send` and `floe receive` each carried the same nine-line loop that drops every ICE entry without a STUN URL when `--no-relay` is set. This adds the loop to the `ice` package as `StunOnly`, beside `HasRelay` (which already exports the matching signature; the cmd package keeps no reference to the ICE types, so the helper cannot live there), then replaces both loops with `iceServers = ice.StunOnly(iceServers)`, keeping the call after `requireRelay` at both sites because `requireRelay` has to see the server's full list.

The body is the send.go loop verbatim: the filter is in place over the input's backing array, an entry is kept or dropped whole (one carrying both a stun and a turn URL survives with both), and the prefix test is case-sensitive. `TestStunOnly` pins each of those as today's contract, aliasing included, so a later change to what `--no-relay` keeps is a decision rather than a side effect. `--no-relay` semantics are unchanged.

Two commits: the helper and its test, then the two replacements. No wire message, user-facing string, flag or Wails binding changes. No release.

## Test plan

- go doc proof against a worktree at the merge-base (773846b), Windows and `GOOS=linux`: `engine/ice` differs by exactly `func StunOnly(servers []webrtc.ICEServer) []webrtc.ICEServer`; `cmd/floe` is identical.
- Verbatim proof: the send.go loop (leading tabs stripped, `iceServers` renamed `servers`) diffs clean against the helper body; the receive.go loop diffs clean against the send.go loop.
- Cobra proof: `floe --help`, `floe send --help` and `floe receive --help` diff empty between a binary built from the merge-base and one built from the branch (both with `-o` outside the tree).
- `cd cli && go vet ./... && go test -count=1 ./...`: 9 packages ok (`engine/transfer` 89 s); `TestStunOnly` passes all 7 subtests. `GOOS=linux go vet ./...`, `go build ./...` and gofmt clean on every changed file.
- `cd desktop && go vet ./...` clean with `frontend/dist` built.
- `node .claude/skills/untrusted-peer-data/scripts/check-consumers.mjs --root .`: 110 rows, 0 unmapped, 0 stale, 0 anchor-missing, 17 warnings; the untouched merge-base reports the same 17 (the two beyond the earlier 15 are `control_test.go` and `format_test.go`, created by #446).
- `node .claude/skills/docs-verify/scripts/docs-check.mjs all`: 0 hard, 41 notes. No em or en dash in any added line.
- Only CI can arbitrate: the other two CLI OSes, E2E x3, Back-compat, the Desktop packaging steps.
