### PR TITLE
refactor(desktop): move the context-menu policy into contextmenu.go

### DIFF
--- a/DESKTOP.md
+++ b/DESKTOP.md
@@ -60,6 +60,7 @@ desktop/               Wails app: imports cli/engine/...
   serverprobe.go       the Settings Test button: probes a server URL in stages
   updatecheck.go       once-a-day check for a newer desktop release, notice only
   config.go            desktop.json: persisted settings kept outside the WebView
+  contextmenu.go       the Explorer "Send with Floe" toggle: its registry key and the bound methods
 go.work                ties cli + desktop for local dev
 ```
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	goruntime "runtime"
 	"strings"
@@ -14,14 +13,6 @@ import (
 )
 
 const desktopUpdateHint = "Update Floe from the Microsoft Store or floe.one/download."
-
-// contextMenuBase is the per-user Explorer context-menu key for all file types.
-const contextMenuBase = `Software\Classes\*\shell\Floe`
-
-// expectedCommand is the context-menu launch command for the given executable.
-func expectedCommand(exe string) string {
-	return fmt.Sprintf(`"%s" "%%1"`, exe)
-}
 
 // filterFileArgs keeps only arguments that point at an existing file or
 // directory, dropping flags, empty strings, and stale paths.
@@ -226,53 +217,6 @@ func (a *App) PasteFiles() []string {
 		}
 	}
 	return nil
-}
-
-// IsPackaged reports whether this build runs with MSIX package identity (the
-// Microsoft Store install). The Settings screen hides the Explorer
-// context-menu toggle when it does: a packaged process's HKCU writes land in
-// a private registry view that Explorer never reads, so the verb cannot work,
-// and a Store uninstall runs no cleanup that could remove a stale entry.
-func (a *App) IsPackaged() bool {
-	return isPackaged()
-}
-
-// EnableContextMenu adds the "Send with Floe" entry to the Explorer right-click
-// menu for the current user (Windows only, unpackaged builds only).
-func (a *App) EnableContextMenu() error {
-	if isPackaged() {
-		// Unreachable through the UI (the toggle is hidden when packaged);
-		// a clear error beats a write that would silently do nothing.
-		return fmt.Errorf("the right-click menu is not available in the Microsoft Store build")
-	}
-	exe, err := os.Executable()
-	if err != nil {
-		return err
-	}
-	return registerContextMenu(contextMenuBase, exe)
-}
-
-// DisableContextMenu removes the Explorer entry. Deliberately not gated on
-// isPackaged: removal is harmless everywhere, so a cleanup call can never fail
-// for channel reasons.
-func (a *App) DisableContextMenu() error {
-	return unregisterContextMenu(contextMenuBase)
-}
-
-// ContextMenuEnabled reports whether the entry exists and points at the current
-// executable; a moved exe reads as disabled until re-enabled. Always false when
-// packaged: the merged registry view could report an entry that Explorer does
-// not actually show, and false is the truth that matters (the feature is off).
-func (a *App) ContextMenuEnabled() bool {
-	if isPackaged() {
-		return false
-	}
-	exe, err := os.Executable()
-	if err != nil {
-		return false
-	}
-	cmd, ok := contextMenuCommand(contextMenuBase)
-	return ok && cmd == expectedCommand(exe)
 }
 
 // notify sends a best-effort OS notification. Failures are ignored so a transfer

--- a/desktop/contextmenu.go
+++ b/desktop/contextmenu.go
@@ -1,0 +1,68 @@
+package main
+
+// The Explorer "Send with Floe" toggle: the registry key it owns, the command
+// it expects to find there, and the bound methods behind the Settings switch.
+// The registry calls live in contextmenu_windows.go, with stubs in
+// contextmenu_other.go. This file carries no build tag because the startup
+// self-heal in app.go calls into it behind a runtime GOOS check, so it must
+// compile on every platform.
+
+import (
+	"fmt"
+	"os"
+)
+
+// contextMenuBase is the per-user Explorer context-menu key for all file types.
+const contextMenuBase = `Software\Classes\*\shell\Floe`
+
+// expectedCommand is the context-menu launch command for the given executable.
+func expectedCommand(exe string) string {
+	return fmt.Sprintf(`"%s" "%%1"`, exe)
+}
+
+// IsPackaged reports whether this build runs with MSIX package identity (the
+// Microsoft Store install). The Settings screen hides the Explorer
+// context-menu toggle when it does: a packaged process's HKCU writes land in
+// a private registry view that Explorer never reads, so the verb cannot work,
+// and a Store uninstall runs no cleanup that could remove a stale entry.
+func (a *App) IsPackaged() bool {
+	return isPackaged()
+}
+
+// EnableContextMenu adds the "Send with Floe" entry to the Explorer right-click
+// menu for the current user (Windows only, unpackaged builds only).
+func (a *App) EnableContextMenu() error {
+	if isPackaged() {
+		// Unreachable through the UI (the toggle is hidden when packaged);
+		// a clear error beats a write that would silently do nothing.
+		return fmt.Errorf("the right-click menu is not available in the Microsoft Store build")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	return registerContextMenu(contextMenuBase, exe)
+}
+
+// DisableContextMenu removes the Explorer entry. Deliberately not gated on
+// isPackaged: removal is harmless everywhere, so a cleanup call can never fail
+// for channel reasons.
+func (a *App) DisableContextMenu() error {
+	return unregisterContextMenu(contextMenuBase)
+}
+
+// ContextMenuEnabled reports whether the entry exists and points at the current
+// executable; a moved exe reads as disabled until re-enabled. Always false when
+// packaged: the merged registry view could report an entry that Explorer does
+// not actually show, and false is the truth that matters (the feature is off).
+func (a *App) ContextMenuEnabled() bool {
+	if isPackaged() {
+		return false
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	cmd, ok := contextMenuCommand(contextMenuBase)
+	return ok && cmd == expectedCommand(exe)
+}

--- a/desktop/packaged_windows.go
+++ b/desktop/packaged_windows.go
@@ -14,7 +14,7 @@ import (
 // the "Send with Floe" verb cannot work), and a Store uninstall runs no
 // cleanup code that could remove a verb pointing at the versioned WindowsApps
 // exe path. The context-menu feature is therefore hidden when packaged; see
-// the guards in app.go.
+// the guards in contextmenu.go.
 //
 // Verified empirically against a loose-layout package of this app (2026-08):
 // the app's registry writes were virtualized into the package's private hive


### PR DESCRIPTION
## Summary

`app.go` held the Explorer "Send with Floe" policy in two places: `contextMenuBase` and `expectedCommand` near the top, and the four bound methods behind the Settings switch (`IsPackaged`, `EnableContextMenu`, `DisableContextMenu`, `ContextMenuEnabled`) further down, with the app lifecycle in between. They now live together in a new `desktop/contextmenu.go`, beside the `contextmenu_windows.go` / `contextmenu_other.go` pair that does the registry work. The file has no build tag and no GOOS suffix on purpose: the startup self-heal in `app.go` calls into it behind a runtime `goruntime.GOOS` check, so it must compile on Linux and macOS, and CI vets the desktop module only on Windows. `app.go` drops the `fmt` import that only the moved code used; `packaged_windows.go`'s "see the guards in app.go" pointer and DESKTOP.md's repo-layout block follow the code. One commit; no behavior change.

## Test plan

Pure-move proofs against a worktree at `2e68702` (the merge-base), with `frontend/dist` built so the embed resolves:

- `go doc -all -u .`: identical (897 lines), so the `*App` method set Wails reflects over is unchanged.
- `desktop/frontend/wailsjs/go/main/App.d.ts`: byte-identical (sha256 `f5dda4f5…`, 23 bound functions), untouched by the change.
- `go test -list . .` sorted: identical (86 funcs). `go test -count=1 -v ./...` PASS/SKIP names sorted: identical to the merge-base tree (122 entries, 121 PASS, 1 SKIP: `TestProbeServerAgainstLiveServer`); suite `ok`.
- `git diff --color-moved=dimmed-zebra`: the only lines not paired as moved are the new file's package, header and import lines, the `fmt` import line leaving `app.go`, the two-line pointer swap in `packaged_windows.go`, and the DESKTOP.md row.

Local checks:

- `cd desktop && go vet ./...` on windows, GOOS=linux and GOOS=darwin: clean (the Linux and macOS vets are the ones CI does not run, and the ones a build-tagged file would have broken silently). `gofmt -l` on the three touched Go files: clean.
- `node .claude/skills/untrusted-peer-data/scripts/check-consumers.mjs --root .`: `110 rows, 0 unmapped, 0 stale, 0 anchor-missing, 17 warnings` (unchanged); the two app.go anchors `notifyTransferFailed` and `func (a *App) notify(` stay in app.go.
- `node .claude/skills/docs-verify/scripts/docs-check.mjs all` (DESKTOP.md is a scan root): `0 hard`. No em dash in any touched file.
- Left to CI: the `Desktop (Wails, windows-latest)` frontend and packaging steps, `E2E` x3, `Back-compat`.
