### PR TITLE
refactor(server): give the stats counter its own module

### DIFF
--- a/.claude/skills/docs-verify/references/claim-map.md
+++ b/.claude/skills/docs-verify/references/claim-map.md
@@ -39,7 +39,7 @@ The map names where a value is stated; grep the old literal repo-wide before fin
 
 ## Rate limits and caps
 
-- server/server.js: `MAX_CONNECTIONS_PER_IP`, `CODE_MAX_REQUESTS`, `STATS_MAX_REPORTS` (fixed, no env var), `MAX_ACTIVE_CODES`, `MAX_REPORT_BYTES`; windows `RATE_LIMIT_WINDOW`, `CODE_RATE_WINDOW`, `STATS_RATE_WINDOW`. server/turn.js: `TURN_MAX_REQUESTS`, `TURN_RATE_WINDOW`.
+- server/server.js: `MAX_CONNECTIONS_PER_IP`, `CODE_MAX_REQUESTS`, `MAX_ACTIVE_CODES`; windows `RATE_LIMIT_WINDOW`, `CODE_RATE_WINDOW`. server/stats.js: `STATS_MAX_REPORTS` (fixed, no env var), `MAX_REPORT_BYTES`; window `STATS_RATE_WINDOW`. server/turn.js: `TURN_MAX_REQUESTS`, `TURN_RATE_WINDOW`.
 - Docs: docs/self-hosting/configuration.mdx table and "Two things about the limits" (script: server rows), CONTRIBUTING.md server table (script), docs/reference/architecture.mdx "Rate limiting" table, docs/reference/http-api.mdx "Rate limit" line under each endpoint, docs/troubleshooting.mdx "429" and "503" sections, CLAUDE.md "Rate Limiting", server/.env.example comments (script, NOTE).
 
 ## Room code TTL

--- a/.claude/skills/docs-verify/scripts/docs-check.mjs
+++ b/.claude/skills/docs-verify/scripts/docs-check.mjs
@@ -79,6 +79,7 @@ export const SURFACES = [
     'desktop',
     'server/server.js',
     'server/turn.js',
+    'server/stats.js',
     'server/.env.example',
     '.env.docker.example',
     'docker-compose.yml',

--- a/.claude/skills/transfer-audit/SKILL.md
+++ b/.claude/skills/transfer-audit/SKILL.md
@@ -428,8 +428,9 @@ receiver's opt-out, and the versions that did it.
   `desktop/app.go`, `desktop/transfer.go`, `desktop/config.go`,
   `cli/cmd/floe/main.go`, `cli/cmd/floe/send.go`, `cli/cmd/floe/receive.go`,
   `cli/engine/transfer/receiver.go`, `cli/engine/peer/connection.go`,
-  `server/server.js` (the connection, code and stats limiters),
-  `server/turn.js` (the TURN limiter and `/api/turn-credentials` precedence).
+  `server/server.js` (the connection and code limiters), `server/stats.js`
+  (the stats limiter), `server/turn.js` (the TURN limiter and
+  `/api/turn-credentials` precedence).
 - Memory: `reference_transfer_audit_harness`,
   `reference_datachannel_early_message_race`,
   `project_floe_local_install_hygiene`, `project_deployment_topology`,

--- a/.claude/skills/transfer-audit/scripts/lib/pacing.mjs
+++ b/.claude/skills/transfer-audit/scripts/lib/pacing.mjs
@@ -1,7 +1,8 @@
 // Pacing ledger against the production limiters (server/turn.js: TURN 20;
-// server/server.js: connections 30, code 60, stats 60; each per IP per
-// rolling 60 s). Pure apart from the injected clock, persisted as JSON at
-// --out/ledger.json so two runs inside one minute share the same window.
+// server/server.js: connections 30, code 60; server/stats.js: stats 60;
+// each per IP per rolling 60 s). Pure apart from the injected clock,
+// persisted as JSON at --out/ledger.json so two runs inside one minute share
+// the same window.
 // Headroom is 50 percent (10 TURN, 15 conn, 30 code) and there is an 8 s
 // floor between leg starts, so the user's own floe.one traffic on the same
 // IP still has room.

--- a/server/server.js
+++ b/server/server.js
@@ -434,8 +434,6 @@ io.on('connection', (socket) => {
     socket.on('disconnecting', () => {
         handleDisconnect(peer);
     });
-
-    socket.on('disconnect', () => {});
 });
 
 // ---------------------------------------------------------------------------

--- a/server/server.js
+++ b/server/server.js
@@ -82,10 +82,14 @@ const {
     turnCredentialsHandler,
 } = require('./turn');
 
-const statsRateLimits = new Map();
-const STATS_RATE_WINDOW = 60000;
-const STATS_MAX_REPORTS = 60; // per IP per minute
-const MAX_REPORT_BYTES = parseInt(process.env.MAX_REPORT_BYTES || '', 10) || (5 * 1024 * 1024 * 1024 * 1024); // 5 TiB
+const {
+    statsRateLimits,
+    STATS_RATE_WINDOW,
+    initStats,
+    validateReportBytes,
+    statsHandler,
+    statsReportHandler,
+} = require('./stats');
 
 // Per-IP limiter for the code endpoints (register + resolve). These were the
 // only unauthenticated HTTP routes without a limiter: unbounded POSTs grow
@@ -162,75 +166,8 @@ app.get('/api/code/:code', codeRateLimiter, (req, res) => {
     res.json({ roomId: entry.roomId });
 });
 
-// ---------------------------------------------------------------------------
-// Global stats — Upstash Redis (durable) + fast in-memory read cache
-//
-// GET /api/stats  — served from cachedTotal; zero Redis reads per poll request.
-// POST /api/stats/report — receiver peers report bytes after a completed transfer.
-//   Validates, increments cachedTotal, then fires INCRBY to Upstash (no-await).
-//   Gracefully degrades to in-memory-only when UPSTASH_* env vars are absent.
-// ---------------------------------------------------------------------------
-
-const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL;
-const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
-const STATS_KEY = 'floe:bytes_total';
-
-let cachedTotal = 0;
-
-async function upstashPost(command) {
-    if (!UPSTASH_URL || !UPSTASH_TOKEN) return null;
-    try {
-        const resp = await fetch(UPSTASH_URL, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${UPSTASH_TOKEN}`,
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(command),
-        });
-        if (!resp.ok) return null;
-        const { result } = await resp.json();
-        return result;
-    } catch {
-        return null;
-    }
-}
-
-async function initStats() {
-    const val = await upstashPost(['GET', STATS_KEY]);
-    if (val !== null) cachedTotal = Number(val) || 0;
-}
-
-function validateReportBytes(bytes, maxBytes) {
-    return Number.isInteger(bytes) && bytes > 0 && bytes <= maxBytes;
-}
-
-app.get('/api/stats', (_req, res) => {
-    res.json({ totalBytes: cachedTotal });
-});
-
-app.post('/api/stats/report', (req, res) => {
-    const ip = req.ip;
-    const now = Date.now();
-
-    if (!statsRateLimits.has(ip)) statsRateLimits.set(ip, []);
-    const timestamps = statsRateLimits.get(ip).filter(t => now - t < STATS_RATE_WINDOW);
-    if (timestamps.length >= STATS_MAX_REPORTS) {
-        return res.status(429).json({ error: 'Too many reports' });
-    }
-    timestamps.push(now);
-    statsRateLimits.set(ip, timestamps);
-
-    const { bytes } = req.body || {};
-    if (!validateReportBytes(bytes, MAX_REPORT_BYTES)) {
-        return res.status(400).json({ error: 'Invalid byte count' });
-    }
-
-    cachedTotal += bytes;
-    upstashPost(['INCRBY', STATS_KEY, bytes]);
-
-    res.json({ totalBytes: cachedTotal });
-});
+app.get('/api/stats', statsHandler);
+app.post('/api/stats/report', statsReportHandler);
 
 // ---------------------------------------------------------------------------
 // Error handling

--- a/server/server.js
+++ b/server/server.js
@@ -41,6 +41,10 @@ function getClientIp(xffHeader, socketAddr) {
     return hops[idx] || socketAddr || 'unknown';
 }
 
+// A room id must be a UUID. handleJoinRoom and POST /api/code both check it,
+// and client/lib/roomLink.ts mirrors the pattern, so keep the two in step.
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const allowedOrigins = [
     process.env.CLIENT_URL,
     'https://www.floe.one',
@@ -82,6 +86,15 @@ const {
     turnCredentialsHandler,
 } = require('./turn');
 
+app.get('/api/turn-credentials', turnCredentialsHandler);
+
+// ---------------------------------------------------------------------------
+// Global stats counter (server/stats.js)
+//
+// Required after dotenv.config() above for the same reason as turn.js:
+// stats.js reads the two Upstash keys and MAX_REPORT_BYTES at require time.
+// ---------------------------------------------------------------------------
+
 const {
     statsRateLimits,
     STATS_RATE_WINDOW,
@@ -90,6 +103,14 @@ const {
     statsHandler,
     statsReportHandler,
 } = require('./stats');
+
+app.get('/api/stats', statsHandler);
+app.post('/api/stats/report', statsReportHandler);
+
+// ---------------------------------------------------------------------------
+// Code phrase API  (/api/code)
+// CLI callers use this to generate and resolve short human-readable codes.
+// ---------------------------------------------------------------------------
 
 // Per-IP limiter for the code endpoints (register + resolve). These were the
 // only unauthenticated HTTP routes without a limiter: unbounded POSTs grow
@@ -118,13 +139,6 @@ function makeRateLimiter(map, windowMs, max) {
     };
 }
 const codeRateLimiter = makeRateLimiter(codeRateLimits, CODE_RATE_WINDOW, CODE_MAX_REQUESTS);
-
-app.get('/api/turn-credentials', turnCredentialsHandler);
-
-// ---------------------------------------------------------------------------
-// Code phrase API  (/api/code)
-// CLI callers use this to generate and resolve short human-readable codes.
-// ---------------------------------------------------------------------------
 
 const words = require('./words.json');
 const codeToRoom = new Map(); // code → { roomId, expires }
@@ -166,9 +180,6 @@ app.get('/api/code/:code', codeRateLimiter, (req, res) => {
     res.json({ roomId: entry.roomId });
 });
 
-app.get('/api/stats', statsHandler);
-app.post('/api/stats/report', statsReportHandler);
-
 // ---------------------------------------------------------------------------
 // Error handling
 // ---------------------------------------------------------------------------
@@ -207,8 +218,6 @@ app.use(errorHandler);
 // ---------------------------------------------------------------------------
 // Rate limiting (Socket.IO connections + WebSocket connections share this map)
 // ---------------------------------------------------------------------------
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const connectionCounts = new Map();
 const RATE_LIMIT_WINDOW = 60000;
@@ -568,12 +577,6 @@ const heartbeat = setInterval(() => {
 wss.on('close', () => clearInterval(heartbeat));
 
 // ---------------------------------------------------------------------------
-// Start
-// ---------------------------------------------------------------------------
-
-const PORT = process.env.PORT || 3001;
-
-// ---------------------------------------------------------------------------
 // Graceful shutdown (SIGTERM from platform, SIGINT from Ctrl-C)
 // ---------------------------------------------------------------------------
 
@@ -590,6 +593,8 @@ function shutdown() {
 // ---------------------------------------------------------------------------
 // Entry point — only bind / register OS signals when run directly (not in tests)
 // ---------------------------------------------------------------------------
+
+const PORT = process.env.PORT || 3001;
 
 if (require.main === module) {
     // Mandatory once uncaughtException is handled below, or a bind failure

--- a/server/stats.js
+++ b/server/stats.js
@@ -1,0 +1,110 @@
+// The global stats counter, lifted out of server.js whole: the per-IP limiter
+// for the report endpoint, the per-report cap, the Upstash Redis client, the
+// in-memory read cache and the two request handlers.
+//
+// server.js still registers both routes, and still sweeps statsRateLimits
+// from its cleanup interval, as it does for turn.js. The registration lines
+// have to stay ahead of app.use(errorHandler): Express dispatches error
+// middleware in registration order, and a route mounted after it falls
+// through to the built-in handler, which serialises err.stack into the body
+// whenever app.get('env') is not exactly 'production'. Exporting handlers
+// rather than a router keeps that ordering visible at the call site.
+//
+// This module reads process.env at require time for the two Upstash keys and
+// MAX_REPORT_BYTES, so it must be required AFTER dotenv.config() in server.js.
+// Required above it, both keys read undefined, upstashPost returns null, and
+// production silently degrades to an in-memory counter that resets on every
+// restart, with no test to notice.
+//
+// initStats() is called only from server.js's require.main === module block,
+// never here at module scope: a require-time Upstash call would also run under
+// node --test, which requires server.js and with it whatever server/.env the
+// checkout holds.
+
+const statsRateLimits = new Map();
+const STATS_RATE_WINDOW = 60000;
+const STATS_MAX_REPORTS = 60; // per IP per minute
+const MAX_REPORT_BYTES = parseInt(process.env.MAX_REPORT_BYTES || '', 10) || (5 * 1024 * 1024 * 1024 * 1024); // 5 TiB
+
+// ---------------------------------------------------------------------------
+// Global stats — Upstash Redis (durable) + fast in-memory read cache
+//
+// GET /api/stats  — served from cachedTotal; zero Redis reads per poll request.
+// POST /api/stats/report — receiver peers report bytes after a completed transfer.
+//   Validates, increments cachedTotal, then fires INCRBY to Upstash (no-await).
+//   Gracefully degrades to in-memory-only when UPSTASH_* env vars are absent.
+// ---------------------------------------------------------------------------
+
+const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL;
+const UPSTASH_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+const STATS_KEY = 'floe:bytes_total';
+
+let cachedTotal = 0;
+
+async function upstashPost(command) {
+    if (!UPSTASH_URL || !UPSTASH_TOKEN) return null;
+    try {
+        const resp = await fetch(UPSTASH_URL, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${UPSTASH_TOKEN}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(command),
+        });
+        if (!resp.ok) return null;
+        const { result } = await resp.json();
+        return result;
+    } catch {
+        return null;
+    }
+}
+
+async function initStats() {
+    const val = await upstashPost(['GET', STATS_KEY]);
+    if (val !== null) cachedTotal = Number(val) || 0;
+}
+
+function validateReportBytes(bytes, maxBytes) {
+    return Number.isInteger(bytes) && bytes > 0 && bytes <= maxBytes;
+}
+
+/** GET /api/stats. Registered by server.js, before the error handler. */
+function statsHandler(_req, res) {
+    res.json({ totalBytes: cachedTotal });
+}
+
+/** POST /api/stats/report. Registered by server.js, before the error handler. */
+function statsReportHandler(req, res) {
+    const ip = req.ip;
+    const now = Date.now();
+
+    if (!statsRateLimits.has(ip)) statsRateLimits.set(ip, []);
+    const timestamps = statsRateLimits.get(ip).filter(t => now - t < STATS_RATE_WINDOW);
+    if (timestamps.length >= STATS_MAX_REPORTS) {
+        return res.status(429).json({ error: 'Too many reports' });
+    }
+    timestamps.push(now);
+    statsRateLimits.set(ip, timestamps);
+
+    const { bytes } = req.body || {};
+    if (!validateReportBytes(bytes, MAX_REPORT_BYTES)) {
+        return res.status(400).json({ error: 'Invalid byte count' });
+    }
+
+    cachedTotal += bytes;
+    upstashPost(['INCRBY', STATS_KEY, bytes]);
+
+    res.json({ totalBytes: cachedTotal });
+}
+
+module.exports = {
+    statsRateLimits,
+    STATS_RATE_WINDOW,
+    STATS_MAX_REPORTS,
+    MAX_REPORT_BYTES,
+    initStats,
+    validateReportBytes,
+    statsHandler,
+    statsReportHandler,
+};


### PR DESCRIPTION
## Summary

The global stats counter lived in `server.js` in two places: its limiter constants sat under the TURN banner, and the Upstash client, the read cache, `initStats`, `validateReportBytes` and both route bodies sat 80 lines further down, with the seed call near the bottom of the file. It now lives in `server/stats.js`, following `server/turn.js` (#415) exactly: state owned by the module behind exported handlers, required after `dotenv.config()`, and `server.js` keeps the two route registrations ahead of `app.use(errorHandler)`, the limiter sweep in its cleanup interval, the `initStats()` call inside `require.main === module`, and the re-exports `server.test.js` reads. Three commits:

1. **The move.** The four moved blocks (the constants, the Upstash and cache block with `initStats` and `validateReportBytes`, and the two route bodies) are byte-identical to `server.js` at 977627d. Every line added to `server.js` is the `require('./stats')` or one of the two registrations. Same commit, because the move stales them: `docs-check.mjs` lists `server/stats.js` in `SURFACES` (its fixture test copies only that list, and `SERVER_KEY_FLOOR` stays 14 across server.js 6, turn.js 5, stats.js 3); the claim map names stats.js for `STATS_MAX_REPORTS`, `MAX_REPORT_BYTES` and `STATS_RATE_WINDOW`; the transfer-audit runbook's pointer list and the pacing ledger's header name stats.js for the stats limiter.
2. **Banners.** After the move the TURN banner headed the TURN require, the stats require and the code endpoints' limiter. Each concern now sits under its own banner with its route registration beside its require, the code limiter moves into the code phrase section it serves, `UUID_REGEX` leaves the connection limiter section for App setup (both room-id checks read it), and `PORT` joins the entry point that uses it. Code lines are reordered, never edited.
3. **The empty listener.** `socket.on('disconnect', () => {})` has done nothing since 3ec9c4e; the `disconnecting` listener above it removes the peer from its room.

Deliberately unchanged: the stats tests stay in `server.test.js`, reached through `server.js`'s re-exports, which is where #415 left the TURN tests. Moving only the stats tests would leave the server's test layout half-converted. Nothing below the HTTP server banner moves (the ws upgrade handler's ordering is protected in CLAUDE.md). No behavior change, so no tag: self-hosters get it with the next `v*`, and `images.yml` publishes `main` and `sha-*` on merge.

## Test plan

- Move proof (commit 1): `diff` of each of the four base blocks (server.js 85-88, 165-206, 209, 213-232 at 977627d) against its place in `stats.js`: all empty. `git diff -U0` of `server.js` adds exactly 10 lines: the 8-line require and the 2 registrations.
- Reorder proof (commit 2): the sorted list of non-comment, non-blank lines in `server.js` is identical before and after (390 lines); the diff's only other changes are the banner lines, the two-line `UUID_REGEX` note and the removed one-line `Start` section.
- `cd server && npm ci && node --test`: 58 tests, 58 pass, and it exits, after each commit (58 on main).
- Behavior smoke against a local `node server.js` (no `.env` in the clone, Upstash pointed at the unroutable 127.0.0.1:9 sentinel floe-run uses, so nothing can reach the public counter), on the unmodified tree and after each commit, compared as JSON: `GET /api/stats` 0, a valid report 200 with the new total, zero / string / over-cap reports 400 `Invalid byte count`, a malformed body 400 `Bad request` from the error handler, the 61st report 429 `Too many reports`, no `Unhandled error` line. Identical every time.
- `node .claude/skills/docs-verify/scripts/docs-check.mjs all`: 0 hard, 41 notes (41 on main); `env` alone 0 hard; `docs-check.test.mjs` 13/13.
- `check-consumers.mjs --root .`: 110 rows, 0 unmapped, 0 stale, 0 anchor-missing (no server rows); `pacing.test.mjs` 11/11.
- Left to CI: Server on Node 20, Docker (the `COPY *.js words.json ./` glob picks up stats.js), e2e x3, back-compat.
